### PR TITLE
feat: AL prereqs + subject vocab for 8 states

### DIFF
--- a/data/al/prereqs.json
+++ b/data/al/prereqs.json
@@ -1,0 +1,3377 @@
+{
+  "ACT 256": {
+    "text": "BUS 241 (min D) or BUS 241 (min T) or BUS 241 (min TD)",
+    "courses": [
+      "BUS 241"
+    ]
+  },
+  "AMT 110": {
+    "text": "AMT 104 and AMT 101 and AMT 105",
+    "courses": [
+      "AMT 104",
+      "AMT 101",
+      "AMT 105"
+    ]
+  },
+  "AMT 111": {
+    "text": "AMT 104 and AMT 101 and AMT 105",
+    "courses": [
+      "AMT 104",
+      "AMT 101",
+      "AMT 105"
+    ]
+  },
+  "AMT 112": {
+    "text": "AMT 104 and AMT 101 and AMT 105",
+    "courses": [
+      "AMT 104",
+      "AMT 101",
+      "AMT 105"
+    ]
+  },
+  "AMT 113": {
+    "text": "AMT 104 and AMT 101 and AMT 105",
+    "courses": [
+      "AMT 104",
+      "AMT 101",
+      "AMT 105"
+    ]
+  },
+  "AMT 114": {
+    "text": "AMT 104 and AMT 101 and AMT 105 and AMT 103",
+    "courses": [
+      "AMT 104",
+      "AMT 101",
+      "AMT 105",
+      "AMT 103"
+    ]
+  },
+  "AMT 115": {
+    "text": "AMT 104 and AMT 101 and AMT 105 and AMT 103",
+    "courses": [
+      "AMT 104",
+      "AMT 101",
+      "AMT 105",
+      "AMT 103"
+    ]
+  },
+  "ART 114": {
+    "text": "ART 113 (min D) or ART 113 (min TD) or ART 113 (min T)",
+    "courses": [
+      "ART 113"
+    ]
+  },
+  "ART 122": {
+    "text": "ART 121 (min D) or ART 121 (min TD) or ART 121 (min T)",
+    "courses": [
+      "ART 121"
+    ]
+  },
+  "ART 127": {
+    "text": "ART 113 (min D) or ART 113 (min T) or ART 113 (min TD) or ART 121 (min D) or ART 121 (min T) or ART 121 (min TD)",
+    "courses": [
+      "ART 113",
+      "ART 121"
+    ]
+  },
+  "ART 234": {
+    "text": "ART 233 (min D) or ART 233 (min TD) or ART 233 (min T)",
+    "courses": [
+      "ART 233"
+    ]
+  },
+  "ART 254": {
+    "text": "ART 253 (min D) or ART 253 (min TD) or ART 253 (min T)",
+    "courses": [
+      "ART 253"
+    ]
+  },
+  "ART 275": {
+    "text": "ART 175 (min D) or ART 175 (min TD) or ART 175 (min T)",
+    "courses": [
+      "ART 175"
+    ]
+  },
+  "ASC 112": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 119": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 120": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 128": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 134": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 148": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 203": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "ASC 210": {
+    "text": "ASC 111 (min D) and ASC 121 (min D) and ASC 122 (min D)",
+    "courses": [
+      "ASC 111",
+      "ASC 121",
+      "ASC 122"
+    ]
+  },
+  "AST 220": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100 (min S) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 116 (min C) or MTH 116 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "MTH 098",
+      "MTH 100",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 116",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "AUM 121": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 122": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 124": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 130": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 133": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 212": {
+    "text": "AUM 162",
+    "courses": [
+      "AUM 162"
+    ]
+  },
+  "AUM 220": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 224": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 230": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 239": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 244": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "AUM 246": {
+    "text": "AUM 101 (min D) and AUM 112 (min D) and AUM 162 (min D)",
+    "courses": [
+      "AUM 101",
+      "AUM 112",
+      "AUM 162"
+    ]
+  },
+  "BIO 101": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 110 (min C) or MTH 108 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 108",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "BIO 102": {
+    "text": "BIO 101 (min D) or BIO 101 (min T) or BIO 101 (min TD)",
+    "courses": [
+      "BIO 101"
+    ]
+  },
+  "BIO 103": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min S) or MTH 108 (min C) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 116 (min C) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 116",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "BIO 104": {
+    "text": "BIO 103 (min D) or BIO 103 (min TD) or BIO 103 (min T)",
+    "courses": [
+      "BIO 103"
+    ]
+  },
+  "BIO 111": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min S) or MTH 108 (min C) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 116 (min C) or MTH 116 (min S) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 231 (min S) or MTH 232 (min C) or MTH 232 (min S) or MTH 238 (min C) or MTH 238 (min S) or MTH 265 (min C) or MTH 265 (min S)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 116",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "BIO 201": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min S) or MTH 110 (min C) or MTH 108 (min C) or MTH 110C (min C) or MTH 110 (min S) or MTH 112 (min C) or MTH 112C (min C) or MTH 112 (min S) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 116 (min C) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 108",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 116",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "BIO 202": {
+    "text": "BIO 201 (min C) or BIO 201 (min TC) or BIO 201 (min T) and BIO 103 (min C) or BIO 103 (min TC) or BIO 103 (min T)",
+    "courses": [
+      "BIO 201",
+      "BIO 103"
+    ]
+  },
+  "BIO 220": {
+    "text": "BIO 103 (min D) or BIO 103 (min TD) or BIO 201 (min D) or BIO 201 (min TD)",
+    "courses": [
+      "BIO 103",
+      "BIO 201"
+    ]
+  },
+  "BUS 215": {
+    "text": "OAD 131 (min C) or ENR 094 (min C) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "OAD 131",
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "BUS 241": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 237 (min C) or MTH 265 (min C)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 237",
+      "MTH 265"
+    ]
+  },
+  "BUS 242": {
+    "text": "BUS 241 (min D) or BUS 241 (min T) or BUS 241 (min TD)",
+    "courses": [
+      "BUS 241"
+    ]
+  },
+  "BUS 245": {
+    "text": "BUS 241 (min D)",
+    "courses": [
+      "BUS 241"
+    ]
+  },
+  "BUS 248": {
+    "text": "BUS 241 (min D)",
+    "courses": [
+      "BUS 241"
+    ]
+  },
+  "BUS 253": {
+    "text": "BUS 241 (min C)",
+    "courses": [
+      "BUS 241"
+    ]
+  },
+  "BUS 271": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "BUS 272": {
+    "text": "BUS 271 (min D) or BUS 271 (min T) or BUS 271 (min TD)",
+    "courses": [
+      "BUS 271"
+    ]
+  },
+  "CAP 121": {
+    "text": "CAP 101 (min D)",
+    "courses": [
+      "CAP 101"
+    ]
+  },
+  "CAP 122": {
+    "text": "CAP 101 (min D)",
+    "courses": [
+      "CAP 101"
+    ]
+  },
+  "CAP 123": {
+    "text": "CAP 101 (min D)",
+    "courses": [
+      "CAP 101"
+    ]
+  },
+  "CAP 202": {
+    "text": "CAP 122 (min D) and CAP 123 (min D)",
+    "courses": [
+      "CAP 122",
+      "CAP 123"
+    ]
+  },
+  "CAP 204": {
+    "text": "CAP 121 (min D)",
+    "courses": [
+      "CAP 121"
+    ]
+  },
+  "CAP 221": {
+    "text": "CAP 202 (min D)",
+    "courses": [
+      "CAP 202"
+    ]
+  },
+  "CAT 224": {
+    "text": "CAT 223 (min D)",
+    "courses": [
+      "CAT 223"
+    ]
+  },
+  "CET 131": {
+    "text": "MDT 105 (min D) and CET 112 (min D) or MDT 105 (min TC) and CET 112 (min TC) or MDT 105 (min T) and CET 112 (min T)",
+    "courses": [
+      "MDT 105",
+      "CET 112"
+    ]
+  },
+  "CET 215": {
+    "text": "CET 101 (min D) or CET 101 (min TD) or CET 101 (min T)",
+    "courses": [
+      "CET 101"
+    ]
+  },
+  "CET 216": {
+    "text": "CET 111 (min D) and CET 112 (min D) or CET 111 (min TD) and CET 112 (min TD) or CET 111 (min T) and CET 112 (min T)",
+    "courses": [
+      "CET 111",
+      "CET 112"
+    ]
+  },
+  "CET 217": {
+    "text": "CET 215 (min D) or CET 215 (min TD) or CET 215 (min T)",
+    "courses": [
+      "CET 215"
+    ]
+  },
+  "CHD 100": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 201": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 202": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 203": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 204": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 205": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 206": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 208": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 209": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C.)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 210": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 214": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 215": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHD 224": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHM 104": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 108 (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 112 (min C) or MTH 112C (min C) or MTH 113 (min C) or MTH 115 (min C) or MTH 120 (min C) or MTH 125 (min C) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C) or ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265",
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C"
+    ]
+  },
+  "CHM 105": {
+    "text": "CHM 104 (min C) or CHM 111 (min C) or CHM 104 (min TC) or CHM 111 (min TC) or CHM 104 (min T) or CHM 111 (min T)",
+    "courses": [
+      "CHM 104",
+      "CHM 111"
+    ]
+  },
+  "CHM 111": {
+    "text": "MTH 112 (min C) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 237 (min C) or MTH 238 (min C) or ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101T (min C) or ENG 101 (min S)",
+    "courses": [
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 237",
+      "MTH 238",
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CHM 112": {
+    "text": "CHM 111 (min C) or CHM 111 (min TC) or CHM 111 (min T) or CHM 111 (min TS) and MTH 112 (min C) or MTH 112 (min TC) or MTH 112 (min T) or MTH 113 (min C) or MTH 113 (min TC) or MTH 115 (min C) or MTH 115 (min TC) or MTH 115 (min TS) or MTH 125 (min C) or MTH 125 (min TC)",
+    "courses": [
+      "CHM 111",
+      "MTH 112",
+      "MTH 113",
+      "MTH 115",
+      "MTH 125"
+    ]
+  },
+  "CHM 221": {
+    "text": "CHM 112 (min D) or CHM 112 (min T) or CHM 112 (min TD)",
+    "courses": [
+      "CHM 112"
+    ]
+  },
+  "CIS 113": {
+    "text": "CIS 146 (min D)",
+    "courses": [
+      "CIS 146"
+    ]
+  },
+  "CIS 117": {
+    "text": "CIS 146 (min D)",
+    "courses": [
+      "CIS 146"
+    ]
+  },
+  "CIS 120": {
+    "text": "CIS 146",
+    "courses": [
+      "CIS 146"
+    ]
+  },
+  "CIS 146": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CIS 147": {
+    "text": "CIS 146 (min D) or CIS 146 (min T) or CIS 146 (min TD)",
+    "courses": [
+      "CIS 146"
+    ]
+  },
+  "CIS 201": {
+    "text": "CIS 146 (min D) and MTH 100 (min D) or MTH 100 (min T) or MTH 100 (min TD) or MTH 098 (min D) or MTH 098 (min T) or MTH 098 (min TD) or MTH 112 (min D) or MTH 112 (min TD) or MTH 113 (min D) or MTH 113 (min TD) or MTH 120 (min D) or MTH 120 (min TD) or MTH 125 (min D) or MTH 125 (min TD) or MTH 265 (min D) or MTH 265 (min TD) or MTH 110 (min D) or MTH 110 (min TD)",
+    "courses": [
+      "CIS 146",
+      "MTH 100",
+      "MTH 098",
+      "MTH 112",
+      "MTH 113",
+      "MTH 120",
+      "MTH 125",
+      "MTH 265",
+      "MTH 110"
+    ]
+  },
+  "CIS 202": {
+    "text": "ENR 094 (min C) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "CIS 207": {
+    "text": "CIS 146 (min D) or CIS 146 (min T) or CIS 146 (min TD)",
+    "courses": [
+      "CIS 146"
+    ]
+  },
+  "CIS 212": {
+    "text": "MTH 098 (min D) or MTH 100 (min D) or MTH 112 (min D) or MTH 113 (min D) or MTH 125 (min D) or MTH 126 (min D)",
+    "courses": [
+      "MTH 098",
+      "MTH 100",
+      "MTH 112",
+      "MTH 113",
+      "MTH 125",
+      "MTH 126"
+    ]
+  },
+  "CIS 246": {
+    "text": "CIS 199 (min C)",
+    "courses": [
+      "CIS 199"
+    ]
+  },
+  "CIS 251": {
+    "text": "CIS 150 (min D)",
+    "courses": [
+      "CIS 150"
+    ]
+  },
+  "CIS 268": {
+    "text": "CIS 130 (min C) or CIS 146 (min C)",
+    "courses": [
+      "CIS 130",
+      "CIS 146"
+    ]
+  },
+  "CIS 269": {
+    "text": "CIS 130 (min C) or CIS 130 (min S) or CIS 146 (min C) or CIS 146 (min S)",
+    "courses": [
+      "CIS 130",
+      "CIS 146"
+    ]
+  },
+  "CIS 271": {
+    "text": "CIS 270 (min D) or CIS 270 (min TD)",
+    "courses": [
+      "CIS 270"
+    ]
+  },
+  "CIS 272": {
+    "text": "CIS 271 (min D) or CIS 271 (min TD)",
+    "courses": [
+      "CIS 271"
+    ]
+  },
+  "CIS 277": {
+    "text": "CIS 199 (min C)",
+    "courses": [
+      "CIS 199"
+    ]
+  },
+  "CIS 282": {
+    "text": "CIS 171 (min D)",
+    "courses": [
+      "CIS 171"
+    ]
+  },
+  "COS 113": {
+    "text": "COS 111 and COS 137 and COS 145 and COS 112",
+    "courses": [
+      "COS 111",
+      "COS 137",
+      "COS 145",
+      "COS 112"
+    ]
+  },
+  "COS 117": {
+    "text": "COS 113 (min D) and COS 114 (min D) and COS 115 (min D) and COS 116 (min D)",
+    "courses": [
+      "COS 113",
+      "COS 114",
+      "COS 115",
+      "COS 116"
+    ]
+  },
+  "COS 118": {
+    "text": "COS 113 (min D) and COS 114 (min D) and COS 115 (min D) and COS 116 (min D)",
+    "courses": [
+      "COS 113",
+      "COS 114",
+      "COS 115",
+      "COS 116"
+    ]
+  },
+  "COS 123": {
+    "text": "COS 117 (min D) and COS 118 (min D) and COS 144 (min D)",
+    "courses": [
+      "COS 117",
+      "COS 118",
+      "COS 144"
+    ]
+  },
+  "COS 144": {
+    "text": "COS 113 (min D) and COS 114 (min D) and COS 115 (min D) and COS 116 (min D)",
+    "courses": [
+      "COS 113",
+      "COS 114",
+      "COS 115",
+      "COS 116"
+    ]
+  },
+  "COS 162": {
+    "text": "COS 117 (min D) and COS 118 (min D) and COS 144 (min D)",
+    "courses": [
+      "COS 117",
+      "COS 118",
+      "COS 144"
+    ]
+  },
+  "COS 167": {
+    "text": "COS 117 (min D) and COS 118 (min D) and COS 144 (min D)",
+    "courses": [
+      "COS 117",
+      "COS 118",
+      "COS 144"
+    ]
+  },
+  "CUA 115": {
+    "text": "CUA 125 (min D)",
+    "courses": [
+      "CUA 125"
+    ]
+  },
+  "CUA 201": {
+    "text": "CUA 116 (min D)",
+    "courses": [
+      "CUA 116"
+    ]
+  },
+  "CUA 205": {
+    "text": "CUA 116 (min D)",
+    "courses": [
+      "CUA 116"
+    ]
+  },
+  "CUA 214": {
+    "text": "CUA 116 (min D)",
+    "courses": [
+      "CUA 116"
+    ]
+  },
+  "CUA 215": {
+    "text": "CUA 116 (min D)",
+    "courses": [
+      "CUA 116"
+    ]
+  },
+  "CUA 285": {
+    "text": "CUA 115 (min D) and CUA 116 (min D)",
+    "courses": [
+      "CUA 115",
+      "CUA 116"
+    ]
+  },
+  "DAT 111": {
+    "text": "DAT 100 (min C) and DAT 101 (min C) and DAT 102 (min C) and DAT 103 (min C) and DAT 104 (min C)",
+    "courses": [
+      "DAT 100",
+      "DAT 101",
+      "DAT 102",
+      "DAT 103",
+      "DAT 104"
+    ]
+  },
+  "DAT 112": {
+    "text": "DAT 100 (min C) and DAT 101 (min C) and DAT 102 (min C) and DAT 103 (min C) and DAT 104 (min C)",
+    "courses": [
+      "DAT 100",
+      "DAT 101",
+      "DAT 102",
+      "DAT 103",
+      "DAT 104"
+    ]
+  },
+  "DAT 113": {
+    "text": "DAT 100 (min C) and DAT 101 (min C) and DAT 102 (min C) and DAT 103 (min C) and DAT 104 (min C)",
+    "courses": [
+      "DAT 100",
+      "DAT 101",
+      "DAT 102",
+      "DAT 103",
+      "DAT 104"
+    ]
+  },
+  "DAT 116": {
+    "text": "DAT 100 (min C) and DAT 101 (min C) and DAT 102 (min C) and DAT 103 (min C) and DAT 104 (min C)",
+    "courses": [
+      "DAT 100",
+      "DAT 101",
+      "DAT 102",
+      "DAT 103",
+      "DAT 104"
+    ]
+  },
+  "DAT 121": {
+    "text": "DAT 111 (min C) and DAT 112 (min C) and DAT 113 (min C) and DAT 116 (min C)",
+    "courses": [
+      "DAT 111",
+      "DAT 112",
+      "DAT 113",
+      "DAT 116"
+    ]
+  },
+  "DAT 122": {
+    "text": "DAT 111 (min C) and DAT 112 (min C) and DAT 113 (min C) and DAT 116 (min C)",
+    "courses": [
+      "DAT 111",
+      "DAT 112",
+      "DAT 113",
+      "DAT 116"
+    ]
+  },
+  "DAT 126": {
+    "text": "DAT 111 (min C) and DAT 112 (min C) and DAT 113 (min C) and DAT 116 (min C)",
+    "courses": [
+      "DAT 111",
+      "DAT 112",
+      "DAT 113",
+      "DAT 116"
+    ]
+  },
+  "DDT 128": {
+    "text": "DDT 104 (min D)",
+    "courses": [
+      "DDT 104"
+    ]
+  },
+  "DDT 132": {
+    "text": "DDT 104 (min D) and DDT 111 (min D) and DDT 124 (min D) and DDT 127 (min D)",
+    "courses": [
+      "DDT 104",
+      "DDT 111",
+      "DDT 124",
+      "DDT 127"
+    ]
+  },
+  "DDT 150": {
+    "text": "DDT 104 (min D)",
+    "courses": [
+      "DDT 104"
+    ]
+  },
+  "DDT 155": {
+    "text": "DDT 104 (min D)",
+    "courses": [
+      "DDT 104"
+    ]
+  },
+  "DDT 193": {
+    "text": "DDT 233 (min D)",
+    "courses": [
+      "DDT 233"
+    ]
+  },
+  "DDT 213": {
+    "text": "DDT 104 (min D)",
+    "courses": [
+      "DDT 104"
+    ]
+  },
+  "DDT 214": {
+    "text": "DDT 104 (min D) and DDT 111 (min D) and DDT 124 (min D) and DDT 127 (min D)",
+    "courses": [
+      "DDT 104",
+      "DDT 111",
+      "DDT 124",
+      "DDT 127"
+    ]
+  },
+  "DDT 233": {
+    "text": "DDT 144 (min D)",
+    "courses": [
+      "DDT 144"
+    ]
+  },
+  "DDT 244": {
+    "text": "DDT 144 (min D)",
+    "courses": [
+      "DDT 144"
+    ]
+  },
+  "DNC 112": {
+    "text": "DNC 111 (min D) or DNC 111 (min S)",
+    "courses": [
+      "DNC 111"
+    ]
+  },
+  "DNC 122": {
+    "text": "DNC 121 (min D) or DNC 121 (min S)",
+    "courses": [
+      "DNC 121"
+    ]
+  },
+  "DNC 141": {
+    "text": "DNC 140 (min D) or DNC 140 (min S)",
+    "courses": [
+      "DNC 140"
+    ]
+  },
+  "DNC 142": {
+    "text": "DNC 141 (min D) or DNC 141 (min S)",
+    "courses": [
+      "DNC 141"
+    ]
+  },
+  "DNC 144": {
+    "text": "DNC 143 (min D) or DNC 143 (min S)",
+    "courses": [
+      "DNC 143"
+    ]
+  },
+  "DNC 161": {
+    "text": "DNC 160 (min D) or DNC 160 (min S)",
+    "courses": [
+      "DNC 160"
+    ]
+  },
+  "DNC 162": {
+    "text": "DNC 161 (min D) or DNC 161 (min S)",
+    "courses": [
+      "DNC 161"
+    ]
+  },
+  "DNC 232": {
+    "text": "DNC 231 (min D) or DNC 231 (min S)",
+    "courses": [
+      "DNC 231"
+    ]
+  },
+  "DNC 233": {
+    "text": "DNC 232 (min D) or DNC 232 (min S)",
+    "courses": [
+      "DNC 232"
+    ]
+  },
+  "DNC 235": {
+    "text": "DNC 234 (min D) or DNC 234 (min S)",
+    "courses": [
+      "DNC 234"
+    ]
+  },
+  "DNC 243": {
+    "text": "DNC 144 (min D) or DNC 144 (min S)",
+    "courses": [
+      "DNC 144"
+    ]
+  },
+  "DNC 244": {
+    "text": "DNC 243 (min D) or DNC 243 (min S)",
+    "courses": [
+      "DNC 243"
+    ]
+  },
+  "DNC 260": {
+    "text": "DNC 162 (min D) or DNC 162 (min S)",
+    "courses": [
+      "DNC 162"
+    ]
+  },
+  "DNC 261": {
+    "text": "DNC 260 (min D) or DNC 260 (min S)",
+    "courses": [
+      "DNC 260"
+    ]
+  },
+  "DNC 262": {
+    "text": "DNC 261 (min D) or DNC 261 (min S)",
+    "courses": [
+      "DNC 261"
+    ]
+  },
+  "DNC 268": {
+    "text": "DNC 267 (min D) or DNC 267 (min S)",
+    "courses": [
+      "DNC 267"
+    ]
+  },
+  "DNC 269": {
+    "text": "DNC 268 (min D) or DNC 268 (min S)",
+    "courses": [
+      "DNC 268"
+    ]
+  },
+  "EET 104": {
+    "text": "EET 103 (min D) or EET 103 (min TD) or EET 103 (min T) or INT 101 (min D)",
+    "courses": [
+      "EET 103",
+      "INT 101"
+    ]
+  },
+  "EET 114": {
+    "text": "EET 103 (min D) or EET 103 (min TD) or EET 103 (min T) or INT 101 (min D) or INT 101 (min TD) or INT 101 (min T)",
+    "courses": [
+      "EET 103",
+      "INT 101"
+    ]
+  },
+  "EET 115": {
+    "text": "EET 103 (min D) or EET 103 (min TD) or EET 103 (min T) or INT 101 (min D) or INT 101 (min TD) or INT 101 (min T)",
+    "courses": [
+      "EET 103",
+      "INT 101"
+    ]
+  },
+  "EET 116": {
+    "text": "EET 114 (min D) or EET 114 (min TD) or EET 114 (min T)",
+    "courses": [
+      "EET 114"
+    ]
+  },
+  "EET 225": {
+    "text": "EET 104 (min D) or INT 103 (min D) or Automotive Manufact Tech (AUT) 111 (min D)",
+    "courses": [
+      "EET 104",
+      "INT 103",
+      "Automotive Manufact Tech (AUT) 111"
+    ]
+  },
+  "EET 260": {
+    "text": "EET 115 (min D) or EET 115 (min TD) or EET 115 (min T)",
+    "courses": [
+      "EET 115"
+    ]
+  },
+  "EET 261": {
+    "text": "EET 250 (min D) and EET 251 (min D) or EET 250 (min TD) and EET 251 (min TD) or EET 250 (min T) and EET 251 (min T)",
+    "courses": [
+      "EET 250",
+      "EET 251"
+    ]
+  },
+  "EGR 125": {
+    "text": "MTH 113 (min C) or MTH 113 (min TC) or MTH 115 (min C) or MTH 115 (min TC) or MTH 125 (min C) or MTH 125 (min TC)",
+    "courses": [
+      "MTH 113",
+      "MTH 115",
+      "MTH 125"
+    ]
+  },
+  "EGR 220": {
+    "text": "PHY 213 (min C) or PHY 213 (min T) or PHY 213 (min TC)",
+    "courses": [
+      "PHY 213"
+    ]
+  },
+  "ELT 109": {
+    "text": "INT 101 (min D) or ELT 108 (min D)",
+    "courses": [
+      "INT 101",
+      "ELT 108"
+    ]
+  },
+  "ELT 114": {
+    "text": "ELT 110 (min D)",
+    "courses": [
+      "ELT 110"
+    ]
+  },
+  "ELT 115": {
+    "text": "ELT 114 (min D) or ELT 114 (min TD) or ELT 114 (min T)",
+    "courses": [
+      "ELT 114"
+    ]
+  },
+  "ELT 117": {
+    "text": "ELT 109 (min D) and INT 103 (min D)",
+    "courses": [
+      "ELT 109",
+      "INT 103"
+    ]
+  },
+  "ELT 118": {
+    "text": "ELT 108 (min D) and ELT 109 (min D)",
+    "courses": [
+      "ELT 108",
+      "ELT 109"
+    ]
+  },
+  "ELT 122": {
+    "text": "ELT 117 (min D) or ELT 117 (min TD) or ELT 117 (min T) or Automotive Manufact Tech (AUT) 117 (min D)",
+    "courses": [
+      "ELT 117",
+      "Automotive Manufact Tech (AUT) 117"
+    ]
+  },
+  "ELT 132": {
+    "text": "ELT 118 (min D)",
+    "courses": [
+      "ELT 118"
+    ]
+  },
+  "ELT 221": {
+    "text": "ELT 109 (min D) or INT 103 (min D)",
+    "courses": [
+      "ELT 109",
+      "INT 103"
+    ]
+  },
+  "EMS 155": {
+    "text": "EMS 118 (min C) and EMS 119 (min C) or EMS 108 (min C)",
+    "courses": [
+      "EMS 118",
+      "EMS 119",
+      "EMS 108"
+    ]
+  },
+  "EMS 156": {
+    "text": "EMS 118 (min C) and EMS 119 (min C) or EMS 108 (min C)",
+    "courses": [
+      "EMS 118",
+      "EMS 119",
+      "EMS 108"
+    ]
+  },
+  "EMS 240": {
+    "text": "EMS 155 (min C) and EMS 156 (min C)",
+    "courses": [
+      "EMS 155",
+      "EMS 156"
+    ]
+  },
+  "EMS 241": {
+    "text": "EMS 118 (min C) and EMS 119 (min C) or EMS 108 (min C) and EMS 155 (min C) and EMS 156 (min C) or EMS 156 (min C)",
+    "courses": [
+      "EMS 118",
+      "EMS 119",
+      "EMS 108",
+      "EMS 155",
+      "EMS 156"
+    ]
+  },
+  "EMS 242": {
+    "text": "EMS 118 (min C) and EMS 119 (min C) or EMS 108 (min C) and EMS 155 (min C) and EMS 156 (min C) or EMS 156 (min C)",
+    "courses": [
+      "EMS 118",
+      "EMS 119",
+      "EMS 108",
+      "EMS 155",
+      "EMS 156"
+    ]
+  },
+  "EMS 244": {
+    "text": "EMS 118 (min C) and EMS 119 (min C) or EMS 108 (min C) and EMS 155 (min C) and EMS 156 (min C) or EMS 156 (min C)",
+    "courses": [
+      "EMS 118",
+      "EMS 119",
+      "EMS 108",
+      "EMS 155",
+      "EMS 156"
+    ]
+  },
+  "EMS 245": {
+    "text": "EMS 240 (min C) and EMS 241 (min C) and EMS 244 (min C) and EMS 257 (min C)",
+    "courses": [
+      "EMS 240",
+      "EMS 241",
+      "EMS 244",
+      "EMS 257"
+    ]
+  },
+  "EMS 246": {
+    "text": "EMS 240 (min C) and EMS 241 (min C) and EMS 244 (min C) and EMS 257 (min C)",
+    "courses": [
+      "EMS 240",
+      "EMS 241",
+      "EMS 244",
+      "EMS 257"
+    ]
+  },
+  "EMS 247": {
+    "text": "EMS 240 (min C) and EMS 241 (min C) and EMS 244 (min C) and EMS 257 (min C)",
+    "courses": [
+      "EMS 240",
+      "EMS 241",
+      "EMS 244",
+      "EMS 257"
+    ]
+  },
+  "EMS 248": {
+    "text": "EMS 240 (min C) and EMS 241 (min C) and EMS 244 (min C) and EMS 257 (min C)",
+    "courses": [
+      "EMS 240",
+      "EMS 241",
+      "EMS 244",
+      "EMS 257"
+    ]
+  },
+  "EMS 253": {
+    "text": "EMS 245 (min C) and EMS 246 (min C) and EMS 247 (min C) and EMS 248 (min C)",
+    "courses": [
+      "EMS 245",
+      "EMS 246",
+      "EMS 247",
+      "EMS 248"
+    ]
+  },
+  "EMS 254": {
+    "text": "EMS 245 (min C) and EMS 246 (min C) and EMS 247 (min C) and EMS 248 (min C)",
+    "courses": [
+      "EMS 245",
+      "EMS 246",
+      "EMS 247",
+      "EMS 248"
+    ]
+  },
+  "EMS 255": {
+    "text": "EMS 245 (min C) and EMS 246 (min C) and EMS 247 (min C) and EMS 248 (min C)",
+    "courses": [
+      "EMS 245",
+      "EMS 246",
+      "EMS 247",
+      "EMS 248"
+    ]
+  },
+  "EMS 256": {
+    "text": "EMS 245 (min C) and EMS 246 (min C) and EMS 247 (min C) and EMS 248 (min C)",
+    "courses": [
+      "EMS 245",
+      "EMS 246",
+      "EMS 247",
+      "EMS 248"
+    ]
+  },
+  "EMS 257": {
+    "text": "EMS 118 (min C) and EMS 119 (min C) or EMS 108 (min C) and EMS 155 (min C) and EMS 156 (min C) or EMS 156 (min C)",
+    "courses": [
+      "EMS 118",
+      "EMS 119",
+      "EMS 108",
+      "EMS 155",
+      "EMS 156"
+    ]
+  },
+  "ENG 099": {
+    "text": "ENR 098 (min C.)",
+    "courses": [
+      "ENR 098"
+    ]
+  },
+  "ENG 101": {
+    "text": "ENG 093 (min C.) or ENG 131 (min C) or ENG 099 (min C.) or ENR 094 (min C.)",
+    "courses": [
+      "ENG 093",
+      "ENG 131",
+      "ENG 099",
+      "ENR 094"
+    ]
+  },
+  "ENG 101C": {
+    "text": "ENR 098 (min C.) or ENG 093 (min C.)",
+    "courses": [
+      "ENR 098",
+      "ENG 093"
+    ]
+  },
+  "ENG 102": {
+    "text": "ENG 101 (min C) or ENG 101 (min TC) or ENG 101C (min C) or ENG 101 (min TS) or ENG 101 (min TP)",
+    "courses": [
+      "ENG 101",
+      "ENG 101C"
+    ]
+  },
+  "ENG 251": {
+    "text": "ENG 102 (min D) or ENG 102 (min TD)",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 252": {
+    "text": "ENG 102 (min D) or ENG 102 (min TD)",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 261": {
+    "text": "ENG 102 (min C) or ENG 102 (min TC) or ENG 102 (min T)",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 262": {
+    "text": "ENG 102 (min C) or ENG 102 (min TC) or ENG 102 (min T)",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 271": {
+    "text": "ENG 102 (min D) or ENG 102 (min TD)",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 272": {
+    "text": "ENG 102 (min D) or ENG 102 (min TD)",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENT 214": {
+    "text": "ADM 202 (min D)",
+    "courses": [
+      "ADM 202"
+    ]
+  },
+  "FRN 102": {
+    "text": "FRN 101 (min D) or FRN 101 (min T) or FRN 101 (min TD)",
+    "courses": [
+      "FRN 101"
+    ]
+  },
+  "GLY 101": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101T (min C) or ENG 101 (min S) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min S) or MTH 108 (min C) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min S)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "GLY 102": {
+    "text": "GLY 101 (min D) or GLY 101 (min S)",
+    "courses": [
+      "GLY 101"
+    ]
+  },
+  "GRN 101": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "HIT 230": {
+    "text": "BIO 120 (min D) or BIO 120 (min T) or BIO 120 (min TD)",
+    "courses": [
+      "BIO 120"
+    ]
+  },
+  "HIT 231": {
+    "text": "BIO 120 (min D) or BIO 120 (min T) or BIO 120 (min TD)",
+    "courses": [
+      "BIO 120"
+    ]
+  },
+  "INT 103": {
+    "text": "INT 101 (min D) or INT 101 (min TD) or INT 101 (min T) or EET 103 (min D)",
+    "courses": [
+      "INT 101",
+      "EET 103"
+    ]
+  },
+  "INT 104": {
+    "text": "MTH 116 (min C) or MTH 116 (min TC) or MTH 100 (min C) or MTH 100 (min TC) or MTH 110 (min C) or MTH 110 (min TC) or MTH 112 (min C) or MTH 112 (min TC) or MTH 113 (min C) or MTH 113 (min TC) or MTH 120 (min C) or MTH 120 (min TC) or MTH 125 (min C) or MTH 125 (min TC) or MTH 126 (min C) or MTH 126 (min TC)",
+    "courses": [
+      "MTH 116",
+      "MTH 100",
+      "MTH 110",
+      "MTH 112",
+      "MTH 113",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126"
+    ]
+  },
+  "INT 113": {
+    "text": "ELT 108 (min D) or INT 101 (min D) and INT 103 (min D)",
+    "courses": [
+      "ELT 108",
+      "INT 101",
+      "INT 103"
+    ]
+  },
+  "INT 213": {
+    "text": "ELT 209 (min D) or INT 113 (min D)",
+    "courses": [
+      "ELT 209",
+      "INT 113"
+    ]
+  },
+  "INT 284": {
+    "text": "INT 184 (min D)",
+    "courses": [
+      "INT 184"
+    ]
+  },
+  "MAT 102": {
+    "text": "MAT 101 (min C) or OAD 211 (min C) and MAT 125 (min C) and MAT 128 (min C) and MAT 215 (min C)",
+    "courses": [
+      "MAT 101",
+      "OAD 211",
+      "MAT 125",
+      "MAT 128",
+      "MAT 215"
+    ]
+  },
+  "MAT 103": {
+    "text": "MAT 101 (min C) or OAD 211 (min C) and MAT 125 (min C) and MAT 128 (min C) and MAT 215 (min C)",
+    "courses": [
+      "MAT 101",
+      "OAD 211",
+      "MAT 125",
+      "MAT 128",
+      "MAT 215"
+    ]
+  },
+  "MAT 111": {
+    "text": "MAT 101 (min C) or OAD 211 (min C) or BIO 120 (min C) and MAT 125 (min C) and MAT 128 (min C) and MAT 215 (min C)",
+    "courses": [
+      "MAT 101",
+      "OAD 211",
+      "BIO 120",
+      "MAT 125",
+      "MAT 128",
+      "MAT 215"
+    ]
+  },
+  "MAT 120": {
+    "text": "MAT 101 (min C) or OAD 211 (min C) or BIO 120 (min C) and MAT 125 (min C) and MAT 128 (min C) and MAT 215 (min C)",
+    "courses": [
+      "MAT 101",
+      "OAD 211",
+      "BIO 120",
+      "MAT 125",
+      "MAT 128",
+      "MAT 215"
+    ]
+  },
+  "MAT 121": {
+    "text": "MAT 102 (min C) and MAT 103 (min C) or BIO 201 (min C) and BIO 202 (min C) and MAT 111 (min C) and MAT 120 (min C) and MAT 211 (min C) and MAT 239 (min C)",
+    "courses": [
+      "MAT 102",
+      "MAT 103",
+      "BIO 201",
+      "BIO 202",
+      "MAT 111",
+      "MAT 120",
+      "MAT 211",
+      "MAT 239"
+    ]
+  },
+  "MAT 200": {
+    "text": "MAT 102 (min C) and MAT 103 (min C) or BIO 201 (min C) and BIO 202 (min C) and MAT 111 (min C) and MAT 120 (min C) and MAT 211 (min C) and MAT 239 (min C)",
+    "courses": [
+      "MAT 102",
+      "MAT 103",
+      "BIO 201",
+      "BIO 202",
+      "MAT 111",
+      "MAT 120",
+      "MAT 211",
+      "MAT 239"
+    ]
+  },
+  "MAT 205": {
+    "text": "MAT 111 (min C)",
+    "courses": [
+      "MAT 111"
+    ]
+  },
+  "MAT 211": {
+    "text": "MAT 101 (min C) or OAD 211 (min C) or BIO 120 (min C) and MAT 125 (min C) and MAT 128 (min C) and MAT 215 (min C)",
+    "courses": [
+      "MAT 101",
+      "OAD 211",
+      "BIO 120",
+      "MAT 125",
+      "MAT 128",
+      "MAT 215"
+    ]
+  },
+  "MAT 216": {
+    "text": "MAT 102 (min C) and MAT 103 (min C) or BIO 201 (min C) and BIO 202 (min C) and MAT 111 (min C) and MAT 120 (min C) and MAT 211 (min C) and MAT 239 (min C)",
+    "courses": [
+      "MAT 102",
+      "MAT 103",
+      "BIO 201",
+      "BIO 202",
+      "MAT 111",
+      "MAT 120",
+      "MAT 211",
+      "MAT 239"
+    ]
+  },
+  "MAT 220": {
+    "text": "MAT 102 (min C) and MAT 103 (min C) or BIO 201 (min C) and BIO 202 (min C) and MAT 111 (min C) and MAT 120 (min C) and MAT 211 (min C) and MAT 239 (min C)",
+    "courses": [
+      "MAT 102",
+      "MAT 103",
+      "BIO 201",
+      "BIO 202",
+      "MAT 111",
+      "MAT 120",
+      "MAT 211",
+      "MAT 239"
+    ]
+  },
+  "MAT 228": {
+    "text": "MAT 102 (min C) and MAT 103 (min C) or BIO 201 (min C) and BIO 202 (min C) and MAT 111 (min C) and MAT 120 (min C) and MAT 211 (min C) and MAT 239 (min C)",
+    "courses": [
+      "MAT 102",
+      "MAT 103",
+      "BIO 201",
+      "BIO 202",
+      "MAT 111",
+      "MAT 120",
+      "MAT 211",
+      "MAT 239"
+    ]
+  },
+  "MAT 229": {
+    "text": "MAT 111 (min C) and MAT 125 (min C) and MAT 200 (min C) and MAT 211 (min C) and MAT 215 (min C) and MAT 216 (min C)",
+    "courses": [
+      "MAT 111",
+      "MAT 125",
+      "MAT 200",
+      "MAT 211",
+      "MAT 215",
+      "MAT 216"
+    ]
+  },
+  "MAT 230": {
+    "text": "MAT 111 (min C) and MAT 205 (min C) and MAT 125 (min C) and MAT 215 (min C) and MAT 216 (min C) and MAT 218 (min C) and MAT 239 (min C) and HPS 105 (min S) or HPS 105 (min C) or OAD 111 (min C) or OAD 111 (min S) and OAD 214 (min C) or OAD 214 (min S) and OAD 215 (min C) or OAD 215 (min S) and OAD 216 (min C) or OAD 216 (min S)",
+    "courses": [
+      "MAT 111",
+      "MAT 205",
+      "MAT 125",
+      "MAT 215",
+      "MAT 216",
+      "MAT 218",
+      "MAT 239",
+      "HPS 105",
+      "OAD 111",
+      "OAD 214",
+      "OAD 215",
+      "OAD 216"
+    ]
+  },
+  "MAT 239": {
+    "text": "MAT 101 (min C) or OAD 211 (min C) or BIO 120 (min C) and MAT 125 (min C) and MAT 128 (min C) and MAT 215 (min C)",
+    "courses": [
+      "MAT 101",
+      "OAD 211",
+      "BIO 120",
+      "MAT 125",
+      "MAT 128",
+      "MAT 215"
+    ]
+  },
+  "MDT 122": {
+    "text": "MDT 105 (min D) or MDT 105 (min TD) or MDT 105 (min T)",
+    "courses": [
+      "MDT 105"
+    ]
+  },
+  "MDT 123": {
+    "text": "MDT 105 (min D) or MDT 105 (min TD) or MDT 105 (min T)",
+    "courses": [
+      "MDT 105"
+    ]
+  },
+  "MDT 146": {
+    "text": "MDT 105 (min D) or MDT 105 (min TD) or MDT 105 (min T)",
+    "courses": [
+      "MDT 105"
+    ]
+  },
+  "MDT 147": {
+    "text": "MDT 105 (min D) or MDT 105 (min TD) or MDT 105 (min T)",
+    "courses": [
+      "MDT 105"
+    ]
+  },
+  "MDT 187": {
+    "text": "MDT 147 (min D) or MDT 147 (min TD) or MDT 147 (min T)",
+    "courses": [
+      "MDT 147"
+    ]
+  },
+  "MDT 202": {
+    "text": "MDT 146 (min C) or MDT 146 (min TC) or MDT 146 (min T)",
+    "courses": [
+      "MDT 146"
+    ]
+  },
+  "MDT 211": {
+    "text": "MDT 105 (min D) or MDT 105 (min TD) or MDT 105 (min T) or MDT 146 (min D) and MDT 111 (min D) or MDT 111 (min TD) or MDT 111 (min T) and MDT 146 (min D) or MDT 146 (min TD) or MDT 146 (min T)",
+    "courses": [
+      "MDT 105",
+      "MDT 146",
+      "MDT 111"
+    ]
+  },
+  "MDT 221": {
+    "text": "MDT 105 (min D) and MDT 111 (min D) or MDT 105 (min TD) and MDT 111 (min TD) or MDT 105 (min T) and MDT 111 (min T)",
+    "courses": [
+      "MDT 105",
+      "MDT 111"
+    ]
+  },
+  "MDT 252": {
+    "text": "MDT 202 (min D) or MDT 202 (min TD) or MDT 202 (min T)",
+    "courses": [
+      "MDT 202"
+    ]
+  },
+  "MDT 261": {
+    "text": "MDT 105 (min D) or MDT 105 (min TD) or MDT 105 (min T)",
+    "courses": [
+      "MDT 105"
+    ]
+  },
+  "MLT 121": {
+    "text": "MLT 141 (min C) and MLT 151 (min C)",
+    "courses": [
+      "MLT 141",
+      "MLT 151"
+    ]
+  },
+  "MLT 141": {
+    "text": "MLT 111 (min C) and MLT 131 (min C) and MLT 181 (min C)",
+    "courses": [
+      "MLT 111",
+      "MLT 131",
+      "MLT 181"
+    ]
+  },
+  "MLT 142": {
+    "text": "MLT 141 (min C) and MLT 151 (min C)",
+    "courses": [
+      "MLT 141",
+      "MLT 151"
+    ]
+  },
+  "MLT 151": {
+    "text": "MLT 111 (min C) and MLT 131 (min C) and MLT 181 (min C)",
+    "courses": [
+      "MLT 111",
+      "MLT 131",
+      "MLT 181"
+    ]
+  },
+  "MLT 191": {
+    "text": "MLT 141 (min C) and MLT 151 (min C)",
+    "courses": [
+      "MLT 141",
+      "MLT 151"
+    ]
+  },
+  "MLT 293": {
+    "text": "MLT 121 (min C) and MLT 142 (min C) and MLT 191 (min C)",
+    "courses": [
+      "MLT 121",
+      "MLT 142",
+      "MLT 191"
+    ]
+  },
+  "MLT 294": {
+    "text": "MLT 121 (min C) and MLT 142 (min C) and MLT 191 (min C)",
+    "courses": [
+      "MLT 121",
+      "MLT 142",
+      "MLT 191"
+    ]
+  },
+  "MLT 295": {
+    "text": "MLT 121 (min C) and MLT 142 (min C) and MLT 191 (min C)",
+    "courses": [
+      "MLT 121",
+      "MLT 142",
+      "MLT 191"
+    ]
+  },
+  "MLT 296": {
+    "text": "MLT 121 (min C) and MLT 142 (min C) and MLT 191 (min C)",
+    "courses": [
+      "MLT 121",
+      "MLT 142",
+      "MLT 191"
+    ]
+  },
+  "MLT 297": {
+    "text": "MLT 121 (min C) and MLT 141 (min C) and MLT 151 (min C)",
+    "courses": [
+      "MLT 121",
+      "MLT 141",
+      "MLT 151"
+    ]
+  },
+  "MSG 101": {
+    "text": "BIO 111 (min C) or BIO 201 (min C) and BIO 202 (min C)",
+    "courses": [
+      "BIO 111",
+      "BIO 201",
+      "BIO 202"
+    ]
+  },
+  "MSG 105": {
+    "text": "MSG 101 (min C) and MSG 102 (min C) and MSG 104 (min C) and BIO 111 (min C) or BIO 111 (min S) or BIO 201 (min C) or BIO 201 (min S) and BIO 202 (min C) or BIO 202 (min S)",
+    "courses": [
+      "MSG 101",
+      "MSG 102",
+      "MSG 104",
+      "BIO 111",
+      "BIO 201",
+      "BIO 202"
+    ]
+  },
+  "MSG 201": {
+    "text": "MSG 105 (min C) and MSG 202 (min C) and MSG 204 (min C)",
+    "courses": [
+      "MSG 105",
+      "MSG 202",
+      "MSG 204"
+    ]
+  },
+  "MSG 202": {
+    "text": "MSG 101 (min C) and MSG 102 (min C) and MSG 104 (min C) and BIO 111 (min C) or BIO 111 (min S) or BIO 201 (min C) or BIO 201 (min S) and BIO 202 (min C) or BIO 202 (min S)",
+    "courses": [
+      "MSG 101",
+      "MSG 102",
+      "MSG 104",
+      "BIO 111",
+      "BIO 201",
+      "BIO 202"
+    ]
+  },
+  "MSG 203": {
+    "text": "MSG 105 (min C) and MSG 202 (min C) and MSG 204 (min C)",
+    "courses": [
+      "MSG 105",
+      "MSG 202",
+      "MSG 204"
+    ]
+  },
+  "MSG 204": {
+    "text": "MSG 101 (min C) and MSG 102 (min C) and MSG 104 (min C)",
+    "courses": [
+      "MSG 101",
+      "MSG 102",
+      "MSG 104"
+    ]
+  },
+  "MSG 205": {
+    "text": "MSG 105 (min C) and MSG 202 (min C) and MSG 204 (min C)",
+    "courses": [
+      "MSG 105",
+      "MSG 202",
+      "MSG 204"
+    ]
+  },
+  "MSG 206": {
+    "text": "MSG 105 (min C) and MSG 202 (min C) and MSG 204 (min C)",
+    "courses": [
+      "MSG 105",
+      "MSG 202",
+      "MSG 204"
+    ]
+  },
+  "MTH 099": {
+    "text": "MTH 098 (min C) or MTH 098 (min C.) or MTH 092 (min S)",
+    "courses": [
+      "MTH 098",
+      "MTH 092"
+    ]
+  },
+  "MTH 100": {
+    "text": "MTH 099 and MTH 099 and MTH 099 and MTH 099 and MTH 099 and MTH 099 and MTH 099 or MTH 098 (min C.) or MTH 098 (min TC) or MTH 110 (min C) or MTH 110 (min TC) or MTH 112 (min C) or MTH 112 (min TC)",
+    "courses": [
+      "MTH 099",
+      "MTH 098",
+      "MTH 110",
+      "MTH 112"
+    ]
+  },
+  "MTH 100C": {
+    "text": "MTH 098 (min C) or MTH 098 (min C.)",
+    "courses": [
+      "MTH 098"
+    ]
+  },
+  "MTH 109": {
+    "text": "MTH 098 (min C) or MTH 098 (min C.)",
+    "courses": [
+      "MTH 098"
+    ]
+  },
+  "MTH 110": {
+    "text": "MTH 098 (min C) or MTH 100 (min TC) or MTH 098 (min C.) or MTH 098 (min TC) or MTH 100 (min C) or MTH 100 (min C.) or MTH 112 (min C) or MTH 113 (min TC) or MTH 113 (min C) or MTH 125 (min TC) or MTH 125 (min C) or MTH 100C (min C) and MTH 099 (min C)",
+    "courses": [
+      "MTH 098",
+      "MTH 100",
+      "MTH 112",
+      "MTH 113",
+      "MTH 125",
+      "MTH 100C",
+      "MTH 099"
+    ]
+  },
+  "MTH 110C": {
+    "text": "MTH 098 (min C) or MTH 098 (min C.)",
+    "courses": [
+      "MTH 098"
+    ]
+  },
+  "MTH 111": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 113 (min D) or MTH 115 (min D)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 113",
+      "MTH 115"
+    ]
+  },
+  "MTH 112": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 111 (min C) or MTH 113 (min D) or MTH 113 (min S) or MTH 115 (min D) or MTH 115 (min S) or MTH 120 (min D) or MTH 125 (min D) or MTH 125 (min S)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 111",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125"
+    ]
+  },
+  "MTH 112C": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 113 (min D) or MTH 115 (min D) or MTH 120 (min D) or MTH 125 (min D)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125"
+    ]
+  },
+  "MTH 113": {
+    "text": "MTH 112 (min C) or MTH 112C (min C) or MTH 115 (min D) or MTH 115 (min S) or MTH 120 (min D) or MTH 120 (min S) or MTH 125 (min D) or MTH 125 (min S)",
+    "courses": [
+      "MTH 112",
+      "MTH 112C",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125"
+    ]
+  },
+  "MTH 115": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 112 (min D) or MTH 112 (min S) or MTH 112C (min D) or MTH 113 (min D) or MTH 113 (min S) or MTH 120 (min D) or MTH 120 (min S) or MTH 125 (min D) or MTH 125 (min S)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 120",
+      "MTH 125"
+    ]
+  },
+  "MTH 120": {
+    "text": "MTH 112 (min C) or MTH 112 (min TC) or MTH 112S (min C) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min TC) or MTH 115 (min C) or MTH 115 (min TC)",
+    "courses": [
+      "MTH 112",
+      "MTH 112S",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115"
+    ]
+  },
+  "MTH 125": {
+    "text": "MTH 113 (min C) or MTH 113 (min TC) or MTH 115 (min C) or MTH 115 (min TC)",
+    "courses": [
+      "MTH 113",
+      "MTH 115"
+    ]
+  },
+  "MTH 126": {
+    "text": "MTH 125 (min C) or MTH 125 (min TC)",
+    "courses": [
+      "MTH 125"
+    ]
+  },
+  "MTH 227": {
+    "text": "MTH 126 (min C) or MTH 126 (min TC)",
+    "courses": [
+      "MTH 126"
+    ]
+  },
+  "MTH 237": {
+    "text": "MTH 126 (min C) or MTH 126 (min TC)",
+    "courses": [
+      "MTH 126"
+    ]
+  },
+  "MTH 238": {
+    "text": "MTH 126 (min C) and MTH 227 (min C)",
+    "courses": [
+      "MTH 126",
+      "MTH 227"
+    ]
+  },
+  "MTH 265": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 108 (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 112 (min D) or MTH 112C (min D) or MTH 112 (min S) or MTH 113 (min D) or MTH 115 (min D) or MTH 120 (min D) or MTH 125 (min D)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125"
+    ]
+  },
+  "MTH 270": {
+    "text": "MTH 125 (min D) or MTH 125 (min TD) or MTH 126 (min D) or MTH 126 (min TD) or MTH 227 (min D) or MTH 227 (min TD)",
+    "courses": [
+      "MTH 125",
+      "MTH 126",
+      "MTH 227"
+    ]
+  },
+  "MUS 111": {
+    "text": "MUS 110 (min D) or MUS 110 (min TD) or MUS 110 (min T)",
+    "courses": [
+      "MUS 110"
+    ]
+  },
+  "MUS 112": {
+    "text": "MUS 111 (min D) or MUS 111 (min TD) or MUS 111 (min T)",
+    "courses": [
+      "MUS 111"
+    ]
+  },
+  "MUS 113": {
+    "text": "MUS 110 (min D) or MUS 110 (min TD) or MUS 110 (min T)",
+    "courses": [
+      "MUS 110"
+    ]
+  },
+  "MUS 114": {
+    "text": "MUS 113 (min D) or MUS 113 (min TD) or MUS 113 (min T)",
+    "courses": [
+      "MUS 113"
+    ]
+  },
+  "MUS 211": {
+    "text": "MUS 112 (min D) or MUS 112 (min TD) or MUS 112 (min T)",
+    "courses": [
+      "MUS 112"
+    ]
+  },
+  "MUS 213": {
+    "text": "MUS 114 (min D)",
+    "courses": [
+      "MUS 114"
+    ]
+  },
+  "NUR 105": {
+    "text": "NUR 102 (min C) and NUR 103 (min C) and NUR 104 (min C) and BIO 201 (min C) and MTH 116 (min C) or MTH 100 (min C) or MTH 112 (min C) or MTH 113 (min C) or MTH 125 (min C) or MTH 100 (min TC) or MTH 112 (min TC) or MTH 113 (min TC) or MTH 125 (min TC) or BIO 201 (min TC) or MTH 100C (min C)",
+    "courses": [
+      "NUR 102",
+      "NUR 103",
+      "NUR 104",
+      "BIO 201",
+      "MTH 116",
+      "MTH 100",
+      "MTH 112",
+      "MTH 113",
+      "MTH 125",
+      "MTH 100C"
+    ]
+  },
+  "NUR 106": {
+    "text": "NUR 102 (min C) and NUR 103 (min C) and NUR 104 (min C) and BIO 201 (min C) and MTH 116 (min C) or MTH 100 (min C) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 112 (min C) or MTH 112C (min C) or MTH 113 (min C) or MTH 115 (min C) or MTH 125 (min C) or MTH 126 (min C) or MTH 227 (min C) or MTH 238 (min C) or MTH 237 (min C) or MTH 265 (min C)",
+    "courses": [
+      "NUR 102",
+      "NUR 103",
+      "NUR 104",
+      "BIO 201",
+      "MTH 116",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 238",
+      "MTH 237",
+      "MTH 265"
+    ]
+  },
+  "NUR 107": {
+    "text": "ENG 101 (min C) or ENG 101C (min C) and BIO 202 (min C) and NUR 105 (min C) and NUR 106 (min C)",
+    "courses": [
+      "ENG 101",
+      "ENG 101C",
+      "BIO 202",
+      "NUR 105",
+      "NUR 106"
+    ]
+  },
+  "NUR 108": {
+    "text": "ENG 101 (min C) or ENG 101C (min C) and BIO 202 (min C) and NUR 105 (min C) and NUR 106 (min C)",
+    "courses": [
+      "ENG 101",
+      "ENG 101C",
+      "BIO 202",
+      "NUR 105",
+      "NUR 106"
+    ]
+  },
+  "NUR 109": {
+    "text": "ENG 101 (min C) and BIO 202 (min C) and NUR 105 (min C) and NUR 106 (min C)",
+    "courses": [
+      "ENG 101",
+      "BIO 202",
+      "NUR 105",
+      "NUR 106"
+    ]
+  },
+  "NUR 112": {
+    "text": "BIO 201 (min C) or BIO 201 (min S) and MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 126 (min S)",
+    "courses": [
+      "BIO 201",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 125",
+      "MTH 126"
+    ]
+  },
+  "NUR 113": {
+    "text": "NUR 112 (min C) and BIO 201 (min C) or BIO 201 (min S) and MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 110 (min S) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 125 (min S) or MTH 125 (min S) or MTH 126 (min C) or MTH 126 (min S) and BIO 202 (min C) or BIO 202 (min S) and ENG 101 (min S) or ENG 101 (min C) or ENG 101T (min C) or ENG 101C (min C) and PSY 210 (min C) or PSY 210 (min S)",
+    "courses": [
+      "NUR 112",
+      "BIO 201",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 125",
+      "MTH 126",
+      "BIO 202",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "PSY 210"
+    ]
+  },
+  "NUR 114": {
+    "text": "NUR 113 (min C) and ENG 101 (min S) or ENG 101 (min C) or ENG 101T (min C) or ENG 101C (min C) and BIO 202 (min C) and PSY 210 (min C) or PSY 210 (min S) and SPH 106 (min S) or SPH 106 (min C) or SPH 107 (min S) or SPH 107 (min C) and NUR 115 (min C)",
+    "courses": [
+      "NUR 113",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "BIO 202",
+      "PSY 210",
+      "SPH 106",
+      "SPH 107",
+      "NUR 115"
+    ]
+  },
+  "NUR 115": {
+    "text": "NUR 113 (min C) and PSY 210 (min C) or PSY 210 (min S) and ENG 101 (min C) or ENG 101T (min C) or ENG 101 (min S) or ENG 101C (min C) and BIO 202 (min C) or BIO 202 (min S) and SPH 106 (min C) or SPH 107 (min C) or SPH 106 (min S) or SPH 107 (min S)",
+    "courses": [
+      "NUR 113",
+      "PSY 210",
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "BIO 202",
+      "SPH 106",
+      "SPH 107"
+    ]
+  },
+  "NUR 199": {
+    "text": "MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min TC) or MTH 110 (min C) or MTH 110C (min C) or MTH 110 (min TC) or MTH 112 (min C) or MTH 112C (min C) or MTH 112 (min TC) or MTH 113 (min C) or MTH 113 (min TC) or MTH 125 (min C) or MTH 125 (min TC) and BIO 201 (min C) or BIO 201 (min TC) and BIO 202 (min C) or BIO 202 (min TC) and ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min TC) and BIO 220 (min C) or BIO 220 (min TC) and PSY 200 (min C) or PSY 200 (min TC)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 125",
+      "BIO 201",
+      "BIO 202",
+      "ENG 101",
+      "ENG 101C",
+      "BIO 220",
+      "PSY 200"
+    ]
+  },
+  "NUR 201": {
+    "text": "ENG 101 (min C) and BIO 201 (min C) and BIO 202 (min C) and MTH 100 (min C) or MTH 110 (min C) or MTH 100C (min C) or MTH 112 (min C) or MTH 113 (min C) or MTH 125 (min C) or MTH 126 (min C) or MTH 227 (min C) or MTH 238 (min C) or MTH 237 (min C) or MTH 120 (min C) or MTH 265 (min C) or MTH 265 (min TC) and NUR 105 (min C) and NUR 106 (min C) or NUR 200 (min C)",
+    "courses": [
+      "ENG 101",
+      "BIO 201",
+      "BIO 202",
+      "MTH 100",
+      "MTH 110",
+      "MTH 100C",
+      "MTH 112",
+      "MTH 113",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 238",
+      "MTH 237",
+      "MTH 120",
+      "MTH 265",
+      "NUR 105",
+      "NUR 106",
+      "NUR 200"
+    ]
+  },
+  "NUR 202": {
+    "text": "PSY 200 (min C) and NUR 201 (min C) or NUR 199 (min C) and BIO 220 (min C)",
+    "courses": [
+      "PSY 200",
+      "NUR 201",
+      "NUR 199",
+      "BIO 220"
+    ]
+  },
+  "NUR 203": {
+    "text": "SPH 106 (min C) or SPH 107 (min C) and PSY 210 (min C) and NUR 202 (min C)",
+    "courses": [
+      "SPH 106",
+      "SPH 107",
+      "PSY 210",
+      "NUR 202"
+    ]
+  },
+  "NUR 204": {
+    "text": "SPH 106 (min C) or SPH 107 (min C) and NUR 202 (min C) and PSY 210 (min C) and NUR 203 (min C)",
+    "courses": [
+      "SPH 106",
+      "SPH 107",
+      "NUR 202",
+      "PSY 210",
+      "NUR 203"
+    ]
+  },
+  "NUR 209": {
+    "text": "MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 125 (min C) or MTH 125 (min S) and BIO 201 (min C) or BIO 201 (min S) and BIO 202 (min C) or BIO 202 (min S) and ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101T (min C) and SPH 106 (min C) or SPH 106 (min S) or SPH 107 (min C) or SPH 107 (min S) and PSY 210 (min C)",
+    "courses": [
+      "MTH 100",
+      "MTH 100C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 113",
+      "MTH 125",
+      "BIO 201",
+      "BIO 202",
+      "ENG 101",
+      "ENG 101T",
+      "SPH 106",
+      "SPH 107",
+      "PSY 210"
+    ]
+  },
+  "NUR 211": {
+    "text": "NUR 209 (min C) or NUR 114 (min C) or NUR 115 (min C) and SPH 106 (min C) or SPH 106 (min S) or SPH 107 (min C) or SPH 107 (min S) and BIO 220 (min C) or BIO 220 (min S)",
+    "courses": [
+      "NUR 209",
+      "NUR 114",
+      "NUR 115",
+      "SPH 106",
+      "SPH 107",
+      "BIO 220"
+    ]
+  },
+  "NUR 221": {
+    "text": "BIO 220 (min C) or BIO 220 (min S) and NUR 211 (min C) and ART 100 (min C) or ART 100 (min S) or MUS 101 (min C) or MUS 101 (min S) or HUM 101 (min C) or HUM 101 (min S) or HUM 999 (min C) or IDS 102 (min C) or IDS 102 (min S) or THR 120 (min C) or THR 120 (min S) or REL 151 (min C) or REL 151 (min S) or REL 152 (min C) or REL 152 (min S) or ENG 271 (min C) or ENG 271 (min S) or ENG 272 (min C) or ENG 272 (min S) or ENG 251 (min C) or ENG 251 (min S) or ENG 252 (min C) or ENG 252 (min S)",
+    "courses": [
+      "BIO 220",
+      "NUR 211",
+      "ART 100",
+      "MUS 101",
+      "HUM 101",
+      "HUM 999",
+      "IDS 102",
+      "THR 120",
+      "REL 151",
+      "REL 152",
+      "ENG 271",
+      "ENG 272",
+      "ENG 251",
+      "ENG 252"
+    ]
+  },
+  "OAD 103": {
+    "text": "OAD 101 (min D) or OAD 101 (min T) or OAD 101 (min TD)",
+    "courses": [
+      "OAD 101"
+    ]
+  },
+  "OAD 104": {
+    "text": "OAD 103 (min D) or OAD 103 (min T) or OAD 103 (min TD)",
+    "courses": [
+      "OAD 103"
+    ]
+  },
+  "OAD 125": {
+    "text": "OAD 103 (min D) or OAD 103 (min T) or OAD 103 (min TD)",
+    "courses": [
+      "OAD 103"
+    ]
+  },
+  "OAD 126": {
+    "text": "OAD 125 (min D) or OAD 125 (min T) or OAD 125 (min TD)",
+    "courses": [
+      "OAD 125"
+    ]
+  },
+  "OAD 212": {
+    "text": "OAD 103 (min D) or OAD 103 (min TD)",
+    "courses": [
+      "OAD 103"
+    ]
+  },
+  "OAD 214": {
+    "text": "OAD 215 (min C)",
+    "courses": [
+      "OAD 215"
+    ]
+  },
+  "OAD 216": {
+    "text": "OAD 215 (min D) or OAD 215 (min TD) or OAD 215 (min T)",
+    "courses": [
+      "OAD 215"
+    ]
+  },
+  "PAS 175": {
+    "text": "PAS 173 (min D)",
+    "courses": [
+      "PAS 173"
+    ]
+  },
+  "PAS 177": {
+    "text": "PAS 175 (min D) and PAS 208 (min D)",
+    "courses": [
+      "PAS 175",
+      "PAS 208"
+    ]
+  },
+  "PAS 208": {
+    "text": "CUA 116 (min D)",
+    "courses": [
+      "CUA 116"
+    ]
+  },
+  "PED 206": {
+    "text": "PED 205 (min D) or PED 205 (min TD)",
+    "courses": [
+      "PED 205"
+    ]
+  },
+  "PHS 111": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min S) or MTH 108 (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 110 (min S) or MTH 112 (min C) or MTH 112C (min C) or MTH 112 (min S) or MTH 116 (min C) or MTH 116 (min S) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265 (min C)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 116",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "PHS 112": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 100 (min C) or ENG 100C (min C) or ENG 100 (min S) or ENG 101T (min C) or MTH 098 (min C.) or MTH 100 (min C) or MTH 100C (min C) or MTH 100 (min S) or MTH 108 (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 110 (min S) or MTH 112 (min C) or MTH 112C (min C) or MTH 112 (min S) or MTH 116 (min C) or MTH 116 (min S) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 120 (min C) or MTH 120 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 227 (min C) or MTH 231 (min C) or MTH 232 (min C) or MTH 237 (min C) or MTH 238 (min C) or MTH 265",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 100",
+      "ENG 100C",
+      "ENG 101T",
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 108",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 116",
+      "MTH 113",
+      "MTH 115",
+      "MTH 120",
+      "MTH 125",
+      "MTH 126",
+      "MTH 227",
+      "MTH 231",
+      "MTH 232",
+      "MTH 237",
+      "MTH 238",
+      "MTH 265"
+    ]
+  },
+  "PHY 115": {
+    "text": "MTH 100 (min D) or MTH 100 (min TD) or MTH 100 (min T) or MTH 110 (min D) or MTH 110 (min T) or MTH 110 (min TD) or MTH 112 (min D) or MTH 112 (min TD) or MTH 112 (min T) or MTH 113 (min D) or MTH 113 (min TD) or MTH 113 (min T) or MTH 125 (min D) or MTH 125 (min TD) or MTH 125 (min T)",
+    "courses": [
+      "MTH 100",
+      "MTH 110",
+      "MTH 112",
+      "MTH 113",
+      "MTH 125"
+    ]
+  },
+  "PHY 120": {
+    "text": "MTH 098 (min D) or MTH 100 (min D) or MTH 100 (min TD) or MTH 100C (min D) or MTH 112 (min D) or MTH 112 (min TD) or MTH 112C (min D)",
+    "courses": [
+      "MTH 098",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 112",
+      "MTH 112C"
+    ]
+  },
+  "PHY 201": {
+    "text": "MTH 113 (min C) or MTH 115 (min C) or MTH 115 (min S) or MTH 125 (min C) or MTH 125 (min S) or ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101T (min C) or ENG 101 (min S)",
+    "courses": [
+      "MTH 113",
+      "MTH 115",
+      "MTH 125",
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "PHY 202": {
+    "text": "PHY 201 (min D) or PHY 201 (min TD)",
+    "courses": [
+      "PHY 201"
+    ]
+  },
+  "PHY 213": {
+    "text": "MTH 125 (min C) or ENR 094 (min C.) or ENG 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S) or ENG 101T (min C)",
+    "courses": [
+      "MTH 125",
+      "ENR 094",
+      "ENG 098",
+      "ENG 101",
+      "ENG 101C",
+      "ENG 101T"
+    ]
+  },
+  "PHY 214": {
+    "text": "PHY 213 (min D) or PHY 213 (min TD) or PHY 213 (min T)",
+    "courses": [
+      "PHY 213"
+    ]
+  },
+  "PRL 102": {
+    "text": "ENG 101 (min D) or ENG 101 (min TD) or ENG 101 (min T) and PRL 101 (min D)",
+    "courses": [
+      "ENG 101",
+      "PRL 101"
+    ]
+  },
+  "PRL 103": {
+    "text": "PRL 101 (min D) or PRL 101 (min T) or PRL 101 (min TD) and ENG 101 (min D) and PRL 102 (min D)",
+    "courses": [
+      "PRL 101",
+      "ENG 101",
+      "PRL 102"
+    ]
+  },
+  "PRL 160": {
+    "text": "PRL 101 (min D) or PRL 101 (min T) or PRL 101 (min TD)",
+    "courses": [
+      "PRL 101"
+    ]
+  },
+  "PRL 210": {
+    "text": "PRL 101 (min D) and PRL 102 (min D) or PRL 101 (min T) or PRL 101 (min TD) and PRL 102 (min T) and PRL 102 (min TD)",
+    "courses": [
+      "PRL 101",
+      "PRL 102"
+    ]
+  },
+  "PRL 230": {
+    "text": "PRL 101 (min D) and PRL 102 (min D) or PRL 101 (min T) or PRL 101 (min TD) and PRL 102 (min T) and PRL 102 (min TD)",
+    "courses": [
+      "PRL 101",
+      "PRL 102"
+    ]
+  },
+  "PRL 240": {
+    "text": "PRL 101 (min D) or PRL 101 (min T) or PRL 101 (min TD)",
+    "courses": [
+      "PRL 101"
+    ]
+  },
+  "PRL 262": {
+    "text": "PRL 101 (min D) and PRL 102 (min D) or PRL 101 (min T) or PRL 101 (min TD) and PRL 102 (min T) and PRL 102 (min TD)",
+    "courses": [
+      "PRL 101",
+      "PRL 102"
+    ]
+  },
+  "PRL 291": {
+    "text": "PRL 101 (min D) and PRL 102 (min D) and PRL 262 (min D) or PRL 101 (min T) and PRL 102 (min T) and PRL 262 (min T) or PRL 101 (min TD) and PRL 102 (min TD) and PRL 262 (min TD) or PRL 160 (min D)",
+    "courses": [
+      "PRL 101",
+      "PRL 102",
+      "PRL 262",
+      "PRL 160"
+    ]
+  },
+  "PSY 210": {
+    "text": "PSY 200 (min D) or PSY 200 (min TD)",
+    "courses": [
+      "PSY 200"
+    ]
+  },
+  "PSY 230": {
+    "text": "PSY 200 (min D) or PSY 200 (min TD) or PSY 200 (min T)",
+    "courses": [
+      "PSY 200"
+    ]
+  },
+  "PTA 200": {
+    "text": "PTA 230 (min C) and PTA 241 (min C) and PTA 253 (min C) and PTA 260 (min C)",
+    "courses": [
+      "PTA 230",
+      "PTA 241",
+      "PTA 253",
+      "PTA 260"
+    ]
+  },
+  "PTA 230": {
+    "text": "BIO 202 (min C) and PTA 232 (min C) and PTA 240 (min C) and PTA 251 (min C) and PTA 290 (min C)",
+    "courses": [
+      "BIO 202",
+      "PTA 232",
+      "PTA 240",
+      "PTA 251",
+      "PTA 290"
+    ]
+  },
+  "PTA 231": {
+    "text": "MTH 100 (min C) or MTH 112 (min C) and PTA 230 (min C) and PTA 241 (min C) and PTA 253 (min C) and PTA 260 (min C)",
+    "courses": [
+      "MTH 100",
+      "MTH 112",
+      "PTA 230",
+      "PTA 241",
+      "PTA 253",
+      "PTA 260"
+    ]
+  },
+  "PTA 241": {
+    "text": "BIO 202 (min C) and PTA 232 (min C) and PTA 240 (min C) and PTA 251 (min C) and PTA 290 (min C)",
+    "courses": [
+      "BIO 202",
+      "PTA 232",
+      "PTA 240",
+      "PTA 251",
+      "PTA 290"
+    ]
+  },
+  "PTA 253": {
+    "text": "BIO 202 (min C) and PTA 232 (min C) and PTA 240 (min C) and PTA 251 (min C) and PTA 290 (min C)",
+    "courses": [
+      "BIO 202",
+      "PTA 232",
+      "PTA 240",
+      "PTA 251",
+      "PTA 290"
+    ]
+  },
+  "PTA 261": {
+    "text": "PTA 260 (min C)",
+    "courses": [
+      "PTA 260"
+    ]
+  },
+  "RAD 122": {
+    "text": "BIO 201 (min C) or BIO 201 (min S) and BIO 202 (min C) or BIO 202 (min S) and RAD 111 (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 124 (min C) and RAD 125 (min C) and MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 110 (min S) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 125 (min C) or MTH 125 (min S)",
+    "courses": [
+      "BIO 201",
+      "BIO 202",
+      "RAD 111",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 124",
+      "RAD 125",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 125"
+    ]
+  },
+  "RAD 124": {
+    "text": "BIO 201 (min C) or BIO 201 (min S) and BIO 202 (min C) or BIO 202 (min S) and RAD 111 (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 122 (min C) and RAD 125 (min C)",
+    "courses": [
+      "BIO 201",
+      "BIO 202",
+      "RAD 111",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 122",
+      "RAD 125"
+    ]
+  },
+  "RAD 125": {
+    "text": "BIO 202 (min C) or BIO 202 (min S) and RAD 111 (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 122 (min C) and RAD 124 (min C)",
+    "courses": [
+      "BIO 202",
+      "RAD 111",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 122",
+      "RAD 124"
+    ]
+  },
+  "RAD 134": {
+    "text": "ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) and RAD 111 (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 122 (min C) and RAD 124 (min C) and RAD 125 (min C) and BIO 202 (min C) or BIO 202 (min S)",
+    "courses": [
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "RAD 111",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 122",
+      "RAD 124",
+      "RAD 125",
+      "BIO 202"
+    ]
+  },
+  "RAD 135": {
+    "text": "ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 122 (min C) and RAD 124 (min C) and RAD 125 (min C)",
+    "courses": [
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 122",
+      "RAD 124",
+      "RAD 125"
+    ]
+  },
+  "RAD 136": {
+    "text": "ENG 101 (min C) or ENG 101 (min S) or ENG 101T (min C) or ENG 101C (min C) and RAD 111 (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 122 (min C) and RAD 124 (min C) and RAD 125 (min C)",
+    "courses": [
+      "ENG 101",
+      "ENG 101T",
+      "ENG 101C",
+      "RAD 111",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 122",
+      "RAD 124",
+      "RAD 125"
+    ]
+  },
+  "RAD 224": {
+    "text": "RAD 227 (min C) and RAD 111 (min C) and RAD 112 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 122 (min C) and RAD 124 (min C) and RAD 125 (min C) and RAD 134 (min C) and RAD 135 (min C) and RAD 136 (min C) and RAD 214 (min C) and RAD 212 (min C) and MUS 101 (min C) or MUS 101 (min S) or ART 100 (min C) or ART 100 (min S) or IDS 102 (min C) or IDS 102 (min S) or HUM 101 (min C) or HUM 101 (min S) or HUM 999 (min C) or THR 120 (min C) or THR 120 (min S) or PHY 206 (min C) or PHY 206 (min S) or REL 151 (min C) or REL 151 (min S) or REL 152 (min C) or REL 152 (min S) or ENG 271 (min C) or ENG 271 (min S) or ENG 272 (min C) or ENG 272 (min S) or ENG 251 (min C) or ENG 251 (min S) or ENG 252 (min C) or ENG 252 (min S) and PSY 200 (min C) or PSY 200 (min S) and ENG 102 (min C) or ENG 102 (min S) or SPH 106 (min C) or SPH 107 (min C) or SPH 107 (min S) or SPH 106 (min S)",
+    "courses": [
+      "RAD 227",
+      "RAD 111",
+      "RAD 112",
+      "RAD 113",
+      "RAD 114",
+      "RAD 122",
+      "RAD 124",
+      "RAD 125",
+      "RAD 134",
+      "RAD 135",
+      "RAD 136",
+      "RAD 214",
+      "RAD 212",
+      "MUS 101",
+      "ART 100",
+      "IDS 102",
+      "HUM 101",
+      "HUM 999",
+      "THR 120",
+      "PHY 206",
+      "REL 151",
+      "REL 152",
+      "ENG 271",
+      "ENG 272",
+      "ENG 251",
+      "ENG 252",
+      "PSY 200",
+      "ENG 102",
+      "SPH 106",
+      "SPH 107"
+    ]
+  },
+  "RAD 227": {
+    "text": "RAD 224 (min C) and RAD 112 (min C) and RAD 111 (min C) and RAD 113 (min C) and RAD 114 (min C) and RAD 134 (min C) and RAD 135 (min C) and RAD 136 (min C) and RAD 212 (min C) and RAD 214 (min C) and HUM 101 (min C) or HUM 101 (min S) or HUM 999 (min C) or ART 100 (min C) or ART 100 (min S) or IDS 102 (min C) or IDS 102 (min S) or THR 120 (min C) or THR 120 (min S) or MUS 101 (min C) or MUS 101 (min S) or Philosophy 206 (min C) or Philosophy 206 (min S) or REL 151 (min C) or REL 151 (min S) or REL 152 (min S) or REL 152 (min C) or REL 271 (min C) or REL 271 (min S) or REL 272 (min C) or REL 272 (min S) or ENG 252 (min C) or ENG 252 (min S) or ENG 251 (min C) or ENG 251 (min S)",
+    "courses": [
+      "RAD 224",
+      "RAD 112",
+      "RAD 111",
+      "RAD 113",
+      "RAD 114",
+      "RAD 134",
+      "RAD 135",
+      "RAD 136",
+      "RAD 212",
+      "RAD 214",
+      "HUM 101",
+      "HUM 999",
+      "ART 100",
+      "IDS 102",
+      "THR 120",
+      "MUS 101",
+      "Philosophy 206",
+      "REL 151",
+      "REL 152",
+      "REL 271",
+      "REL 272",
+      "ENG 252",
+      "ENG 251"
+    ]
+  },
+  "RPT 220": {
+    "text": "RPT 210 (min C)",
+    "courses": [
+      "RPT 210"
+    ]
+  },
+  "RPT 222": {
+    "text": "RPT 212 (min C)",
+    "courses": [
+      "RPT 212"
+    ]
+  },
+  "RPT 230": {
+    "text": "RPT 220 (min C)",
+    "courses": [
+      "RPT 220"
+    ]
+  },
+  "RPT 240": {
+    "text": "RPT 230 (min C)",
+    "courses": [
+      "RPT 230"
+    ]
+  },
+  "RTR 115": {
+    "text": "RTR 130 (min D) or RTR 130 (min TD) or RTR 130 (min T)",
+    "courses": [
+      "RTR 130"
+    ]
+  },
+  "RTR 131": {
+    "text": "RTR 130 (min D) or RTR 130 (min TD) or RTR 130 (min T)",
+    "courses": [
+      "RTR 130"
+    ]
+  },
+  "RTR 150": {
+    "text": "RTR 130 (min D) or RTR 130 (min TD) or RTR 130 (min T)",
+    "courses": [
+      "RTR 130"
+    ]
+  },
+  "RTR 210": {
+    "text": "RTR 150 (min D) or RTR 150 (min TD) or RTR 150 (min T)",
+    "courses": [
+      "RTR 150"
+    ]
+  },
+  "RTR 220": {
+    "text": "RTR 210 (min D) or RTR 210 (min TD) or RTR 210 (min T)",
+    "courses": [
+      "RTR 210"
+    ]
+  },
+  "RTR 226": {
+    "text": "RTR 150 (min D) and RTR 131 (min D) or RTR 150 (min TD) and RTR 131 (min TD) or RTR 150 (min T) and RTR 131 (min T)",
+    "courses": [
+      "RTR 150",
+      "RTR 131"
+    ]
+  },
+  "RTR 230": {
+    "text": "RTR 150 (min D) or RTR 150 (min TD) or RTR 150 (min T)",
+    "courses": [
+      "RTR 150"
+    ]
+  },
+  "RTR 257": {
+    "text": "RTR 227 (min D) or RTR 227 (min TD) or RTR 227 (min T)",
+    "courses": [
+      "RTR 227"
+    ]
+  },
+  "RTR 270": {
+    "text": "RTR 220 (min D) or RTR 220 (min TD) or RTR 220 (min T)",
+    "courses": [
+      "RTR 220"
+    ]
+  },
+  "RTR 275": {
+    "text": "RTR 210 (min D) or RTR 210 (min TD) or RTR 210 (min T)",
+    "courses": [
+      "RTR 210"
+    ]
+  },
+  "SOC 210": {
+    "text": "SOC 200 (min D) or SOC 200 (min TD) or SOC 200 (min T)",
+    "courses": [
+      "SOC 200"
+    ]
+  },
+  "SPA 101": {
+    "text": "ENR 094 (min C.) or ENR 098 (min C.) or ENG 101 (min C) or ENG 101C (min C) or ENG 101 (min S)",
+    "courses": [
+      "ENR 094",
+      "ENR 098",
+      "ENG 101",
+      "ENG 101C"
+    ]
+  },
+  "SPA 102": {
+    "text": "SPA 101 (min D) or SPA 101 (min TD) or SPA 101 (min T)",
+    "courses": [
+      "SPA 101"
+    ]
+  },
+  "SUR 100": {
+    "text": "SUR 108 (min C) or HPS 114 (min C) and BIO 103 (min C) or BIO 103 (min S) and BIO 201 (min C) or BIO 201 (min S) and HPS 105 (min C) or HPS 105 (min S) and SPH 106 (min C) or SPH 106 (min S) or SPH 107 (min C) or SPH 107 (min S) and PSY 200 (min C) or PSY 200 (min S) or PSY 210 (min C) or PSY 210 (min S) and MTH 108 (min C) or MTH 108 (min S) or MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 110 (min C) or MTH 110C (min C) or MTH 110 (min S) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 113 (min C) or MTH 113 (min S) or MTH 115 (min C) or MTH 115 (min S) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 126 (min S) and ENG 101 (min C) or ENG 101 (min S) or ENG 101C (min C) and SUR 109 (min C) or SUR 109 (min S)",
+    "courses": [
+      "SUR 108",
+      "HPS 114",
+      "BIO 103",
+      "BIO 201",
+      "HPS 105",
+      "SPH 106",
+      "SPH 107",
+      "PSY 200",
+      "PSY 210",
+      "MTH 108",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 113",
+      "MTH 115",
+      "MTH 125",
+      "MTH 126",
+      "ENG 101",
+      "ENG 101C",
+      "SUR 109"
+    ]
+  },
+  "SUR 104": {
+    "text": "SUR 101 (min C) and SUR 102 (min C) and SUR 103 (min C)",
+    "courses": [
+      "SUR 101",
+      "SUR 102",
+      "SUR 103"
+    ]
+  },
+  "SUR 105": {
+    "text": "SUR 101 (min C) and SUR 102 (min C) and SUR 107 (min C) and SUR 100 (min C) and SUR 109 (min C) and SUR 108 (min C) or HPS 114 (min C) and BIO 220 (min C) or BIO 220 (min S) and IDS 102 (min C) or IDS 102 (min S) or ART 100 (min C) or ART 100 (min S) or MUS 101 (min C) or MUS 101 (min S) or THR 120 (min C) or THR 120 (min S) or HUM 101 (min C) or HUM 101 (min S) or REL 151 (min C) or REL 151 (min S) or REL 152 (min C) or REL 152 (min S) or ENG 271 (min C) or ENG 272 (min C) or ENG 271 (min S) or ENG 272 (min S)",
+    "courses": [
+      "SUR 101",
+      "SUR 102",
+      "SUR 107",
+      "SUR 100",
+      "SUR 109",
+      "SUR 108",
+      "HPS 114",
+      "BIO 220",
+      "IDS 102",
+      "ART 100",
+      "MUS 101",
+      "THR 120",
+      "HUM 101",
+      "REL 151",
+      "REL 152",
+      "ENG 271",
+      "ENG 272"
+    ]
+  },
+  "SUR 106": {
+    "text": "SUR 100 (min C) and SUR 109 (min C) and SUR 101 (min C) and SUR 102 (min C) and SUR 107 (min C) and SUR 108 (min C) or HPS 114 (min C) and BIO 220 (min C) or BIO 220 (min S) and IDS 102 (min C) or IDS 102 (min S) or MUS 101 (min C) or MUS 101 (min S) or ART 100 (min C) or ART 100 (min S) or THR 120 (min C) or THR 120 (min S) or HUM 101 (min C) or HUM 101 (min S) or REL 151 (min C) or REL 151 (min S) or REL 152 (min C) or REL 152 (min S) or ENG 271 (min S) or ENG 271 (min C) or ENG 272 (min C) or ENG 272 (min S)",
+    "courses": [
+      "SUR 100",
+      "SUR 109",
+      "SUR 101",
+      "SUR 102",
+      "SUR 107",
+      "SUR 108",
+      "HPS 114",
+      "BIO 220",
+      "IDS 102",
+      "MUS 101",
+      "ART 100",
+      "THR 120",
+      "HUM 101",
+      "REL 151",
+      "REL 152",
+      "ENG 271",
+      "ENG 272"
+    ]
+  },
+  "SUR 108": {
+    "text": "SUR 101 (min C) and SUR 102 (min C) and SUR 103 (min C)",
+    "courses": [
+      "SUR 101",
+      "SUR 102",
+      "SUR 103"
+    ]
+  },
+  "SUR 109": {
+    "text": "BIO 103 (min C) or BIO 103 (min S) and BIO 201 (min C) or BIO 201 (min S) and HPS 105 (min C) or HPS 105 (min S) and ENG 101 (min C) or ENG 101 (min S) or ENG 101C (min C) and SPH 106 (min C) or SPH 106 (min S) or SPH 107 (min C) or SPH 107 (min S) and PSY 200 (min C) or PSY 200 (min S) or PSY 210 (min C) or PSY 210 (min S) and HPS 114 (min C) or SUR 108 (min C) and MTH 108 (min C) or MTH 108 (min S) or MTH 100 (min C) or MTH 100 (min S) or MTH 100C (min C) or MTH 110 (min C) or MTH 110 (min S) or MTH 110C (min C) or MTH 112 (min C) or MTH 112 (min S) or MTH 112C (min C) or MTH 115 (min C) or MTH 115 (min S) or MTH 115C (min C) or MTH 125 (min C) or MTH 125 (min S) or MTH 126 (min C) or MTH 126 (min S) or MTH 113 (min C) or MTH 113C (min C) or MTH 113 (min S) and SUR 100 (min C) or SUR 100 (min S)",
+    "courses": [
+      "BIO 103",
+      "BIO 201",
+      "HPS 105",
+      "ENG 101",
+      "ENG 101C",
+      "SPH 106",
+      "SPH 107",
+      "PSY 200",
+      "PSY 210",
+      "HPS 114",
+      "SUR 108",
+      "MTH 108",
+      "MTH 100",
+      "MTH 100C",
+      "MTH 110",
+      "MTH 110C",
+      "MTH 112",
+      "MTH 112C",
+      "MTH 115",
+      "MTH 115C",
+      "MTH 125",
+      "MTH 126",
+      "MTH 113",
+      "MTH 113C",
+      "SUR 100"
+    ]
+  },
+  "SUR 111": {
+    "text": "SUR 101 (min C) and SUR 102 (min C) and SUR 107 (min C) and BIO 220 (min C) or BIO 220 (min S) and ART 100 (min C) or ART 100 (min S) or MUS 101 (min C) or MUS 101 (min S) or HUM 101 (min C) or HUM 101 (min S) or IDS 102 (min C) or IDS 102 (min S) or THR 120 (min C) or THR 120 (min S) or REL 151 (min C) or REL 151 (min S) or REL 152 (min C) or REL 152 (min S) or ENG 271 (min C) or ENG 271 (min S) or ENG 272 (min C) or ENG 272 (min S) and SUR 100 (min C) and SUR 109 (min C) and SUR 108 (min C) or HPS 114 (min C) or HPS 114 (min S)",
+    "courses": [
+      "SUR 101",
+      "SUR 102",
+      "SUR 107",
+      "BIO 220",
+      "ART 100",
+      "MUS 101",
+      "HUM 101",
+      "IDS 102",
+      "THR 120",
+      "REL 151",
+      "REL 152",
+      "ENG 271",
+      "ENG 272",
+      "SUR 100",
+      "SUR 109",
+      "SUR 108",
+      "HPS 114"
+    ]
+  },
+  "SUR 205": {
+    "text": "SUR 104 (min C) and SUR 108 (min C) and SUR 211 (min C)",
+    "courses": [
+      "SUR 104",
+      "SUR 108",
+      "SUR 211"
+    ]
+  },
+  "SUR 210": {
+    "text": "SUR 104 (min C) and SUR 108 (min C) and SUR 211 (min C)",
+    "courses": [
+      "SUR 104",
+      "SUR 108",
+      "SUR 211"
+    ]
+  },
+  "SUR 211": {
+    "text": "SUR 101 (min C) and SUR 102 (min C) and SUR 103 (min C)",
+    "courses": [
+      "SUR 101",
+      "SUR 102",
+      "SUR 103"
+    ]
+  },
+  "THR 114": {
+    "text": "THR 113 (min D)",
+    "courses": [
+      "THR 113"
+    ]
+  },
+  "THR 115": {
+    "text": "THR 114 (min D)",
+    "courses": [
+      "THR 114"
+    ]
+  },
+  "THR 132": {
+    "text": "THR 131 (min D) or THR 131 (min TD) or THR 131 (min T)",
+    "courses": [
+      "THR 131"
+    ]
+  },
+  "VET 120": {
+    "text": "VET 110 (min C) or VET 110 (min S) and VET 113 (min C) or VET 113 (min S) and VET 114 (min C) or VET 114 (min S) and VET 247 (min C) or VET 247 (min S)",
+    "courses": [
+      "VET 110",
+      "VET 113",
+      "VET 114",
+      "VET 247"
+    ]
+  },
+  "VET 122": {
+    "text": "VET 230 (min C) and VET 234 (min C) and VET 275 (min C) and VET 280 (min C)",
+    "courses": [
+      "VET 230",
+      "VET 234",
+      "VET 275",
+      "VET 280"
+    ]
+  },
+  "VET 124": {
+    "text": "VET 113 (min C) or VET 113 (min S) and VET 110 (min C) or VET 110 (min S) and VET 114 (min C) or VET 114 (min S) and VET 247 (min C) or VET 247 (min S)",
+    "courses": [
+      "VET 113",
+      "VET 110",
+      "VET 114",
+      "VET 247"
+    ]
+  },
+  "VET 126": {
+    "text": "VET 120 (min C) and VET 124 (min C) and VET 236 (min C) and VET 247 (min C)",
+    "courses": [
+      "VET 120",
+      "VET 124",
+      "VET 236",
+      "VET 247"
+    ]
+  },
+  "VET 230": {
+    "text": "VET 120 (min C) or VET 120 (min S) and VET 124 (min C) or VET 124 (min S) and VET 126 (min C) or VET 126 (min S) and VET 236 (min C) or VET 236 (min S) and VET 280 (min C) or VET 280 (min S)",
+    "courses": [
+      "VET 120",
+      "VET 124",
+      "VET 126",
+      "VET 236",
+      "VET 280"
+    ]
+  },
+  "VET 234": {
+    "text": "VET 120 (min C) or VET 120 (min S) and VET 124 (min C) or VET 124 (min S) and VET 126 (min C) or VET 126 (min S) and VET 236 (min C) or VET 236 (min S) and VET 280 (min C) or VET 280 (min S)",
+    "courses": [
+      "VET 120",
+      "VET 124",
+      "VET 126",
+      "VET 236",
+      "VET 280"
+    ]
+  },
+  "VET 236": {
+    "text": "VET 113 (min C) or VET 113 (min S) and VET 110 (min C) or VET 110 (min S) and VET 114 (min C) or VET 114 (min S) and VET 247 (min C) or VET 247 (min S)",
+    "courses": [
+      "VET 113",
+      "VET 110",
+      "VET 114",
+      "VET 247"
+    ]
+  },
+  "VET 240": {
+    "text": "VET 230 (min C) and VET 234 (min C) and VET 275 (min C) and VET 280 (min C)",
+    "courses": [
+      "VET 230",
+      "VET 234",
+      "VET 275",
+      "VET 280"
+    ]
+  },
+  "VET 244": {
+    "text": "VET 230 (min C) and VET 234 (min C) and VET 275 (min C) and VET 280 (min C)",
+    "courses": [
+      "VET 230",
+      "VET 234",
+      "VET 275",
+      "VET 280"
+    ]
+  },
+  "VET 246": {
+    "text": "VET 120 (min C) or VET 120 (min S) and VET 124 (min C) or VET 124 (min S) and VET 126 (min C) or VET 126 (min S) and VET 236 (min C) or VET 236 (min S) and VET 280 (min C) or VET 280 (min S)",
+    "courses": [
+      "VET 120",
+      "VET 124",
+      "VET 126",
+      "VET 236",
+      "VET 280"
+    ]
+  },
+  "VET 247": {
+    "text": "VET 110 (min C) and VET 112 (min C) and VET 114 (min C)",
+    "courses": [
+      "VET 110",
+      "VET 112",
+      "VET 114"
+    ]
+  },
+  "VET 250": {
+    "text": "VET 230 (min C) and VET 234 (min C) and VET 275 (min C) and VET 280 (min C)",
+    "courses": [
+      "VET 230",
+      "VET 234",
+      "VET 275",
+      "VET 280"
+    ]
+  },
+  "VET 275": {
+    "text": "VET 120 (min C) or VET 120 (min S) and VET 124 (min C) or VET 124 (min S) and VET 126 (min C) or VET 126 (min S) and VET 236 (min C) or VET 236 (min S) and VET 280 (min C) or VET 280 (min S)",
+    "courses": [
+      "VET 120",
+      "VET 124",
+      "VET 126",
+      "VET 236",
+      "VET 280"
+    ]
+  },
+  "VET 280": {
+    "text": "VET 120 (min C) and VET 124 (min C) and VET 236 (min C) and VET 247 (min C)",
+    "courses": [
+      "VET 120",
+      "VET 124",
+      "VET 236",
+      "VET 247"
+    ]
+  },
+  "WDT 120": {
+    "text": "WDT 107 (min D)",
+    "courses": [
+      "WDT 107"
+    ]
+  },
+  "WDT 221": {
+    "text": "WDT 115 (min D)",
+    "courses": [
+      "WDT 115"
+    ]
+  }
+}

--- a/data/al/subject-vocab.json
+++ b/data/al/subject-vocab.json
@@ -1,0 +1,1962 @@
+{
+  "state": "al",
+  "generated_at": "2026-05-13T03:53:10.832Z",
+  "subjects": [
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 22,
+      "section_count": 1131,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED DIFFERENTIAL EQUATIONS I",
+        "CALCULUS AND ITS APPLICATIONS",
+        "CALCULUS I",
+        "CALCULUS II",
+        "CALCULUS III"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 12,
+      "section_count": 958,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "AMERICAN LITERATURE I",
+        "AMERICAN LITERATURE II",
+        "APPLIED WRITING",
+        "English Composition I w/Support",
+        "ENGLISH COMPOSITION II"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 11,
+      "section_count": 544,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "BIO 201 FH1 Spring &#39;26/ Monday 8-10:15",
+        "GENERAL MICROBIOLOGY",
+        "Human Anatomy",
+        "Human Anatomy &amp; Physiology II",
+        "Human Biology"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 7,
+      "section_count": 421,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Directed Studies in History",
+        "HISTORY OF WESTERN CIVILIZATION I",
+        "HISTORY OF WESTERN CIVILIZATION II",
+        "UNITED STATES HISTORY I",
+        "UNITED STATES HISTORY II"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 25,
+      "section_count": 350,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Adult Nursing",
+        "Adult/Child Nursing",
+        "Adv Evidence Based Reason Sim",
+        "ADV NURSING CONCEPT SIMULATION",
+        "ADVANCED EVIDENCE BASED CLINICAL REASONING"
+      ]
+    },
+    {
+      "prefix": "WDT",
+      "name": "Welding",
+      "course_count": 30,
+      "section_count": 336,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Rdg for Fabrication",
+        "Certification",
+        "Co-Op",
+        "Consumable Welding App Lab",
+        "Consumable Welding Application"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 39,
+      "section_count": 286,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED JAVA",
+        "ADVANCED MICROCOMPUTER APPLICATIONS",
+        "C ++ PROGRAMMING",
+        "CISCO CCNA I",
+        "CISCO CCNA II"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 3,
+      "section_count": 281,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ABNORMAL PSYCHOLOGY",
+        "GENERAL PSYCHOLOGY",
+        "Human Growth &amp; Development"
+      ]
+    },
+    {
+      "prefix": "SPH",
+      "name": "SPH",
+      "course_count": 3,
+      "section_count": 252,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "FUNDAMENTALS OF ORAL COMMUNICATION",
+        "FUNDAMENTALS OF PUBLIC SPEAKING",
+        "INTRO TO INTERPERSONAL COMM"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 21,
+      "section_count": 231,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Accounting with Quickbooks",
+        "Business Communications",
+        "BUSINESS INTERNSHIP I",
+        "BUSINESS STATISTICS I",
+        "BUSINESS STATISTICS II"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 20,
+      "section_count": 208,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DIGITAL PHOTOGRAPHY",
+        "ART APPRECIATION",
+        "Art History I",
+        "ART HISTORY II",
+        "Art Museum Survey"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 25,
+      "section_count": 197,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADV EMT LAB",
+        "ADVANCED COMPETENCIES FOR PARAMEDIC",
+        "ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+        "ADVANCED EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+        "APPLIED ANATOMY AND PHYSIOLOGY FOR THE PARAMEDIC"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 34,
+      "section_count": 194,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Esthetics",
+        "Advanced Esthetics Applications",
+        "Applied Chemistry for Cos Lab",
+        "Bacteriology and Sanitation",
+        "BASIC SPA TECHNIQUES"
+      ]
+    },
+    {
+      "prefix": "ORI",
+      "name": "Orientation",
+      "course_count": 2,
+      "section_count": 193,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Orientation and Student Success",
+        "ORIENTATION TO COLLEGE"
+      ]
+    },
+    {
+      "prefix": "MUP",
+      "name": "Private",
+      "course_count": 52,
+      "section_count": 166,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Private Cello I",
+        "Private Cello III",
+        "PRIVATE CLARINET I",
+        "Private Clarinet II",
+        "PRIVATE CLARINET III"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 11,
+      "section_count": 145,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "BASIC MUSICIANSHIP",
+        "CONVOCATION",
+        "MUSIC APPRECIATION",
+        "MUSIC THEORY I",
+        "MUSIC THEORY II"
+      ]
+    },
+    {
+      "prefix": "INT",
+      "name": "INT",
+      "course_count": 37,
+      "section_count": 143,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Advanced Process Simulation",
+        "Advanced Programmable Logic Controllers",
+        "BLUEPRINT READING FOR INDUSTRIAL TECHNICIANS",
+        "Concepts of Solid State Electronics"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Airframe",
+      "course_count": 10,
+      "section_count": 117,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "AIRCRAFT SHEETMETAL STRUCTURES",
+        "AIRFRAME SYSTEMS I",
+        "AIRFRAME SYSTEMS II",
+        "AIRFRAME SYSTEMS III",
+        "AIRFRAME SYSTEMS IV"
+      ]
+    },
+    {
+      "prefix": "CHD",
+      "name": "Child Development",
+      "course_count": 19,
+      "section_count": 111,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADMINISTRATION OF CHILD DEVELOPMENT PROGRAMS",
+        "Child Development Seminar",
+        "CHILD DEVELOPMENT TRENDS SEMINAR",
+        "Child Growth &amp; Development Principles",
+        "CHILDREN&#39;S CREATIVE EXPERIENCES"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 29,
+      "section_count": 111,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Basic Concepts of Interpersonal Relationships",
+        "CLINICAL PROCEDURES I FOR THE MEDICAL ASSISTANT",
+        "CLINICAL PROCEDURES II FOR THE MEDICAL ASSISTANT",
+        "Clinical Specialties For Medical Assistants",
+        "EKG TECHNICIAN"
+      ]
+    },
+    {
+      "prefix": "OAD",
+      "name": "OAD",
+      "course_count": 26,
+      "section_count": 102,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED HEALTH INFORMATION MANAGEMENT",
+        "ADVANCED KEYBOARDING",
+        "Advanced Word Processing",
+        "BEGINNING KEYBOARDING",
+        "BUSINESS COMMUNICATIONS"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "Varsity",
+      "course_count": 31,
+      "section_count": 95,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "CURRENT ISSUES IN SPORTS MANAGEMENT",
+        "FOUNDATIONS OF PHYSICAL EDUCATION",
+        "FOUNDATIONS OF SPORT PSYCHOLOGY",
+        "FUNDAMENTALS OF FITNESS",
+        "GEN. CONDITIONING-BEGINNING"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 92,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "PRINCIPLES OF MACROECONOMICS I",
+        "PRINCIPLES OF MICROECONOMICSII"
+      ]
+    },
+    {
+      "prefix": "MUL",
+      "name": "MUL",
+      "course_count": 30,
+      "section_count": 92,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "CHORUS IV",
+        "CLASS PIANO I",
+        "CLASS PIANO II",
+        "Class Piano III",
+        "CLASS VOICE I"
+      ]
+    },
+    {
+      "prefix": "HED",
+      "name": "Health",
+      "course_count": 9,
+      "section_count": 84,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "CARE AND PREVENTION OF ATHLETIC INJURIES",
+        "COMMUNITY HEALTH",
+        "DRUG EDUCATION",
+        "FIRST AID",
+        "INTRODUCTION TO HEALTH OCCUPATIONS"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "ACR",
+      "course_count": 22,
+      "section_count": 80,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Commercial Air Conditioning Systems",
+        "Commercial Refrigeration",
+        "COMMERICAL HEATING SYSTEMS",
+        "Customer Relation in HVAC",
+        "FUND OF GAS HEATING SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 22,
+      "section_count": 73,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "AC/DC Machines",
+        "Advanced AC/DC Machines",
+        "ADVANCED PROGRAMMABLE CONTROLS",
+        "Co-Op"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 5,
+      "section_count": 71,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "COLLEGE CHEMISTRY I",
+        "COLLEGE CHEMISTRY II",
+        "Introduction to Chemistry II",
+        "INTRODUCTION TO INORGANIC CHEMISTRY",
+        "ORGANIC CHEMISTRY I"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 17,
+      "section_count": 68,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "COMMUNITY RELATIONS",
+        "CONSTITUTIONAL LAW",
+        "Crime Scene Investigation",
+        "CRIMINAL INVESTIGATIONS",
+        "CRIMINAL LAW AND PROCEDURE"
+      ]
+    },
+    {
+      "prefix": "DDT",
+      "name": "DDT",
+      "course_count": 27,
+      "section_count": 67,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED 3D MODELING",
+        "ARCHITECTURAL DRAFTING",
+        "BASIC 3D MODELING",
+        "BASIC COMPUTER AIDED DRAFTING AND DESIGN",
+        "BASIC SURVEYING"
+      ]
+    },
+    {
+      "prefix": "ILT",
+      "name": "ILT",
+      "course_count": 30,
+      "section_count": 66,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "193",
+        "AC FUNDAMENTALS",
+        "AC/DC CIRCUIT ANALYSIS",
+        "ADVANCED INDUSTRIAL CONTROLS",
+        "CERTIFICATION PREP LAB"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "MTT",
+      "course_count": 26,
+      "section_count": 63,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "BASIC COMPUTER NUMERIC CONTROL MILLING PROGRAMMING I",
+        "BASIC COMPUTER NUMERICAL CONTROL",
+        "BASIC COMPUTER NUMERICAL CONTROL TURNING PROGRAMMING I",
+        "Basic Print Rdg for Machinists",
+        "CNC Graphics: Turning"
+      ]
+    },
+    {
+      "prefix": "WKO",
+      "name": "Workplace",
+      "course_count": 6,
+      "section_count": 57,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "MSSC Qual. Prac. &amp; Measurement",
+        "MSSC Safety Course",
+        "NCCER CORE",
+        "WORKPLACE SKILLS",
+        "WORKPLACE SKILLS DEVELOPMENT I"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 2,
+      "section_count": 56,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO SOCIOLOGY",
+        "SOCIAL PROBLEMS"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 14,
+      "section_count": 50,
+      "colleges": [
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Education IV",
+        "CLINICAL EDUCATION V",
+        "Image Evaluation &amp; Pathology",
+        "IMAGING EQUIPMENT",
+        "Introduction to Radiography"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Philosophy",
+      "course_count": 3,
+      "section_count": 48,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Ethics & the Health Sciences",
+        "INTRODUCTION TO PHILOSOPHY",
+        "Philosophy 206 - Ethics and Society"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 3,
+      "section_count": 45,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "HISTORY OF WORLD RELIGIONS",
+        "SURVEY OF THE NEW TESTAMENT",
+        "SURVEY OF THE OLD TESTAMENT"
+      ]
+    },
+    {
+      "prefix": "DNC",
+      "name": "Dance",
+      "course_count": 26,
+      "section_count": 44,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "BALLET TECHNIQUE I",
+        "BALLET TECHNIQUE II",
+        "BALLET TECHNIQUE III",
+        "BALLET TECHNIQUE IV",
+        "CHOREOGRAPHY I"
+      ]
+    },
+    {
+      "prefix": "AUM",
+      "name": "AUM",
+      "course_count": 19,
+      "section_count": 43,
+      "colleges": [
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Adv Electrical &amp; Electronic Sy",
+        "ADVANCED AUTOMOTIVE ENGINES",
+        "Auto Transmission & Transaxle",
+        "Automotive Emissions",
+        "Automotive Engines"
+      ]
+    },
+    {
+      "prefix": "ENR",
+      "name": "Writing",
+      "course_count": 1,
+      "section_count": 40,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Writing &amp; Reading for College"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 4,
+      "section_count": 40,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "HUMANITIES FORUM",
+        "INTRODUCTION TO THE HUMANITIES I",
+        "INTRODUCTION TO THE HUMANITIES II",
+        "PTK LEADERSHIP DEVELOPMENT"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 2,
+      "section_count": 40,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "AMERICAN NATIONAL GOVERNMENT",
+        "INTRODUCTION TO POLITICAL SCIENCE"
+      ]
+    },
+    {
+      "prefix": "THR",
+      "name": "THR",
+      "course_count": 10,
+      "section_count": 40,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Acting for Film and Television",
+        "Acting Techniques I",
+        "Acting Techniques II",
+        "Intro to Theatrical Design",
+        "Stage Movement I"
+      ]
+    },
+    {
+      "prefix": "IDS",
+      "name": "Ethics",
+      "course_count": 1,
+      "section_count": 39,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ETHICS"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "EET",
+      "course_count": 15,
+      "section_count": 38,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Circuit Fabrication I",
+        "Conc of Solid State Elect",
+        "Concepts of Digital Elect",
+        "Concepts of Elect Circuits"
+      ]
+    },
+    {
+      "prefix": "RPT",
+      "name": "RPT",
+      "course_count": 20,
+      "section_count": 37,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "ACID BASE REGULATION AND ABG ANALYSIS",
+        "ANATOMY AND PHYSIOLOGY FOR THE RCP",
+        "CLINICAL PRACTICE I",
+        "CLINICAL PRACTICE II",
+        "CLINICAL PRACTICE III"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 8,
+      "section_count": 34,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "General Physics I - Trigonometry Based",
+        "GENERAL PHYSICS I WITH CALCULUS",
+        "GENERAL PHYSICS II WITH CALCULUS",
+        "GENERAL PHYSICS II-TRIGONOMETRY BASED",
+        "INTRODUCTION TO PHYSICS"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 2,
+      "section_count": 34,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO SPANISH",
+        "INTRODUCTORY SPANISH II"
+      ]
+    },
+    {
+      "prefix": "MDT",
+      "name": "Cadd",
+      "course_count": 14,
+      "section_count": 33,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Adv Mechanical Drawings",
+        "Adv Solid Works CADD",
+        "Advanced Inventor CADD",
+        "Architectural Drawing",
+        "Architectural Drawing II"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 32,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "PHYSICAL SCIENCE I",
+        "PHYSICAL SCIENCE II"
+      ]
+    },
+    {
+      "prefix": "ADM",
+      "name": "ADM",
+      "course_count": 16,
+      "section_count": 31,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADD MFG PRODUCTION TECHNIQUES",
+        "ADDITIVE MFG PROCESS-POLYMERS",
+        "Design Innovation",
+        "FLUID SYSTEMS",
+        "Freehand Sketching"
+      ]
+    },
+    {
+      "prefix": "CUA",
+      "name": "CUA",
+      "course_count": 13,
+      "section_count": 31,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED FOOD PREPARATION",
+        "CULINARY ARTS SCULPTURE",
+        "CULINARY CAPSTONE",
+        "FOOD PREPARATION",
+        "FOOD PURCHASING AND COST CONTROL"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "CLINICAL IMMUNOLOGY",
+        "Hematology",
+        "Integrated Lab Simulation",
+        "Laboratory Techniques",
+        "MEDICAL LABORATORY PRACTICUM CHEMISTRY AND IMMUNOLOGY"
+      ]
+    },
+    {
+      "prefix": "RTR",
+      "name": "Realtime",
+      "course_count": 21,
+      "section_count": 30,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Civil/Criminal Law/Terminology",
+        "Judicial Procedures",
+        "Moot Court Practicum II",
+        "Realtime Application",
+        "Realtime Lab I"
+      ]
+    },
+    {
+      "prefix": "ASE",
+      "name": "ASE",
+      "course_count": 12,
+      "section_count": 29,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Automatic Transmission and Transaxle",
+        "AUTOMOTIVE EMISSIONS I",
+        "Automotive Engines",
+        "Braking Systems",
+        "Drive Train and Axles"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surgical",
+      "course_count": 15,
+      "section_count": 29,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED SURGICAL TECHNIQUES",
+        "Clinical Procedures",
+        "INTRODUCTION TO SURGICAL EQUIPMENT, INSTRUMENTATION, AND SUPPLIES",
+        "INTRODUCTION TO SURGICAL TECHNOLOGY",
+        "PHARMACOLOGY FOR THE SURGICAL TECHNOLOGIST"
+      ]
+    },
+    {
+      "prefix": "ABR",
+      "name": "ABR",
+      "course_count": 15,
+      "section_count": 28,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Automotive Cutting &amp; Welding",
+        "Automotive Glass &amp; Trim",
+        "Automotive Plastic Repairs",
+        "Automotive Structural Analysis",
+        "Automotive Structural Repair"
+      ]
+    },
+    {
+      "prefix": "VET",
+      "name": "Veterinary",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ANIMAL DISEASES AND IMMUNOLOGY",
+        "ANIMAL PHARMACOLOGY AND TOXICOLOGY",
+        "CLINICAL ANATOMY AND PHYSIOLOGY OF ANIMALS",
+        "CLINICAL PROCEDURES AND PATHOLOGY",
+        "INTRODUCTION TO VETERINARY TECHNOLOGY"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 19,
+      "section_count": 25,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Pathology",
+        "Abdominal Sonography",
+        "Adv Echocardiographic Mod",
+        "Echo Clinical",
+        "Foundations of Sonography"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 17,
+      "section_count": 25,
+      "colleges": [
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Field Work I",
+        "Directed Studies for PTA",
+        "Functional Anatomy and Kinesiology"
+      ]
+    },
+    {
+      "prefix": "AMP",
+      "name": "Reciprocating",
+      "course_count": 5,
+      "section_count": 24,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "RECIPROCATING ENGINE INSPECTIONS AND PROPELLERS",
+        "RECIPROCATING ENGINES AND THEORY",
+        "reciprocating Engines Overhaul",
+        "TURBINE ENGINE INSPECTION AND OVERHAUL",
+        "TURBINE ENGINE THEORY AND SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "CAR",
+      "name": "CAR",
+      "course_count": 15,
+      "section_count": 24,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Concrete and Forming",
+        "CONSTRUCTION BASICS",
+        "Construction Project Mgmt",
+        "Constructions Basics Lab",
+        "Floor, Wall, and Ceiling Spec"
+      ]
+    },
+    {
+      "prefix": "MCM",
+      "name": "Student",
+      "course_count": 7,
+      "section_count": 24,
+      "colleges": [
+        "enterprise-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO MASS COMMUNICATIONS",
+        "STUDENT PUBLICATIONS"
+      ]
+    },
+    {
+      "prefix": "IET",
+      "name": "IET",
+      "course_count": 3,
+      "section_count": 23,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "BASIC ELECTRICITY",
+        "FLUID POWER SYSTEMS",
+        "ROTATING MACHINERY AND CONTROLS"
+      ]
+    },
+    {
+      "prefix": "PFT",
+      "name": "Pipe",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "BUTT WELD PIPE FITTING AND PIPE RIGGING",
+        "INTRODUCTION TO PIPEFITTING",
+        "INTRODUCTION TO PIPEFITTING BLUEPRINTS",
+        "INTRODUCTION TO PIPEFITTING TOOLS",
+        "INTRODUCTION TO PIPING SYSTEMS, DRAWINGS AND DETAIL SHEETS"
+      ]
+    },
+    {
+      "prefix": "DAT",
+      "name": "Dental",
+      "course_count": 14,
+      "section_count": 20,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "BASIC SCIENCES FOR DENTAL ASSISTING",
+        "CLINICAL PRACTICE I",
+        "CLINICAL PRACTICE II",
+        "DENTAL ANATOMY AND PHYSIOLOGY",
+        "Dental Assisting Seminar"
+      ]
+    },
+    {
+      "prefix": "HPS",
+      "name": "Medical",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "BASIC PHARMACOLOGY",
+        "Medical Terminology",
+        "Medical Terminology for Health Care",
+        "Overview of Complementary and Alternative Health Therapies",
+        "Safety/Clin Practice"
+      ]
+    },
+    {
+      "prefix": "PRL",
+      "name": "PRL",
+      "course_count": 11,
+      "section_count": 20,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED LEGAL RESEARCH AND WRITING",
+        "BASIC RESEARCH AND WRITING",
+        "Civil Law/and Procedures",
+        "COMMERCIAL LAW",
+        "CRIMINAL LAW AND PROCEDURE"
+      ]
+    },
+    {
+      "prefix": "ASC",
+      "name": "ASC",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "COMMERCIAL REFRIGERATION",
+        "FUND. OF ELECTRIC HEAT SYSTEMS",
+        "FUND. OF GAS HEATING SYSTEMS",
+        "HEAT LOAD CALCULATIONS",
+        "HEAT PUMP SYSTEMS I"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 16,
+      "section_count": 18,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Vocabulary",
+        "Composition II",
+        "Composition IV",
+        "Composition Vi",
+        "Eng Grammar/Struc II"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 3,
+      "section_count": 18,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Prin Physical Geography I",
+        "Principles Phys Geography Ii",
+        "WORLD REGIONAL GEOGRAPHY"
+      ]
+    },
+    {
+      "prefix": "PHM",
+      "name": "Pharmacy",
+      "course_count": 9,
+      "section_count": 16,
+      "colleges": [
+        "chattahoochee-valley-community-college"
+      ],
+      "sample_titles": [
+        "Billings and Computers",
+        "Drugs and Health",
+        "Institutional Pharmacy",
+        "Introduction to Pharmacy",
+        "Pharmacology I"
+      ]
+    },
+    {
+      "prefix": "MSP",
+      "name": "MSP",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "BASIC BLUEPRINTS READING",
+        "BASIC CNC MILLING",
+        "BASIC MACHINING CALCULATIONS",
+        "COMPUTER NUMERICAL CONTROL",
+        "COMPUTER NUMERICAL CONTROL LAB"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "CAP",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED MODELING",
+        "CGI ANIMATION",
+        "CGI SHADING, LIGHTING,AND RENDERING",
+        "CGI SOFTWARE BASICS",
+        "COMPUTER GRAPHICS HISTORY"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "CET",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Surveying",
+        "Engineering Blueprints",
+        "Fundamentals of Surveying",
+        "Highway Design &amp; Construction",
+        "Intro to Engineering Tech"
+      ]
+    },
+    {
+      "prefix": "HUS",
+      "name": "HUS",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Activity Therapy",
+        "Alcohol/Drug Seminar",
+        "Clinical Internship I",
+        "Clinical Internship II",
+        "Clinical Internship III"
+      ]
+    },
+    {
+      "prefix": "MSG",
+      "name": "Massage",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO THERAPEUTIC MASSAGE",
+        "MASSAGE THERAPY CLINICAL I",
+        "MASSAGE THERAPY CLINICAL II",
+        "MASSAGE THERAPY LAB I",
+        "MASSAGE THERAPY LAB II"
+      ]
+    },
+    {
+      "prefix": "CNC",
+      "name": "Comp",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "enterprise-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Adv Comp Num Cntrl Milling",
+        "Basic Comp Numerical Control",
+        "CNC GRAPHICS PROGRAM: MILLING",
+        "Comp Numeric Control Milling",
+        "Comp Numeric Control Turning"
+      ]
+    },
+    {
+      "prefix": "DEM",
+      "name": "DEM",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Basic Engines",
+        "Diesel Engine Lab",
+        "Electrical/Electronic Fundamen",
+        "Electronic Engine Systems",
+        "Equipment Safety/Mech Fundamen"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "enterprise-state-community-college",
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Health Care Delivery System",
+        "HEALTH DATA CONTENT & STRUCT",
+        "HIT COMPUTER APPLICATION LAB",
+        "HIT COMPUTER APPLICATIONS",
+        "HIT Legal/Ethical Issues"
+      ]
+    },
+    {
+      "prefix": "NAS",
+      "name": "Assistant",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "LONG-TERM CARE NURSING ASSISTANT",
+        "Medication Assistant"
+      ]
+    },
+    {
+      "prefix": "SAL",
+      "name": "Entrepreneurship",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "ENTREPRENEURSHIP FOR SALON/SPA",
+        "Salon Management &amp; Technology"
+      ]
+    },
+    {
+      "prefix": "LDR",
+      "name": "Leadership",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO LEADERSHIP: THEORY, CONTEXT AND PRACTICE"
+      ]
+    },
+    {
+      "prefix": "PAS",
+      "name": "Baking",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED BAKING",
+        "BAKING AND PASTRY CAPSTONE CLASS",
+        "FOUNDATIONS OF BAKING",
+        "PASTRIES I",
+        "PASTRIES II"
+      ]
+    },
+    {
+      "prefix": "MRT",
+      "name": "Engines",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "FUEL AND LUBRICATION SYSTEMS",
+        "MACHINE ENGINES AND DRIVES",
+        "MARINE ENGINES AND INBOARD DRIVES",
+        "MARINE ENGINES AND OUTBOARD DRIVES",
+        "MARINE RIGGING AND TRAILERS"
+      ]
+    },
+    {
+      "prefix": "HSM",
+      "name": "Planning",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "EVENT PLANNING AND MANAGEMENT",
+        "HOSPITALITY FIELD EXPERIENCE I",
+        "HOSPITALITY MARKETING",
+        "MEETING AND CONVENTION MANAGEMENT",
+        "PLANNING AND DEVELOPMENT OF LEISURE PROGRAMS AND FESTIVALS"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "ENGINEERING FOUNDATIONS",
+        "ENGINEERING MECHANICS - STATICS",
+        "MODERN GRAPHICS FOR ENGINEERS"
+      ]
+    },
+    {
+      "prefix": "HEC",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "gadsden-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Nutrition"
+      ]
+    },
+    {
+      "prefix": "HMM",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "BEVERAGE SELECTION AND APPRECIATION",
+        "CURRENT TOPICS IN HOSPITALITY MANAGEMENT",
+        "HOTEL/RESTAURANT AND TRAVEL LAW",
+        "HUMAN RESOURCE MANAGEMENT",
+        "RESTAURANT SERVICE MANAGEMENT I"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "coastal-alabama-community-college",
+        "enterprise-state-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "INDIVIDUAL INCOME TAXES",
+        "SPREADSHEET SOFTWARE"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "coastal-alabama-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "AUDIO VISUAL MATERIALS AND METHODS",
+        "AUDIO VISUAL MATERIALS AND METHODS APPLICATIONS",
+        "LESSON PLAN IMPLEMENTATION",
+        "SPECIAL TOPICS IN COS",
+        "TEACHER MENTORSHIP"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "Masonry",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Brick/Block Masonry Fundamentals",
+        "Brick/Block Masonry Fundamentals II",
+        "Brick/Block Masonry Fundamentals III",
+        "MASONRY FUNDAMENTALS - 10938 - MAS 111 - EP3"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "Accounting",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "gadsden-state-community-college",
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Cost Accounting",
+        "Individual Income Tax",
+        "Payroll Accounting"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "gadsden-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Astronomy"
+      ]
+    },
+    {
+      "prefix": "AVT",
+      "name": "Aviation",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "enterprise-state-community-college"
+      ],
+      "sample_titles": [
+        "AIRCRAFT INSTALLATION/SOLDE",
+        "AVIATION COMMUNICATIONS",
+        "AVIATION ELECTRONICS LAB I",
+        "AVIATION ELECTRONICS THEORY",
+        "PULSE AND RADAR CIRCUITS"
+      ]
+    },
+    {
+      "prefix": "CAT",
+      "name": "Electronic",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "CURRENT TOPS IN COMMERCIAL ART",
+        "ELECTRONIC PUBLISHING I",
+        "ELECTRONIC PUBLISHING II",
+        "LAYOUT AND DESIGN",
+        "WEBSITE DEVELOPMENT"
+      ]
+    },
+    {
+      "prefix": "FSC",
+      "name": "Fire",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "chattahoochee-valley-community-college"
+      ],
+      "sample_titles": [
+        "FIRE DEPT SAFETY OFFICER",
+        "FIRE INVESTIGATOR I",
+        "INTRO TO THE FIRE SERVICE",
+        "INTRODUCTION TO FIRE PREV/EDU",
+        "NATL INCIDENT MGMT SYSTEMS I"
+      ]
+    },
+    {
+      "prefix": "FRN",
+      "name": "Introductory",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTORY FRENCH I",
+        "INTRODUCTORY FRENCH II"
+      ]
+    },
+    {
+      "prefix": "MHT",
+      "name": "Psychology",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Addiction and Forensic Psychology",
+        "Introduction to Abnormal Psychology",
+        "Introduction to Inpatient and Residential Operations",
+        "Management of Behavioral Crisis"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Introductory Technical English II"
+      ]
+    },
+    {
+      "prefix": "GLY",
+      "name": "Geology",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO GEOLOGY I",
+        "INTRODUCTION TO GEOLOGY II"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "GRD",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "enterprise-state-community-college"
+      ],
+      "sample_titles": [
+        "3-D FUNDAMENTALS",
+        "3D GRAPHICS & ANIMATION",
+        "DIGITAL VIDEO FOUNDATION"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Mechanical",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "enterprise-state-community-college"
+      ],
+      "sample_titles": [
+        "MECHANICAL SYSTEMS I",
+        "Mechanical Systems II"
+      ]
+    },
+    {
+      "prefix": "ORT",
+      "name": "Orientation",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Orientation for Career Students"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "chattahoochee-valley-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "INDUSTRIAL ROBOTICS",
+        "INJECTION MOLD SETTER LAB"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Exploring Teaching as a Prof"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "Autocad",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED AUTOCAD CADD",
+        "MACHINE DESIGN"
+      ]
+    },
+    {
+      "prefix": "GRN",
+      "name": "Introductory",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "gadsden-state-community-college",
+        "southern-union-state-community-college"
+      ],
+      "sample_titles": [
+        "Introductory German I"
+      ]
+    },
+    {
+      "prefix": "MAH",
+      "name": "Introductory",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "Introductory Mathematics I"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Fund of Selling"
+      ]
+    },
+    {
+      "prefix": "PCT",
+      "name": "Process",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO PROCESS TECHNOLOGY",
+        "UNIT MAINTENANCE"
+      ]
+    },
+    {
+      "prefix": "VCM",
+      "name": "Digital",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "chattahoochee-valley-community-college"
+      ],
+      "sample_titles": [
+        "GRAPHICS SOFTWARE APPLICATIONS",
+        "INTRO TO DIGITAL PHOTOGRAPHY"
+      ]
+    },
+    {
+      "prefix": "AGP",
+      "name": "Poultry",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Poultry Production"
+      ]
+    },
+    {
+      "prefix": "BUC",
+      "name": "Construction",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "coastal-alabama-community-college"
+      ],
+      "sample_titles": [
+        "BASIC CONSTRUCTION LAYOUT"
+      ]
+    },
+    {
+      "prefix": "ETP",
+      "name": "Small",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Small Business Management"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "Phys",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "gadsden-state-community-college"
+      ],
+      "sample_titles": [
+        "Phys Supp/Dist Mgmt"
+      ]
+    },
+    {
+      "prefix": "SPC",
+      "name": "Speech",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "george-c-wallace-community-college-dothan"
+      ],
+      "sample_titles": [
+        "ORAL COMMUNICATION SKILLS"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/fl/subject-vocab.json
+++ b/data/fl/subject-vocab.json
@@ -1,0 +1,4731 @@
+{
+  "state": "fl",
+  "generated_at": "2026-05-13T03:53:10.875Z",
+  "subjects": [
+    {
+      "prefix": "ENC",
+      "name": "Writing",
+      "course_count": 19,
+      "section_count": 1218,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Compressed Developmental Writing II",
+        "Dev Reading &amp; Writing Combined",
+        "Developmental Writing I",
+        "Developmental Writing I and II Combined",
+        "ENC 1102 - Written Communication II"
+      ]
+    },
+    {
+      "prefix": "BSC",
+      "name": "Biology",
+      "course_count": 55,
+      "section_count": 965,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "BASIC ANATOMY/PHYS",
+        "BIOLOGICAL ISSUES",
+        "Biological Principles for Non-Majors",
+        "Biological Science Combined",
+        "Biology for Science Majors I"
+      ]
+    },
+    {
+      "prefix": "MAC",
+      "name": "MAC",
+      "course_count": 13,
+      "section_count": 729,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Analytic Geometry &amp; Calculus I",
+        "Calc/Analytic Geometry I Honor",
+        "Calculus for Business and Social Science I",
+        "Calculus with Analytic Geometry II",
+        "Calculus with Analytic Geometry III"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 145,
+      "section_count": 584,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Adult Health Nursing II",
+        "Adult Health Nursing III",
+        "Adult Health Nursing IV",
+        "Adult I Nursing (Generic)",
+        "Adult I Nursing Clinical (Generic)"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 13,
+      "section_count": 526,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Compressed Developmental Mathematics I",
+        "Compressed Developmental Mathematics II",
+        "Developmental Arithmetic with Algebra",
+        "Developmental Math Combined",
+        "Developmental Math I"
+      ]
+    },
+    {
+      "prefix": "POS",
+      "name": "Government",
+      "course_count": 8,
+      "section_count": 434,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "American National Government",
+        "Government and the Media",
+        "HONORS AMERICAN GOVERNMENT",
+        "Honors American National Government",
+        "Introduction to Political Science"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 9,
+      "section_count": 429,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "20th &amp; 21st Century HUM Honors",
+        "Greek &amp;Roman Humanities Honors",
+        "Humanities: Contemp Perspectiv",
+        "Humanities: The Ancient World to the Middle Ages",
+        "Humanities: The Renaissance to the Modern Day"
+      ]
+    },
+    {
+      "prefix": "AMH",
+      "name": "History",
+      "course_count": 7,
+      "section_count": 378,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Contemporary United States History",
+        "History of the United States to 1876",
+        "History of the United States, Since 1877",
+        "Introductory Survey Since 1877",
+        "Introductory Survey to 1877"
+      ]
+    },
+    {
+      "prefix": "SPC",
+      "name": "Speech",
+      "course_count": 9,
+      "section_count": 373,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Fundamentals of Speech Communication",
+        "Fundamentals of Speech- Honors",
+        "Group Discussion",
+        "Interpersonal Comm - Honors",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "CGS",
+      "name": "CGS",
+      "course_count": 32,
+      "section_count": 360,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Microcomputer Applications",
+        "Computer Fundamentals",
+        "Computer Fundamentals and Appl",
+        "Computer Information Systems",
+        "Database Design &amp; Implmntn"
+      ]
+    },
+    {
+      "prefix": "MGF",
+      "name": "Mathematical",
+      "course_count": 6,
+      "section_count": 344,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro to Mathematical Thinking",
+        "Liberal Arts Mathematics I",
+        "Liberal Arts Mathematics II",
+        "Mathematical Thinking",
+        "Mathematical Thinking - Honors"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 26,
+      "section_count": 317,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Chemistry for Health Sciences",
+        "Gen Chem Qual Analysis II",
+        "Gen Chem with Qual Analysis I",
+        "General Chemistry and Qualitative Analysis",
+        "General Chemistry and Qualitative Analysis I"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 6,
+      "section_count": 288,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Honors General Psychology",
+        "Intern Expl in Psychology",
+        "Introduction to Psychology",
+        "Positive Psychology",
+        "Survey of Forensic Psychology"
+      ]
+    },
+    {
+      "prefix": "STA",
+      "name": "Statistics",
+      "course_count": 3,
+      "section_count": 277,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Introduction to Probability and Statistics I",
+        "Pathway to Statistics",
+        "Statistical Methods - Honors"
+      ]
+    },
+    {
+      "prefix": "SLS",
+      "name": "SLS",
+      "course_count": 19,
+      "section_count": 273,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Acad Pathways College Success",
+        "Career Enhancement",
+        "Career Exploration",
+        "Career Exploration and Develop",
+        "Career Planning"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 7,
+      "section_count": 269,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Financial Literacy",
+        "Internship Explor in Economics",
+        "Prin of Economics-Macro-Honors",
+        "Prin of Economics-Micro-Honors",
+        "Principles of Economics, Macro"
+      ]
+    },
+    {
+      "prefix": "GEB",
+      "name": "Business",
+      "course_count": 32,
+      "section_count": 243,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Applied Business Technologies",
+        "BAS Foundations",
+        "Bus. Presntns &amp; Comm",
+        "Business Admin Capstone",
+        "Business Communication for Professional Effectiveness"
+      ]
+    },
+    {
+      "prefix": "CJK",
+      "name": "CJK",
+      "course_count": 46,
+      "section_count": 234,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "CMS Criminal Justice Defensive Tactics",
+        "CMS First Aid for Criminal Justice Officers",
+        "CMS LE Vehicle Operations",
+        "Communications",
+        "Communications for Correctional Officers"
+      ]
+    },
+    {
+      "prefix": "HSC",
+      "name": "HSC",
+      "course_count": 34,
+      "section_count": 229,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "BASIC PRIN DISEASE",
+        "Care For An Aging Population",
+        "Community Health Problems",
+        "Emergency First Aid &amp; CPR",
+        "Epidemiology"
+      ]
+    },
+    {
+      "prefix": "MAN",
+      "name": "Management",
+      "course_count": 50,
+      "section_count": 220,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Acquisitions Management",
+        "Applied Concept Human Resource",
+        "Applied Mgmt. Concepts",
+        "Applied Organizational Behavior",
+        "Capstone Project in Supervision and Management"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 80,
+      "section_count": 217,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Advanced Clinical Internship",
+        "Advanced Medical Life Support",
+        "Anatomy for Paramedics",
+        "Aquatic First Aid/CPR/02"
+      ]
+    },
+    {
+      "prefix": "ACG",
+      "name": "Accounting",
+      "course_count": 16,
+      "section_count": 179,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Accounting Capstone",
+        "Accounting for Managers and Investors (Non-Majors)",
+        "Accounting for the Microcomputer",
+        "Acctg: Conc &amp; Pract",
+        "ACG 2021 - Principles of Financial Accounting"
+      ]
+    },
+    {
+      "prefix": "MCB",
+      "name": "Microbiology",
+      "course_count": 6,
+      "section_count": 175,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Directed Independent Research",
+        "Microbiology",
+        "Microbiology Allied Health",
+        "Microbiology Laboratory"
+      ]
+    },
+    {
+      "prefix": "COP",
+      "name": "Programming",
+      "course_count": 44,
+      "section_count": 171,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Java Programming",
+        "Advanced Programming Techniques",
+        "Applied Data Structs and Algs",
+        "Basic Web Page Programming",
+        "C Programming"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 13,
+      "section_count": 165,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "Elementary Spanish I Lab",
+        "Elementary Spanish II",
+        "Elementary Spanish II Lab",
+        "FIRST YR SPAN II"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 9,
+      "section_count": 161,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Biomedical Ethics",
+        "Ethics and Critical Thinking",
+        "Ethics Critical Think - Honors",
+        "Ethics of Technology",
+        "Intro to Philosophical Reasoni"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 22,
+      "section_count": 154,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Basic Concepts of Physics",
+        "Coll Physics II w Algebra Trig",
+        "College Physics I",
+        "College Physics I Laboratory",
+        "Fundamentals of Physics"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 26,
+      "section_count": 151,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Beginning Ceramics",
+        "Ceramics II",
+        "Ceramics Wheel Throwing",
+        "Color Fundamentals",
+        "Digital Imaging I"
+      ]
+    },
+    {
+      "prefix": "DEP",
+      "name": "Psychology",
+      "course_count": 8,
+      "section_count": 130,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Adolescent Psychology",
+        "Child Growth and Development",
+        "Child Psychology",
+        "Develop Psychology Honors",
+        "Human Development"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "CET",
+      "course_count": 44,
+      "section_count": 129,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Administering Windows Server",
+        "Advanced Cybersec Operations",
+        "Advanced Network Security",
+        "Advanced Programming Apps",
+        "CCNA1 Introduction to Networks"
+      ]
+    },
+    {
+      "prefix": "ARH",
+      "name": "History",
+      "course_count": 9,
+      "section_count": 124,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Art Appreciation and Introduction to Visual Arts",
+        "Art History: Modern Art",
+        "Art History: Prehistoric through Renaissance",
+        "History of Architecture",
+        "History of Art, Ancient to Renaissance"
+      ]
+    },
+    {
+      "prefix": "EAP",
+      "name": "EAP",
+      "course_count": 28,
+      "section_count": 123,
+      "colleges": [
+        "gulfcoast",
+        "polk",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Composition for ELL",
+        "Advanced Reading for ELL",
+        "English for Academic Purposes: Reading 6",
+        "English for Academic Purposes: Writing 6",
+        "ESL GRAMMAR II"
+      ]
+    },
+    {
+      "prefix": "HUN",
+      "name": "Nutrition",
+      "course_count": 11,
+      "section_count": 122,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Basics of Personal Nutrition",
+        "Cultural Nutrition and Health",
+        "Essentials of Human Nutrition",
+        "Food and Culture",
+        "Healthy Cuisine and Nutrition"
+      ]
+    },
+    {
+      "prefix": "PMT",
+      "name": "Welder",
+      "course_count": 49,
+      "section_count": 120,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "nwfsc",
+        "phsc"
+      ],
+      "sample_titles": [
+        "Advanced Shielded Metal/Arc Welding of Pipe",
+        "Advanced SMAW",
+        "Advanced Welder 1: GTAW Pipe I",
+        "Advanced Welder 1: GTAW Pipe II",
+        "Advanced Welder 1: SMAW Pipe I"
+      ]
+    },
+    {
+      "prefix": "RTE",
+      "name": "RTE",
+      "course_count": 61,
+      "section_count": 113,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Administration and Supervision",
+        "Advanced Imaging Modalities",
+        "Advanced MRI Procedures",
+        "Advanced Patient Care",
+        "Anatomy for the Medical Imager"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "LIT",
+      "course_count": 13,
+      "section_count": 112,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Contemporary Literature",
+        "Horror Fantasy &amp; Science Fict",
+        "Intro. Children&#39;s Literature",
+        "INTRODUCTION TO LIT",
+        "Introduction to Literature:The Gothic Imagination"
+      ]
+    },
+    {
+      "prefix": "CCJ",
+      "name": "CCJ",
+      "course_count": 33,
+      "section_count": 103,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Capstone Experience in Criminal Justice",
+        "CAPSTONE: CRIM JUS",
+        "Contemp Issues in Crim Justice",
+        "Crime and Public Policy",
+        "Crime and the Media"
+      ]
+    },
+    {
+      "prefix": "GRA",
+      "name": "GRA",
+      "course_count": 45,
+      "section_count": 101,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Computer Graphics",
+        "Advanced Graphic Design I",
+        "Advanced Graphic Design II",
+        "Advanced Interactive Design I",
+        "Business/Ethics of Graph Desig"
+      ]
+    },
+    {
+      "prefix": "CTS",
+      "name": "CTS",
+      "course_count": 44,
+      "section_count": 99,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "A+ Hardware",
+        "Advanced Router Technology (CISCO-CCNA)",
+        "Cloud Essentials",
+        "Cloud Services",
+        "Computer &amp; Network Security (Security +)"
+      ]
+    },
+    {
+      "prefix": "EEC",
+      "name": "EEC",
+      "course_count": 51,
+      "section_count": 89,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Art, Music, Movement",
+        "Child Nutrition Hlth &amp; Safety",
+        "Child, Family, &amp; Comm Partner",
+        "Curriculum Activities in Early Childhood (Child Dev.)",
+        "Curriculum Programs-Preschool"
+      ]
+    },
+    {
+      "prefix": "FSS",
+      "name": "FSS",
+      "course_count": 49,
+      "section_count": 89,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Cake Decorating",
+        "Applied Techniques in Food Service",
+        "Baking and Pastries I",
+        "Baking and Pastries II",
+        "Baking Ingredients &amp; Tech"
+      ]
+    },
+    {
+      "prefix": "DIG",
+      "name": "Digital",
+      "course_count": 45,
+      "section_count": 88,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "3D Character Animation",
+        "Adv Digital Video and Sound",
+        "Advanced Motion Graphics",
+        "Advanced Videography",
+        "AI for Game Development"
+      ]
+    },
+    {
+      "prefix": "EVR",
+      "name": "Environmental",
+      "course_count": 7,
+      "section_count": 88,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Environmental Studies Practicum",
+        "Honors Introduction to Environmental Science",
+        "Intro to Environ Science + Lab",
+        "Introduction to Environmental Science",
+        "Introduction to Environmental Science Lab"
+      ]
+    },
+    {
+      "prefix": "SYG",
+      "name": "SYG",
+      "course_count": 7,
+      "section_count": 88,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Contemporary Social Problems",
+        "Deviant Behavior",
+        "INTRO SOC PSYCHOLOGY",
+        "Introduction to Sociology",
+        "Marriage and the Family"
+      ]
+    },
+    {
+      "prefix": "ESC",
+      "name": "Earth",
+      "course_count": 3,
+      "section_count": 86,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Earth and Space Science",
+        "Earth and Space Science Survey",
+        "Introduction to Earth Science"
+      ]
+    },
+    {
+      "prefix": "HFT",
+      "name": "HFT",
+      "course_count": 30,
+      "section_count": 83,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Banquet and Convention Management",
+        "Beer Wine and Bev Essentials",
+        "Beverage Mngmnt and Service",
+        "Convention Service and Management",
+        "Convention Services"
+      ]
+    },
+    {
+      "prefix": "EDF",
+      "name": "EDF",
+      "course_count": 20,
+      "section_count": 82,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Analysis and Application of Ethical, Legal, and Safety Issues in Schools",
+        "Arts Wellness Elementary Class",
+        "Assessment of Learning and Beh",
+        "Child &amp; Adolescent Dev for Ed",
+        "Children in Schools: Legal"
+      ]
+    },
+    {
+      "prefix": "MUL",
+      "name": "Music",
+      "course_count": 4,
+      "section_count": 81,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Hist and Apprec of Jazz and Ro",
+        "Music Appreciation",
+        "Music Appreciation - Fine and Performing Arts Department",
+        "Popular &amp; Jazz Music America"
+      ]
+    },
+    {
+      "prefix": "PLA",
+      "name": "PLA",
+      "course_count": 37,
+      "section_count": 80,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Civil Litigation",
+        "Advanced Real Property",
+        "Capstone: Internship in Paralegal/Legal Assisting",
+        "Case Management for Paralegals",
+        "Certified Paralegal Exam Revie"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "Sign",
+      "course_count": 14,
+      "section_count": 79,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "1st and 2nd Lang Acquis ASL",
+        "American Sign Lang. I Lab",
+        "American Sign Lang. II Lab",
+        "American Sign Language I",
+        "American Sign Language II"
+      ]
+    },
+    {
+      "prefix": "AER",
+      "name": "Automotive",
+      "course_count": 20,
+      "section_count": 76,
+      "colleges": [
+        "fgc",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Automotive Cooperative Education 1",
+        "Automotive Cooperative Education 2",
+        "Automotive Heating and Air Conditioning",
+        "Automotive Heating and Air Conditioning Lab",
+        "Co-op Work Experience in Automotive Services"
+      ]
+    },
+    {
+      "prefix": "DRV",
+      "name": "Sdapp",
+      "course_count": 4,
+      "section_count": 70,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "ADAPT",
+        "SDAPP - COURT ORDERED",
+        "SDAPP - ELECTIVE",
+        "SDAPP - TCAC"
+      ]
+    },
+    {
+      "prefix": "FFP",
+      "name": "Fire",
+      "course_count": 27,
+      "section_count": 68,
+      "colleges": [
+        "gulfcoast",
+        "scf",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Apparatus Operations",
+        "Bldg Cnstrctn for Fire Service",
+        "Blueprint Reading and Plans Re",
+        "Company Officer",
+        "Ethic/Legal Fire Service"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "Conditioning",
+      "course_count": 33,
+      "section_count": 67,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Air Conditioning I",
+        "Air Conditioning II",
+        "Air Conditioning III",
+        "Air Conditioning Internship I",
+        "Air Conditioning Internship II"
+      ]
+    },
+    {
+      "prefix": "HSA",
+      "name": "Health",
+      "course_count": 32,
+      "section_count": 67,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Capstone: Health Care Management",
+        "Current Issues in Health",
+        "Current Trends/Contemporary Issues in Healthcare",
+        "Health Care Delivery",
+        "HEALTH CARE DELIVERY IN THE UNITED STATES"
+      ]
+    },
+    {
+      "prefix": "DEH",
+      "name": "Dental",
+      "course_count": 28,
+      "section_count": 66,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Clin Dental Hygiene II Lab",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Community Dental Health",
+        "Community Dental Health I"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 35,
+      "section_count": 65,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "CAPSTONE EXP: BIT",
+        "Cloud Administrator Essentials",
+        "Cloud Data Analytics Essential",
+        "Cloud Developer Essentials",
+        "Cloud Management and Design"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 10,
+      "section_count": 64,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Business Finance",
+        "Financial &amp; Econ. Managemnt",
+        "Financial Management",
+        "FINANCIAL MANAGEMENT",
+        "International Finance"
+      ]
+    },
+    {
+      "prefix": "OST",
+      "name": "OST",
+      "course_count": 29,
+      "section_count": 64,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Business Communication",
+        "Business Communications",
+        "Customer Relations",
+        "Desktop Publishing",
+        "Document Formatting and Keyboarding"
+      ]
+    },
+    {
+      "prefix": "ETP",
+      "name": "ETP",
+      "course_count": 26,
+      "section_count": 63,
+      "colleges": [
+        "cfk",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Basic Electricity for Line Basic Electricity for Lineworkers",
+        "Basic Electricity for Lineworkers Lab",
+        "Co-op Work Experience in Electrical Distribution",
+        "Electrical Distribution Structures",
+        "Electrical Distribution Structures Lab"
+      ]
+    },
+    {
+      "prefix": "MUM",
+      "name": "MUM",
+      "course_count": 24,
+      "section_count": 63,
+      "colleges": [
+        "nwfsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Adv. Music Studio Production",
+        "Audio &amp; Acoustic Fundamentals",
+        "Audio Systems Design",
+        "Business of Music",
+        "Business of Music II Entrepren"
+      ]
+    },
+    {
+      "prefix": "DAA",
+      "name": "Dance",
+      "course_count": 47,
+      "section_count": 62,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Ballet I for Majors",
+        "Ballet II",
+        "Ballet II for Majors",
+        "Ballet III"
+      ]
+    },
+    {
+      "prefix": "TPA",
+      "name": "TPA",
+      "course_count": 35,
+      "section_count": 62,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Computer Asst Draft Entertain",
+        "Costume Design",
+        "Costume Pattern Drafting/Drap",
+        "Design Seminar",
+        "Drafting for the Theatre I"
+      ]
+    },
+    {
+      "prefix": "BUL",
+      "name": "Business",
+      "course_count": 10,
+      "section_count": 58,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Business Law I",
+        "Business Law II",
+        "Cyberlaw",
+        "EMPLOYMENT LAW",
+        "Law And Business"
+      ]
+    },
+    {
+      "prefix": "CJE",
+      "name": "CJE",
+      "course_count": 30,
+      "section_count": 58,
+      "colleges": [
+        "cfk",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "ADV CRIME SCENE INVE",
+        "Advanced Crime Scene Technology",
+        "Career Choice in Criminal Just",
+        "Comparative Criminal Justice Systems",
+        "Crime Analysis I"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 4,
+      "section_count": 58,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro to the New Testament",
+        "Introduction to Religion",
+        "Introduction to Religion in America",
+        "Introduction to World Religions"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 8,
+      "section_count": 58,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Honors Understanding Theatre",
+        "Introduction to Theater",
+        "Play Production",
+        "Script Analysis",
+        "Special Topics in Theatre"
+      ]
+    },
+    {
+      "prefix": "ARR",
+      "name": "Repair",
+      "course_count": 15,
+      "section_count": 57,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Advanced Painting Techniques",
+        "Advanced Painting Techniques Lab",
+        "Applied Techniques in Auto Body Repair",
+        "Applied Techniques in Auto Body Repair Lab",
+        "Auto Collision Repair and Refinishing Lab I"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 32,
+      "section_count": 57,
+      "colleges": [
+        "fgc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "ADV CODING APP",
+        "Adv. Coding &amp; Reimbursement",
+        "Advanced Medical Coding",
+        "Anatomy and Physiology",
+        "Basic CPT Coding"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 2,
+      "section_count": 55,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Introduction to Astronomy",
+        "Lab for Intro to Astronomy"
+      ]
+    },
+    {
+      "prefix": "STS",
+      "name": "Surgical",
+      "course_count": 32,
+      "section_count": 55,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Advanced Integrated Surgical Sciences",
+        "Advanced Surgical Procedures for the Surgical Assistant",
+        "Fundamentals of Surgical Technology",
+        "Introduction to Surgical Technology",
+        "Management in Healthcare"
+      ]
+    },
+    {
+      "prefix": "MAR",
+      "name": "Marketing",
+      "course_count": 13,
+      "section_count": 54,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Consumer Behavior",
+        "Entrepreneurial Marketing",
+        "International Marketing",
+        "Marketing &amp; Today&#39;s Job Mkt",
+        "Marketing for Managers"
+      ]
+    },
+    {
+      "prefix": "DES",
+      "name": "Dental",
+      "course_count": 28,
+      "section_count": 53,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Basic Communications and Human Relations",
+        "Dental Anatomy",
+        "Dental Materials",
+        "Dental Materials and Expanded Duties",
+        "Dental Materials and Expanded Duties Lab"
+      ]
+    },
+    {
+      "prefix": "BUZ",
+      "name": "BUZ",
+      "course_count": 4,
+      "section_count": 52,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "5 GENERATIONS IN THE WORKFORCE",
+        "LEADERSHIP HIGHLANDS Fall 2025",
+        "Lean Fundamentals Aug 8",
+        "Math Immersion / Mentorship"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Anthropology",
+      "course_count": 5,
+      "section_count": 50,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro to Cultural Anthropology",
+        "Introduction to Anthropology",
+        "Introduction to Archaeology",
+        "Introductory Anthropology Hon",
+        "Lost Tribes and Sunken Continents"
+      ]
+    },
+    {
+      "prefix": "MUN",
+      "name": "Ensemble",
+      "course_count": 37,
+      "section_count": 49,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Chamber Choir II",
+        "Chamber Choir III",
+        "Chamber Ensemble",
+        "College Orchestra I",
+        "College Orchestra II"
+      ]
+    },
+    {
+      "prefix": "MVV",
+      "name": "Voice",
+      "course_count": 15,
+      "section_count": 49,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "App Music Voice I",
+        "App Music Voice II",
+        "Applied IB - Voice",
+        "Applied IIB - Voice",
+        "Applied Major Voice II Lab"
+      ]
+    },
+    {
+      "prefix": "RET",
+      "name": "Care",
+      "course_count": 43,
+      "section_count": 49,
+      "colleges": [
+        "gulfcoast",
+        "polk",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Adv Respiratory Critical Care",
+        "Advan Cardiopul Critical Care",
+        "Advance Critical Care Capstone",
+        "Basic Physiology Monitoring",
+        "Cardiac Ultrasnd Clin Prac II"
+      ]
+    },
+    {
+      "prefix": "FIL",
+      "name": "Film",
+      "course_count": 15,
+      "section_count": 48,
+      "colleges": [
+        "polk",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Film Analysis and Critique",
+        "Film Camera Techniques",
+        "Film Crew Workshop",
+        "Film Gripping",
+        "Film Lighting"
+      ]
+    },
+    {
+      "prefix": "EEX",
+      "name": "EEX",
+      "course_count": 22,
+      "section_count": 45,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Assessment of All Young Children &amp; Field Experience",
+        "Behav Intv &amp; Pract in Exc Stdt",
+        "Behavior Management in Early Learning",
+        "Blending Early Childhood Methods &amp; Field Experience",
+        "Capstone Experience: Exceptional Student Education"
+      ]
+    },
+    {
+      "prefix": "MUT",
+      "name": "Music",
+      "course_count": 14,
+      "section_count": 45,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Ear Train &amp; Sight Sing I",
+        "Ear Train &amp; Sight Sing III",
+        "Ear Training and Sight Singing I",
+        "Ear Training and Sight Singing III",
+        "EAR TRAINING II"
+      ]
+    },
+    {
+      "prefix": "PEN",
+      "name": "Scuba",
+      "course_count": 5,
+      "section_count": 45,
+      "colleges": [
+        "cfk",
+        "gulfcoast"
+      ],
+      "sample_titles": [
+        "Advanced Diving Theory and Practice",
+        "Basic Scuba Diving",
+        "Fitness Swim",
+        "Scuba Equipment Maintenance and Repair",
+        "Water Aerobics"
+      ]
+    },
+    {
+      "prefix": "PHT",
+      "name": "PHT",
+      "course_count": 34,
+      "section_count": 45,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf"
+      ],
+      "sample_titles": [
+        "Advanced Rehab Concept PT Lab",
+        "Advanced Rehab Concepts in Physical Therapy",
+        "Advanced Rehab Concepts in PT",
+        "Appld Anat &amp; Kines Lab",
+        "Applied Anat and Kinesiology"
+      ]
+    },
+    {
+      "prefix": "EUH",
+      "name": "Western",
+      "course_count": 8,
+      "section_count": 44,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Ancient and Medieval West Civ",
+        "Ancient History I",
+        "History of World War II and the Holocaust",
+        "Modern Western Civ",
+        "Modern Western Civ - Honors"
+      ]
+    },
+    {
+      "prefix": "ETI",
+      "name": "ETI",
+      "course_count": 23,
+      "section_count": 43,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced CNC Machine Processes",
+        "Applied Mechanics",
+        "Applied Project Management",
+        "Cncpts Lean Manu &amp; Six Sigma",
+        "Co-op Education Training Assignment in Manufacturing"
+      ]
+    },
+    {
+      "prefix": "OCB",
+      "name": "Marine",
+      "course_count": 26,
+      "section_count": 43,
+      "colleges": [
+        "cfk",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Capstone Experience: Marine Resource Management",
+        "Coral Reef Biology and Management",
+        "Directed Individual Study",
+        "Diseases and Parasites in Marine Aquaculture",
+        "Diseases and Parasites in Marine Aquaculture Laboratory"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "EET",
+      "course_count": 17,
+      "section_count": 42,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Circuit Analysis",
+        "Electricity II - AC Circuits",
+        "Electronic Devices and Circuits",
+        "Electronics I",
+        "Electronics III"
+      ]
+    },
+    {
+      "prefix": "MEA",
+      "name": "Medical",
+      "course_count": 24,
+      "section_count": 42,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Admin Office Procedures",
+        "EKG Technician APCT",
+        "EKG Technician APCT Lab",
+        "Intro to Medical Assisting",
+        "Introduction to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "SON",
+      "name": "Sonography",
+      "course_count": 33,
+      "section_count": 42,
+      "colleges": [
+        "gulfcoast",
+        "polk",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography I",
+        "Abdominal Sonography I Lab",
+        "Abdominal Sonography II",
+        "ABDOMINAL SONOGRY I",
+        "Clinical Education I"
+      ]
+    },
+    {
+      "prefix": "PRN",
+      "name": "Nursing",
+      "course_count": 23,
+      "section_count": 39,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "phsc",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Body Structure and Function",
+        "Comprehensive Nursing and Transitional Skills A (Maternal-Child Nursing)",
+        "Comprehensive Nursing and Transitional Skills Clinical",
+        "Comprehensive Nursing and Transitional Skills Theory",
+        "Fundamentals of Nursing (PN)"
+      ]
+    },
+    {
+      "prefix": "CRW",
+      "name": "Writing",
+      "course_count": 8,
+      "section_count": 37,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Creative Writing and Adv Comp",
+        "Creative Writing I",
+        "Creative Writing II",
+        "Creative Writing III",
+        "Honors Creative Writing"
+      ]
+    },
+    {
+      "prefix": "MTE",
+      "name": "Marine",
+      "course_count": 22,
+      "section_count": 37,
+      "colleges": [
+        "cfk",
+        "gulfcoast"
+      ],
+      "sample_titles": [
+        "2 and 4 Cycle Outboard Repair and Maintenance",
+        "2&4 Cycle Outboard Theory",
+        "Applied Marine Electricity",
+        "Basic Seamanship",
+        "Coastal Navigation"
+      ]
+    },
+    {
+      "prefix": "MVW",
+      "name": "MVW",
+      "course_count": 25,
+      "section_count": 37,
+      "colleges": [
+        "gulfcoast",
+        "scf"
+      ],
+      "sample_titles": [
+        "App. Music Saxophone II",
+        "Applied I - Clarinet",
+        "Applied I - Flute",
+        "Applied IB - Clarinet",
+        "Applied IB - Flute"
+      ]
+    },
+    {
+      "prefix": "PAD",
+      "name": "Public",
+      "course_count": 20,
+      "section_count": 37,
+      "colleges": [
+        "phsc",
+        "polk",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Administrative Law",
+        "Applied Research Methods",
+        "Community Relations Theory and Practice",
+        "CONT ISS PUB SAFETY",
+        "Contemporary Issues In Public Safety/Homeland Security"
+      ]
+    },
+    {
+      "prefix": "RED",
+      "name": "Reading",
+      "course_count": 25,
+      "section_count": 37,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Basic Foundations of Reading",
+        "Diag/Instr Intervents in Read",
+        "Diagnosis &amp; Instr Interv Read",
+        "Diagnostic and Corrective Reading Strategies",
+        "Diagnostic and Instructional Interventions in Reading"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "Security",
+      "course_count": 12,
+      "section_count": 36,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Cloud Infrastructure Security",
+        "Cybercrime Investigation",
+        "Cybersecurity Operations",
+        "Enterprise Networking, Security and Automation (Cisco Academy)",
+        "Enterprise Security"
+      ]
+    },
+    {
+      "prefix": "MVK",
+      "name": "Piano",
+      "course_count": 17,
+      "section_count": 36,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Applied IIB - Piano",
+        "Applied Music - Piano I",
+        "Applied Music Piano IB",
+        "Applied Music: Piano",
+        "Applied Music: Piano Prep"
+      ]
+    },
+    {
+      "prefix": "MVS",
+      "name": "MVS",
+      "course_count": 32,
+      "section_count": 35,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Applied I - Cello",
+        "Applied I - String Bass",
+        "Applied I - Viola",
+        "Applied I - Violin",
+        "Applied IB - Cello"
+      ]
+    },
+    {
+      "prefix": "OCE",
+      "name": "Oceanography",
+      "course_count": 6,
+      "section_count": 35,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro to Oceanography-Honors",
+        "Introduction to Oceanography",
+        "Oceanography",
+        "OCEANOGRAPHY",
+        "Scientific Writing"
+      ]
+    },
+    {
+      "prefix": "TDR",
+      "name": "Drafting",
+      "course_count": 14,
+      "section_count": 34,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Advanced and Detail Drafting",
+        "Advanced and Detail Drafting Lab",
+        "Architectural Drafting",
+        "Architectural Drafting Lab",
+        "Civil Drafting"
+      ]
+    },
+    {
+      "prefix": "CJL",
+      "name": "Criminal",
+      "course_count": 11,
+      "section_count": 33,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "CONSTITUTIONAL LAW",
+        "Courts and the Criminal Justice System",
+        "CRIM EVIDNCE &amp; PROC",
+        "Criminal Evidence &amp; Procedure",
+        "Criminal Evidence and Proc"
+      ]
+    },
+    {
+      "prefix": "TDZ",
+      "name": "Class",
+      "course_count": 9,
+      "section_count": 33,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "CDL Class A: 20 hr",
+        "CDL Class A: 33-hr",
+        "CDL Class B-20hr",
+        "CDL Class B: 33-hr",
+        "CDL EXAM"
+      ]
+    },
+    {
+      "prefix": "AML",
+      "name": "Literature",
+      "course_count": 4,
+      "section_count": 32,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Amer Lit Colonial-Civil War",
+        "American Literature through the Civil War",
+        "American Literature: Reconstruction to Present",
+        "Florida Writers and Florida Literature"
+      ]
+    },
+    {
+      "prefix": "ASC",
+      "name": "ASC",
+      "course_count": 27,
+      "section_count": 32,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk"
+      ],
+      "sample_titles": [
+        "ADV/HI-ALT AERODYNMC",
+        "Advanced Unmanned Vehicle Systems Operations",
+        "Aerodynamics",
+        "AEROSPACE LAW/ETHICS",
+        "Aircraft Systems &amp; Components"
+      ]
+    },
+    {
+      "prefix": "INR",
+      "name": "International",
+      "course_count": 2,
+      "section_count": 32,
+      "colleges": [
+        "phsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "International Politics Honors",
+        "Introduction to International Relations"
+      ]
+    },
+    {
+      "prefix": "ETS",
+      "name": "ETS",
+      "course_count": 22,
+      "section_count": 31,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Automated Proc Controls",
+        "Automated Process and Control",
+        "Automated Process Control",
+        "Control Systems and Networking",
+        "Electro-Hydraulics &amp; Pneumatics"
+      ]
+    },
+    {
+      "prefix": "PGY",
+      "name": "Photography",
+      "course_count": 16,
+      "section_count": 31,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Underwater Photography",
+        "Commercial Photography",
+        "Creative Videomaking",
+        "Digital Photo I",
+        "Digital Photography"
+      ]
+    },
+    {
+      "prefix": "ETD",
+      "name": "ETD",
+      "course_count": 15,
+      "section_count": 30,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "3D Computer-Aided Drafting and",
+        "Advanced CADD",
+        "Architectural Drafting",
+        "Computer Aided Drafting II",
+        "Engineering Design CAD"
+      ]
+    },
+    {
+      "prefix": "CCZ",
+      "name": "Blscpr",
+      "course_count": 1,
+      "section_count": 29,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "BLS/CPR - Phlebotomy Students"
+      ]
+    },
+    {
+      "prefix": "CEN",
+      "name": "Software",
+      "course_count": 12,
+      "section_count": 29,
+      "colleges": [
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Advanced Database Development",
+        "Intern in Comp Tech &amp; Sftw Dev",
+        "Mobile Device Software Develop",
+        "Open Source Web Technologies",
+        "Sem in Advanced Software Dev"
+      ]
+    },
+    {
+      "prefix": "TPP",
+      "name": "TPP",
+      "course_count": 19,
+      "section_count": 29,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Acting for the Camera",
+        "Acting I",
+        "Acting II",
+        "Acting III",
+        "Audition Techniques"
+      ]
+    },
+    {
+      "prefix": "CED",
+      "name": "Yoga",
+      "course_count": 2,
+      "section_count": 27,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "LP History and Murals ArtLab27",
+        "YOGA"
+      ]
+    },
+    {
+      "prefix": "EDG",
+      "name": "EDG",
+      "course_count": 15,
+      "section_count": 27,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Class Mgmt,Safety, Law, Ethics",
+        "Classroom Management and Communication",
+        "Clsrm Mgmt, Sch Safe, Law&amp;Ethi",
+        "Curriculum &amp; Instruction",
+        "Experiential Learning in Educ"
+      ]
+    },
+    {
+      "prefix": "ETM",
+      "name": "ETM",
+      "course_count": 18,
+      "section_count": 27,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "polk",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Auto &amp; Control Des Thru Commis",
+        "Auto &amp; Controls Fundamentals",
+        "Auto and Controls Integration",
+        "Auto Electrical Systems &amp; Devi",
+        "Automated Building Operations"
+      ]
+    },
+    {
+      "prefix": "CLP",
+      "name": "Psychology",
+      "course_count": 3,
+      "section_count": 26,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Foundations of Abnormal Psychology",
+        "Psychology of Adjustment"
+      ]
+    },
+    {
+      "prefix": "HLP",
+      "name": "Concepts",
+      "course_count": 2,
+      "section_count": 26,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Concepts of Wellness",
+        "Fitnss and Wellnss for Life I"
+      ]
+    },
+    {
+      "prefix": "HUS",
+      "name": "HUS",
+      "course_count": 17,
+      "section_count": 26,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Admin in Human Services",
+        "Basic Counseling Skills",
+        "Capstone: Human Resources Management",
+        "Cognitive and Behavioral Thera",
+        "Current Issues in Mental Healt"
+      ]
+    },
+    {
+      "prefix": "MVB",
+      "name": "MVB",
+      "course_count": 24,
+      "section_count": 25,
+      "colleges": [
+        "gulfcoast",
+        "scf"
+      ],
+      "sample_titles": [
+        "Applied I - Euphonium",
+        "Applied I - Trombone",
+        "Applied I - Trumpet",
+        "Applied IB - Euphonium",
+        "Applied IB - Trombone"
+      ]
+    },
+    {
+      "prefix": "REA",
+      "name": "Reading",
+      "course_count": 6,
+      "section_count": 25,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Compressed Developmental Reading",
+        "Critical Reading Techniques",
+        "Developmental Reading I",
+        "Developmental Reading I and II Combined",
+        "Modularized Developmental Reading"
+      ]
+    },
+    {
+      "prefix": "WOH",
+      "name": "World",
+      "course_count": 4,
+      "section_count": 25,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "World Civ: Erly Hmns Thru expn",
+        "World Civ: Modn Per Ren to Prt",
+        "World History Since 1500",
+        "World History to 1500"
+      ]
+    },
+    {
+      "prefix": "XPS",
+      "name": "XPS",
+      "course_count": 15,
+      "section_count": 25,
+      "colleges": [
+        "gulfcoast"
+      ],
+      "sample_titles": [
+        "ACI Report Writing for Criminal Investigations",
+        "Breath Test Operator",
+        "Child Sex Crimes Investigation",
+        "CJSTC Vehicle Operation Instructor",
+        "Correctional Officer Proficiency Course (EOT)"
+      ]
+    },
+    {
+      "prefix": "BCA",
+      "name": "Electrical",
+      "course_count": 20,
+      "section_count": 24,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Electrical Internship I",
+        "Electrical Internship II",
+        "Electrical Internship III",
+        "Electrical Internship IV",
+        "Electrical Internship V"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "Occupational",
+      "course_count": 14,
+      "section_count": 24,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Occupational Business Communications",
+        "Occupational Customer Relations",
+        "Occupational Intermediate Keyboarding",
+        "Occupational Introduction to Business",
+        "Occupational Introductory Keyboarding"
+      ]
+    },
+    {
+      "prefix": "CAI",
+      "name": "CAI",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "nwfsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Artif. Intelligence Apps",
+        "Artif. Intelligence Ethics",
+        "Artif. Intelligence Thinking",
+        "Intro Practical Deep Learning",
+        "Intro Practical Machine Learn"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "Entrepreneurship",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Bld. &amp; Present a Bus. Plan",
+        "Bus. Operations Entrepreneurs",
+        "Digital Marketing",
+        "Entrepreneurship and Small Business Management",
+        "Introduction to Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "NCH",
+      "name": "Life",
+      "course_count": 1,
+      "section_count": 23,
+      "colleges": [
+        "phsc"
+      ],
+      "sample_titles": [
+        "Basic Life Support for Healthcare Providers"
+      ]
+    },
+    {
+      "prefix": "OTH",
+      "name": "OTH",
+      "course_count": 19,
+      "section_count": 23,
+      "colleges": [
+        "polk",
+        "scf"
+      ],
+      "sample_titles": [
+        "Intro to Occ Therapy Lab",
+        "Intro. to Occupational Therapy",
+        "Leadership &amp; Management",
+        "LEV II FLD/PHYDIS",
+        "LEV II FLD/PSYSO"
+      ]
+    },
+    {
+      "prefix": "ATF",
+      "name": "Flight",
+      "course_count": 16,
+      "section_count": 22,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "polk"
+      ],
+      "sample_titles": [
+        "ADV F.I.-INSTRUMENT",
+        "Certified Flight Instructor I",
+        "CMMRCL PILOT FLGHT",
+        "COMM. M.ENGINE ADD&#39;L",
+        "Commercial Flight I"
+      ]
+    },
+    {
+      "prefix": "BCN",
+      "name": "BCN",
+      "course_count": 14,
+      "section_count": 22,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "B.I.M. (REVIT with Dynamo)",
+        "Bldg Constr Material &amp; Methods",
+        "Blueprnt Read For Comm Const",
+        "Building Systems Management",
+        "Construction Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "BCZ",
+      "name": "Certified",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Basic Construction Carp./Roof.",
+        "Basic Construction Electrical",
+        "Certified Fiber Optics Special",
+        "Certified Fiber Optics Splicin",
+        "Certified Fiber Optics Technic"
+      ]
+    },
+    {
+      "prefix": "HCP",
+      "name": "Phlebotomy",
+      "course_count": 10,
+      "section_count": 22,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Basic Healthcare Worker",
+        "Career Transition APCT",
+        "Career Transition APCT Lab",
+        "Nursing Assistant (long-term)",
+        "Nursing Assistant APCT"
+      ]
+    },
+    {
+      "prefix": "PEL",
+      "name": "PEL",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Adv Bsktball/Men",
+        "Adv Bsktball/Women",
+        "Baseball II",
+        "Basketball I",
+        "Intercollegiate Baseball Workshop"
+      ]
+    },
+    {
+      "prefix": "PEM",
+      "name": "PEM",
+      "course_count": 16,
+      "section_count": 21,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "BASIC CONDITIONING",
+        "Circuit Training",
+        "Concepts of Life Fitness",
+        "Hlth Analysis &amp; Body Condition",
+        "Jogging and Distance Walking I"
+      ]
+    },
+    {
+      "prefix": "AVM",
+      "name": "AVM",
+      "course_count": 18,
+      "section_count": 20,
+      "colleges": [
+        "phsc",
+        "polk"
+      ],
+      "sample_titles": [
+        "AIR TRANSPRT SYS MGT",
+        "AIRLINE MANAGEMENT",
+        "AIRLINE OPERATIONS",
+        "AIRPORT MANAGEMENT",
+        "AIRPORT OPERATIONS"
+      ]
+    },
+    {
+      "prefix": "ENL",
+      "name": "ENL",
+      "course_count": 3,
+      "section_count": 20,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "British Literature:The Middle Ages through Late 17th Century",
+        "English Lit: Rom Period to Prs",
+        "Introduction to Shakespeare"
+      ]
+    },
+    {
+      "prefix": "ATT",
+      "name": "Pilot",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "phsc",
+        "polk"
+      ],
+      "sample_titles": [
+        "Advanced Aircraft Turbo-Prop &amp; Turbine Operations",
+        "Certified Flight Instructor Gr",
+        "Commercial Pilot Ground School",
+        "FUND. OF AV.INSTRCTN",
+        "INSTRMNT PILOT GRND"
+      ]
+    },
+    {
+      "prefix": "MNA",
+      "name": "MNA",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Case Studies in HR Mgmt",
+        "Compensation and Benefts Sys",
+        "Customer Service",
+        "HR Recruitment, Sel &amp; Staffing",
+        "Human Res: Emp Rel &amp; Regs"
+      ]
+    },
+    {
+      "prefix": "REE",
+      "name": "Property",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "phsc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Florida Real Estate Law",
+        "Intro to Property Management",
+        "Leasing and Marketing",
+        "Mngmnt of Specialized Housing",
+        "Property Management Law"
+      ]
+    },
+    {
+      "prefix": "ATR",
+      "name": "Automotive",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "gulfcoast"
+      ],
+      "sample_titles": [
+        "Circuit Training",
+        "Fitness Swim/Areob",
+        "Low/Moderate Impact Strength Training",
+        "Pilates",
+        "Yoga"
+      ]
+    },
+    {
+      "prefix": "EGN",
+      "name": "Engineering",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "gulfcoast",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Computation and Programming",
+        "Engineering &amp; Tech Calculus I",
+        "Engineering &amp; Tech Calculus II",
+        "Engineering Analysis",
+        "Engineering Analysis-Dynamics"
+      ]
+    },
+    {
+      "prefix": "LDR",
+      "name": "Leadership",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "phsc",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Change Leadership",
+        "Contemporary Issues in Leadership",
+        "Introduction to Leadership",
+        "Negotiating Conflict",
+        "Teamwork Collab Group Dynamics"
+      ]
+    },
+    {
+      "prefix": "TSL",
+      "name": "Esol",
+      "course_count": 10,
+      "section_count": 18,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "ESOL Issues and Strategies",
+        "ESOL Methods Curric &amp; Assessmn",
+        "ESOL Methods, Curriculum and Assessment",
+        "Foundations of ESOL-Second Language Acquisition",
+        "Methods of Teaching and Assessing ESOL Students"
+      ]
+    },
+    {
+      "prefix": "CJC",
+      "name": "CJC",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "phsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Administration of Correctional Institutions",
+        "American Corrections",
+        "CORRECTIONS/PENOLOGY",
+        "Criminal Behavior",
+        "Introduction to Corrections"
+      ]
+    },
+    {
+      "prefix": "EPI",
+      "name": "EPI",
+      "course_count": 13,
+      "section_count": 17,
+      "colleges": [
+        "phsc",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Assessing Teaching &amp; Learning",
+        "Assessment and Differentiated Instruction in Reading",
+        "Classroom Management",
+        "Field Experience",
+        "Field Experience I"
+      ]
+    },
+    {
+      "prefix": "ISM",
+      "name": "ISM",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Agile Project Managment",
+        "Cybersecurity Analytics",
+        "Cybersecurity Fundamentals",
+        "Data Mgmt. &amp; Analytics",
+        "Database Design &amp; Admin"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "nwfsc",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Basic Concepts of Phlebotomy",
+        "Clinical Chemistry II",
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Clinical Practicum III"
+      ]
+    },
+    {
+      "prefix": "TRA",
+      "name": "TRA",
+      "course_count": 3,
+      "section_count": 17,
+      "colleges": [
+        "fgc",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "CDL for Electrical Line Service",
+        "Intro to Supply Chain Manageme",
+        "Tractor Trailer Truck Driver"
+      ]
+    },
+    {
+      "prefix": "DEA",
+      "name": "DEA",
+      "course_count": 14,
+      "section_count": 16,
+      "colleges": [
+        "gulfcoast",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Allied Dental Theory",
+        "Clinical Practice I",
+        "Clinical Practice I Lab",
+        "Clinical Practice II",
+        "Clinical Practice II Lab"
+      ]
+    },
+    {
+      "prefix": "FRE",
+      "name": "French",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "nwfsc",
+        "scf",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Elementary French I Lab",
+        "Elementary French II"
+      ]
+    },
+    {
+      "prefix": "MAP",
+      "name": "Differential",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Elementary Differential Equats"
+      ]
+    },
+    {
+      "prefix": "MTB",
+      "name": "Mathematics",
+      "course_count": 4,
+      "section_count": 16,
+      "colleges": [
+        "gulfcoast",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Business Mathematics",
+        "Math for Health-Related Professions",
+        "Mathematics for Engin Tech",
+        "Technical Mathematics"
+      ]
+    },
+    {
+      "prefix": "ARC",
+      "name": "ARC",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "gulfcoast",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Architectural Design 1",
+        "Architectural Design II",
+        "Architectural Design III",
+        "COOP/Work Experience/Architecture",
+        "Intro to Digital Architecture"
+      ]
+    },
+    {
+      "prefix": "DSC",
+      "name": "Security",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "gulfcoast",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "FOUND PUBLIC SAFETY",
+        "Global Terrorism",
+        "Industrial Security",
+        "Intel Analysis and Security",
+        "Intro. to Homeland Security"
+      ]
+    },
+    {
+      "prefix": "MMC",
+      "name": "Media",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Communications Law and Ethics",
+        "Data Literacy for Communicator",
+        "Mass Communications",
+        "Mass Media",
+        "Media Convergence"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "gulfcoast",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Music Technology",
+        "Special Prob in Musical Theate",
+        "Student Recital",
+        "Student Recital Attendance"
+      ]
+    },
+    {
+      "prefix": "EME",
+      "name": "Technology",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "cfk",
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Integrating Technology in the Classroom",
+        "Introduction to Technology for Educators"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "COS",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "fgc",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Chemical Hair Restructuring I",
+        "Cosmetology Concepts I",
+        "Cosmetology Concepts II",
+        "Cosmetology Concepts III",
+        "Hair Coloring Bleaching I"
+      ]
+    },
+    {
+      "prefix": "GLY",
+      "name": "Geology",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "phsc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "Introduction to Geology",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "LIS",
+      "name": "LIS",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "scf",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Introduction to Information Literacy",
+        "Library Skills",
+        "Research Strategies for College Students"
+      ]
+    },
+    {
+      "prefix": "TIZ",
+      "name": "Msha",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "MSHA REFRESHER",
+        "NEW MINER TRAINING"
+      ]
+    },
+    {
+      "prefix": "PCB",
+      "name": "Biology",
+      "course_count": 7,
+      "section_count": 11,
+      "colleges": [
+        "cfk",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Cell Biology",
+        "Ecology",
+        "Environmental Biology",
+        "Introduction to Ecology: Environment",
+        "Lab for Cell Biology"
+      ]
+    },
+    {
+      "prefix": "SBM",
+      "name": "Small",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "fgc",
+        "nwfsc",
+        "polk",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Small Business Management"
+      ]
+    },
+    {
+      "prefix": "VLZ",
+      "name": "VLZ",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "BREATH TEST BASIC OPERATORS",
+        "Building/Maintain Behaviors",
+        "CHILD ABUSE INVESTIGATIONS",
+        "CMS INSTRUCTOR TECHNIQUES",
+        "DISCIPLINE/SPEC CONFINEMENT"
+      ]
+    },
+    {
+      "prefix": "CHD",
+      "name": "Child Development",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "fgc",
+        "polk"
+      ],
+      "sample_titles": [
+        "CHILD GRTH/DEVEL",
+        "EARLY CHILD CURR",
+        "EARLY LEARNING PRACT",
+        "FACILITATE DEVELOPMT",
+        "Motor Development and Play"
+      ]
+    },
+    {
+      "prefix": "CJJ",
+      "name": "Juvenile",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "gulfcoast",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro to Juvenile Procedure",
+        "Juvenile Delinquency &amp; Rehab",
+        "Juvenile Justice",
+        "Social Problems of Youth"
+      ]
+    },
+    {
+      "prefix": "FFZ",
+      "name": "Fire",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "COMPANY OFFICER",
+        "Fire Apparatus Operations",
+        "FIRE SERVICE COURSE",
+        "Special Topics Fire Sci"
+      ]
+    },
+    {
+      "prefix": "MKA",
+      "name": "MKA",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "cfk",
+        "phsc",
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Principles of Advertising",
+        "Principles Of Selling",
+        "Retailing",
+        "The Business of Diving"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Maint",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Aviation Maint Tech Airfrme IV",
+        "Aviation Maint Tech Gen I",
+        "Aviation Maint Tech Gen II",
+        "Aviation Maint Tech Gen III",
+        "Aviation Maint Tech Gen IV"
+      ]
+    },
+    {
+      "prefix": "APA",
+      "name": "Accounting",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "College Accounting",
+        "Computerized Accounting Applic",
+        "Introduction to Accounting",
+        "Payroll Accounting"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "Plant",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "fgc",
+        "gulfcoast",
+        "nwfsc",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Botany",
+        "Plant Biology",
+        "Plant Diversity",
+        "Plants and Society",
+        "Principles of Plant Growth"
+      ]
+    },
+    {
+      "prefix": "EDE",
+      "name": "EDE",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "fgc",
+        "nwfsc",
+        "polk",
+        "scf"
+      ],
+      "sample_titles": [
+        "Engineering for Elementary Learners",
+        "Final Intern: Elementary Ed",
+        "Integ Language Arts, SSI, Lit",
+        "Integ Practicum: Elem Ed",
+        "Integrate Art Music &amp; Phys. Ed"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Film as Narrative Art",
+        "IND STUDY - ENC1101",
+        "Literature and Film",
+        "World Cinema"
+      ]
+    },
+    {
+      "prefix": "FOS",
+      "name": "Food",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "nwfsc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Food Service Sanitation and Safety"
+      ]
+    },
+    {
+      "prefix": "MVP",
+      "name": "Percussion",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "scf"
+      ],
+      "sample_titles": [
+        "Applied I - Percussion",
+        "Applied IB - Percussion",
+        "Applied II - Percussion",
+        "Applied IIB - Percussion",
+        "Applied Music Percussion I"
+      ]
+    },
+    {
+      "prefix": "CAP",
+      "name": "Data",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "polk",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "DATA MINING",
+        "DATA WAREHSE DSGN/CR",
+        "Game Design I",
+        "Human-Computer Interaction",
+        "Machine Learning Essentials"
+      ]
+    },
+    {
+      "prefix": "IDH",
+      "name": "IDH",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "gulfcoast",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Honors Research",
+        "Honors Research Process",
+        "Honors Symposium",
+        "Interdisciplinary Honors BioArt I",
+        "MOLECULAR BIO 21st CENTURY"
+      ]
+    },
+    {
+      "prefix": "LAE",
+      "name": "Language",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Children&#39;s Literature",
+        "Language Arts in the Elementary School",
+        "Teaching Language Arts",
+        "Writng Across the Curriculum"
+      ]
+    },
+    {
+      "prefix": "TAX",
+      "name": "Indv",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "gulfcoast",
+        "phsc",
+        "scf",
+        "sjrstate",
+        "southflorida",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Federal Income Tax",
+        "Principles of Taxation I",
+        "Small Business &amp; Indv Taxes",
+        "Tax Indv &amp; Small Businesses"
+      ]
+    },
+    {
+      "prefix": "WLZ",
+      "name": "Welding",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Advanced Welding",
+        "Principles &amp; Practices Welding"
+      ]
+    },
+    {
+      "prefix": "ACZ",
+      "name": "Test",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "EPA TEST",
+        "FUNDAMENTALS AIR CONDITIONING"
+      ]
+    },
+    {
+      "prefix": "CVT",
+      "name": "Cardio",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "phsc",
+        "polk"
+      ],
+      "sample_titles": [
+        "Basic Arrhythmias",
+        "CARDIO III PRE-PRACT",
+        "CARDIO VI PRACTICUM",
+        "Cardiovascular Capstone &amp; Revi",
+        "INVASIVE CARDIO II"
+      ]
+    },
+    {
+      "prefix": "EMZ",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "EMERGENCY VEHICLE OPERATION",
+        "Special Topics EMS"
+      ]
+    },
+    {
+      "prefix": "GCO",
+      "name": "GCO",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "Golf and Landscape Irrigation",
+        "Integrated Pest Management I",
+        "Integrated Pest Management II",
+        "Materials Calculations",
+        "Turfgrass Science"
+      ]
+    },
+    {
+      "prefix": "ISC",
+      "name": "Diving",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "cfk",
+        "scf"
+      ],
+      "sample_titles": [
+        "Advanced Research Diving",
+        "Basic Research Diving",
+        "STEM Undergrad Research"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Meteorology",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "cfk",
+        "phsc"
+      ],
+      "sample_titles": [
+        "Introduction to Meteorology"
+      ]
+    },
+    {
+      "prefix": "MUC",
+      "name": "Composition",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Applied I - Composition",
+        "Applied IB - Composition",
+        "Applied II - Composition",
+        "Applied IIB - Composition",
+        "Composition And Songwriting"
+      ]
+    },
+    {
+      "prefix": "MUH",
+      "name": "Music",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "polk",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Folk/Trad Music of World Cult",
+        "History of Rock Music",
+        "Music History"
+      ]
+    },
+    {
+      "prefix": "PET",
+      "name": "Athletic",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "nwfsc",
+        "sjrstate",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Care &amp; Prev. of Athletic Inj",
+        "Care/Prev of Athletic Injuries",
+        "Intro Physical Education"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "fgc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Applied Agricultural Chemistry",
+        "Intro Vegetable Gardening",
+        "Introduction to Plant Science"
+      ]
+    },
+    {
+      "prefix": "QMB",
+      "name": "Methods",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "nwfsc",
+        "phsc",
+        "polk",
+        "scf"
+      ],
+      "sample_titles": [
+        "Business Mathematics",
+        "QUAN METHODS IN BUS",
+        "Quant Methods for Business"
+      ]
+    },
+    {
+      "prefix": "SCE",
+      "name": "SCE",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "fgc",
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "ADVD MTHDS TEACH SCI",
+        "Prin/Meth Scienc K-6",
+        "Teaching Science in Elementary School"
+      ]
+    },
+    {
+      "prefix": "TRZ",
+      "name": "Forklift",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "FORKLIFT TRAINING"
+      ]
+    },
+    {
+      "prefix": "VHZ",
+      "name": "Cert",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "CERT NURSING ASST INTRO HEALTH"
+      ]
+    },
+    {
+      "prefix": "EDP",
+      "name": "Educational",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Educational Psychology"
+      ]
+    },
+    {
+      "prefix": "GEA",
+      "name": "World",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "scf"
+      ],
+      "sample_titles": [
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Elementary German I",
+        "Elementary German I Lab",
+        "Elementary German ll"
+      ]
+    },
+    {
+      "prefix": "JOU",
+      "name": "Journalism",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "scf",
+        "valencia"
+      ],
+      "sample_titles": [
+        "College Magazine Production I",
+        "College Magazine Production II",
+        "Introduction to Journalism",
+        "News Reporting"
+      ]
+    },
+    {
+      "prefix": "LIN",
+      "name": "Languages",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Languages of the World",
+        "Writing &amp; Grammar"
+      ]
+    },
+    {
+      "prefix": "MAE",
+      "name": "Math",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "nwfsc",
+        "polk",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "How Children Learn Math",
+        "How Children Learn Mathematics",
+        "Prin Mthds Teachng Math K-6",
+        "Teaching Math in Elem School"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "SUR",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Basic Surveying Measurements",
+        "Hwy Drafting and Route Desgn",
+        "Intro to GIS"
+      ]
+    },
+    {
+      "prefix": "ABEX",
+      "name": "Adult",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "Adult Education Reasoning through Language Arts",
+        "Basic Adult Education Math I, II, III, & IV"
+      ]
+    },
+    {
+      "prefix": "AOM",
+      "name": "Sustainable",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro Sustainable Agriculture",
+        "Types and Systems of Agri Oper"
+      ]
+    },
+    {
+      "prefix": "BCT",
+      "name": "Construction",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Bldg Construction Estimating",
+        "Construction Estimating",
+        "Structural Systems in Const."
+      ]
+    },
+    {
+      "prefix": "CGZ",
+      "name": "Windows",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "INTRO MS EXCEL WINDOWS",
+        "INTRO MS WORD WINDOWS",
+        "INTRODUCTION TO POWER POINT"
+      ]
+    },
+    {
+      "prefix": "COT",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Foundations Discrete Math"
+      ]
+    },
+    {
+      "prefix": "CPO",
+      "name": "Comparative",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "gulfcoast",
+        "scf"
+      ],
+      "sample_titles": [
+        "Comparative Government"
+      ]
+    },
+    {
+      "prefix": "DAN",
+      "name": "Dance",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "nwfsc",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Dance Appreciation",
+        "Music for Dance",
+        "Survey of Dance"
+      ]
+    },
+    {
+      "prefix": "EGS",
+      "name": "Electrical",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Electrical Networks",
+        "Internship in Engineering",
+        "Prin Electrical Engineering"
+      ]
+    },
+    {
+      "prefix": "ENY",
+      "name": "Entomology",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Principles Of Entomology"
+      ]
+    },
+    {
+      "prefix": "GEDX",
+      "name": "Gedr",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "GED(r) Comprehensive Levels 5&6 Math",
+        "GED(r) Comprehensive RLA Reasoning through Language Arts"
+      ]
+    },
+    {
+      "prefix": "GEY",
+      "name": "Nutrition",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "scf"
+      ],
+      "sample_titles": [
+        "Communicating with Older Adult",
+        "Nutrition and Gerontology"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "cfk",
+        "gulfcoast",
+        "phsc"
+      ],
+      "sample_titles": [
+        "Fundamentals of Remote Sensing",
+        "Fundamentals Of Remote Sensing",
+        "Geographic Information Systems",
+        "Introduction to Geographic Information Systems"
+      ]
+    },
+    {
+      "prefix": "LAT",
+      "name": "Latin",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Elementary Latin I",
+        "Elementary Latin II"
+      ]
+    },
+    {
+      "prefix": "NSP",
+      "name": "Theory",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Nurs Care Military &amp; Veterans",
+        "Perioperative Nursing Theory",
+        "Registered Nurse First Assistant Theory",
+        "Registered Nurse First Assistant Theory Lab and Clinical"
+      ]
+    },
+    {
+      "prefix": "OCA",
+      "name": "Occupational",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Occupational Desktop Publishing with PowerPoint",
+        "Occupational Spreadsheet Applications",
+        "Occupational Word Processing MS Word"
+      ]
+    },
+    {
+      "prefix": "PHC",
+      "name": "Public",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Introduction to Public Health"
+      ]
+    },
+    {
+      "prefix": "WFHX",
+      "name": "Blshcp",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "CPR BLS/HCP"
+      ]
+    },
+    {
+      "prefix": "ARE",
+      "name": "Creativity",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Art and Creativity"
+      ]
+    },
+    {
+      "prefix": "CWZ",
+      "name": "Disaster",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Avon Park Chamber Lunch Learn",
+        "DISASTER PREPAREDNESS TRAINING"
+      ]
+    },
+    {
+      "prefix": "EOC",
+      "name": "EOC",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "cfk",
+        "phsc"
+      ],
+      "sample_titles": [
+        "Breathing Gases and Decompression Theory",
+        "Introduction to Unmanned Maritime Systems",
+        "Recompression Chamber Operations"
+      ]
+    },
+    {
+      "prefix": "ETC",
+      "name": "Materials",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Eng Materials and Processes",
+        "Hydraulics and Hydrology"
+      ]
+    },
+    {
+      "prefix": "FES",
+      "name": "Evolution",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "scf"
+      ],
+      "sample_titles": [
+        "Emerging Issues in Environmental Disaster Management",
+        "Evolution of Emergency Mgt"
+      ]
+    },
+    {
+      "prefix": "INP",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "polk",
+        "scf"
+      ],
+      "sample_titles": [
+        "HUMAN RELAT BUS-IN"
+      ]
+    },
+    {
+      "prefix": "PEO",
+      "name": "Sports",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "gulfcoast",
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Coaching Theory",
+        "Sports Officiating"
+      ]
+    },
+    {
+      "prefix": "PEQ",
+      "name": "Divemaster",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cfk"
+      ],
+      "sample_titles": [
+        "Divemaster",
+        "Scuba Instructor Training"
+      ]
+    },
+    {
+      "prefix": "RMI",
+      "name": "Insurance",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "phsc",
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Personal Insurance Planning",
+        "Principles of Insurance",
+        "Risk in Business &amp; Society"
+      ]
+    },
+    {
+      "prefix": "SCJX",
+      "name": "State",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "State Exam Review"
+      ]
+    },
+    {
+      "prefix": "SOP",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Human Sexuality"
+      ]
+    },
+    {
+      "prefix": "SSE",
+      "name": "Teaching",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "scf",
+        "sjrstate",
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Teaching Social Science in the Elementary School"
+      ]
+    },
+    {
+      "prefix": "SWS",
+      "name": "Soil",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "fgc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Soil Science",
+        "Soils and Fertilizers"
+      ]
+    },
+    {
+      "prefix": "TAR",
+      "name": "Residential",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "gulfcoast",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Architectural Drawing l",
+        "Residential Architectural Design",
+        "Residential Design Lab"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "Agriculture",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Co-op Education Training Assignment in Agriculture",
+        "Internship in Agriculture"
+      ]
+    },
+    {
+      "prefix": "BCH",
+      "name": "Biochemistry",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Biochemistry I",
+        "Lab for Biochemistry I"
+      ]
+    },
+    {
+      "prefix": "EDH",
+      "name": "College",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "phsc"
+      ],
+      "sample_titles": [
+        "Seminar in College Teaching and Learning",
+        "Seminar in Community and State Colleges in Higher Education"
+      ]
+    },
+    {
+      "prefix": "ETG",
+      "name": "Coopwork",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "gulfcoast"
+      ],
+      "sample_titles": [
+        "COOP/Work Experience/Engineering"
+      ]
+    },
+    {
+      "prefix": "EVS",
+      "name": "Environmental",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "Environmental Science Technology Practicum",
+        "Water Technologies"
+      ]
+    },
+    {
+      "prefix": "FAS",
+      "name": "Aquaculture",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "cfk"
+      ],
+      "sample_titles": [
+        "Aquaculture and Seafood Policy",
+        "Aquaculture Best Management Practices"
+      ]
+    },
+    {
+      "prefix": "ITA",
+      "name": "Italian",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "scf"
+      ],
+      "sample_titles": [
+        "Elementary Italian I",
+        "Elementary Italian I Lab"
+      ]
+    },
+    {
+      "prefix": "MUE",
+      "name": "Early",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Early Child Music and Movement"
+      ]
+    },
+    {
+      "prefix": "ORH",
+      "name": "Landscape",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "fgc",
+        "valencia"
+      ],
+      "sample_titles": [
+        "Landscape Plants",
+        "Nursery Operation and Mgmt"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "Physical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "fgc",
+        "polk"
+      ],
+      "sample_titles": [
+        "Physical Science",
+        "PHYSICAL SCIENCE"
+      ]
+    },
+    {
+      "prefix": "PUR",
+      "name": "Public",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intro to Public Relations"
+      ]
+    },
+    {
+      "prefix": "SCM",
+      "name": "Capstone",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "polk"
+      ],
+      "sample_titles": [
+        "INTRO TO SCM",
+        "SCM CAPSTONE"
+      ]
+    },
+    {
+      "prefix": "SOW",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "gulfcoast",
+        "scf"
+      ],
+      "sample_titles": [
+        "Intro to Social Work",
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "SPM",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "scf",
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Introduction to Sports Managem"
+      ]
+    },
+    {
+      "prefix": "VCZ",
+      "name": "Middle",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "CRIMES AGAINST CHILDREN",
+        "MIDDLE MANAGEMENT"
+      ]
+    },
+    {
+      "prefix": "ACO",
+      "name": "Payroll",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Payroll Accounting"
+      ]
+    },
+    {
+      "prefix": "BAN",
+      "name": "Banking",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Principles of Banking"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Intern New Media Communication"
+      ]
+    },
+    {
+      "prefix": "ECP",
+      "name": "Economic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "scf"
+      ],
+      "sample_titles": [
+        "Economic Prob &amp; Policy"
+      ]
+    },
+    {
+      "prefix": "IDS",
+      "name": "Explorations",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "sjrstate"
+      ],
+      "sample_titles": [
+        "Honors Explorations"
+      ]
+    },
+    {
+      "prefix": "IPM",
+      "name": "Principle",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Principle Integrated Pest Man"
+      ]
+    },
+    {
+      "prefix": "LAH",
+      "name": "Latin",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "scf"
+      ],
+      "sample_titles": [
+        "Latin American History"
+      ]
+    },
+    {
+      "prefix": "LDE",
+      "name": "Landscape",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southflorida"
+      ],
+      "sample_titles": [
+        "Landscape Design"
+      ]
+    },
+    {
+      "prefix": "LEI",
+      "name": "Outdoor",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Outdoor Recreation Management"
+      ]
+    },
+    {
+      "prefix": "MUO",
+      "name": "Opera",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "valencia"
+      ],
+      "sample_titles": [
+        "Opera &amp; Music Theatre Workshop"
+      ]
+    },
+    {
+      "prefix": "PPE",
+      "name": "Personality",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "polk"
+      ],
+      "sample_titles": [
+        "PERSONALITY THEORIES"
+      ]
+    },
+    {
+      "prefix": "RTV",
+      "name": "Television",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "scf"
+      ],
+      "sample_titles": [
+        "Intro to Television Production"
+      ]
+    },
+    {
+      "prefix": "WFTX",
+      "name": "Welding",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "fgc"
+      ],
+      "sample_titles": [
+        "Welding Fundamentals"
+      ]
+    },
+    {
+      "prefix": "XSB",
+      "name": "Entrepreneurship",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "nwfsc"
+      ],
+      "sample_titles": [
+        "Entrepreneurship &amp; Small Business"
+      ]
+    },
+    {
+      "prefix": "ZOO",
+      "name": "Fisheries",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cfk"
+      ],
+      "sample_titles": [
+        "Fisheries Management"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/ia/subject-vocab.json
+++ b/data/ia/subject-vocab.json
@@ -1,0 +1,1659 @@
+{
+  "state": "ia",
+  "generated_at": "2026-05-13T03:53:10.889Z",
+  "subjects": [
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 15,
+      "section_count": 338,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Essen of Anatomy & Physiology",
+        "General Biology I",
+        "General Biology IA",
+        "General Biology II",
+        "General Biology IIA"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 7,
+      "section_count": 314,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "ALP Writing",
+        "Comp I: Technical Writing",
+        "Composition I",
+        "Composition I Success",
+        "Composition II"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 29,
+      "section_count": 292,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Algebra I",
+        "Algebra II",
+        "Applied Math",
+        "Applied Math Topics",
+        "Business & Financial Math"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 15,
+      "section_count": 219,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adolescent Psychology",
+        "Child and Adolescent Psycholog",
+        "Developmental Psychology",
+        "Educational Psychology"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 15,
+      "section_count": 203,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Classical Physics I",
+        "Classical Physics I Lab",
+        "Classical Physics II",
+        "Classical Physics II Lab",
+        "College Physics I"
+      ]
+    },
+    {
+      "prefix": "SPC",
+      "name": "Speech",
+      "course_count": 6,
+      "section_count": 156,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Comm for Hlth Cr Professionals",
+        "Fundamentals of Oral Communica",
+        "Intercultural Communications",
+        "Interpersonal Communication",
+        "Professional Communications"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 51,
+      "section_count": 132,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Audio Engineering Internship",
+        "Audio Mastering",
+        "Audio Mixing I",
+        "Audio Mixing II",
+        "Chamber Choir I"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 12,
+      "section_count": 127,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Criminology",
+        "Human Sexuality",
+        "Intro to Social Work",
+        "Introduction to Sociology",
+        "Juvenile Delinquency"
+      ]
+    },
+    {
+      "prefix": "WEL",
+      "name": "Welding",
+      "course_count": 16,
+      "section_count": 125,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "FCAW-Flux & Cutting",
+        "Fund / Shielded Metal Arc Weld",
+        "Gas Metal Arc Welding",
+        "Gas Tungsten Arc Welding",
+        "GMAW-MIG"
+      ]
+    },
+    {
+      "prefix": "HSC",
+      "name": "HSC",
+      "course_count": 5,
+      "section_count": 112,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "A & P for Allied Hlth Programs",
+        "Math for Healthcare",
+        "Medical Terminology",
+        "Nurse Aide",
+        "Sterile Processing Fund"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 15,
+      "section_count": 106,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Ethics",
+        "Business Law I",
+        "Business Math and Calculators",
+        "Business Statistics"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 12,
+      "section_count": 94,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "African American History",
+        "Contemporary World Affairs",
+        "Nazi Germany",
+        "The '60's & the Vietnam War",
+        "U.S. History Since 1877"
+      ]
+    },
+    {
+      "prefix": "PNN",
+      "name": "Nursing",
+      "course_count": 12,
+      "section_count": 94,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Foundation Nursing Clinical II",
+        "Foundations Nursing Clinical I",
+        "Foundations of Nursing I",
+        "Foundations of Nursing II",
+        "Health Concepts I"
+      ]
+    },
+    {
+      "prefix": "ADN",
+      "name": "Nursing",
+      "course_count": 14,
+      "section_count": 90,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Adv Concepts in Mental Health",
+        "Advanced Concepts of Nursing",
+        "Advanced Mental Health Nursing",
+        "Advd Concepts Nursing Clinical",
+        "Complex Health Concepts"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 26,
+      "section_count": 87,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Employee Comp/Benefits Mgmt",
+        "Employee Evaluation/Training",
+        "Human Resource Mgmt",
+        "Independent Study",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "NET",
+      "name": "NET",
+      "course_count": 29,
+      "section_count": 87,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Applied Computer Security",
+        "Cisco Packet Tracer",
+        "Cloud Infrastructure",
+        "Cloud Systems Administration",
+        "Computer Internship"
+      ]
+    },
+    {
+      "prefix": "HCM",
+      "name": "HCM",
+      "course_count": 46,
+      "section_count": 83,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "A la Carte Cooking",
+        "A la Carte Cooking Lab",
+        "Advanced Baking",
+        "Advanced Food Preparation",
+        "Basic Food Prep (Lec/Lab)"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 11,
+      "section_count": 79,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "General Chemistry I",
+        "General Chemistry II",
+        "Intro to Chemistry",
+        "Intro to General Chemistry",
+        "Intro to Organic and Biochem"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 17,
+      "section_count": 77,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "2-D Design",
+        "3-D Design",
+        "Art Appreciation",
+        "Art History I",
+        "Art History II"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 38,
+      "section_count": 77,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        ".NET Development II",
+        "Adv. Client-Side Scripting",
+        "AI Fundamentals",
+        "Assessments and Audits",
+        "Boundary Protection"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 9,
+      "section_count": 75,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "CNC Milling Operator",
+        "CNC Project",
+        "CNC Turning Operator",
+        "Lean Manufacturing"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 29,
+      "section_count": 74,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Advcd Auto Engine & Elec Diagn",
+        "Auto & Diesel Fuel Systems",
+        "Auto Brake Systems & Service",
+        "Auto Engine Perform III",
+        "Auto Engine Repair & Rebuild"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 9,
+      "section_count": 68,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Children's Literature",
+        "Educational Psychology",
+        "Exceptional Learner",
+        "Field Experience & Seminar",
+        "Foundations of Education"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 19,
+      "section_count": 67,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Constitutional Crim Procedure",
+        "Criminal Investigation",
+        "Criminal Justice Job Shadow",
+        "Criminal Law",
+        "Criminalistics"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 14,
+      "section_count": 65,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Computer Account - QuickBooks",
+        "Computer Accounting",
+        "Cost Accounting",
+        "Financial Accounting",
+        "Gov & Non-Profit Accounting"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 5,
+      "section_count": 64,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Ethics in Business",
+        "Ethics in the Media",
+        "Intro to Logic",
+        "Introduction to Ethics",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 4,
+      "section_count": 63,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Information Computing",
+        "Intro to Computers",
+        "Intro to Informatn Technology",
+        "Operating Systems"
+      ]
+    },
+    {
+      "prefix": "AGV",
+      "name": "AGV",
+      "course_count": 39,
+      "section_count": 62,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Animal Anat & Physiology II",
+        "Animal Anatomy & Physiology I",
+        "Animal Nutrition",
+        "Avian,Exotic,Lab Animal Care",
+        "Canine and Feline Behavior"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 17,
+      "section_count": 53,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Art & Music for Young Children",
+        "Child Growth & Development",
+        "Child Health, Safety, and Nutr",
+        "Communication With Families",
+        "Early Child Field Experience"
+      ]
+    },
+    {
+      "prefix": "DEA",
+      "name": "Dental",
+      "course_count": 27,
+      "section_count": 49,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Dental Assisting Clinic I",
+        "Dental Assisting Clinic II",
+        "Dental Assisting Experience I",
+        "Dental Assisting Experience II",
+        "Dental Assisting Principles"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "ECN",
+      "course_count": 3,
+      "section_count": 49,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Economics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 8,
+      "section_count": 49,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "American Film",
+        "Changes & Choices",
+        "Humanities of the Early World",
+        "Humanities of the Modern World",
+        "Humanities of the Renaissance"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 9,
+      "section_count": 41,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "African American Literature",
+        "American Lit Since Mid-1800s",
+        "Contemporary Literature",
+        "Film as Literature",
+        "Introduction to Literature"
+      ]
+    },
+    {
+      "prefix": "MMS",
+      "name": "Media",
+      "course_count": 30,
+      "section_count": 41,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Audio Production",
+        "Advanced Video Production I",
+        "Audio Production",
+        "Broadcast Promotions",
+        "Broadcstng & Streaming Online"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 18,
+      "section_count": 40,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Coding",
+        "Allied Health Statistics",
+        "Career Seminar",
+        "CPT Coding",
+        "Health Informatics"
+      ]
+    },
+    {
+      "prefix": "MUA",
+      "name": "Voice",
+      "course_count": 9,
+      "section_count": 39,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Applied Piano",
+        "Applied Piano I",
+        "Applied Piano II",
+        "Applied Piano III",
+        "Applied Voice"
+      ]
+    },
+    {
+      "prefix": "DSL",
+      "name": "DSL",
+      "course_count": 28,
+      "section_count": 36,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning/Refrigeration",
+        "Automatic Drive Train",
+        "Chassis/Drive Line",
+        "Cooperative Experience",
+        "Diesel Engine Repair"
+      ]
+    },
+    {
+      "prefix": "HCR",
+      "name": "HCR",
+      "course_count": 20,
+      "section_count": 36,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Adv Domestic Heating and AC",
+        "Air Balancing",
+        "App Pract II Advcd Repair/Ser",
+        "App Practices III: Installatn",
+        "Appl Pract I: Repair & Service"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 5,
+      "section_count": 35,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "American National Government",
+        "American State and Local Govt",
+        "Comparative Govt & Politics",
+        "Honors Study",
+        "International Relations"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 18,
+      "section_count": 35,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Education III",
+        "Clinical Education IV",
+        "Clinical Education V"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 2,
+      "section_count": 33,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Conservation Biology",
+        "Environmental Science"
+      ]
+    },
+    {
+      "prefix": "AGA",
+      "name": "AGA",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Corn and Soybean Prod",
+        "Crop Development, Prod, & Mgmt",
+        "Crop Protection",
+        "Fertilizers",
+        "Forage Production"
+      ]
+    },
+    {
+      "prefix": "DRA",
+      "name": "Theatre",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Busn of Being Perfrming Artist",
+        "History of Musical Theater",
+        "Intro to Film"
+      ]
+    },
+    {
+      "prefix": "MAP",
+      "name": "Medical",
+      "course_count": 15,
+      "section_count": 31,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Admin Medical Office Procedure",
+        "Advanced Med Office Procedures",
+        "Basics of Pharmacology",
+        "Clinical Procedures I",
+        "Clinical Procedures II"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 18,
+      "section_count": 30,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Pediatric Life Suppo",
+        "Basic Cardiac Life Sup Instruc",
+        "Emerg Med Tech II Clinical",
+        "Emergency Medical Tech I",
+        "Emergency Medical Tech II"
+      ]
+    },
+    {
+      "prefix": "CON",
+      "name": "Construction",
+      "course_count": 17,
+      "section_count": 29,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Reading",
+        "Building Construction Tech I",
+        "Building Construction Tech II",
+        "Commercial Print Reading",
+        "Construction Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "FLS",
+      "name": "Spanish",
+      "course_count": 5,
+      "section_count": 29,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Intermediate Spanish I",
+        "Intermediate Spanish II"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 9,
+      "section_count": 28,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Customer Service",
+        "Customer Service Strategies",
+        "International Marketing",
+        "Marketing Internship I",
+        "Merchandising"
+      ]
+    },
+    {
+      "prefix": "AGB",
+      "name": "AGB",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Ag Law, Taxation & Records",
+        "Agribusiness Internship I",
+        "Agricultural Finance",
+        "Agricultural Law",
+        "Agricultural Selling"
+      ]
+    },
+    {
+      "prefix": "DHY",
+      "name": "Dental",
+      "course_count": 25,
+      "section_count": 27,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Biomaterials Dental Hygienist",
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Clinical Dental Hygiene IV"
+      ]
+    },
+    {
+      "prefix": "ITP",
+      "name": "Information Technology Programming",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Comparative Discourse Analysis",
+        "Deaf Studies",
+        "Eng Vocab-Grammar/Intrprtrs",
+        "Interpreter Certification Prep",
+        "Interpreting Skills Lab I"
+      ]
+    },
+    {
+      "prefix": "SDV",
+      "name": "Student Development",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "College Success Skills - ELL",
+        "Critical & Creative Thinking",
+        "Honors Colloquium",
+        "Strategies for Acad Success"
+      ]
+    },
+    {
+      "prefix": "CIM",
+      "name": "CIM",
+      "course_count": 9,
+      "section_count": 24,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Abstracting Prin & Practice II",
+        "Abstracting Prin & Practices I",
+        "Cancer Pathophysiology",
+        "Cancer Stats & Epidemiology",
+        "CIM Capstone"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 16,
+      "section_count": 23,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Adv Programmable Logic Control",
+        "Advncd Programmable Logic Cont",
+        "Circuit Analysis I",
+        "Digital Circuits I"
+      ]
+    },
+    {
+      "prefix": "PEC",
+      "name": "Sports",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Sports Medicine",
+        "Introduction to Coaching",
+        "Sports Officiating",
+        "Theory & Princ of Rec Sport"
+      ]
+    },
+    {
+      "prefix": "ELE",
+      "name": "Electrical",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Fundamentals",
+        "Advanced Wiring Systems",
+        "Basic Electrical Principles",
+        "Basics of Wiring",
+        "DC Fundamentals"
+      ]
+    },
+    {
+      "prefix": "PEH",
+      "name": "PEH",
+      "course_count": 5,
+      "section_count": 20,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "First Aid",
+        "Health",
+        "Personal Wellness",
+        "Principles of Weight Training",
+        "Sports Nutrition"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "Physical",
+      "course_count": 5,
+      "section_count": 19,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Exploring Physical Science",
+        "Introduction to Earth Science",
+        "Meteorology, Weather & Climate",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 1,
+      "section_count": 19,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Survey of World Religions"
+      ]
+    },
+    {
+      "prefix": "WBL",
+      "name": "WBL",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Internship: AFNR",
+        "Internship: Human Services",
+        "Internship: Indust Tech",
+        "Practicum/Field Exp: Indus Tec"
+      ]
+    },
+    {
+      "prefix": "AGS",
+      "name": "AGS",
+      "course_count": 8,
+      "section_count": 17,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Animal Science",
+        "Beef Cattle Science",
+        "Beef Production",
+        "Genetics",
+        "Prin of Animal Nutrition"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 9,
+      "section_count": 17,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language I Lab",
+        "American Sign Language II",
+        "American Sign Language II Lab",
+        "American Sign Language III"
+      ]
+    },
+    {
+      "prefix": "IND",
+      "name": "IND",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Equipment Safety & Operation",
+        "Intro to Process Control",
+        "Mechanical Drives I",
+        "Mechatronics",
+        "Print Reading"
+      ]
+    },
+    {
+      "prefix": "AVR",
+      "name": "AVR",
+      "course_count": 10,
+      "section_count": 16,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "3D Modeling and Animation I",
+        "3D Modeling and Animation II",
+        "Applied Interactive Projects",
+        "AR & XR Development",
+        "AVR Portfolio Prep I"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 2,
+      "section_count": 16,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Communication Skills",
+        "Intro to Mass Media"
+      ]
+    },
+    {
+      "prefix": "ATR",
+      "name": "Automotive",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Fluid Power Systems",
+        "Industrial Robotics",
+        "Intermediate Robotics",
+        "Intro to Industrial Robotics"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 8,
+      "section_count": 15,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "3D Scanning",
+        "Design for AM",
+        "Intermediate 3D Printing",
+        "Introduction to CAD/CAM",
+        "Parametric Modeling III"
+      ]
+    },
+    {
+      "prefix": "GLS",
+      "name": "Contemporary",
+      "course_count": 1,
+      "section_count": 15,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Contemporary World Issues"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surgical",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Adv Concepts in Surgical Tech",
+        "Advanced Surgical Technology",
+        "Basic Surgical Principles",
+        "Clinical I",
+        "Clinical II"
+      ]
+    },
+    {
+      "prefix": "ADI",
+      "name": "Sonography",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography I",
+        "Cardiac Sono Clinical Educ. I",
+        "Cardiac Sonography I",
+        "Sect Anatomy for Diag Img",
+        "Sono Clinic Practicum V"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Anthropology",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Cultural Anthropology",
+        "Introduction to Anthropology"
+      ]
+    },
+    {
+      "prefix": "HSV",
+      "name": "HSV",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Agency & Community Resources",
+        "Counseling Techniques",
+        "Ethics of Human Service Prof",
+        "Fundamentals of Case Mgmt",
+        "Group Counseling Techniques"
+      ]
+    },
+    {
+      "prefix": "ADM",
+      "name": "ADM",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Business English",
+        "Career Capstone",
+        "Keyboarding and Doc Production",
+        "Records Management",
+        "Transcription"
+      ]
+    },
+    {
+      "prefix": "AVM",
+      "name": "Aviation",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Aviation Airframe I",
+        "Aviation Airframe II",
+        "Aviation Airframe III",
+        "Aviation Airframe IV",
+        "Aviation Mechanics General I"
+      ]
+    },
+    {
+      "prefix": "BCA",
+      "name": "Computer",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Computer Business Applications",
+        "Computer Fund for Technicians",
+        "Desktop Publishing",
+        "Integrated Computer Bus Apps"
+      ]
+    },
+    {
+      "prefix": "CNS",
+      "name": "CNS",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Conservation",
+        "Employment Experience",
+        "Fisheries Management",
+        "Occupations in Conservation",
+        "Wilderness Experience"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Corporate Finance",
+        "Personal Finance"
+      ]
+    },
+    {
+      "prefix": "AGC",
+      "name": "AGC",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Ag Computers",
+        "Seminar I",
+        "Seminar II"
+      ]
+    },
+    {
+      "prefix": "AGH",
+      "name": "AGH",
+      "course_count": 7,
+      "section_count": 8,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Equipment Repair",
+        "Horticulture Pest Management",
+        "Intro to Turfgrass Mgt",
+        "Landscape Construction",
+        "Landscape Maintenance"
+      ]
+    },
+    {
+      "prefix": "EGT",
+      "name": "Engineering Technology",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Fluid Power Fundamentals",
+        "Fluid Power Troubleshooting"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "GRA",
+      "name": "GRA",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Photography",
+        "Audio/Video Production Basics",
+        "Computer Literacy",
+        "Digital Color Theory",
+        "Digital Photography"
+      ]
+    },
+    {
+      "prefix": "PET",
+      "name": "PET",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Care & Prev Athletic Injuries",
+        "Personal Trainer",
+        "Taping and Bracing"
+      ]
+    },
+    {
+      "prefix": "PLU",
+      "name": "Plumbing",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Applied Plumbing Practices",
+        "Commercial Code",
+        "Commercial Plumbing Lab",
+        "Pipefitting for Maint Trades",
+        "Plan & Prnt Rding for Plumbing"
+      ]
+    },
+    {
+      "prefix": "GRT",
+      "name": "GRT",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Calc & Measurements for GA",
+        "Color Correction",
+        "Intro to GA Technology",
+        "Issues in Graphic Arts Tech",
+        "Packaging Design"
+      ]
+    },
+    {
+      "prefix": "HSE",
+      "name": "HSE",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Air and Water Quality",
+        "Contingency Plan/Incident Mgmt",
+        "Hazardous Mat Health Effects",
+        "Industrial Hygiene",
+        "Legal Asp-Occ Safety & Health"
+      ]
+    },
+    {
+      "prefix": "WDV",
+      "name": "WDV",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Content Management Systems I",
+        "Intro HTML and CSS",
+        "Mobile Application Development",
+        "Mobile Web Apps",
+        "Social Media Branding"
+      ]
+    },
+    {
+      "prefix": "DAN",
+      "name": "Dance",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Dance I",
+        "Dance II",
+        "Dance III",
+        "Hip Hop and Modern Dance"
+      ]
+    },
+    {
+      "prefix": "DAT",
+      "name": "Data",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Data Analytics Capstone",
+        "Data Analytics I",
+        "Data Analytics II",
+        "Introduction to Data Analytics"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "Indesign",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Illustrator",
+        "InDesign I",
+        "Indesign II",
+        "Photoshop"
+      ]
+    },
+    {
+      "prefix": "HON",
+      "name": "HON",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Honors Independent Study",
+        "Honors Service Learning",
+        "Intro to Honors"
+      ]
+    },
+    {
+      "prefix": "JOU",
+      "name": "Journalism",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Ethics in the Media",
+        "Intro to Mass Media"
+      ]
+    },
+    {
+      "prefix": "PEV",
+      "name": "Varsity",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Prog Resistance Training I",
+        "Varsity Sports Participation I"
+      ]
+    },
+    {
+      "prefix": "AGP",
+      "name": "Precision",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Precision Agricultural Apps",
+        "Precision Farming Systems"
+      ]
+    },
+    {
+      "prefix": "CFR",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro to Computer Forensics"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "eastern-iowa-community-college-district",
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Engineering I",
+        "Engineering II",
+        "Statics"
+      ]
+    },
+    {
+      "prefix": "FIR",
+      "name": "FIR",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Firefighter I",
+        "Hydraulics & Pumping Appl",
+        "Strategy & Tactics"
+      ]
+    },
+    {
+      "prefix": "MIL",
+      "name": "MIL",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Dept of the AF Professionalsm",
+        "Leadership Laboratory",
+        "Team & Leadrshp Fundamentals I"
+      ]
+    },
+    {
+      "prefix": "PEA",
+      "name": "Speed",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Speed & Conditioning I"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "English Lang Learner Comm Succ"
+      ]
+    },
+    {
+      "prefix": "CSP",
+      "name": "Infection",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Infection Cntrl/Health Reg"
+      ]
+    },
+    {
+      "prefix": "ESP",
+      "name": "Gaming",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Gaming Studies"
+      ]
+    },
+    {
+      "prefix": "FLF",
+      "name": "French",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Elementary French I"
+      ]
+    },
+    {
+      "prefix": "FLG",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "eastern-iowa-community-college-district"
+      ],
+      "sample_titles": [
+        "Intermediate German I"
+      ]
+    },
+    {
+      "prefix": "SER",
+      "name": "Advcd",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "iowa-western-community-college"
+      ],
+      "sample_titles": [
+        "Advcd Solar Engy: Photovoltaic"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/ky/subject-vocab.json
+++ b/data/ky/subject-vocab.json
@@ -1,0 +1,3814 @@
+{
+  "state": "ky",
+  "generated_at": "2026-05-13T03:53:10.965Z",
+  "subjects": [
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 31,
+      "section_count": 2543,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aspects of Human Biology",
+        "Basic Anatomy/Physiology w/Lab",
+        "Biology I",
+        "Biology II",
+        "Biology Laboratory I"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 32,
+      "section_count": 1937,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Mathematics",
+        "Brief Calculus w/ Applications",
+        "Business Mathematics",
+        "Calculus I",
+        "Calculus II"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 24,
+      "section_count": 1660,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Business Writing",
+        "Creative Writ: Short Story Wor",
+        "Creative Writing: (Sub Req)",
+        "English Workshop",
+        "Greek & Roman Myth. in Trans."
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 70,
+      "section_count": 1128,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "3D Animation for Video Games",
+        "3D Modeling for Video Games",
+        "Administering Windows Server",
+        "Adv Data Organization Software",
+        "Advanced Productivity Software"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 35,
+      "section_count": 1112,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Welding A",
+        "Basic Welding B",
+        "Blueprint Reading for Welding",
+        "Blueprint Reading/Welding Lab",
+        "Cooperative Education Program"
+      ]
+    },
+    {
+      "prefix": "NSG",
+      "name": "Nursing",
+      "course_count": 16,
+      "section_count": 1053,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Behavioral Health Nursing",
+        "Bridge to Nursing",
+        "Maternal Newborn Nursing",
+        "Medical Surgical Nursing I",
+        "Medical Surgical Nursing II"
+      ]
+    },
+    {
+      "prefix": "NAA",
+      "name": "Nursing",
+      "course_count": 2,
+      "section_count": 1016,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Nursing Assistant II",
+        "Nursing Assistant Skills I"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "EET",
+      "course_count": 49,
+      "section_count": 1014,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Alt Enr Photo and Wind Ele Gen",
+        "Basic Electricity",
+        "Cooperative Education Program",
+        "Electrical Construction",
+        "Electrical Construction I"
+      ]
+    },
+    {
+      "prefix": "BAS",
+      "name": "BAS",
+      "course_count": 24,
+      "section_count": 836,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Management Skills",
+        "Business Employability Seminar",
+        "Business Internship",
+        "Customer Svc Improvement Skill",
+        "Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 10,
+      "section_count": 708,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Appl Statistics in Psychology",
+        "General Psychology",
+        "Human Potential",
+        "Human Relations",
+        "Lifespan Psychology"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 9,
+      "section_count": 665,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Public Speaking",
+        "Business and Professional Comm",
+        "Communication in Small Group",
+        "Intercollegiate Debating",
+        "Intro to Communications"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 20,
+      "section_count": 654,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "African American Hist to 1865",
+        "African-Amer Hist 1865-Present",
+        "Hist Persp Prisons Police Work",
+        "History Europe Post-17th Cent.",
+        "History Europe to Mid-17th Cen"
+      ]
+    },
+    {
+      "prefix": "ACR",
+      "name": "ACR",
+      "course_count": 29,
+      "section_count": 511,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Boilers",
+        "Building Controls I",
+        "Building Controls II",
+        "Chillers",
+        "Commercial HVAC Systems"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "Success",
+      "course_count": 4,
+      "section_count": 487,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Achieving Academic Success",
+        "First Year Experience and Appl",
+        "Orientation to College",
+        "Strategies for College Success"
+      ]
+    },
+    {
+      "prefix": "IMT",
+      "name": "IMT",
+      "course_count": 32,
+      "section_count": 470,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "5S",
+        "Adv Prog Logic Controllers Lab",
+        "Advanced Program Logic Control",
+        "IMT Cooperative Education",
+        "Indus Maint Elect Motors I Lab"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 18,
+      "section_count": 434,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Chemistry in Society",
+        "Chemistry in Society Lab",
+        "Gen College Chemistry Lab I",
+        "General College Chem Lab II",
+        "General College Chemistry I"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 19,
+      "section_count": 422,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Fluid Power",
+        "Basic Digital and Devices",
+        "Basic Telecomm Install & Maint",
+        "Blueprint Reading",
+        "Circuits I"
+      ]
+    },
+    {
+      "prefix": "MVC",
+      "name": "Metroversity",
+      "course_count": 2,
+      "section_count": 411,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Metroversity Topics"
+      ]
+    },
+    {
+      "prefix": "NPN",
+      "name": "Nursing",
+      "course_count": 14,
+      "section_count": 371,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Childbearing Family",
+        "Clinical Practicum",
+        "Fundamentals of Nursing Care",
+        "Intro to Health Deviation",
+        "Introduction to Pharmacology"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 26,
+      "section_count": 341,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Firearms Less Lethan Weapn",
+        "Comm Correct:Probatns & Parole",
+        "Criminal Courtroom Procedures",
+        "Criminal Investigations",
+        "Criminal Justice Capstone"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 36,
+      "section_count": 325,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adv EMT (AEMT) Laboratory Skil",
+        "Advanced EMT",
+        "Cardiac and Trauma Lab",
+        "Cardiovascular Emergencies",
+        "Clinical Experience I"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 26,
+      "section_count": 323,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "2-Dimensional Design",
+        "3-Dimensional Design",
+        "African American Art",
+        "Ancient Through Mediev Art His",
+        "Ceramics I"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 7,
+      "section_count": 318,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Deviant Behavior",
+        "Inequality in Society",
+        "Intro to Sociology",
+        "Media, Society, and Culture",
+        "Modern Social Problems"
+      ]
+    },
+    {
+      "prefix": "CMM",
+      "name": "CMM",
+      "course_count": 26,
+      "section_count": 305,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adv 3D Code Seq/Macro Sys",
+        "Adv Industrial Machining II",
+        "Advance Industrial Machining I",
+        "Advanced Industrial Machining",
+        "Applied Machining"
+      ]
+    },
+    {
+      "prefix": "MIT",
+      "name": "Medical",
+      "course_count": 16,
+      "section_count": 305,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Coding Exam Preparation",
+        "Electronic Medical Records",
+        "Introduction to Medical Trans",
+        "Legal Issues in Med Info Manag"
+      ]
+    },
+    {
+      "prefix": "ADX",
+      "name": "ADX",
+      "course_count": 8,
+      "section_count": 294,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Auto Electricity Lab",
+        "Basic Automotive Electricity",
+        "Climate Control",
+        "Climate Control Lab",
+        "Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 15,
+      "section_count": 291,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Physics",
+        "College Physics I",
+        "College Physics I Laboratory",
+        "College Physics II",
+        "College Physics II Laboratory"
+      ]
+    },
+    {
+      "prefix": "MAI",
+      "name": "Medical",
+      "course_count": 17,
+      "section_count": 286,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Admin Procedures for Med Assis",
+        "App Pharmacology for Med Assis",
+        "Dosage Calculations",
+        "Introduction Medical Assisting",
+        "Med Assist Lab & Clinic Pro II"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 19,
+      "section_count": 274,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Automat Transmis/Transaxle Lab",
+        "Automat Transmission/Transaxle",
+        "Basic Fuel & Ignition Sys",
+        "Basic Fuel & Ignition Sys Lab",
+        "Brake Systems"
+      ]
+    },
+    {
+      "prefix": "ATE",
+      "name": "Aircraft",
+      "course_count": 18,
+      "section_count": 270,
+      "colleges": [
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Powerplan Rel Sys III",
+        "Aircraft Powerplant Rel Sys II",
+        "Aircraft Powerplant Rel Sys IV",
+        "Aircraft Powerplant Rel Syst I",
+        "Aircraft Structures I"
+      ]
+    },
+    {
+      "prefix": "AHS",
+      "name": "AHS",
+      "course_count": 6,
+      "section_count": 265,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Diversity in Health Care",
+        "Human Growth and Development",
+        "Intro to Body Structure & Func",
+        "Intro to Health Occupations",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "IEC",
+      "name": "IEC",
+      "course_count": 16,
+      "section_count": 262,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Admin of Early Childhood Ed",
+        "Business Admin of ECE Programs",
+        "Child Guidance",
+        "Creative Expressions in IECE",
+        "Curriculum Design and Instruct"
+      ]
+    },
+    {
+      "prefix": "RCP",
+      "name": "RCP",
+      "course_count": 21,
+      "section_count": 247,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Advanced Cardiopulmonary Evalu",
+        "Advanced Diagnostic Procedures",
+        "Advanced Ventilatory Support",
+        "Cardiopulmonary Anatomy & Phy"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Clinical",
+      "course_count": 20,
+      "section_count": 239,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Chemistry",
+        "Clinical Chemistry I",
+        "Clinical Chemistry II",
+        "Clinical Diagnos Microbio II",
+        "Clinical Diagnostic Microbio I"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 17,
+      "section_count": 226,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Dimensioning/Measurement",
+        "Architectural Design",
+        "Building Information Modeling",
+        "Construction Techniques",
+        "Cooperative Education"
+      ]
+    },
+    {
+      "prefix": "STA",
+      "name": "Statistics",
+      "course_count": 7,
+      "section_count": 216,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Additional Topics in Statistic",
+        "Applied Statistics",
+        "Intro to Applied Statistics",
+        "Intro to Statistical Reasoning",
+        "Statistical Methods and Motiva"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 214,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Contemporary Economic Issues",
+        "Intro to Global Economics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics",
+        "Special Topics/Economics"
+      ]
+    },
+    {
+      "prefix": "HMS",
+      "name": "HMS",
+      "course_count": 13,
+      "section_count": 195,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Practices in Human",
+        "Crisis Intervention",
+        "Drugs/Society/Human Behavior",
+        "Effect. Client Relations in Hu",
+        "Foundational Skills in Profess"
+      ]
+    },
+    {
+      "prefix": "CAR",
+      "name": "Construction",
+      "course_count": 19,
+      "section_count": 190,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Co-op in Construction",
+        "Concrete Formwork",
+        "Concrete Formwork Lab",
+        "Green Building",
+        "Interior and Exterior Fin. Lab"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 14,
+      "section_count": 190,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "African American Music History",
+        "American Music History",
+        "Class Instruction in Piano I",
+        "Class Instruction in Piano II",
+        "Class Instruction in Piano III"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 18,
+      "section_count": 189,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Beginning Listening & Speaking",
+        "Beginning Writing",
+        "Begng Conv Non-Ntv Eng Speak",
+        "Begng Voc Non-Ntv Eng Speakers",
+        "Col Grammar I Non Native Speak"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 18,
+      "section_count": 186,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Baking & Pastry Arts",
+        "Applied Intro to Culinary Arts",
+        "Basic Baking",
+        "Basic Food Production",
+        "Basic Nutrition"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 2,
+      "section_count": 185,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Financial Accounting",
+        "Managerial Accounting"
+      ]
+    },
+    {
+      "prefix": "AIT",
+      "name": "AIT",
+      "course_count": 32,
+      "section_count": 177,
+      "colleges": [
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Equipment Maintenance",
+        "Advanced Mechanical",
+        "Advanced PLCs",
+        "Automation Capstone",
+        "Basic Electrical Controls"
+      ]
+    },
+    {
+      "prefix": "DIT",
+      "name": "DIT",
+      "course_count": 21,
+      "section_count": 173,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Brakes",
+        "Brakes Lab",
+        "Cooperative Education",
+        "Diesel Engine Repair",
+        "Diesel Engine Repair Lab"
+      ]
+    },
+    {
+      "prefix": "OST",
+      "name": "Office",
+      "course_count": 10,
+      "section_count": 165,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Admin. Office Simulations",
+        "Administrative Office Technolo",
+        "Adv Microsoft Applications",
+        "Adv Word Proc Application",
+        "Business Comm. Technology"
+      ]
+    },
+    {
+      "prefix": "RDG",
+      "name": "Reading",
+      "course_count": 5,
+      "section_count": 154,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "College Reading",
+        "Improved College Reading",
+        "Reading for College Classroom",
+        "Reading Laboratory",
+        "Reading Workshop"
+      ]
+    },
+    {
+      "prefix": "TRU",
+      "name": "Truck",
+      "course_count": 1,
+      "section_count": 152,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Truck Driving"
+      ]
+    },
+    {
+      "prefix": "DMI",
+      "name": "DMI",
+      "course_count": 17,
+      "section_count": 151,
+      "colleges": [
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum II",
+        "Clinical Practicum III",
+        "Clinical Practicum V",
+        "Image Analysis",
+        "Med Term for Radiographers"
+      ]
+    },
+    {
+      "prefix": "PHB",
+      "name": "Phlebotomy",
+      "course_count": 5,
+      "section_count": 145,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Phlebotomy",
+        "Phlebotomy",
+        "Phlebotomy Clinical",
+        "Phlebotomy for Healthcare Work",
+        "Phlebotomy: Clinical Experienc"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 9,
+      "section_count": 142,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Child & Adolescent Development",
+        "Classroom Assessment",
+        "Elemen & Middle Sch Literature",
+        "Elementary School Literature",
+        "Intro to American Education"
+      ]
+    },
+    {
+      "prefix": "IRW",
+      "name": "Reading",
+      "course_count": 3,
+      "section_count": 142,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "maysville-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Int Reading and Writing Worksh",
+        "Integrated Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "COS",
+      "name": "Cosmetology",
+      "course_count": 19,
+      "section_count": 140,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "somerset-community-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Accelerated Student Teaching",
+        "Cosmetology I Practical Applic",
+        "Cosmetology I Theory",
+        "Cosmetology I, 6-1",
+        "Cosmetology II Practical Appli"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 6,
+      "section_count": 134,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Business Ethics",
+        "Ethics",
+        "Intro to Philosophy",
+        "Introductory Logic",
+        "Medical Ethics"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 5,
+      "section_count": 124,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Astrobiology",
+        "Frontiers of Astronomy",
+        "Introductory Astronomy Lab",
+        "Stars, Galaxies, Universe",
+        "The Solar System"
+      ]
+    },
+    {
+      "prefix": "CPR",
+      "name": "Healthcare",
+      "course_count": 1,
+      "section_count": 121,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hopkinsville-community-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "CPR Healthcare Professionals"
+      ]
+    },
+    {
+      "prefix": "IMG",
+      "name": "IMG",
+      "course_count": 29,
+      "section_count": 120,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Adv Patient Care inRadiography",
+        "Basic Computed Tomography",
+        "Clinical I",
+        "Clinical II",
+        "Clinical III"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 23,
+      "section_count": 111,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "madisonville-community-college",
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Agricultural Internship I",
+        "Agriculture Business & Records",
+        "Agriculture Marketing & Sales",
+        "Animal Nutrition",
+        "Applications in Animal Technol"
+      ]
+    },
+    {
+      "prefix": "KHP",
+      "name": "Fitness",
+      "course_count": 10,
+      "section_count": 110,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Walking for Fitness",
+        "Beginning Weight Training",
+        "Beginning Yoga",
+        "Concepts of Health and Fitness",
+        "Cross-training"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surgical",
+      "course_count": 16,
+      "section_count": 110,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Surgical Technology",
+        "Pathophysiology for Surg Techs",
+        "Perioperative Bioscience",
+        "Principles of Surgical Assisti",
+        "Surg Tech Fund/Theory"
+      ]
+    },
+    {
+      "prefix": "GLY",
+      "name": "Geology",
+      "course_count": 9,
+      "section_count": 108,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Dinosaur Laboratory",
+        "Dinosaurs and Disasters",
+        "Environmental Geology",
+        "Environmental Geology Lab",
+        "Geology of the National Parks"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 5,
+      "section_count": 104,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "Culture Politics in Dev Nation",
+        "Introduction to Public Policy",
+        "State Government",
+        "World Politics"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 9,
+      "section_count": 100,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Appalachian Seminar",
+        "Appalachian Studies I",
+        "Intro to African Literature",
+        "Intro to Holocaust Lit & Film",
+        "Intro to Native American Lit"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 10,
+      "section_count": 100,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Crisis Intervention",
+        "Cultural DiversityHuman Servic",
+        "Development of Social Welfare",
+        "Intro to Gerontology",
+        "Intro to Social Services"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 7,
+      "section_count": 99,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Earth's Physical Environm Lab",
+        "Earth's Physical Environment",
+        "Environmental Science",
+        "Human Geography",
+        "Lands/Peoples of Non-West Wrld"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 4,
+      "section_count": 99,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Comparative Religion",
+        "Intro to Religious Studies",
+        "Introduction the New Testament",
+        "Introduction the Old Testament"
+      ]
+    },
+    {
+      "prefix": "FPX",
+      "name": "Fluid",
+      "course_count": 2,
+      "section_count": 98,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Fluid Power",
+        "Fluid Power Lab"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 98,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Pathophysiology",
+        "Health Care Communication",
+        "Health Care Delivery & Mgmt",
+        "HlthCare Basic Skills Clinical",
+        "Pharmacology"
+      ]
+    },
+    {
+      "prefix": "VCC",
+      "name": "VCC",
+      "course_count": 18,
+      "section_count": 96,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "somerset-community-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Photoshop",
+        "Apparel Graphics & Production",
+        "Computer Graphics I",
+        "Computer Graphics II",
+        "Design Concepts"
+      ]
+    },
+    {
+      "prefix": "DPT",
+      "name": "DPT",
+      "course_count": 7,
+      "section_count": 95,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Additive Manufacturing for Sup",
+        "Intr to Powder-Based Add Manuf",
+        "Intro Engineering Mech 3Dprint",
+        "Intro to 3D Printing Tech",
+        "Research Lab Experience"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 11,
+      "section_count": 95,
+      "colleges": [
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Clinical Practicum III",
+        "Functional Anatomy/Kinesiology",
+        "Med/Surg Cond in Phys Therapy"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 5,
+      "section_count": 95,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Elemen Spanish I",
+        "Elemen Spanish II",
+        "Hispanic Culture: (Ct or Reg)",
+        "Intermediate Spanish I",
+        "Intermediate Spanish II"
+      ]
+    },
+    {
+      "prefix": "FIR",
+      "name": "FIR",
+      "course_count": 21,
+      "section_count": 92,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "owensboro-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aircraft Rescue Firefighting",
+        "Basic Firefighting I",
+        "Basic Firefighting II",
+        "Basic Firefighting III",
+        "Basic Firefighting IV"
+      ]
+    },
+    {
+      "prefix": "APT",
+      "name": "Process",
+      "course_count": 22,
+      "section_count": 90,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Application Process Operations",
+        "Federally Mandated Training",
+        "Instrumentation",
+        "Lineman Technology I",
+        "Lineman Technology I Lab"
+      ]
+    },
+    {
+      "prefix": "BRX",
+      "name": "Blueprint",
+      "course_count": 5,
+      "section_count": 89,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Blueprint Read Machinist",
+        "Basic Blueprint Reading",
+        "Blueprint Reading Construction",
+        "Blueprint Reading Machinist",
+        "Mechanical Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "IET",
+      "name": "IET",
+      "course_count": 15,
+      "section_count": 78,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Automated Motor Controls",
+        "Basic Electricity",
+        "Blueprint Reading/Schematics",
+        "Electro-Hydraulics and Pneumat",
+        "Intro to Machine Tool Operatio"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "ANT",
+      "course_count": 9,
+      "section_count": 74,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Biological Anthropology Labora",
+        "Cultural Diversity Mod World",
+        "Food and Culture",
+        "Intro to Biological Anthropolo",
+        "Intro to Comparative Religion"
+      ]
+    },
+    {
+      "prefix": "CYS",
+      "name": "CYS",
+      "course_count": 16,
+      "section_count": 69,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "henderson-community-college",
+        "somerset-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cyber Systems",
+        "Comp Operating Systems Forensi",
+        "Cryptography",
+        "Cybersecurity Capstone",
+        "Cybersecurity Foundations"
+      ]
+    },
+    {
+      "prefix": "EDP",
+      "name": "EDP",
+      "course_count": 3,
+      "section_count": 64,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "henderson-community-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Human Development & Learning",
+        "Motivation and Classroom Manag",
+        "Teaching Exceptional Learners"
+      ]
+    },
+    {
+      "prefix": "FWT",
+      "name": "Commercial",
+      "course_count": 12,
+      "section_count": 62,
+      "colleges": [
+        "madisonville-community-college"
+      ],
+      "sample_titles": [
+        "CFI & CFII Flight Lab",
+        "CFI & CFII Ground School",
+        "Commercial Flight Lab",
+        "Commercial Flight Lab Phase II",
+        "Commercial ME Ground & Lab"
+      ]
+    },
+    {
+      "prefix": "ACT",
+      "name": "Accounting",
+      "course_count": 7,
+      "section_count": 61,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "henderson-community-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Computerized Accounting System",
+        "Financial Accounting Topics",
+        "Fundamentals of Accounting I",
+        "Fundamentals of Accounting II",
+        "Individual Tax"
+      ]
+    },
+    {
+      "prefix": "IMD",
+      "name": "IMD",
+      "course_count": 25,
+      "section_count": 58,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "3D Animation for Video Games",
+        "3D Modeling for Video Games",
+        "Advanced Desktop Publishing",
+        "Advanced Photoshop",
+        "Beginning Web Design"
+      ]
+    },
+    {
+      "prefix": "VCA",
+      "name": "VCA",
+      "course_count": 16,
+      "section_count": 58,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "somerset-community-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advertising Design",
+        "Basic Advertising Design",
+        "Basic Photography",
+        "Color Theory",
+        "Commercial Photography"
+      ]
+    },
+    {
+      "prefix": "ACH",
+      "name": "ACH",
+      "course_count": 20,
+      "section_count": 56,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "hazard-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Building Material & Constru II",
+        "Building Materials & Constru I",
+        "Computer Aided Drafting I",
+        "Construction Documents I",
+        "Construction Documents II"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Clinical",
+      "course_count": 27,
+      "section_count": 54,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Abdominal Review",
+        "Abdominal Sonography",
+        "Cardiac Clinical Education I",
+        "Cardiac Clinical Education II",
+        "Cardiac Clinical Education III"
+      ]
+    },
+    {
+      "prefix": "THA",
+      "name": "THA",
+      "course_count": 12,
+      "section_count": 54,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Acting I: Fundamentals/Acting",
+        "Acting II/Scene Study(Realism)",
+        "Acting III/Scene Study(Styles)",
+        "Acting Techniques",
+        "American Theatre"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 18,
+      "section_count": 53,
+      "colleges": [
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college"
+      ],
+      "sample_titles": [
+        "Adaptations and Documentation",
+        "Applied Anatomy & Kinesiology",
+        "Clinical Seminar",
+        "Community Practice",
+        "Intro Occupational Therapy"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 13,
+      "section_count": 52,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Classification Sy III",
+        "Clinical Classification Sys I",
+        "Clinical Classification Sys II",
+        "Clinical Practicum I",
+        "Clinical Practicum II"
+      ]
+    },
+    {
+      "prefix": "KMA",
+      "name": "Medication",
+      "course_count": 2,
+      "section_count": 49,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Kentucky Medication Aide",
+        "KY Cert Medication Aide II"
+      ]
+    },
+    {
+      "prefix": "REA",
+      "name": "Real",
+      "course_count": 7,
+      "section_count": 44,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Appraising",
+        "Property Management",
+        "Real Estate Finance",
+        "Real Estate Law",
+        "Real Estate Marketing"
+      ]
+    },
+    {
+      "prefix": "MNA",
+      "name": "Medicaid",
+      "course_count": 1,
+      "section_count": 42,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Medicaid Nurse Aide"
+      ]
+    },
+    {
+      "prefix": "VCM",
+      "name": "VCM",
+      "course_count": 10,
+      "section_count": 42,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "somerset-community-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "2-D Animation",
+        "3-D Animation",
+        "Advanced Digital Video",
+        "Advanced Webpage Design",
+        "After Effects"
+      ]
+    },
+    {
+      "prefix": "PSM",
+      "name": "PSM",
+      "course_count": 12,
+      "section_count": 41,
+      "colleges": [
+        "hazard-community-and-technical-college",
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Bluegrass Traditional Band/Ens",
+        "Bluegrass Traditional Harm/Par",
+        "Bluegrass/Trad Msc His II Evol",
+        "Bluegrass/Trad Msc His III Str",
+        "Bluegrass/Trad Music His I Geo"
+      ]
+    },
+    {
+      "prefix": "NFS",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 40,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Human Nutrition & Wellness"
+      ]
+    },
+    {
+      "prefix": "PGL",
+      "name": "PGL",
+      "course_count": 14,
+      "section_count": 39,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "madisonville-community-college"
+      ],
+      "sample_titles": [
+        "Civil Litigation I",
+        "Civil Litigation II",
+        "Ethics",
+        "Family Law",
+        "Law Office Management"
+      ]
+    },
+    {
+      "prefix": "ISX",
+      "name": "Safety",
+      "course_count": 3,
+      "section_count": 38,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "hopkinsville-community-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Industrial Safety",
+        "Intro to Industrial Safety",
+        "Special Topics Indust Safety"
+      ]
+    },
+    {
+      "prefix": "DHP",
+      "name": "Dental",
+      "course_count": 15,
+      "section_count": 37,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Community Dental Health",
+        "Dental Hygiene I",
+        "Dental Hygiene II",
+        "Dental Hygiene III",
+        "Dental Hygiene IV"
+      ]
+    },
+    {
+      "prefix": "NIP",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 36,
+      "colleges": [
+        "madisonville-community-college"
+      ],
+      "sample_titles": [
+        "Adv Alterations in Health Well",
+        "Fundamentals in Health Wellnes",
+        "Intro Alterations Health Well",
+        "Transition Practice H&W Manage",
+        "Transition to Practice"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 7,
+      "section_count": 34,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III",
+        "American Sign Language IV"
+      ]
+    },
+    {
+      "prefix": "HFT",
+      "name": "Pilot",
+      "course_count": 9,
+      "section_count": 32,
+      "colleges": [
+        "madisonville-community-college"
+      ],
+      "sample_titles": [
+        "CFI & CFII Flight Lab",
+        "CFI & CFII Ground School",
+        "Commercial Heli Flight Lab",
+        "Heli Instrmt Pilot Flight Lab",
+        "Helicopter Commercial Pilot"
+      ]
+    },
+    {
+      "prefix": "PHA",
+      "name": "Pharmacy",
+      "course_count": 9,
+      "section_count": 32,
+      "colleges": [
+        "jefferson-community-and-technical-college",
+        "somerset-community-college"
+      ],
+      "sample_titles": [
+        "Admixture Preparations",
+        "Admixtures for IV Therapy",
+        "Pharmaceutical Calculations",
+        "Pharmacology I",
+        "Pharmacology II"
+      ]
+    },
+    {
+      "prefix": "ORP",
+      "name": "Orthotics",
+      "course_count": 14,
+      "section_count": 31,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Experience I",
+        "Clinical Experience II",
+        "Intro to Orthotics and Prosthe",
+        "Lower Extremity Orthotics I",
+        "Lower Extremity Orthotics II"
+      ]
+    },
+    {
+      "prefix": "VET",
+      "name": "Veterinary",
+      "course_count": 17,
+      "section_count": 31,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Animal Anatomy and Physiology",
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Exotic and Lab Animal Medicine",
+        "Intro to Veterinary Tech Lab"
+      ]
+    },
+    {
+      "prefix": "FRT",
+      "name": "FRT",
+      "course_count": 3,
+      "section_count": 30,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Special Topics in Firefighting",
+        "Special Topics in Rescue",
+        "Special Topics/Indus Fire Pro"
+      ]
+    },
+    {
+      "prefix": "EQS",
+      "name": "Equine",
+      "course_count": 13,
+      "section_count": 27,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Equine Physiology",
+        "Equine Bloodstock",
+        "Equine Care Lab",
+        "Equine Health and Medications",
+        "Equine Legal & Bus Principles"
+      ]
+    },
+    {
+      "prefix": "PLB",
+      "name": "Plumbing",
+      "course_count": 14,
+      "section_count": 26,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Plumbing Lab",
+        "Backflow Prevention",
+        "Basic Plumbing Skills",
+        "Basic Theory of Plumbing",
+        "Cooperative Education"
+      ]
+    },
+    {
+      "prefix": "BTN",
+      "name": "BTN",
+      "course_count": 12,
+      "section_count": 25,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Lab Calc for Biotech",
+        "Bioinformatics I",
+        "Bioinformatics II",
+        "Biotechnology Learning Lab",
+        "Biotechnology Techniques I"
+      ]
+    },
+    {
+      "prefix": "DAH",
+      "name": "DAH",
+      "course_count": 6,
+      "section_count": 24,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Dental Sciences",
+        "Infection Control/Med Emerg",
+        "Materials In Dentistry",
+        "Oral Pathology",
+        "Oral Radiology"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Contemporary",
+      "course_count": 1,
+      "section_count": 23,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Contemporary Mathematics"
+      ]
+    },
+    {
+      "prefix": "CS",
+      "name": "CS",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Discrete Mathematics",
+        "Intro to Computer Programming",
+        "Intro to Program Design, etc",
+        "Introduction to Data Structure"
+      ]
+    },
+    {
+      "prefix": "WGS",
+      "name": "Wmens",
+      "course_count": 2,
+      "section_count": 22,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Wmen's Gnd Std Soc Sc",
+        "Intro Wmn's Gnder Stds Art Hum"
+      ]
+    },
+    {
+      "prefix": "CRT",
+      "name": "CRT",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Practicum",
+        "Introduction Collision Repair",
+        "Mechanical Electrical Componts",
+        "Mechanical/Electrical Comp Lab",
+        "Non-Struct Analysis/Dmg Rp Lab"
+      ]
+    },
+    {
+      "prefix": "BTS",
+      "name": "BTS",
+      "course_count": 17,
+      "section_count": 20,
+      "colleges": [
+        "madisonville-community-college"
+      ],
+      "sample_titles": [
+        "Biomed Tech Sys: Career Persp",
+        "Clinical Exper Biomed Tech Sys",
+        "Critical Care Monitor & Instr",
+        "Dign Med Eqp & Non Rad Img Mod",
+        "Env Risk Prec Measures BTS Prf"
+      ]
+    },
+    {
+      "prefix": "DAS",
+      "name": "DAS",
+      "course_count": 6,
+      "section_count": 20,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinical Externship",
+        "Dental Assisting I",
+        "Dental Assisting II",
+        "Preventive Dentistry",
+        "Seminar I"
+      ]
+    },
+    {
+      "prefix": "MSG",
+      "name": "Massage",
+      "course_count": 14,
+      "section_count": 20,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "hopkinsville-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Massage I",
+        "Advanced Clinical Massage II",
+        "Advanced Medical Massage I",
+        "Advanced Medical Massage II",
+        "Massage Therapy Pathology"
+      ]
+    },
+    {
+      "prefix": "GEN",
+      "name": "GEN",
+      "course_count": 6,
+      "section_count": 19,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Career and Life Skills Develop",
+        "Development of Leadership",
+        "Employment & Professional Skil",
+        "Foundations of Learning",
+        "Introduction to College"
+      ]
+    },
+    {
+      "prefix": "AFS",
+      "name": "Aerospace",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aerospace Studies I",
+        "Aerospace Studies II",
+        "Leadership Laboratory 1",
+        "Leadership Laboratory I",
+        "Leadership Laboratory II"
+      ]
+    },
+    {
+      "prefix": "AMS",
+      "name": "Army",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Army Doctrine and Team Develop",
+        "Basic Military Science Lab",
+        "Foundations of Agile and Adapt",
+        "Introduction to the Army",
+        "Leadership and Ethics"
+      ]
+    },
+    {
+      "prefix": "COE",
+      "name": "Cooperative",
+      "course_count": 1,
+      "section_count": 18,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "henderson-community-college",
+        "jefferson-community-and-technical-college",
+        "madisonville-community-college",
+        "maysville-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education"
+      ]
+    },
+    {
+      "prefix": "EGY",
+      "name": "EGY",
+      "course_count": 3,
+      "section_count": 18,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "gateway-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Energy Utility Technologies",
+        "Outside Plant Communications",
+        "Solar / Photovoltaic Tech"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "Nursing",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "LPN-ADN Transition",
+        "Nursing Care I",
+        "Nursing Care II",
+        "Nursing Care III",
+        "Nursing Care IV"
+      ]
+    },
+    {
+      "prefix": "SFA",
+      "name": "Safety",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "hazard-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "owensboro-community-and-technical-college",
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Industrial Health, Safety, and",
+        "Industrial Safety",
+        "Intro to Industrial Safety",
+        "Safety and First Aid"
+      ]
+    },
+    {
+      "prefix": "DHG",
+      "name": "Dental",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "big-sandy-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Periodontology",
+        "Clinical Dental Hygiene I",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Community Dental Health Issues"
+      ]
+    },
+    {
+      "prefix": "FAM",
+      "name": "Family",
+      "course_count": 2,
+      "section_count": 17,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "maysville-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Human Sexuality",
+        "Intro to Family Science"
+      ]
+    },
+    {
+      "prefix": "LOM",
+      "name": "Management",
+      "course_count": 6,
+      "section_count": 17,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "somerset-community-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Supply Chain Mngmnt",
+        "Introduction to Logistics Mgmt",
+        "Lean for Logistics",
+        "Project Management",
+        "Supply Chain Management"
+      ]
+    },
+    {
+      "prefix": "ENC",
+      "name": "College",
+      "course_count": 3,
+      "section_count": 16,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Found of College Writing I",
+        "Found of College Writing II",
+        "Introduction to College Writin"
+      ]
+    },
+    {
+      "prefix": "EST",
+      "name": "EST",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "App Projects in Envir Sci Tech",
+        "Aquatic Chemistry Laboratory",
+        "Environmental Analysis Laborat",
+        "Environmental Law & Regulation",
+        "Environmental Sampling Laborat"
+      ]
+    },
+    {
+      "prefix": "HFL",
+      "name": "HFL",
+      "course_count": 11,
+      "section_count": 16,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Compliance Codes Standard III",
+        "Compliance, Codes Standard I",
+        "Healthcare Fac Leadrshp Cap I",
+        "Helthcre Fac Ledrship Cap II",
+        "Infection Control and Prev"
+      ]
+    },
+    {
+      "prefix": "BIT",
+      "name": "Industry",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Selected Topics Bus & Indust:",
+        "Special Topics Bus & Industry"
+      ]
+    },
+    {
+      "prefix": "FLM",
+      "name": "FLM",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Cinematic Arts Internship",
+        "Cinematography",
+        "Film Boot Camp",
+        "Film Directing",
+        "Filmmakg: Storyboard thru Prod"
+      ]
+    },
+    {
+      "prefix": "ISM",
+      "name": "Fundamental",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "maysville-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Fundamental of Instrumentation",
+        "Fundamentals of Process Contrl"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Science",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "elizabethtown-community-and-technical-college",
+        "jefferson-community-and-technical-college",
+        "maysville-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Science and Society"
+      ]
+    },
+    {
+      "prefix": "DLC",
+      "name": "Digital",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Digital Literacy"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Library",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Genealogy Services in Library",
+        "Introduction to Reference Serv",
+        "Library Administration",
+        "Library Services for Adults",
+        "Library Services for Children"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Managing Quality",
+        "Operations Management",
+        "Project Management",
+        "Special Topics: Management",
+        "Strategic Management"
+      ]
+    },
+    {
+      "prefix": "EES",
+      "name": "Electronics",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Basic Electronics"
+      ]
+    },
+    {
+      "prefix": "HEO",
+      "name": "Heavy",
+      "course_count": 9,
+      "section_count": 10,
+      "colleges": [
+        "hazard-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Bulldozer Operator",
+        "Heavy Equipment Operating I",
+        "Heavy Equipment Operating II",
+        "Heavy Equipment Operating III",
+        "Heavy Equipment Operations"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advertising and Promotion",
+        "Consumer Behavior",
+        "Personal Selling",
+        "Retail Management"
+      ]
+    },
+    {
+      "prefix": "PLW",
+      "name": "Engineering",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "hazard-community-and-technical-college",
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Aerospace Engineering",
+        "Introduction to Engineering De",
+        "Medical Interventions",
+        "Principles of Biomedical Sci",
+        "Principles of Engineering"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "Civil",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "big-sandy-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Civil Engineering Graphics",
+        "Civil Engineering Materials",
+        "Hydrology and Drainage",
+        "Infrastructure Analysis and De"
+      ]
+    },
+    {
+      "prefix": "JUS",
+      "name": "Criminal",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "gateway-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "hazard-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Mechatronics",
+        "Lean Operations",
+        "Manufact Engineering Tech Caps",
+        "Production Management"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "Visual",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Visual Studies"
+      ]
+    },
+    {
+      "prefix": "FLK",
+      "name": "FLK",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "maysville-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Cultural Diversity in the U.S.",
+        "Introduction to Folk Studies",
+        "Supernatural Folklore"
+      ]
+    },
+    {
+      "prefix": "FRE",
+      "name": "French",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Elemen French I",
+        "Elemen French II",
+        "Intermediate French I"
+      ]
+    },
+    {
+      "prefix": "HOS",
+      "name": "Hospitality",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college",
+        "southcentral-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Hospitality Mgmt",
+        "Tourism Marketing"
+      ]
+    },
+    {
+      "prefix": "SMT",
+      "name": "Surveying",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "big-sandy-community-and-technical-college",
+        "hazard-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Boundary Law",
+        "Land Surveying Graphics",
+        "Principles of Surveying",
+        "Professional Ethics & Conduct",
+        "Surveying Lab"
+      ]
+    },
+    {
+      "prefix": "ANA",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "somerset-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Human Anatomy"
+      ]
+    },
+    {
+      "prefix": "ME",
+      "name": "Computer",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Engineering Thermodynamics I",
+        "Intro to Computer Graphics"
+      ]
+    },
+    {
+      "prefix": "SDC",
+      "name": "Planning",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "ashland-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Career Planning Seminar",
+        "Stress Management",
+        "Transfer Planning"
+      ]
+    },
+    {
+      "prefix": "WPP",
+      "name": "Workplace",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "ashland-community-and-technical-college",
+        "bluegrass-community-and-technical-college",
+        "elizabethtown-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Workplace Principles"
+      ]
+    },
+    {
+      "prefix": "CDH",
+      "name": "Dental",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "big-sandy-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Community Dental Health Coordi",
+        "Dental Health Advocacy and Out",
+        "Dental Health Communication Sk",
+        "Dental Health Teaching and Lea"
+      ]
+    },
+    {
+      "prefix": "EX",
+      "name": "Experiential",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Experiential Education"
+      ]
+    },
+    {
+      "prefix": "FHT",
+      "name": "Life",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Electric and Med Gas Comp Work",
+        "Electrical and Medical Gas Com",
+        "Life Safety and Vent Comp Work",
+        "Life Safety and Ventilation Co"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Elementary German I"
+      ]
+    },
+    {
+      "prefix": "GIS",
+      "name": "Geographic Information Systems",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Geospatial Programming",
+        "Geospatial Web Mapping",
+        "Intro to Geographic Info Systm",
+        "Remote Sensing"
+      ]
+    },
+    {
+      "prefix": "NMI",
+      "name": "NMI",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "hazard-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Clinic II",
+        "Clinical Procedures II",
+        "Nuc Physics and Instrumentatio",
+        "Radionuclides and Pharm."
+      ]
+    },
+    {
+      "prefix": "QMS",
+      "name": "Quality",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "gateway-community-and-technical-college",
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Quality System",
+        "Special Topics: Quality Manag."
+      ]
+    },
+    {
+      "prefix": "TA",
+      "name": "Projects",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "somerset-community-college"
+      ],
+      "sample_titles": [
+        "Special Projects Theatre Arts"
+      ]
+    },
+    {
+      "prefix": "TEC",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "elizabethtown-community-and-technical-college",
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Technical Communications"
+      ]
+    },
+    {
+      "prefix": "AEG",
+      "name": "Additive",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "CAD for Additive Engineering",
+        "Extrusion 3D Printing Hardware",
+        "Intro to Additive Eng Tech"
+      ]
+    },
+    {
+      "prefix": "EM",
+      "name": "Statics",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "somerset-community-college",
+        "southcentral-kentucky-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Statics"
+      ]
+    },
+    {
+      "prefix": "HFO",
+      "name": "Healthcare",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Healthcare Facilities Orientat"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese I",
+        "Beginning Japanese II",
+        "Intermediate Japanese I"
+      ]
+    },
+    {
+      "prefix": "BBT",
+      "name": "Hfccabletv",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "big-sandy-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Cellular Techn",
+        "Introduction to HFC/Cable-TV"
+      ]
+    },
+    {
+      "prefix": "CHW",
+      "name": "Comm",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Comm for Health Workers",
+        "Org and Community Outreach"
+      ]
+    },
+    {
+      "prefix": "COED",
+      "name": "Practicum",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "madisonville-community-college",
+        "southcentral-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Practicum"
+      ]
+    },
+    {
+      "prefix": "EE",
+      "name": "Circuits",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "southcentral-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Circuits and Networks I"
+      ]
+    },
+    {
+      "prefix": "ETT",
+      "name": "Voice",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "southeast-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Voice & Data Installer Lev II"
+      ]
+    },
+    {
+      "prefix": "HSM",
+      "name": "Homeland",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Emergency Management",
+        "Intro to Homeland Security"
+      ]
+    },
+    {
+      "prefix": "INF",
+      "name": "Programming",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Elementary Programming"
+      ]
+    },
+    {
+      "prefix": "JAT",
+      "name": "Communications",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Communications Practicum"
+      ]
+    },
+    {
+      "prefix": "JOU",
+      "name": "Journalism",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bluegrass-community-and-technical-college",
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro to Journalism"
+      ]
+    },
+    {
+      "prefix": "MBS",
+      "name": "Medical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Coding for Reimbursement",
+        "Medical Insurance & Claim Proc"
+      ]
+    },
+    {
+      "prefix": "MRN",
+      "name": "Marine",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "west-kentucky-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Applied Marine Weather",
+        "Marine Crew Wellness"
+      ]
+    },
+    {
+      "prefix": "MUP",
+      "name": "Voice",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Voice"
+      ]
+    },
+    {
+      "prefix": "PGY",
+      "name": "Elemen",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Elemen Physiology"
+      ]
+    },
+    {
+      "prefix": "TNT",
+      "name": "Truck",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Special Topics: Truck Driving"
+      ]
+    },
+    {
+      "prefix": "EFM",
+      "name": "Personal",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "elizabethtown-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Personal Financial Management"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "somerset-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Exploration I"
+      ]
+    },
+    {
+      "prefix": "EQM",
+      "name": "Commercial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Intro Commercial Breeding Prac"
+      ]
+    },
+    {
+      "prefix": "ESP",
+      "name": "Energy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Energy Systems"
+      ]
+    },
+    {
+      "prefix": "HRS",
+      "name": "Independguidedstudy",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "owensboro-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Independ/Guided-Study Project"
+      ]
+    },
+    {
+      "prefix": "IES",
+      "name": "International",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "International Student Experien"
+      ]
+    },
+    {
+      "prefix": "LIN",
+      "name": "Information",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "bluegrass-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Information Literacy"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "Pneumatic",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Advanced Pneumatic Systems"
+      ]
+    },
+    {
+      "prefix": "PMX",
+      "name": "Precision",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "big-sandy-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Precision Measurement"
+      ]
+    },
+    {
+      "prefix": "RAE",
+      "name": "Elem",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Elem Modern Standard Arabic"
+      ]
+    },
+    {
+      "prefix": "SUS",
+      "name": "Sustainability",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "jefferson-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Introduction to Sustainability"
+      ]
+    },
+    {
+      "prefix": "UST",
+      "name": "Commercial",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "hazard-community-and-technical-college"
+      ],
+      "sample_titles": [
+        "Commercial Drone Operations"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/mi/subject-vocab.json
+++ b/data/mi/subject-vocab.json
@@ -1,0 +1,6593 @@
+{
+  "state": "mi",
+  "generated_at": "2026-05-13T03:53:11.007Z",
+  "subjects": [
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 77,
+      "section_count": 1009,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Creative Writing",
+        "African American Lit",
+        "African-American Literature",
+        "Am Lit To Civil War",
+        "Am Lit To Present"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 64,
+      "section_count": 648,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Algebraic Essentials",
+        "Analytic Geometry & Calc II",
+        "Analytic Geometry & Calculus I",
+        "Analytical Geometry and Calculus I",
+        "Analytical Geometry and Calculus II"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 37,
+      "section_count": 557,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "African-American Literature",
+        "American Ethnic Literature",
+        "American Lit 1865 to Present",
+        "British Lit 1800 to Present",
+        "British Lit to 1800"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 56,
+      "section_count": 529,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Anatomy & Physiology I",
+        "Anatomy & Physiology II",
+        "Basic Hum Anat Phy",
+        "Basic Human Anatomy",
+        "Basic Human Nutrition"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 41,
+      "section_count": 418,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Anat/Phys-Norm Struc/Fun &amp; Lab",
+        "Anatomy & Physlgy II",
+        "Anatomy & Physlogy I",
+        "Biology of Exercise",
+        "Biology of the Florida Keys"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 50,
+      "section_count": 395,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Algebra for Statistics",
+        "Algebra for Stats",
+        "Applied Calculus",
+        "Basic Algebra",
+        "Business Mathematics"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 95,
+      "section_count": 335,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        ".Net Programming I",
+        "3D Modeling",
+        "Advanced HTML Web Development",
+        "Advanced Information Tech",
+        "Appl W-Microcomp"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 88,
+      "section_count": 318,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "2-D Design",
+        "Acrylic Painting",
+        "Adv Theories in Oil Painting",
+        "Advanced Figure Drawing",
+        "Advanced Jewelry"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 32,
+      "section_count": 299,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Assess of Co-Occur Disorders",
+        "Behavior Modification",
+        "Child Development",
+        "Child Psychology"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 60,
+      "section_count": 270,
+      "colleges": [
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Advertising Dynamics",
+        "Business Ethics",
+        "Business Internship",
+        "Business Law 1",
+        "Business Law and Ethics"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 29,
+      "section_count": 241,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adolescent Psychology",
+        "Applied Psychology",
+        "Brain and Behavior",
+        "Child Psychology"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 18,
+      "section_count": 239,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Basic Statistics",
+        "Calculus I",
+        "Calculus II",
+        "Calculus III",
+        "College Algebra"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 24,
+      "section_count": 227,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Audio Production",
+        "Communication Fundamentals",
+        "Family Communication",
+        "Fundamentals of Speaking",
+        "Fundamentals of Speech"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 25,
+      "section_count": 188,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Analysis of Social Problems",
+        "Comptem Soc Problems",
+        "Family Social Work",
+        "Group Dynamics &amp; Counseling",
+        "Intro. to Social Work"
+      ]
+    },
+    {
+      "prefix": "NRSG",
+      "name": "Care",
+      "course_count": 28,
+      "section_count": 187,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Adult Patient Care (B) Clinic",
+        "Adult Patient Care (B) Lab",
+        "Adv. Care Adult Patient",
+        "Adv. Care Adult Patient Clinic",
+        "Adv. Care Adult Patient Lab"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 12,
+      "section_count": 177,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Communication in the Workplace",
+        "Dynamics of Communication",
+        "Fund of Public Speaking",
+        "Fundamentals Public Speaking",
+        "Intercultural Communication"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 38,
+      "section_count": 167,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Basic Chemistry",
+        "Biological Chemistry",
+        "Chemistry 101 Fundamentals",
+        "Chemistry for Health Science",
+        "Chemistry Fundamentals - Lec"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 22,
+      "section_count": 160,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Art of Being Human",
+        "Arts & Lit: Renaissance-Modern",
+        "Arts/Lit: Origins of West Trad",
+        "Bible",
+        "Comparative Religions"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 28,
+      "section_count": 148,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Bioethics",
+        "Biomedical Ethics",
+        "Business Ethics",
+        "Contemporary Moral Issues",
+        "Critical Thinking"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 29,
+      "section_count": 145,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "African History",
+        "African-American History",
+        "Ancient World",
+        "Cont Amer US Hist",
+        "Contemporary World"
+      ]
+    },
+    {
+      "prefix": "BMG",
+      "name": "BMG",
+      "course_count": 31,
+      "section_count": 127,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Bus and Supply Chain Analytics",
+        "Business Communication",
+        "Business Law I",
+        "Business on the Internet",
+        "Business Statistics"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 29,
+      "section_count": 125,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Internship",
+        "Accounting with Quickbooks",
+        "Acct for the Sm Business Owner",
+        "Computerized Accounting",
+        "Computerized Acct"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 35,
+      "section_count": 125,
+      "colleges": [
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health I",
+        "Adult Health II",
+        "Adult Health III",
+        "Adult Mental Hlth/Maladap Beh",
+        "Assessment in Nursing"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 14,
+      "section_count": 124,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Comparative Economic Systems",
+        "Financial Literacy",
+        "Intro Economics",
+        "Personal Money Mgmt",
+        "Power, Authority and Exchange"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 41,
+      "section_count": 114,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Adv Gas Tung Cer",
+        "Adv Proc Stick MIG",
+        "Advanced ARC Welding",
+        "Advanced Welding",
+        "Advanced Welding Processes"
+      ]
+    },
+    {
+      "prefix": "WAF",
+      "name": "Welding",
+      "course_count": 17,
+      "section_count": 110,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Adv Shielded Metal Arc Welding",
+        "Advanced Metal Fabrication",
+        "Automated Welding and Cutting",
+        "Basic Metal Fabrication",
+        "Cutting, Gouging &amp; Weld Repair"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 20,
+      "section_count": 104,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "20th Century History",
+        "African Amer Hist 1877-PRESENT",
+        "African Amer History to 1877",
+        "African-American History",
+        "Dev US from Civil War"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 15,
+      "section_count": 103,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Business Admin Internship",
+        "Business and Technical",
+        "Business Capstone",
+        "Business Law I",
+        "Financial Applications"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 44,
+      "section_count": 97,
+      "colleges": [
+        "oakland-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Pastry",
+        "Artisan Breads",
+        "Baking",
+        "Beginning Cake Decorating",
+        "Butchery"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 7,
+      "section_count": 95,
+      "colleges": [
+        "mid-michigan-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Economic Principles I - Macro",
+        "Economic Principles II - Micro",
+        "Introduction to Economics",
+        "Prin of Econ (micro)",
+        "Prin of Econ Macro"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 43,
+      "section_count": 92,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Art and Entertainment Law",
+        "Beginning Guitar",
+        "Community Concert Band",
+        "Concert Band",
+        "Conducting"
+      ]
+    },
+    {
+      "prefix": "MGMT",
+      "name": "Management",
+      "course_count": 28,
+      "section_count": 90,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Mgmt Communication",
+        "Compensation Management",
+        "Creative Thinking for Business",
+        "Developing and Leading Teams",
+        "Diversity in the Workplace"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 28,
+      "section_count": 87,
+      "colleges": [
+        "lansing-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Administration of Early Childhood Programs",
+        "Child Development",
+        "Child Special Needs",
+        "Core Teaching Elem",
+        "Core Teaching Secnd"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 29,
+      "section_count": 86,
+      "colleges": [
+        "lansing-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Adv Concepts Practical Nursing",
+        "Adv Cont Reg Nurs",
+        "Care of Adults 1",
+        "Care of Adults 1 Clinical",
+        "Care of Adults 2"
+      ]
+    },
+    {
+      "prefix": "PSYCH",
+      "name": "Psychology",
+      "course_count": 9,
+      "section_count": 85,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Child Psychology",
+        "Educational Psychology",
+        "Human Relations",
+        "Human Sexuality",
+        "Intro Psychology"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 35,
+      "section_count": 84,
+      "colleges": [
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Adv Writing/Reading Aca Purp",
+        "Advanced ESL Grammar II",
+        "Advanced ESL Pronunciation",
+        "Advanced ESL Read &amp; Listen",
+        "Advanced ESL Writing"
+      ]
+    },
+    {
+      "prefix": "MUSC",
+      "name": "Music",
+      "course_count": 31,
+      "section_count": 82,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Applied Lesson I",
+        "Applied Lesson II",
+        "Applied Lesson III",
+        "Applied Lesson IV",
+        "Aural Skills I"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 38,
+      "section_count": 81,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "2D AutoCAD",
+        "3D Printing App Polyjet",
+        "3D Printing Applications FDM",
+        "Adv Draft/Design Co-Op Intern",
+        "Advanced Solidworks App"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 46,
+      "section_count": 81,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Radiographic Procedur",
+        "Advancements in Imaging",
+        "Clinical Education",
+        "Clinical Education I",
+        "Clinical Education II"
+      ]
+    },
+    {
+      "prefix": "MUS.",
+      "name": "MUS.",
+      "course_count": 65,
+      "section_count": 78,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Music Technology",
+        "Applied Music I",
+        "Applied Music II",
+        "Applied Music III",
+        "Applied Music IV"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 21,
+      "section_count": 78,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Applied Physics",
+        "College Physics I Lec/Lab",
+        "College Physics II",
+        "Engineering Physics I",
+        "Engineering Physics II"
+      ]
+    },
+    {
+      "prefix": "ARTS",
+      "name": "Art",
+      "course_count": 31,
+      "section_count": 77,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "2D Design",
+        "3D Design",
+        "Adobe Photoshop",
+        "Art Appreciation",
+        "Art Entrepreneurship"
+      ]
+    },
+    {
+      "prefix": "MUSIC",
+      "name": "Music",
+      "course_count": 59,
+      "section_count": 77,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Applied Music - Piano 2",
+        "Applied Music Instrumental 1",
+        "Applied Music Instrumental 2",
+        "Applied Music Instrumental 3",
+        "Applied Music Instrumental 4"
+      ]
+    },
+    {
+      "prefix": "NRS",
+      "name": "NRS",
+      "course_count": 22,
+      "section_count": 77,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Assessment-Lab",
+        "Behavioral Health",
+        "Bh-Clinical",
+        "Clinical",
+        "Health Assessment"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 16,
+      "section_count": 76,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Biological Anthropology",
+        "Cult Diversity in Cont. Soc.",
+        "Cultural Anthropology",
+        "Environmental Anth",
+        "Food, Culture, and Environment"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "EMS",
+      "course_count": 13,
+      "section_count": 76,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Basic Skills Comp for Paramed",
+        "Emerg. Medical Resp",
+        "EMS Communications",
+        "EMT B",
+        "EMT Clinical"
+      ]
+    },
+    {
+      "prefix": "HSC",
+      "name": "HSC",
+      "course_count": 9,
+      "section_count": 75,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Basic Nursing Assistant Skills",
+        "Cardiac Telemetry Monitoring",
+        "CPR/AED and First Aid",
+        "Foundations of Caregiving",
+        "General and Therapeutic Nutr"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 18,
+      "section_count": 74,
+      "colleges": [
+        "montcalm-community-college",
+        "mott-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Applied Acctg",
+        "Comp Acct Using QuickBooks",
+        "Computerized Accounting",
+        "Cost Accounting",
+        "Cost Acctg"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 19,
+      "section_count": 73,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Analytical Physics I &amp; Lab",
+        "Analytical Physics II &amp; Lab",
+        "Applied Physics",
+        "Astronomy",
+        "College Physics I"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 11,
+      "section_count": 73,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Basic Spanish- Second Sem",
+        "Elem Spanish",
+        "Elem Spanish II",
+        "Elementary Spanish 1",
+        "Elementary Spanish I"
+      ]
+    },
+    {
+      "prefix": "SOCL",
+      "name": "SOCL",
+      "course_count": 4,
+      "section_count": 70,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Contemporary Social Problems",
+        "Introduction to Sociology",
+        "Marriage and Family",
+        "Race and Ethnicity"
+      ]
+    },
+    {
+      "prefix": "BUA",
+      "name": "Business",
+      "course_count": 15,
+      "section_count": 67,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Advertising, Promotion & PR",
+        "Business Admin Capstone",
+        "Business Administration Capsto",
+        "Business Law I",
+        "Contemporary Business"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "DMS",
+      "course_count": 40,
+      "section_count": 67,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Abd Sonography",
+        "Abdomen and Small Parts Sono",
+        "Abdominal Pathological Imaging",
+        "Adult Echo II",
+        "Advanced Sonography"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 30,
+      "section_count": 64,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Client Growth & Dev",
+        "Community Relations Crim Just",
+        "Corrections Law",
+        "Crim Investigation/Case Prep",
+        "Crime and Delinquency"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 4,
+      "section_count": 64,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Intro to Philosophy",
+        "Introduction to Formal Logic",
+        "Introduction to Informal Logic"
+      ]
+    },
+    {
+      "prefix": "CEM",
+      "name": "Chemistry",
+      "course_count": 10,
+      "section_count": 62,
+      "colleges": [
+        "jackson-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Chem &amp; Lab",
+        "Fundamentals of Chemistry",
+        "General Chemistry I",
+        "General Chemistry I &amp; Lab",
+        "General Chemistry II"
+      ]
+    },
+    {
+      "prefix": "ACAD",
+      "name": "Firstyear",
+      "course_count": 1,
+      "section_count": 60,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "First-Year Experience"
+      ]
+    },
+    {
+      "prefix": "ATT",
+      "name": "ATT",
+      "course_count": 30,
+      "section_count": 59,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Adv Special Vehicl Prototyping",
+        "Advanced Metal Shaping",
+        "Alt. Vehicle Fund. &amp; Safety",
+        "Alum Weld for Transport Apps",
+        "Applied Transportation Welding"
+      ]
+    },
+    {
+      "prefix": "CHSE",
+      "name": "CHSE",
+      "course_count": 15,
+      "section_count": 59,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Comp-Med Ins Billing/Coding",
+        "EKG Technician",
+        "Electronic Hlth Records Intro",
+        "Health Law and Ethics",
+        "Intro to Health Professions"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 28,
+      "section_count": 57,
+      "colleges": [
+        "montcalm-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Applied Music III:Guitar&amp;Bass",
+        "Applied Music IV:Guitar &amp; Bass",
+        "Applied Music V:Guitar &amp; Bass",
+        "Aural Skills I",
+        "Aural Skills III"
+      ]
+    },
+    {
+      "prefix": "NADN",
+      "name": "Nursing",
+      "course_count": 11,
+      "section_count": 57,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "College Success for Nursing",
+        "Foundations of Nursing",
+        "Leadership Capstone",
+        "Maternity and Pediatric Nursing",
+        "Nursing Care of the Adult Patient"
+      ]
+    },
+    {
+      "prefix": "PFHW",
+      "name": "PFHW",
+      "course_count": 3,
+      "section_count": 57,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Healthy Lifestyles",
+        "Human Nutrition",
+        "Stress Management"
+      ]
+    },
+    {
+      "prefix": "PHO",
+      "name": "Photography",
+      "course_count": 26,
+      "section_count": 57,
+      "colleges": [
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Color Photography",
+        "Advanced Darkroom Photography",
+        "Advanced Digital Photography",
+        "Beginning Darkroom Photography",
+        "Beginning Digital Photography"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 24,
+      "section_count": 56,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals",
+        "Ac/Refrig Ctrls I",
+        "Air Conditioning I",
+        "Air Conditioning II",
+        "Applied Electricity I"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 12,
+      "section_count": 56,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Advanced Welding",
+        "Automotive Welding",
+        "Fundamentals of Welding",
+        "Intro to WLD",
+        "Metal Fabrication"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 25,
+      "section_count": 55,
+      "colleges": [
+        "mid-michigan-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Admin of ECE Programs",
+        "Adv Practical Exper",
+        "Child Development",
+        "Child Guidance",
+        "Clas Beh Und Soc Com"
+      ]
+    },
+    {
+      "prefix": "MDA",
+      "name": "Medical",
+      "course_count": 12,
+      "section_count": 55,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Med Assisting Clinical Skills",
+        "Med Off Ins Coding & Bill App",
+        "Med Off Insur Coding/Billing",
+        "Med Off Software Applications",
+        "Medical Assist Practicum II"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Anthropology",
+      "course_count": 11,
+      "section_count": 54,
+      "colleges": [
+        "mid-michigan-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Archaeological Field Methods",
+        "Biological Anthropology",
+        "Cultural Anthropology",
+        "Intro to Cult Anth",
+        "Intro to Cultural Anthropology"
+      ]
+    },
+    {
+      "prefix": "SLI",
+      "name": "SLI",
+      "course_count": 18,
+      "section_count": 54,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Lang (ASL) V",
+        "American Sign Lang (ASL) VI",
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III"
+      ]
+    },
+    {
+      "prefix": "COMA",
+      "name": "Comm",
+      "course_count": 6,
+      "section_count": 53,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Argument and Debate",
+        "Fund of Speech",
+        "Intercultural Comm",
+        "Interpersonal Comm",
+        "Intro Comm Studies"
+      ]
+    },
+    {
+      "prefix": "MKTG",
+      "name": "Marketing",
+      "course_count": 14,
+      "section_count": 53,
+      "colleges": [
+        "lansing-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Consumer Behavior",
+        "Digital Promotion Methods",
+        "Intro to Digital Marketing",
+        "Marketing Internship"
+      ]
+    },
+    {
+      "prefix": "PEA",
+      "name": "PEA",
+      "course_count": 21,
+      "section_count": 52,
+      "colleges": [
+        "muskegon-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Aerobic Movement for Fitness",
+        "Archery",
+        "Basic Canoeing/Kayaking",
+        "Beach Volleyball",
+        "Beginning Pickleball"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "PHL",
+      "course_count": 10,
+      "section_count": 52,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Ethics",
+        "Ethic &amp; Leg Issues Health Care",
+        "Ethical Issues",
+        "Ethics",
+        "Existentialism"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 20,
+      "section_count": 51,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Ambulatory Coding Practicum",
+        "Basic Ambulatory Coding",
+        "Comp Appl Hlthcare",
+        "Foun Hlth Info Mgmt",
+        "Healthcare Stats Info Mgmt"
+      ]
+    },
+    {
+      "prefix": "COMG",
+      "name": "Computersprac",
+      "course_count": 1,
+      "section_count": 50,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Computers-Prac. App"
+      ]
+    },
+    {
+      "prefix": "ELTE",
+      "name": "ELTE",
+      "course_count": 21,
+      "section_count": 50,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Basic Wiring Installation",
+        "Control Panel Assembly",
+        "Electric Motor Maintenance",
+        "Electrical Mathematics",
+        "Electrical Prints for Building"
+      ]
+    },
+    {
+      "prefix": "ACCG",
+      "name": "Accounting",
+      "course_count": 15,
+      "section_count": 47,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Info for Management",
+        "Accounting Internship",
+        "Accounting Systems",
+        "Accounting with QuickBooks",
+        "Auditing"
+      ]
+    },
+    {
+      "prefix": "MHS",
+      "name": "MHS",
+      "course_count": 10,
+      "section_count": 47,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Assess Treat Plan Addiction",
+        "Ethics and Values in MH",
+        "Family Systems",
+        "Group Dynamics Soc Wk",
+        "Interpersonal Theory/Practice"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 12,
+      "section_count": 47,
+      "colleges": [
+        "lansing-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "American Political System",
+        "Campaigns &amp; Elections",
+        "Comparative Political Systems",
+        "International Relations",
+        "Intro to Political Science"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 12,
+      "section_count": 46,
+      "colleges": [
+        "jackson-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Adv. CAM Programming",
+        "Advanced Mastercam",
+        "Bas Machine Process",
+        "Basic Comp Num Con",
+        "Basic Mastercam"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 6,
+      "section_count": 45,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "General Chemistry I",
+        "General Chemistry II",
+        "Introductory Chemistry",
+        "Organic Chemistry I",
+        "Organic Chemistry II"
+      ]
+    },
+    {
+      "prefix": "CJUS",
+      "name": "CJUS",
+      "course_count": 21,
+      "section_count": 44,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Correctional Clients",
+        "Correctional Institutions",
+        "Crime Causes and Conditions",
+        "Criminal Investigation",
+        "Criminal Justice Org/Admin"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "Design",
+      "course_count": 21,
+      "section_count": 43,
+      "colleges": [
+        "muskegon-community-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Design Projects",
+        "Brand Identity Design",
+        "Computer Design",
+        "Digital Illustration",
+        "Digital Typography"
+      ]
+    },
+    {
+      "prefix": "CITP",
+      "name": "Programming",
+      "course_count": 10,
+      "section_count": 42,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Adv JAVA Programming for Busn",
+        "Advanced C#.NET Programming",
+        "Intro to C#.NET Programming",
+        "Intro to Mobile App Devel",
+        "Intro to Programming - Python"
+      ]
+    },
+    {
+      "prefix": "STAT",
+      "name": "Statistics",
+      "course_count": 2,
+      "section_count": 41,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Probability and Stats",
+        "Introduction to Statistics"
+      ]
+    },
+    {
+      "prefix": "CAB",
+      "name": "Success",
+      "course_count": 1,
+      "section_count": 40,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Stu Success Career"
+      ]
+    },
+    {
+      "prefix": "DHYG",
+      "name": "DHYG",
+      "course_count": 17,
+      "section_count": 40,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Periodontology",
+        "Comm Dental Health I",
+        "Dent Matl for Dhyg",
+        "Dent Matl for Dhyg Lab",
+        "Dental Anatomy"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 17,
+      "section_count": 40,
+      "colleges": [
+        "lansing-community-college",
+        "mott-community-college",
+        "muskegon-community-college",
+        "schoolcraft-community-college-district",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Crime Mapping",
+        "Cultural Geography",
+        "Geography of North America",
+        "Global Climate Crisis",
+        "Introduction to Geography"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 8,
+      "section_count": 39,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to GIS",
+        "Michigan Geography",
+        "Phy Geo Lab",
+        "Physical Geography",
+        "World Geography"
+      ]
+    },
+    {
+      "prefix": "MU",
+      "name": "Ensemble",
+      "course_count": 30,
+      "section_count": 39,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Class Piano",
+        "Class Piano",
+        "Class Piano - Non-Music Maj-",
+        "Class Piano for Music Majors",
+        "College Singers"
+      ]
+    },
+    {
+      "prefix": "ART.",
+      "name": "ART.",
+      "course_count": 21,
+      "section_count": 38,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Art Appreciation",
+        "Art Hist High Renais to Modern",
+        "Basic Drawing",
+        "Basic Illustration",
+        "Drawing II"
+      ]
+    },
+    {
+      "prefix": "CPS",
+      "name": "Programming",
+      "course_count": 12,
+      "section_count": 37,
+      "colleges": [
+        "jackson-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Java Concepts",
+        "An Intro to Programming /Java",
+        "Android Programming",
+        "Data Structures C++",
+        "Intro Prog With C++"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 4,
+      "section_count": 37,
+      "colleges": [
+        "mid-michigan-college",
+        "muskegon-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science",
+        "Intro Environ Sci and Lab",
+        "Intro to Env and Society",
+        "Introduction to Sustainability"
+      ]
+    },
+    {
+      "prefix": "GSC",
+      "name": "Geology",
+      "course_count": 3,
+      "section_count": 37,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Intro to Environmental Geology",
+        "Introductory Geology"
+      ]
+    },
+    {
+      "prefix": "SPA",
+      "name": "Spanish",
+      "course_count": 3,
+      "section_count": 37,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Spanish I",
+        "Beginning Spanish II",
+        "Intermediate Spanish I"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Surgical",
+      "course_count": 22,
+      "section_count": 37,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Biomed &amp; MIS",
+        "Capstone & Certificate Prep",
+        "Clinical Education I",
+        "Clinical Practicum II",
+        "Clinical Practicum III"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 16,
+      "section_count": 36,
+      "colleges": [
+        "muskegon-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Basic Criminalistics",
+        "Correctional Instit/Facility",
+        "Corrections I",
+        "Crime Prevention & Juvenile",
+        "Criminal Invest"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 11,
+      "section_count": 36,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Basic Elec. & Fluid",
+        "Basic Programmable Controllers",
+        "Circuit Analysis I",
+        "Circuit Analysis II",
+        "Commercial Wiring"
+      ]
+    },
+    {
+      "prefix": "HVA",
+      "name": "HVAC",
+      "course_count": 21,
+      "section_count": 36,
+      "colleges": [
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Controls",
+        "Basic Princpls HVACR Controls",
+        "Commercial Refrigeration II",
+        "Cooperative Internship",
+        "Energy Audits"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "LEGL",
+      "course_count": 13,
+      "section_count": 36,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Business Law-Basic Principles",
+        "Business Organizations",
+        "Computer Appl for the Law Ofc",
+        "Domestic Relations",
+        "eDiscovery"
+      ]
+    },
+    {
+      "prefix": "MID",
+      "name": "Strategies",
+      "course_count": 2,
+      "section_count": 36,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Career Readiness",
+        "Strategies for Success/College"
+      ]
+    },
+    {
+      "prefix": "AHLT",
+      "name": "AHLT",
+      "course_count": 9,
+      "section_count": 35,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Clin Histolog Tech",
+        "Dosage & Solution",
+        "Medical Terminology",
+        "Multicultural Health Care",
+        "Nutrition for Health"
+      ]
+    },
+    {
+      "prefix": "CNT",
+      "name": "CNT",
+      "course_count": 15,
+      "section_count": 34,
+      "colleges": [
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "CCNA Networking 1",
+        "CCNA Networking 2",
+        "Compu Hware Tblshtg",
+        "Compu Sware Tblshtg",
+        "Compu User Support"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 5,
+      "section_count": 34,
+      "colleges": [
+        "mid-michigan-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Comparative World Politics",
+        "International Relations",
+        "Intro to Amer Govt",
+        "Intro. to American Government",
+        "Urban and State Politics"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "Sign",
+      "course_count": 19,
+      "section_count": 34,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Interpreting",
+        "Advanced Sign to Voice",
+        "American Sign Language I",
+        "American Sign Language II",
+        "American Sign Language III"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "SOCI",
+      "course_count": 6,
+      "section_count": 34,
+      "colleges": [
+        "montcalm-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Marriage and Family",
+        "Minority Groups in America",
+        "Principles of Sociology",
+        "Social Problems",
+        "Sociology"
+      ]
+    },
+    {
+      "prefix": "ASC",
+      "name": "Strategies",
+      "course_count": 6,
+      "section_count": 33,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "College Success Skills",
+        "Critical Thinking Strategies",
+        "Critical Thinking-Advanced",
+        "Lecture Learning Strategies",
+        "Test Taking Strategies"
+      ]
+    },
+    {
+      "prefix": "ELEC",
+      "name": "ELEC",
+      "course_count": 20,
+      "section_count": 33,
+      "colleges": [
+        "mott-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Advanced PLC and Motion Control",
+        "Comm/Indust. Electric Systems",
+        "Control Panel Building",
+        "Digital Electronics",
+        "Electric Motors, Transformers"
+      ]
+    },
+    {
+      "prefix": "AUTM",
+      "name": "AUTM",
+      "course_count": 15,
+      "section_count": 32,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Auto Heating/Air Conditioning",
+        "Automotive Electrical I",
+        "Automotive Electrical II",
+        "Automotive Electrical III",
+        "Automotive Engine Repair"
+      ]
+    },
+    {
+      "prefix": "BUSI",
+      "name": "Business",
+      "course_count": 10,
+      "section_count": 32,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Business Law I",
+        "Business Law II",
+        "Human Resource Management",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "CRIM",
+      "name": "Criminal",
+      "course_count": 11,
+      "section_count": 32,
+      "colleges": [
+        "montcalm-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "American Criminal Law",
+        "Client Growth and Development",
+        "Client Relations in Corrections",
+        "Criminal Investigation",
+        "Introduction of Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "SOCW",
+      "name": "Social",
+      "course_count": 13,
+      "section_count": 32,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Child Welfare",
+        "Co-Occurring Disorders Substan",
+        "Intro to Community Development",
+        "Intro to Social Work",
+        "Intro to Substance Abuse"
+      ]
+    },
+    {
+      "prefix": "SOCY",
+      "name": "SOCY",
+      "course_count": 4,
+      "section_count": 32,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Human Sexuality",
+        "Introduction to Criminology",
+        "Introduction to Sociology",
+        "Marriage & Family"
+      ]
+    },
+    {
+      "prefix": "PER",
+      "name": "PER",
+      "course_count": 8,
+      "section_count": 31,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Group Exercise",
+        "Jogging",
+        "Med First Responder/First Resp",
+        "Physical Fitness",
+        "Physical Well-Being Modern Soc"
+      ]
+    },
+    {
+      "prefix": "CHDV",
+      "name": "CHDV",
+      "course_count": 14,
+      "section_count": 30,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Caring for School-Age Children",
+        "Caring for Youngest Learners",
+        "Child Growth/Develop: 0-12 Yrs",
+        "Child Guidance/Communication",
+        "Creativity and Play"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 21,
+      "section_count": 30,
+      "colleges": [
+        "lansing-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Acting 1 Theory El",
+        "Acting I - Contemporary",
+        "Acting-Shakespeare",
+        "Audition Workshop",
+        "Improvisation"
+      ]
+    },
+    {
+      "prefix": "CNS",
+      "name": "CNS",
+      "course_count": 17,
+      "section_count": 29,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Career Planning",
+        "Cloud Computing",
+        "Computer Networking 3",
+        "Computer Neworking 2",
+        "Enhancing Self-Esteem"
+      ]
+    },
+    {
+      "prefix": "DMAC",
+      "name": "DMAC",
+      "course_count": 14,
+      "section_count": 29,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Digital Cinematography I",
+        "Digital Cinematography II",
+        "Digital Presentation &amp; Signage",
+        "Ethics and Impact of the Media",
+        "Intro to Audio Production"
+      ]
+    },
+    {
+      "prefix": "ECD",
+      "name": "Child",
+      "course_count": 16,
+      "section_count": 29,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Building Blocks Early Care- I",
+        "Building Blocks Early Care- II",
+        "Child Assessment",
+        "Child Development",
+        "Child Development Practicum"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 22,
+      "section_count": 29,
+      "colleges": [
+        "mid-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Biophysical Agents I",
+        "Biophysical Agents I Lab",
+        "Biophysical Agents II",
+        "Biophysical Agents II Lab",
+        "Cardiopulmonary"
+      ]
+    },
+    {
+      "prefix": "FYS",
+      "name": "Life",
+      "course_count": 2,
+      "section_count": 28,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Life Maps",
+        "Navigating College and Life"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 14,
+      "section_count": 27,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Adapt Early Child Currica",
+        "Adm Progs Yng Cld",
+        "App Child Develop & Fam Engage",
+        "Child Observation & Assessment",
+        "Curriculum Plan/Early Childhoo"
+      ]
+    },
+    {
+      "prefix": "INDS",
+      "name": "Industrial",
+      "course_count": 9,
+      "section_count": 27,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Machine Operations",
+        "Basic CNC Machining",
+        "Hydraulics",
+        "Industrial Applied Geometry",
+        "Industrial Applied Right Angle and"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "mott-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Alt. Fuel and Hybrid Elec Veh.",
+        "Automatic Transmission",
+        "Automotive Fundamentals",
+        "Brake Systems",
+        "Brakes and Braking Systems"
+      ]
+    },
+    {
+      "prefix": "CJT",
+      "name": "Criminal",
+      "course_count": 14,
+      "section_count": 26,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Criminal Evidence &amp; Procedure",
+        "Criminal Investigation",
+        "Criminal Justice Constit Law",
+        "Criminal Justice Ethics",
+        "Criminal Law"
+      ]
+    },
+    {
+      "prefix": "CSMO",
+      "name": "Cosmetology",
+      "course_count": 22,
+      "section_count": 26,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Adv Cosmetology Theory II",
+        "Adv Cosmetology Theory III",
+        "Advance Cosmetology Theory IV",
+        "Advanced Cosmetology Lab I",
+        "Advanced Cosmetology Lab II"
+      ]
+    },
+    {
+      "prefix": "DHY",
+      "name": "Dental",
+      "course_count": 20,
+      "section_count": 26,
+      "colleges": [
+        "jackson-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Biochemistry & Nutrition",
+        "Clinical Dental Hygiene II",
+        "Clinical Dental Hygiene III",
+        "Clinical Dh 1",
+        "Clinical Techniques"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 5,
+      "section_count": 26,
+      "colleges": [
+        "lansing-community-college",
+        "mott-community-college",
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Geology",
+        "Introduction to Geology",
+        "Natural Disasters",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "GLG",
+      "name": "GLG",
+      "course_count": 6,
+      "section_count": 26,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Geol Nat&#39;l Parks &amp; Monuments",
+        "Intro to Earth Science &amp; Lab",
+        "Physical Geology and Lab",
+        "Principles of GIS",
+        "The Earth Through Time"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "History",
+      "course_count": 9,
+      "section_count": 26,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Ancient and Medieval Europe",
+        "History of Transportation Tech",
+        "Michigan History",
+        "The Ancient and Medieval World",
+        "The Civil War Era, 1845-1877"
+      ]
+    },
+    {
+      "prefix": "HUMS",
+      "name": "Western",
+      "course_count": 5,
+      "section_count": 26,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "American Cultural Experience",
+        "Art of Being Human",
+        "Mythology",
+        "The Western World since 1500",
+        "The Western World to 1500"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "MA",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "muskegon-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Med Assist Clinical Lab I",
+        "Med Assist Clinical Lab II",
+        "Med Assist Clinical Lec II",
+        "Med Assist Pharmacology",
+        "Med Asst Clinical Lec 1"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 8,
+      "section_count": 26,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Beg Conversational Spanish I",
+        "Elem Spanish I",
+        "Elem Spanish II",
+        "Elementary Spanish II",
+        "First Year Spanish I"
+      ]
+    },
+    {
+      "prefix": "HOC",
+      "name": "HOC",
+      "course_count": 4,
+      "section_count": 25,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "CPR & First Aid",
+        "EKG Technician",
+        "Intro Health Occupations",
+        "Phlebotomy Tech"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 3,
+      "section_count": 25,
+      "colleges": [
+        "jackson-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "American Natl Govt",
+        "International Relations",
+        "Intro to American Government"
+      ]
+    },
+    {
+      "prefix": "ATMN",
+      "name": "Industrial",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Advanced PLC",
+        "Automation Maintenance",
+        "Electrical Circuit Analysis",
+        "Industrial Automation I",
+        "Industrial Automation II"
+      ]
+    },
+    {
+      "prefix": "AVAF",
+      "name": "Aircraft",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Electrical I",
+        "Aircraft Electrical II",
+        "Aircraft Instruments",
+        "Aircraft Structures I",
+        "Aircraft Structures II"
+      ]
+    },
+    {
+      "prefix": "CMIS",
+      "name": "Computer",
+      "course_count": 5,
+      "section_count": 24,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Document Production",
+        "Computer Literacy",
+        "Introduction to Computer",
+        "Microsoft Outlook",
+        "Office Administration"
+      ]
+    },
+    {
+      "prefix": "EARTH",
+      "name": "EARTH",
+      "course_count": 4,
+      "section_count": 24,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Earth Systems",
+        "Environ Science",
+        "Intro Geology",
+        "Weather and Climate"
+      ]
+    },
+    {
+      "prefix": "METS",
+      "name": "METS",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Robotics",
+        "Automated Systems",
+        "Gen. Prevent/Predictive Maint",
+        "Industrial Hydraulics",
+        "Industrial Pneumatics"
+      ]
+    },
+    {
+      "prefix": "OPA",
+      "name": "OPA",
+      "course_count": 6,
+      "section_count": 24,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Crime Scene Investigation",
+        "Firearms Training",
+        "Health, Wellness, and Safety",
+        "Law and the Public Servant",
+        "Subject Control Training"
+      ]
+    },
+    {
+      "prefix": "PLG",
+      "name": "PLG",
+      "course_count": 13,
+      "section_count": 24,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "eDiscovery",
+        "Evidence Prep and Property Law",
+        "Legal Ethics",
+        "Legal Research",
+        "Legal Technology"
+      ]
+    },
+    {
+      "prefix": "CASD",
+      "name": "Skills",
+      "course_count": 3,
+      "section_count": 23,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Human Relations Skills",
+        "Stress Management",
+        "Study and Learning Skills"
+      ]
+    },
+    {
+      "prefix": "CULA",
+      "name": "Culinary Arts",
+      "course_count": 12,
+      "section_count": 23,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "A la Carte Dining/Tableservice",
+        "Catering Techniques",
+        "Co-Op Ed/Internshp",
+        "Culinary Knife Skills",
+        "Food and Wine Pairing"
+      ]
+    },
+    {
+      "prefix": "MEDIA",
+      "name": "MEDIA",
+      "course_count": 16,
+      "section_count": 23,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Design & Technology",
+        "Digi Illustration",
+        "Digital Imaging",
+        "Digital Photography",
+        "Hist Graphic Design"
+      ]
+    },
+    {
+      "prefix": "AAP",
+      "name": "AAP",
+      "course_count": 17,
+      "section_count": 22,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "AAP Internship",
+        "Adv Word Proc Appltn",
+        "Adv Word Proc/Keybrd",
+        "Beg Word Proc/Keybrd",
+        "Business Comm I"
+      ]
+    },
+    {
+      "prefix": "FIRE",
+      "name": "Fire",
+      "course_count": 13,
+      "section_count": 22,
+      "colleges": [
+        "lansing-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Bldg Construction/Fire Protect",
+        "Fire Academy",
+        "Fire Behavior &amp; Combustion",
+        "Fire Fighter 1",
+        "Fire Fighter 2"
+      ]
+    },
+    {
+      "prefix": "SPEE",
+      "name": "Public",
+      "course_count": 2,
+      "section_count": 22,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Public Speaking",
+        "Introduction to Human Communication"
+      ]
+    },
+    {
+      "prefix": "WEL",
+      "name": "Welding",
+      "course_count": 8,
+      "section_count": 22,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "\"Stick\" Welding",
+        "Advanced TIG Welding",
+        "Fabrication Machine Basics",
+        "Gas Tungsten Arc Weld (GTAW)",
+        "MIG Welding"
+      ]
+    },
+    {
+      "prefix": "ACRD",
+      "name": "Strateg",
+      "course_count": 2,
+      "section_count": 21,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Strateg Rdng for Science/Techn",
+        "Strateg Rdng for Soc Sci & Bus"
+      ]
+    },
+    {
+      "prefix": "CITF",
+      "name": "Systems",
+      "course_count": 5,
+      "section_count": 21,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Information Technology Ethics",
+        "Intro Computer Info Systems",
+        "IT Project Management",
+        "Operating Systems Concepts",
+        "Systems Analysis and Design"
+      ]
+    },
+    {
+      "prefix": "CITN",
+      "name": "CITN",
+      "course_count": 9,
+      "section_count": 21,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Ent Networking Sec Automation",
+        "Introduction to Networks",
+        "IoT &amp; Automation Fundamentals",
+        "IT Security Foundations",
+        "Linux Operating System"
+      ]
+    },
+    {
+      "prefix": "ELECT",
+      "name": "ELECT",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "AC Circuits Math Model",
+        "AC/DC Motors",
+        "Basic Meas Report Skills",
+        "DC Circuits Math Model",
+        "Digital Logic Circuits"
+      ]
+    },
+    {
+      "prefix": "ISYS",
+      "name": "ISYS",
+      "course_count": 13,
+      "section_count": 21,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Administering Windows Server",
+        "CISCO Routers and Switches",
+        "Configuring Windows Devices",
+        "Installing Windows Server",
+        "Internship"
+      ]
+    },
+    {
+      "prefix": "POLI",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 21,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "American Political System"
+      ]
+    },
+    {
+      "prefix": "ROB",
+      "name": "Robotic",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Adv Programmble/Control Appl",
+        "Collaborative Robotics",
+        "Industrial Robotic Application",
+        "Interpolated/Weld Robotic App",
+        "Introduction to Robotic Tech"
+      ]
+    },
+    {
+      "prefix": "AVPP",
+      "name": "Engine",
+      "course_count": 10,
+      "section_count": 20,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Aircraft Propeller Systems",
+        "Powerplant Certification",
+        "Powerplant Instruments",
+        "Reciprocating Engine",
+        "Reciprocating Engine Systems"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 8,
+      "section_count": 20,
+      "colleges": [
+        "mid-michigan-college",
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Engineering Circuits I",
+        "Engineering Digital Circuits",
+        "Engineering Programming",
+        "Engineering Thermodynamics",
+        "Introduction to Engineering"
+      ]
+    },
+    {
+      "prefix": "CRJU",
+      "name": "CRJU",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Admn. Concepts",
+        "Court Testimony and Document",
+        "Crim Law Procedure",
+        "Ethics & Leadership in CJ",
+        "Intr Law Enf & Adm"
+      ]
+    },
+    {
+      "prefix": "DEN",
+      "name": "Dental",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Practice",
+        "Advanced Functions",
+        "Alt Dental Asst Educ Proj",
+        "Basic Clinical for DA",
+        "Biomedical Science"
+      ]
+    },
+    {
+      "prefix": "GSCI",
+      "name": "GSCI",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Advanced ArcGIS",
+        "Automating Workflows in GIS",
+        "Beginning ArcGIS",
+        "Cartography in GIS",
+        "Drone Flight for Industry"
+      ]
+    },
+    {
+      "prefix": "HSW",
+      "name": "HSW",
+      "course_count": 8,
+      "section_count": 19,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Assess of Co-Occur Disorders",
+        "Experience Seminar",
+        "Family Social Work",
+        "Field Internship/Seminar I",
+        "Group Dynamics and Counseling"
+      ]
+    },
+    {
+      "prefix": "MED",
+      "name": "MED",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "jackson-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Clinical",
+        "Ins Billing and Coding - MA",
+        "Intro to Body Systems",
+        "Intro to Medical Assisting",
+        "MA Capstone"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Auto Brake Systems Svc",
+        "Auto Tune-Up & Emissions Svc",
+        "Automotive Electrical Svc",
+        "Automotive Fundamentals",
+        "Cooperative Internship"
+      ]
+    },
+    {
+      "prefix": "CITA",
+      "name": "Microsoft",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Microsoft Office",
+        "Microsoft Access Database",
+        "Microsoft Excel",
+        "Microsoft Excel-Advanced",
+        "Microsoft Outlook"
+      ]
+    },
+    {
+      "prefix": "CSS",
+      "name": "CSS",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "muskegon-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "College Success Seminar",
+        "Cybersecurity Essentials",
+        "Cybersecurity Operations",
+        "Intro to Network Security",
+        "Network Security"
+      ]
+    },
+    {
+      "prefix": "DAST",
+      "name": "DAST",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Dental & Oral Anatomy Lab",
+        "Dental and Oral Anatomy",
+        "Dental Materials",
+        "Dental Materials Lab",
+        "Dental Office Emergencies"
+      ]
+    },
+    {
+      "prefix": "FYEX",
+      "name": "Exper",
+      "course_count": 2,
+      "section_count": 18,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "1st Yr Exper: Pers & Ac Succ",
+        "Career Exploration & Dec Makin"
+      ]
+    },
+    {
+      "prefix": "GDT",
+      "name": "Design",
+      "course_count": 11,
+      "section_count": 18,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "History of Graphic Design",
+        "Imaging and Illustration",
+        "Interface Design I",
+        "Interface Design II",
+        "Introduction to Graphic Design"
+      ]
+    },
+    {
+      "prefix": "GNST",
+      "name": "Success",
+      "course_count": 1,
+      "section_count": 18,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Success Skills for the 21st Century"
+      ]
+    },
+    {
+      "prefix": "METM",
+      "name": "METM",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CNC Machining",
+        "Advanced Mastercam",
+        "Basic Mastercam",
+        "Introduction to CNC Machining",
+        "Machine Tool Operations"
+      ]
+    },
+    {
+      "prefix": "MOA",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 18,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Medical Law and Ethics",
+        "Medical Office Procedures",
+        "Medical Terminology",
+        "Principles-Med Coding/Billing"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 13,
+      "section_count": 18,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Appl Exer Physiol",
+        "Beginning Swimming",
+        "Exercise Techniques",
+        "Facilities Oper",
+        "First Aid"
+      ]
+    },
+    {
+      "prefix": "TDSN",
+      "name": "Design",
+      "course_count": 6,
+      "section_count": 18,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Advanced CAD",
+        "Geometric Dimensioning &",
+        "Industrial Documentation and",
+        "Integrated Design for Manufacturing",
+        "Tool & Die Design Production"
+      ]
+    },
+    {
+      "prefix": "PAM",
+      "name": "Public",
+      "course_count": 4,
+      "section_count": 17,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Hr Public Sector",
+        "Introduction to Public Admin",
+        "Nonpr Leadership&bgt",
+        "Public Policy Making"
+      ]
+    },
+    {
+      "prefix": "PFKN",
+      "name": "PFKN",
+      "course_count": 10,
+      "section_count": 17,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Athletic Training Principles",
+        "Biomechanics",
+        "Exercise Physiology",
+        "Exercise Physiology Lab",
+        "Foundations of Kinesiology"
+      ]
+    },
+    {
+      "prefix": "ALH",
+      "name": "ALH",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Clinical Proc. I",
+        "Clinical Proc. II",
+        "Insurance Billing",
+        "Med Asst Off Extern",
+        "Medical Law and Ethi"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "muskegon-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Dynamics",
+        "Intro ENGR & Tech",
+        "Introduction to Engineering",
+        "Mechanics Materials",
+        "Statics"
+      ]
+    },
+    {
+      "prefix": "NCT",
+      "name": "NCT",
+      "course_count": 8,
+      "section_count": 16,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "2D CAD CAM CNC Programming",
+        "Adv Manual Program/NC Tool Op",
+        "CNC Programming NC Tool",
+        "Foundation Manufacturing (CNC)",
+        "Geometric Dimensioning &amp; Toler"
+      ]
+    },
+    {
+      "prefix": "PEAC",
+      "name": "PEAC",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Training",
+        "Circuit Training for Wellness",
+        "Physical Condition",
+        "Pilates: Beginning",
+        "Self-Defense"
+      ]
+    },
+    {
+      "prefix": "PTA.",
+      "name": "PTA.",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Practice",
+        "Clinical Practice III",
+        "Clnical Practice I",
+        "Didactic Capstone",
+        "Health Care Management"
+      ]
+    },
+    {
+      "prefix": "ACCO",
+      "name": "Accounting",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Cost Accounting",
+        "Federal Income Tax",
+        "Intermediate Accounting I",
+        "Internship",
+        "Principles of Accounting I"
+      ]
+    },
+    {
+      "prefix": "ASL.",
+      "name": "American",
+      "course_count": 2,
+      "section_count": 15,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II"
+      ]
+    },
+    {
+      "prefix": "CITS",
+      "name": "Support",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Computer Support: A+ Cert Prep",
+        "Helpdesk Support Specialist",
+        "Intro to Basic Electronics",
+        "IT Professional Internship",
+        "Networking for PC Technicians"
+      ]
+    },
+    {
+      "prefix": "CSTC",
+      "name": "Information",
+      "course_count": 5,
+      "section_count": 15,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Cloud Essentials",
+        "Data Analytics",
+        "Information Technology Fundamentals",
+        "Project Management for Information",
+        "Scripting for Server Administration"
+      ]
+    },
+    {
+      "prefix": "EGY",
+      "name": "Utilities",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Adv. Utilities",
+        "Energy Ind Fund",
+        "Fund - Utilities",
+        "I - Utilities"
+      ]
+    },
+    {
+      "prefix": "MEDA",
+      "name": "MEDA",
+      "course_count": 12,
+      "section_count": 15,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Intro MA Med Terms &amp; Patho I",
+        "Intro MA Med Terms &amp; Patho II",
+        "Legal &amp; Ethical Concepts",
+        "MA Administrative Skills I",
+        "MA Administrative Skills II"
+      ]
+    },
+    {
+      "prefix": "METD",
+      "name": "Mechanical",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Unigraphics/NX",
+        "Basic Mechanical Drafting",
+        "Basic Unigraphics/NX",
+        "Geometric Dimension/Tolerance",
+        "Industrial Blueprint Reading"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "PHED",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Introduction to Coaching",
+        "Introduction to Recreation",
+        "Life Wellness",
+        "Phys Ed- Taekwondo",
+        "Practicum"
+      ]
+    },
+    {
+      "prefix": "PHOT",
+      "name": "PHOT",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "lansing-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Basic Photography",
+        "Commercial Portraiture",
+        "Digital Photog. for Non-Majors",
+        "Digital Photography",
+        "Intro to Comm Studio Photo"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 6,
+      "section_count": 15,
+      "colleges": [
+        "lansing-community-college",
+        "montcalm-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Field Experience",
+        "Introduction to Social Welfare",
+        "Introduction to Social Work",
+        "Social Work Interviewing",
+        "Social Work/Interview Skills"
+      ]
+    },
+    {
+      "prefix": "TH",
+      "name": "TH",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Applied Theater-Acting",
+        "Applied Theater-Costuming",
+        "Applied Theater-Performance",
+        "Applied Theater-Product Crew",
+        "Applied Theater-Scenery Cons"
+      ]
+    },
+    {
+      "prefix": "AIM",
+      "name": "AIM",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Adv CNC Programming",
+        "Adv Prog Logic Controllers",
+        "Ba Mach Shop Pract",
+        "CNC Programming",
+        "Cnc Programming II"
+      ]
+    },
+    {
+      "prefix": "ANI",
+      "name": "ANI",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "3D Animation III",
+        "3D Modeling &amp; Prod. Pipeline",
+        "Advanced Game Level Design",
+        "Concept Development for Animat",
+        "Fund. of Movement &amp; Animation"
+      ]
+    },
+    {
+      "prefix": "AST",
+      "name": "Astronomy",
+      "course_count": 1,
+      "section_count": 14,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "General Astronomy"
+      ]
+    },
+    {
+      "prefix": "CADD",
+      "name": "CADD",
+      "course_count": 12,
+      "section_count": 14,
+      "colleges": [
+        "mott-community-college",
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "2D CADD Applications",
+        "Adv Dimensionint & Geometric",
+        "Arch Blueprint Reading w/CADD",
+        "Blueprint Reading/Engineering Graphics I",
+        "CADD Product Design Apps"
+      ]
+    },
+    {
+      "prefix": "CAR",
+      "name": "CAR",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Aluminum Repair and Welding",
+        "Auto Body Fundamentals",
+        "Automotive Detailing and Prep",
+        "Collision Welding",
+        "Damage Analy, Est and Cus Srv"
+      ]
+    },
+    {
+      "prefix": "CJS",
+      "name": "CJS",
+      "course_count": 11,
+      "section_count": 14,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Communications in Crim Just",
+        "Correctional Facilities",
+        "Crim Investigation",
+        "Crim Law/Pol Offcrs",
+        "Evidence and Police Pt 1"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "Macroeconomics",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Macroeconomics",
+        "Microeconomics"
+      ]
+    },
+    {
+      "prefix": "ELTC",
+      "name": "ELTC",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Basic Industrial Robotics",
+        "Controls for Automation",
+        "Electrical Troubleshooting",
+        "Electricity-Basic",
+        "Industrial Electricity"
+      ]
+    },
+    {
+      "prefix": "FLM",
+      "name": "Film",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "American Film",
+        "International Cinema",
+        "Introduction to Film",
+        "The Horror Film"
+      ]
+    },
+    {
+      "prefix": "INT",
+      "name": "Design",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Computer Aided Int Design I",
+        "Computer Aided Int Design II",
+        "Design Internship I",
+        "Interior Design Materials",
+        "Introduction-Interior Design"
+      ]
+    },
+    {
+      "prefix": "MSGE",
+      "name": "Massage",
+      "course_count": 7,
+      "section_count": 14,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Anatomy/Physiology Massage I",
+        "Career Longevity",
+        "Event Massage",
+        "Massage for Beginners",
+        "Massage I"
+      ]
+    },
+    {
+      "prefix": "RES",
+      "name": "Respiratory",
+      "course_count": 10,
+      "section_count": 14,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Cardiopulm Path II",
+        "Cardiopulminary Patho I",
+        "Clinical Practice I",
+        "Clinical Practice II",
+        "Clinical Practice IV"
+      ]
+    },
+    {
+      "prefix": "RT",
+      "name": "RT",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Adult Mechanical Ventilation",
+        "Adv Clinical Practice I",
+        "Advanced Clinical II",
+        "Basic Patient Care Skills",
+        "Clinical IV"
+      ]
+    },
+    {
+      "prefix": "AMS",
+      "name": "Auto",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Auto Engine Fund & Overhl",
+        "Auto Service Intro Pt. 1",
+        "Auto Service Introduction",
+        "Automotive Tech Internship",
+        "Basic Auto Electricity"
+      ]
+    },
+    {
+      "prefix": "ARTH",
+      "name": "Art History",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Art History to the Renaissance",
+        "Arts of Asia",
+        "Contemporary Art",
+        "Masterpieces of Art &amp; Music",
+        "West. Art: Renaissance to 1900"
+      ]
+    },
+    {
+      "prefix": "BOS",
+      "name": "BOS",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Keyboarding",
+        "Beginning Keyboarding",
+        "Database Applications",
+        "Elect Planning, Sharing &amp; Orgn",
+        "Intermediate Keyboarding"
+      ]
+    },
+    {
+      "prefix": "DESN",
+      "name": "Design",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Design Careers",
+        "Design Center I",
+        "Design Center II",
+        "Design I",
+        "Design Internship"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Arts in the Classroom",
+        "Child Growth & Development",
+        "Exploring Teaching",
+        "Intro Teach in Diverse Society",
+        "Intro to Teaching"
+      ]
+    },
+    {
+      "prefix": "EMTA",
+      "name": "EMTA",
+      "course_count": 5,
+      "section_count": 13,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "EMS Instr-Coord Student Teach",
+        "EMS Instructor-Coordinator",
+        "EMT Clinical",
+        "EMT Medical Trauma",
+        "EMT Skills"
+      ]
+    },
+    {
+      "prefix": "MRI",
+      "name": "MRI",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "southwestern-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Applied Sectional Anatomy",
+        "Clinical Practice 1",
+        "Clinical Practice 3",
+        "Computer Apps/Medical Imaging",
+        "MRI Certification Exam Prep"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "MTT",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Machining Processes",
+        "Fundamentals of CAM",
+        "G&M Code CNC Programming",
+        "Intro to Machine Tools",
+        "Introduction to CNC"
+      ]
+    },
+    {
+      "prefix": "RTAD",
+      "name": "Respiratory",
+      "course_count": 12,
+      "section_count": 13,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Critical Respiratory Care",
+        "Resp Procedures",
+        "Respir Clinic Care Practic III",
+        "Respiratory Assessment",
+        "Respiratory Clinic Practice II"
+      ]
+    },
+    {
+      "prefix": "SURG",
+      "name": "Surg",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "lansing-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Adv Surg Procedures",
+        "Intro To Surg Tech",
+        "Sterile Pro Clin 1",
+        "Sterile Processing",
+        "Surg Patient Care"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 9,
+      "section_count": 13,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Audition & Business of Acting",
+        "Improvisation",
+        "Introduction to Theatre",
+        "Theatre Activity"
+      ]
+    },
+    {
+      "prefix": "CITW",
+      "name": "Development",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Internet Literacy",
+        "Web Development HTML &amp; CSS",
+        "Web Development JavaScript",
+        "Web Development PHP &amp; MySQL",
+        "Web Site Management"
+      ]
+    },
+    {
+      "prefix": "CIVL",
+      "name": "CIVL",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Civil Drafting",
+        "Civil Technology Internship",
+        "Density Certification",
+        "Route Survey",
+        "Site Dsgn &amp; Layout/Civil Techn"
+      ]
+    },
+    {
+      "prefix": "ECDV",
+      "name": "Child",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Administration of Early Childhood",
+        "Child Development: Infants &",
+        "Child Development: Preschool/School",
+        "Children with Special Needs"
+      ]
+    },
+    {
+      "prefix": "ELE",
+      "name": "ELE",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Basic Electronics",
+        "Battery Manufacturing",
+        "Electrical Fundamentals",
+        "Prog. Controllers (PLCs) I",
+        "Semiconductor Manufacturing"
+      ]
+    },
+    {
+      "prefix": "ELTA",
+      "name": "ELTA",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "AC Fundamentals - Electrician",
+        "Basic Electrical Calculations",
+        "Elect. Industry Orientation",
+        "Introduction to Fire Alarms",
+        "PLC Overview for Electricians"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "ENT",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Business Plan",
+        "Ent Marketing Niche",
+        "Entrepreneurship 101"
+      ]
+    },
+    {
+      "prefix": "FFA",
+      "name": "Fire",
+      "course_count": 5,
+      "section_count": 12,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Communication and Command",
+        "Fire Apparatus and Training",
+        "Fire Behavior/Detect/Suppress",
+        "HAZMAT/Wildland/Special Rescu",
+        "Health, Wellness, and Safety"
+      ]
+    },
+    {
+      "prefix": "GEL",
+      "name": "Earth",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Earth Science",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "HCA",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Competency Capstone",
+        "Fiscal Mgt in HC Facilities",
+        "HCA Externship",
+        "Health Facil Maint/Sanitation",
+        "Intro to Health Care Admin"
+      ]
+    },
+    {
+      "prefix": "HEA",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 12,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "HEED",
+      "name": "HEED",
+      "course_count": 7,
+      "section_count": 12,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Emergency Medical Technician I",
+        "Medical Terminology",
+        "Medication Aide",
+        "Nurses Assistant",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "PFFT",
+      "name": "Fitness",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Core Strength &amp; Flexiblty Trng",
+        "Introduction to Fitness",
+        "Total Fitness A-Fitness",
+        "Yoga: Beginning"
+      ]
+    },
+    {
+      "prefix": "RELG",
+      "name": "Religions",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Asian Religions and Traditions",
+        "Intro to World Religions",
+        "Introduction to Christianity"
+      ]
+    },
+    {
+      "prefix": "SRT",
+      "name": "Record",
+      "course_count": 6,
+      "section_count": 12,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Adv Audio Prod 1",
+        "Adv Audio Prod 2",
+        "Basic Sound Record Tech 1",
+        "Basic Sound Record Tech 2",
+        "Ear Train Record Engineers"
+      ]
+    },
+    {
+      "prefix": "TECH",
+      "name": "Industrialconstruction",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "lansing-community-college",
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Industrial/Construction Safety",
+        "Survey of Technology Careers"
+      ]
+    },
+    {
+      "prefix": "AH",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Electronic Health Records",
+        "Environ. Stressors & Nutrit.",
+        "Medical Insurance Billing",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "ASTR",
+      "name": "Astronomy",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "lansing-community-college",
+        "mott-community-college",
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Cosmology",
+        "General Astronomy",
+        "Introductory Astronomy",
+        "Solar System"
+      ]
+    },
+    {
+      "prefix": "CMUS",
+      "name": "Enrichment",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "ENRICH App IV -Ind Instr Voice",
+        "Enrich Collegiate Chorale",
+        "Enrich Tenor-Bass Ensemble",
+        "Enrichment Choral Scholars",
+        "Enrichment Individual Music Instruction"
+      ]
+    },
+    {
+      "prefix": "CORR",
+      "name": "Corr",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Client Rel in Corr",
+        "Client-Growth/Dev",
+        "Corr Instit/Facil",
+        "Intro Corrections",
+        "Legal Issues Corr"
+      ]
+    },
+    {
+      "prefix": "DCTM",
+      "name": "DCTM",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Architectural Drawing/CAD I",
+        "Codes and Specifications",
+        "Construction Management I",
+        "Construction Management II",
+        "Drafting/Intro to CAD"
+      ]
+    },
+    {
+      "prefix": "ED",
+      "name": "ED",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Anti-bias Curriculum in ECE",
+        "Child Development (age 0-8)",
+        "Children's Literature",
+        "Early Childhood Observe Assess",
+        "Infant-Toddler Development"
+      ]
+    },
+    {
+      "prefix": "HERT",
+      "name": "Equipment",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Diesel Fuel Systems",
+        "Equipment HVAC/Cab Controls",
+        "Equipment Hydraulics",
+        "Equipment Introduction",
+        "Equipment Powertrain"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 5,
+      "section_count": 11,
+      "colleges": [
+        "oakland-community-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese I",
+        "Beginning Japanese II",
+        "Elementary Japanese I",
+        "First Year Japanese II",
+        "Intermediate Japanese I"
+      ]
+    },
+    {
+      "prefix": "MAET",
+      "name": "Media",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Documentary Production",
+        "Intro to Media Production",
+        "Intro to Screenwriting",
+        "Media Aesthetics",
+        "Media History and Theory"
+      ]
+    },
+    {
+      "prefix": "MECH",
+      "name": "MECH",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "mott-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanc CNC Setup Prog & Opera",
+        "Advanc Mach for Tool & Maint",
+        "Machining",
+        "Mastercam",
+        "Mechanical Components & Drives"
+      ]
+    },
+    {
+      "prefix": "NCAS",
+      "name": "Noncredit",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Noncredit Academic Supprt-PSYC",
+        "Noncredit Academic Supprt-RELG",
+        "Noncredit Academic Supprt-SOCL"
+      ]
+    },
+    {
+      "prefix": "NCCE",
+      "name": "Multiinstrumental",
+      "course_count": 2,
+      "section_count": 11,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Massage for Beginners",
+        "Multi-Instrumental Music Ensem"
+      ]
+    },
+    {
+      "prefix": "SLIE",
+      "name": "SLIE",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language III",
+        "American Sign Language V",
+        "ASL to English I",
+        "ASL to English II",
+        "Interpret/Transliterating II"
+      ]
+    },
+    {
+      "prefix": "THR",
+      "name": "Theatre",
+      "course_count": 3,
+      "section_count": 11,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Fund of Acting I",
+        "Introduction to Theatre",
+        "Theatre Practicum"
+      ]
+    },
+    {
+      "prefix": "VID",
+      "name": "Video",
+      "course_count": 8,
+      "section_count": 11,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Digital Cinematography",
+        "Documentary Video Production I",
+        "Foundations Digital Video II",
+        "Foundations in Digital Video I",
+        "Lighting for Video"
+      ]
+    },
+    {
+      "prefix": "ARB",
+      "name": "Arabic",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "oakland-community-college",
+        "schoolcraft-community-college-district",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Arabic I",
+        "Beginning Arabic II",
+        "Elementary Arabic 1",
+        "Elementary Arabic 2",
+        "First Year Arabic I"
+      ]
+    },
+    {
+      "prefix": "CMN",
+      "name": "Construction",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Cnst Bldg Systems & Materials",
+        "Cnst Contracts & Admin",
+        "Const. Planning & Scheduling",
+        "Construction Applications",
+        "Construction Drawings"
+      ]
+    },
+    {
+      "prefix": "COMN",
+      "name": "Network",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Client & Server Network Admin",
+        "Info Security in a Digital Age",
+        "Network Essentials",
+        "Netwrk Infrstruc Config & Impl",
+        "Routing Protocol & Networking"
+      ]
+    },
+    {
+      "prefix": "FRE",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 10,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Beginning French I",
+        "Beginning French II"
+      ]
+    },
+    {
+      "prefix": "IST",
+      "name": "Industrial",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Fund for the Drafting Industry",
+        "Industrial Math I",
+        "Industrial Math II",
+        "Industrial Math III",
+        "Industrial Print Reading"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "MET",
+      "course_count": 7,
+      "section_count": 10,
+      "colleges": [
+        "muskegon-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Basic Cast Metals",
+        "Heat Treatment",
+        "Industrial Materials",
+        "Intro Materials Sci",
+        "Intro Phys Met"
+      ]
+    },
+    {
+      "prefix": "NSC",
+      "name": "Science",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Contemporary Climate Science",
+        "Fund. Ag Science",
+        "Scientific Inquiry",
+        "Scientific Inquiry Lab"
+      ]
+    },
+    {
+      "prefix": "PNC",
+      "name": "Medsurg",
+      "course_count": 4,
+      "section_count": 10,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Med-Surg I",
+        "Med-Surg II",
+        "Ms I Clinical",
+        "Ms II Clinicals"
+      ]
+    },
+    {
+      "prefix": "PSCI",
+      "name": "PSCI",
+      "course_count": 5,
+      "section_count": 10,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Contemp Polit Issues-Us Govt",
+        "International Relations",
+        "Intro to American Government",
+        "Intro to Political Science",
+        "Labor Studies"
+      ]
+    },
+    {
+      "prefix": "PSCN",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Intro to American Government"
+      ]
+    },
+    {
+      "prefix": "SKL",
+      "name": "Skill",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Skill Building Program"
+      ]
+    },
+    {
+      "prefix": "AHEA",
+      "name": "Emergency",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Emergency Health Care",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "Class",
+      "course_count": 1,
+      "section_count": 9,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Class A CDL"
+      ]
+    },
+    {
+      "prefix": "DART",
+      "name": "DART",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Commercial Design I",
+        "Digital Imaging",
+        "Photographic Foundations II"
+      ]
+    },
+    {
+      "prefix": "HEAL",
+      "name": "HEAL",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Card Pulm Resuscit",
+        "Nutrition Basics for Consumer",
+        "Safety and Emergency Response"
+      ]
+    },
+    {
+      "prefix": "HRA",
+      "name": "HRA",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Adv Comm Refrig",
+        "Comm Refrig Design",
+        "Epa Refridge Handler",
+        "Fund of Electricity",
+        "Heating Fundamentals"
+      ]
+    },
+    {
+      "prefix": "INSU",
+      "name": "Insurance",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Claims and Underwriting",
+        "Commercial Insurance",
+        "Insurance Agency Operations",
+        "Insurance Internship",
+        "Intro to Financial Advising"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "Machining",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "2-D CAD/CAM Comp Aid Des Mch",
+        "Adv. Comp Aid Design",
+        "Advanced Machining",
+        "Basic Machining",
+        "Intermediate Machining"
+      ]
+    },
+    {
+      "prefix": "NCCT",
+      "name": "NCCT",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Corrections Academy 80hr",
+        "Health and Wellness for Police",
+        "UAS Part 107 Exam &amp; Flight Ori"
+      ]
+    },
+    {
+      "prefix": "OTA.",
+      "name": "OTA.",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Assistive Tech. in OT",
+        "Cndtns/Psychosocial Dysfun",
+        "Intro Occupational Therapy",
+        "OTA Internship I",
+        "OTA Internship II"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Death & Dying",
+        "Intro to Religion",
+        "Religion, Race, Class & Discri"
+      ]
+    },
+    {
+      "prefix": "YOG",
+      "name": "Yoga",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "De-stressing with Meditation",
+        "Yoga I",
+        "Yoga II"
+      ]
+    },
+    {
+      "prefix": "ACS",
+      "name": "Success",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Academic and Career Success",
+        "Career Decision Making",
+        "College Success Seminar",
+        "Information Literacy"
+      ]
+    },
+    {
+      "prefix": "AT",
+      "name": "AT",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Engine Performance",
+        "Automotive Air Conditioning",
+        "Automotive Brakes",
+        "Automotive Power Plants",
+        "Electrical Systems II"
+      ]
+    },
+    {
+      "prefix": "AVGM",
+      "name": "Aviation",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Aviation General I",
+        "Aviation General II",
+        "Aviation General III",
+        "Materials and Processes"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Gen'l College Chem I",
+        "Intro Chemistry",
+        "Organic Chemistry I - Lab",
+        "Organic Chemistry I - Lecture"
+      ]
+    },
+    {
+      "prefix": "COLLS",
+      "name": "COLLS",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "App Lrn Theory Nurs",
+        "College Reading",
+        "Critical Read Think App"
+      ]
+    },
+    {
+      "prefix": "COMS",
+      "name": "Programming",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Intro to .NET Programming",
+        "Intro to Linux Administration",
+        "Introduction to C++",
+        "Introduction to Programming"
+      ]
+    },
+    {
+      "prefix": "CONS",
+      "name": "CONS",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Building Analyst/Envelope",
+        "Interior Finishes",
+        "Intermediate Construction Practices",
+        "Internship",
+        "Trade Mathematics-Construction"
+      ]
+    },
+    {
+      "prefix": "DRA",
+      "name": "Acting",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Improvisational Acting I",
+        "Improvisational Acting II"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Tech",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Emerg Med Tech Basic",
+        "Para Field Intern",
+        "Paramedic Tech 1",
+        "Paramedic Tech 2",
+        "Paramedic Tech 3"
+      ]
+    },
+    {
+      "prefix": "ENST",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Environmental Science"
+      ]
+    },
+    {
+      "prefix": "ESOL",
+      "name": "Esol",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "ESOL Combined Skills Level 5",
+        "ESOL Combined Skills Level 6"
+      ]
+    },
+    {
+      "prefix": "FR",
+      "name": "French",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "muskegon-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Elementary French 1",
+        "Elementary French 2",
+        "Intermediate French 1"
+      ]
+    },
+    {
+      "prefix": "HE",
+      "name": "HE",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Community First Aid and Safe",
+        "Concepts of Health/Wellbeing",
+        "Industr Safety/Wkplace Trng",
+        "Nutrition for Fitness & Spor"
+      ]
+    },
+    {
+      "prefix": "HPF",
+      "name": "HPF",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Intro to Exercise Sci",
+        "Lineworker Fitness",
+        "Managing Stress & Health",
+        "Personalized Fitness",
+        "Stress Management"
+      ]
+    },
+    {
+      "prefix": "HUSE",
+      "name": "Human",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Child Abuse and Neglect",
+        "Human Services Practicum",
+        "Introduction to Human Services",
+        "Personal Dynamics/Interviewing",
+        "The Family: Addiction/Violence"
+      ]
+    },
+    {
+      "prefix": "NDXT",
+      "name": "NDXT",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "EEG Applications",
+        "EEG Clinical Practical 2",
+        "EEG Pre-Clinical Preparation",
+        "EEG Procedures/Pathology 2",
+        "EEG Procedures/Pathology 3"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "Astronomy",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Intro Astronomy",
+        "Intro Physcl Science"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "SSC",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Death & Dying",
+        "Intro to Religion",
+        "Introduction to Global Studies",
+        "Introduction to Podcasting",
+        "Soc Sci & Cont Amerc"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "Sign",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "mid-michigan-college",
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "Ba Amer Sign Lang I",
+        "Ba Amer Sign Lang II"
+      ]
+    },
+    {
+      "prefix": "AUD",
+      "name": "AUD",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Audio Production Techniques II",
+        "Introduction to Audio Tech",
+        "Introduction to Live Sound",
+        "Pro Tools Fundamentals I",
+        "Pro Tools Fundamentals II"
+      ]
+    },
+    {
+      "prefix": "BAKE",
+      "name": "BAKE",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Bake Shop I",
+        "Basic Cake Decorating",
+        "Introduction to Baking",
+        "Pastry Techniques",
+        "Plated Desserts"
+      ]
+    },
+    {
+      "prefix": "BDT",
+      "name": "BDT",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Adv Brewing Distill",
+        "Beer Styles & Sensory",
+        "Brewhouse Oper Tech",
+        "Brewing Science",
+        "Cellar Pkg Qual Mgmt"
+      ]
+    },
+    {
+      "prefix": "CITC",
+      "name": "Cybersecurity",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Cybersecurity Incident Respons",
+        "Cybersecurity Risk Management",
+        "Ethical Hacking",
+        "System Defense"
+      ]
+    },
+    {
+      "prefix": "COMI",
+      "name": "COMI",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Data Analytics Capstone",
+        "Database Concepts",
+        "Intro to Computer Info Systems",
+        "Supporting End Users"
+      ]
+    },
+    {
+      "prefix": "CPSC",
+      "name": "Computer",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Algorithms and Computing w/C++",
+        "Computer Science Structures",
+        "Computing and Data Structures",
+        "Intro to Computer Science"
+      ]
+    },
+    {
+      "prefix": "DNC",
+      "name": "Dance",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Ballet II",
+        "Dance Appreciation",
+        "Modern Dance I",
+        "Modern Dance II"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "Film",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Film"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "German",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "jackson-college",
+        "muskegon-community-college",
+        "oakland-community-college",
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Beginning German I",
+        "Elementary German 1",
+        "Elementary German I",
+        "Intermediate German 1"
+      ]
+    },
+    {
+      "prefix": "GLS",
+      "name": "GLS",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Intro. to Global Studies",
+        "Topic: History of Science",
+        "Topics in GLS - European Exp.",
+        "Topics in GLS - Spain"
+      ]
+    },
+    {
+      "prefix": "HED",
+      "name": "Health",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Intro to Exercise Science",
+        "Intro to Health Professions",
+        "Public Health Internship",
+        "Stress Management"
+      ]
+    },
+    {
+      "prefix": "JAPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Elementary Japanese I",
+        "Elementary Japanese II",
+        "Intermediate Japanese I",
+        "Intermediate Japanese II"
+      ]
+    },
+    {
+      "prefix": "LIB",
+      "name": "Library",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Collection Management",
+        "Information Research Methods",
+        "Intro to Library Services",
+        "Intro to Reference Resources",
+        "Intro. to Library Technology"
+      ]
+    },
+    {
+      "prefix": "MCT",
+      "name": "Systems",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Fluid Power Systems",
+        "Fluid Power Systems",
+        "Gen Prevent/Predictive Mainten",
+        "Integrated Systems",
+        "Mechanical Drives I"
+      ]
+    },
+    {
+      "prefix": "MIC",
+      "name": "MIC",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Coder Capstone",
+        "Physician Office Medical Codin",
+        "Principles of Coding/Billing"
+      ]
+    },
+    {
+      "prefix": "MILS",
+      "name": "Army",
+      "course_count": 4,
+      "section_count": 7,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Fndtion of Army Leadership-Lab",
+        "Foundations of Army Leadership",
+        "Mil Ldrshp/Decision Making-Lab",
+        "Mil Leadrshp &amp; Decision Making"
+      ]
+    },
+    {
+      "prefix": "NCEL",
+      "name": "Listeningspeaking",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "ESL Com Skill 3-out of country",
+        "ESL Listening-Speaking"
+      ]
+    },
+    {
+      "prefix": "RSP",
+      "name": "Clinical",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Applications",
+        "Cardiopulmonary Struct/Func",
+        "Clinical Practic I",
+        "Clinical Practice II",
+        "Critical Care Equip and Proc"
+      ]
+    },
+    {
+      "prefix": "W",
+      "name": "Welding",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Basic Welding",
+        "Gas Metal Arc Welding (MIG)",
+        "Gas Tungsten Arc Welding (tig)",
+        "Pipe Welding",
+        "Structural Welding"
+      ]
+    },
+    {
+      "prefix": "BLDT",
+      "name": "Framing",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Builder Pre-Licensure Prep",
+        "Building Exterior Construction",
+        "Residential Bldg Internship",
+        "Steel Framing",
+        "Structural Framing"
+      ]
+    },
+    {
+      "prefix": "CITO",
+      "name": "Cloud",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Cloud Architecting with AWS",
+        "Cloud Development Ops with AWS",
+        "Cloud Foundations with AWS"
+      ]
+    },
+    {
+      "prefix": "CNET",
+      "name": "Ccna",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "CCNA1 Cisco Networking Fundamentals",
+        "CCNA3 Cisco Scaling Networks"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Command Line Fundamentals",
+        "Computer Forensics",
+        "Computer Systems Technology I",
+        "Computer Systems Technology II",
+        "Digital Logic and Computer Dsn"
+      ]
+    },
+    {
+      "prefix": "EXSC",
+      "name": "Strength",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Strength and",
+        "Personal Training Preparation"
+      ]
+    },
+    {
+      "prefix": "INTE",
+      "name": "Industrial",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Industrial Robotics",
+        "Industrial Robotics Vision",
+        "Internship",
+        "Introduction to Manufacturing Systems"
+      ]
+    },
+    {
+      "prefix": "MEC",
+      "name": "MEC",
+      "course_count": 5,
+      "section_count": 6,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Blueprint Read for Manufactur",
+        "Materials and Processes",
+        "Mechanisms &amp; Intro Mechatronic",
+        "Mechatronics Capstone",
+        "Pneumatics &amp; Hydraulics"
+      ]
+    },
+    {
+      "prefix": "MRKT",
+      "name": "Marketing",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Principles of Marketing",
+        "Promotion & Advertising"
+      ]
+    },
+    {
+      "prefix": "PHT",
+      "name": "Phrm",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Comm Pharm Sim Lab",
+        "Comm Phrm Practical",
+        "Hosp Pharm Sim Lab",
+        "Hosp Phrm Practical",
+        "Pharmacol Phrm Tech"
+      ]
+    },
+    {
+      "prefix": "UTL",
+      "name": "Hvac",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning 1",
+        "Heat Sys 1",
+        "Intro. to HVAC",
+        "Refr Hand. & HVAC"
+      ]
+    },
+    {
+      "prefix": "AERO",
+      "name": "Usaf",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "USAF Heritage &amp; Values II",
+        "USAF Heritage &amp; Values II-Lab",
+        "USAF Team &amp; Leadership Fund II",
+        "USAF Team/Leadrshp Fund II-Lab"
+      ]
+    },
+    {
+      "prefix": "AVAU",
+      "name": "Drone",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Drone Flight-Capstone",
+        "Drone Flight Orient.-FAA Exam",
+        "Drone Maintenance"
+      ]
+    },
+    {
+      "prefix": "CITD",
+      "name": "Concepts",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Database Concepts",
+        "SQL Concepts"
+      ]
+    },
+    {
+      "prefix": "CITI",
+      "name": "Foundations",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "AI Foundations",
+        "Intro to Machine Learning"
+      ]
+    },
+    {
+      "prefix": "COMC",
+      "name": "Core",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "A+ Core Hardware Components",
+        "A+ Operating Systems"
+      ]
+    },
+    {
+      "prefix": "CON",
+      "name": "Construction",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Construction Conc. and Masonry",
+        "Construction Finishes-Exterior",
+        "Construction Finishes-Interior",
+        "Construction Framing II",
+        "Intro to Construction Tech"
+      ]
+    },
+    {
+      "prefix": "ENTR",
+      "name": "Entrepreneurial",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurial Marketing",
+        "Entrepreneurial Mindset",
+        "Opportunity Analysis"
+      ]
+    },
+    {
+      "prefix": "FMG.",
+      "name": "Food",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Food Safety & Sanitation",
+        "Food Service Math",
+        "Meat Fabric & Identification"
+      ]
+    },
+    {
+      "prefix": "FSA",
+      "name": "Fire",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Bldg Const for Fire Service",
+        "Fire Hydraulics & Water Supp",
+        "Fire Protection Systems/Equip",
+        "Fire Service Administration",
+        "Intro to Fire Protection"
+      ]
+    },
+    {
+      "prefix": "HUMA",
+      "name": "HUMA",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Introduction to American Pop Culture",
+        "Introduction to Film",
+        "Introduction to Non-Western Civilization"
+      ]
+    },
+    {
+      "prefix": "ISCI",
+      "name": "Physical",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Integrated Physical Science",
+        "Physical Science Concepts",
+        "S.T.E.M. Workplace Practices"
+      ]
+    },
+    {
+      "prefix": "SCI.",
+      "name": "Scientific",
+      "course_count": 1,
+      "section_count": 5,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Scientific Inquiry"
+      ]
+    },
+    {
+      "prefix": "SMT",
+      "name": "Sport",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Esport in Society",
+        "Hist & Soc Issues in Sport",
+        "Intro. Sport Management",
+        "Sport Management Internship"
+      ]
+    },
+    {
+      "prefix": "AGT",
+      "name": "AGT",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Ag. Internship",
+        "Integrated Pest Mgmt",
+        "Precision Farming",
+        "Safety & Bio Security"
+      ]
+    },
+    {
+      "prefix": "CBPA",
+      "name": "Baking",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Baking",
+        "Intro Baking Pastry Ski & Tech",
+        "Pastries"
+      ]
+    },
+    {
+      "prefix": "ECM",
+      "name": "ECM",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Advanced Information Tech",
+        "AI in Marketing",
+        "UX, Web & Content Creation"
+      ]
+    },
+    {
+      "prefix": "FRN",
+      "name": "French",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college",
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Elem French I",
+        "Elementary French I",
+        "First Year French I"
+      ]
+    },
+    {
+      "prefix": "FRSC",
+      "name": "Survey",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Introd to Autopsy Techniques",
+        "Survey of Forensic Science"
+      ]
+    },
+    {
+      "prefix": "FSN",
+      "name": "Found",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Found Natural/Life Science"
+      ]
+    },
+    {
+      "prefix": "HFPR",
+      "name": "HFPR",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Exercise Physiology",
+        "Introduction to Kinesiology",
+        "Tech & App of Hlth & Fit Equip",
+        "Theory & App of Hlt & Fitness"
+      ]
+    },
+    {
+      "prefix": "HONR",
+      "name": "Colloquy",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Community Service Practicum I",
+        "Community Service Practicum II",
+        "Honors Colloquy I",
+        "Honors Colloquy II"
+      ]
+    },
+    {
+      "prefix": "HP",
+      "name": "Hydraulicspneumatics",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Hydraulics",
+        "Hydraulics/Pneumatics"
+      ]
+    },
+    {
+      "prefix": "HUC.",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Health Unit Coor",
+        "Health Unit Coor-Practicum"
+      ]
+    },
+    {
+      "prefix": "LTL",
+      "name": "Band",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Community Concert Band",
+        "Jazz Band Ltl",
+        "Jc Choir Ltl",
+        "Jc Drumline Ltl"
+      ]
+    },
+    {
+      "prefix": "MIB",
+      "name": "Professional",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Billing Capstone",
+        "Professional Medical Biller"
+      ]
+    },
+    {
+      "prefix": "NCHE",
+      "name": "Provider",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "AHA BLS Provider CPR"
+      ]
+    },
+    {
+      "prefix": "NCSH",
+      "name": "Pathways",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "SSH Pathways Seminar"
+      ]
+    },
+    {
+      "prefix": "OTPT",
+      "name": "Anatomy",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Applied Anatomy",
+        "Applied Anatomy Lab",
+        "Physical Medicine Terminology"
+      ]
+    },
+    {
+      "prefix": "RDG",
+      "name": "Integrated",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Integrated Reading and Writing"
+      ]
+    },
+    {
+      "prefix": "SCM",
+      "name": "Supply",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro Supply Chain",
+        "Supply Chain Ops"
+      ]
+    },
+    {
+      "prefix": "STS",
+      "name": "Orientation",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Co-Op Education Orientation",
+        "College Placement Orientation",
+        "Interviewing Skills",
+        "Resume Writing"
+      ]
+    },
+    {
+      "prefix": "TMAT",
+      "name": "Technical",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Math-Technical II",
+        "Technical Math I"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "Agriculture",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Introduction to Agriculture",
+        "Introduction to Crop and Plant",
+        "Professional Agriculture Sem"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "Animal",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Animal Science"
+      ]
+    },
+    {
+      "prefix": "ALT",
+      "name": "Prin",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Prin of Alternative Energy"
+      ]
+    },
+    {
+      "prefix": "APP",
+      "name": "Technology",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Applied Technology"
+      ]
+    },
+    {
+      "prefix": "BCOM",
+      "name": "Business",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Adv. Business & Tech Communi"
+      ]
+    },
+    {
+      "prefix": "BISC",
+      "name": "Biological",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Biological Science"
+      ]
+    },
+    {
+      "prefix": "CBSY",
+      "name": "Ethical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Ethical Hacking"
+      ]
+    },
+    {
+      "prefix": "CMG",
+      "name": "Const",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Const Site Safety &amp; OSHA Req",
+        "Construction Graphics",
+        "Intro to Const Management"
+      ]
+    },
+    {
+      "prefix": "COMW",
+      "name": "Page",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Dynamic Web Pages",
+        "Intro to Web Page Creation"
+      ]
+    },
+    {
+      "prefix": "DMU",
+      "name": "Audio",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Audio Recording I",
+        "Audio Recording III",
+        "Digital M/Aud Capstone Project"
+      ]
+    },
+    {
+      "prefix": "EEC",
+      "name": "Digital",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "DC Fundamentals",
+        "Digital Electronics"
+      ]
+    },
+    {
+      "prefix": "ENVR",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "montcalm-community-college"
+      ],
+      "sample_titles": [
+        "Environmental Science (Lec Only)"
+      ]
+    },
+    {
+      "prefix": "GERO",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Human Aging"
+      ]
+    },
+    {
+      "prefix": "HAS",
+      "name": "HAS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Hunting Strategies",
+        "Outdoor Industry Internship",
+        "Safety and Survival"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "HS",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro Emergency Management",
+        "Intro Homeland Security",
+        "Transp & Border Sec"
+      ]
+    },
+    {
+      "prefix": "ITA",
+      "name": "Italian",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Italian I",
+        "Beginning Italian II",
+        "Italian Culture & Conversation"
+      ]
+    },
+    {
+      "prefix": "LABR",
+      "name": "Labor",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Employment Law for Managers",
+        "Intro to Labor Relations"
+      ]
+    },
+    {
+      "prefix": "NCMA",
+      "name": "Math",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Mathematics",
+        "Math Refresher"
+      ]
+    },
+    {
+      "prefix": "PEP",
+      "name": "Personal",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Coaching",
+        "Personal Training"
+      ]
+    },
+    {
+      "prefix": "PFWT",
+      "name": "Weight",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Weight Training",
+        "Weight Training I"
+      ]
+    },
+    {
+      "prefix": "PHSC",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Intro Physical Science L&l"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Nature",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "The Nature of Science"
+      ]
+    },
+    {
+      "prefix": "SPE",
+      "name": "Child",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Child Special Needs",
+        "Special Education"
+      ]
+    },
+    {
+      "prefix": "ARBC",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Standard Arabic"
+      ]
+    },
+    {
+      "prefix": "ARCH",
+      "name": "Sustainable",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "History of Architecture II",
+        "Sustainable Site Design"
+      ]
+    },
+    {
+      "prefix": "ATHL",
+      "name": "Athletic",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Athletic Training Clinical I",
+        "Intro to Athletic Training"
+      ]
+    },
+    {
+      "prefix": "AVEL",
+      "name": "Flight",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Flight Line Testing"
+      ]
+    },
+    {
+      "prefix": "BCON",
+      "name": "Surveying",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Building Construction Codes",
+        "Elementary Surveying"
+      ]
+    },
+    {
+      "prefix": "BMET",
+      "name": "Bmet",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Biomed Term 1",
+        "BMET Internship 2"
+      ]
+    },
+    {
+      "prefix": "COR",
+      "name": "Corrections",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro Corrections"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Jazz",
+        "Intro to Dance Techniques"
+      ]
+    },
+    {
+      "prefix": "FFT",
+      "name": "Fire",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Fund of Fire Prevention",
+        "Intro to Fire Protection"
+      ]
+    },
+    {
+      "prefix": "FSH",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Foundations of Humanities"
+      ]
+    },
+    {
+      "prefix": "GRM",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "First Year German I"
+      ]
+    },
+    {
+      "prefix": "HES",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Human Lifespan Dev"
+      ]
+    },
+    {
+      "prefix": "HONS",
+      "name": "Diversity",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Soc Diversity Engagement Lab",
+        "Social Diversity & Engagement"
+      ]
+    },
+    {
+      "prefix": "JAPA",
+      "name": "Japanese",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Japanese",
+        "Intermediate Japanese"
+      ]
+    },
+    {
+      "prefix": "JRN",
+      "name": "Journalism",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Feature Writing",
+        "Introduction to Journalism"
+      ]
+    },
+    {
+      "prefix": "JRNL",
+      "name": "Newswriting",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Newswriting and Reporting",
+        "Opinion Writing"
+      ]
+    },
+    {
+      "prefix": "LEAD",
+      "name": "Leadership",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Leadership Development I",
+        "Leadership Development II"
+      ]
+    },
+    {
+      "prefix": "MSE",
+      "name": "Metallurgy",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Material Sci Fund - Metallurgy",
+        "Welding Metallurgy"
+      ]
+    },
+    {
+      "prefix": "NATP",
+      "name": "Nursing",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Nursing Asst Course"
+      ]
+    },
+    {
+      "prefix": "NCBD",
+      "name": "Builder",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Builder Pre-Licensure Prep"
+      ]
+    },
+    {
+      "prefix": "NCJT",
+      "name": "Electrical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Control Technician",
+        "ESL Skills Level 2B"
+      ]
+    },
+    {
+      "prefix": "NCLD",
+      "name": "Leadership",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Leadership Practicum I",
+        "Leadership Practicum II"
+      ]
+    },
+    {
+      "prefix": "NCRD",
+      "name": "Math",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Basic Math Fdn 100"
+      ]
+    },
+    {
+      "prefix": "NCRW",
+      "name": "Foundations",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Foundations for Success"
+      ]
+    },
+    {
+      "prefix": "NFS",
+      "name": "Clinical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Clinical Nutrition",
+        "Explore Spec Diets"
+      ]
+    },
+    {
+      "prefix": "OSH",
+      "name": "Industry",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "OSH Construction",
+        "OSH Gen Industry"
+      ]
+    },
+    {
+      "prefix": "PHS",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Physical Science for Educators"
+      ]
+    },
+    {
+      "prefix": "POSC",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "American Government"
+      ]
+    },
+    {
+      "prefix": "PST",
+      "name": "Professional",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Professional Skills Lab"
+      ]
+    },
+    {
+      "prefix": "ROBAT",
+      "name": "Tool",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Rbt Tool Ops & Prg"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "jackson-college",
+        "mid-michigan-college"
+      ],
+      "sample_titles": [
+        "Intro Social Work",
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "TAX",
+      "name": "Income",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Income Taxes For Individuals"
+      ]
+    },
+    {
+      "prefix": "THTR",
+      "name": "Theatre",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Acting I - Fundament of Acting",
+        "Theatre Appreciation"
+      ]
+    },
+    {
+      "prefix": "AEET",
+      "name": "Alternative",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Alternative Energy Practicum"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "Technology",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Technology"
+      ]
+    },
+    {
+      "prefix": "BLC",
+      "name": "Blockchain",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Blockchain & Cryptography"
+      ]
+    },
+    {
+      "prefix": "CGT",
+      "name": "Digital",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Digital Imaging 1 Photoshop"
+      ]
+    },
+    {
+      "prefix": "CHEE",
+      "name": "Enrichment",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "southwestern-michigan-college"
+      ],
+      "sample_titles": [
+        "Enrichment Nurses Assistant"
+      ]
+    },
+    {
+      "prefix": "CHW",
+      "name": "Community",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Community Health Worker"
+      ]
+    },
+    {
+      "prefix": "CM",
+      "name": "Culinary",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Culinary Law"
+      ]
+    },
+    {
+      "prefix": "DDT",
+      "name": "Fund",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Fund for the Drafting Industry"
+      ]
+    },
+    {
+      "prefix": "ELAP",
+      "name": "Engl",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Engl for Acad Purposes-Interme"
+      ]
+    },
+    {
+      "prefix": "ETT",
+      "name": "Electrical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Print Reading"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Elem French"
+      ]
+    },
+    {
+      "prefix": "GRMN",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "Elementary German I"
+      ]
+    },
+    {
+      "prefix": "ICS",
+      "name": "Italiansa",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Basic Italian-SA"
+      ]
+    },
+    {
+      "prefix": "ITAL",
+      "name": "Italian",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Elementary Italian 1"
+      ]
+    },
+    {
+      "prefix": "MBC",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Medical Coding Capstone"
+      ]
+    },
+    {
+      "prefix": "NCCC",
+      "name": "College",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "lansing-community-college"
+      ],
+      "sample_titles": [
+        "College Connect - Math"
+      ]
+    },
+    {
+      "prefix": "OCE",
+      "name": "Oceanography",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Oceanography"
+      ]
+    },
+    {
+      "prefix": "ODA",
+      "name": "Critical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "oakland-community-college"
+      ],
+      "sample_titles": [
+        "Critical Issues in Dispatch"
+      ]
+    },
+    {
+      "prefix": "OFC",
+      "name": "Sports",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Sports Officiating"
+      ]
+    },
+    {
+      "prefix": "PPA",
+      "name": "Prepa",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Intro to Pre-PA"
+      ]
+    },
+    {
+      "prefix": "QC",
+      "name": "Quality",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Quality Control-Basic"
+      ]
+    },
+    {
+      "prefix": "QM",
+      "name": "Qual",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Intro Qual Imprv"
+      ]
+    },
+    {
+      "prefix": "RE",
+      "name": "Real",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "schoolcraft-community-college-district"
+      ],
+      "sample_titles": [
+        "Real Est PreLicense"
+      ]
+    },
+    {
+      "prefix": "REA",
+      "name": "Precollege",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "washtenaw-community-college"
+      ],
+      "sample_titles": [
+        "Pre-College Reading Clinic"
+      ]
+    },
+    {
+      "prefix": "REC",
+      "name": "Recreation",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Recreation & Leisur"
+      ]
+    },
+    {
+      "prefix": "STEM",
+      "name": "Undergraduate",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "mott-community-college"
+      ],
+      "sample_titles": [
+        "Undergraduate Research Methods"
+      ]
+    },
+    {
+      "prefix": "STM",
+      "name": "Sustainability",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "jackson-college"
+      ],
+      "sample_titles": [
+        "Intro to Sustainability"
+      ]
+    },
+    {
+      "prefix": "WGS",
+      "name": "Lgbtq",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "muskegon-community-college"
+      ],
+      "sample_titles": [
+        "LGBTQ Studies"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/mo/subject-vocab.json
+++ b/data/mo/subject-vocab.json
@@ -1,0 +1,3133 @@
+{
+  "state": "mo",
+  "generated_at": "2026-05-13T03:53:11.037Z",
+  "subjects": [
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 43,
+      "section_count": 634,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "African American Literature",
+        "American Lit After 1865",
+        "American Lit Before 1865",
+        "CHILDREN'S LITERATURE",
+        "Classical Mythology"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 43,
+      "section_count": 557,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ALGEBRA FOR CALCULUS W/SUPP",
+        "ALGEBRAIC STRUCTURES",
+        "ANALYTIC GEOMETRY/CALCULUS I",
+        "ANALYTIC GEOMETRY/CALCULUS II",
+        "ANALYTIC GEOMETRY/CALCULUS III"
+      ]
+    },
+    {
+      "prefix": "ENGL",
+      "name": "English",
+      "course_count": 16,
+      "section_count": 431,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "African-American Literature",
+        "American Literature 1860-Present",
+        "American Literature to 1860",
+        "British Literature to 1750",
+        "Composition &amp; Reading I"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 18,
+      "section_count": 429,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Algebra Principles",
+        "Analytic Geometry and Calculus I",
+        "Analytic Geometry and Calculus II",
+        "Analytic Geometry and Calculus III",
+        "Calculus for Business and Social Science"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 67,
+      "section_count": 422,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "metropolitan-community-college-kansas-city",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Painting",
+        "AFRICA, OCEANIA, AMERICAS ART",
+        "ART AND EXPERIENCE",
+        "Art Appreciation",
+        "ART HISTORY II"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 29,
+      "section_count": 369,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "A&amp;P for Pre-Hosp Healthcare",
+        "Anatomy &amp; Physiology I Lab",
+        "Anatomy &amp; Physiology II Lab",
+        "Biology for Majors I Lab",
+        "Biology for Majors II Lab"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 23,
+      "section_count": 346,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adolescent Psych",
+        "ADOLESCENT PSYCHOLOGY",
+        "BEHAVIORAL SCIENCES SEMINAR",
+        "Child Development"
+      ]
+    },
+    {
+      "prefix": "BCS",
+      "name": "BCS",
+      "course_count": 10,
+      "section_count": 333,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CARDIOPULMONARY A&P",
+        "ESSENTIALS IN HUMAN BIOLOGY",
+        "FRESHMEN-LEVEL SPECIAL TOPICS",
+        "HEALTH SCIENCES NUTRITION",
+        "HUMAN ANATOMY"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "History",
+      "course_count": 17,
+      "section_count": 256,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "African-American History",
+        "ANCIENT & MEDIEVAL WORLD HIST",
+        "Ancient &amp; Medieval Civilizatn",
+        "Missouri History",
+        "Missouri History (EL)"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 10,
+      "section_count": 253,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Fundamentals of Communication",
+        "Honors Fund of Communication",
+        "INTERPERSONAL COMMUNICATION",
+        "Intro to Audio Technology",
+        "Intro to Television Production"
+      ]
+    },
+    {
+      "prefix": "BIOL",
+      "name": "Biology",
+      "course_count": 14,
+      "section_count": 251,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology",
+        "Environmental Science",
+        "General Biology",
+        "General Biology for Majors I",
+        "General Biology for Majors II"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 7,
+      "section_count": 246,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "African American History",
+        "Foundations of Western Civilization",
+        "Modern Western Civilization",
+        "Spec Topic: Civil Rights Movem",
+        "United States History since 1865"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 29,
+      "section_count": 241,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADMINISTRATIVE PROCEDURES",
+        "Basic Business Statistics",
+        "Business Communications",
+        "BUSINESS COMMUNICATIONS",
+        "Business Law"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 45,
+      "section_count": 224,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Database Concepts",
+        "Advanced Info Systems Security",
+        "BACKEND WEB DEVELOPMENT",
+        "C# PROGRAMMING I",
+        "C# PROGRAMMING II"
+      ]
+    },
+    {
+      "prefix": "MUSI",
+      "name": "MUSI",
+      "course_count": 36,
+      "section_count": 218,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Choir I",
+        "Choir II",
+        "Choir III",
+        "Choir IV",
+        "Class Guitar I"
+      ]
+    },
+    {
+      "prefix": "BUSN",
+      "name": "Business",
+      "course_count": 26,
+      "section_count": 173,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Business Capstone",
+        "Business Communications",
+        "Business Management",
+        "Business Writing",
+        "Consumer Behavior"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 17,
+      "section_count": 166,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Chem for Health Sci Recitation",
+        "Chem Hlth Sci Lec and Lab",
+        "Concepts in Chemistry",
+        "FRESHMEN-LEVEL SPECIAL TOPICS",
+        "Gen Chemistry I Lec & Lab"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 6,
+      "section_count": 160,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Fundamentals of Human Communication",
+        "Fundamentals of Speech",
+        "Intercultural Communication",
+        "Interpersonal Communication",
+        "Introduction to Film"
+      ]
+    },
+    {
+      "prefix": "PSYC",
+      "name": "Psychology",
+      "course_count": 6,
+      "section_count": 158,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Adolescent Psychology",
+        "Child Development",
+        "Death and Dying",
+        "General Psychology",
+        "Human Lifespan Development"
+      ]
+    },
+    {
+      "prefix": "COL",
+      "name": "College",
+      "course_count": 10,
+      "section_count": 152,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "Freshman Sem: College to Work",
+        "Health and Wellness",
+        "Introduction to College",
+        "Mastering College Experience"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 33,
+      "section_count": 143,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Arc Welding",
+        "ADV GAS METAL/FLUX ARC WLD",
+        "ADV SHIELDED METAL ARC WLD",
+        "Adv Welding Tech I",
+        "Adv Welding Tech II"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 13,
+      "section_count": 136,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Gen Phys II Lec",
+        "GENERAL PHYSICS I",
+        "General Physics I Lab",
+        "GENERAL PHYSICS II",
+        "General Physics II Lab"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 8,
+      "section_count": 134,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "General College Chemistry I",
+        "General College Chemistry II",
+        "Introductory Chemistry for Health Sciences",
+        "Organic Chemistry I",
+        "Organic Chemistry II"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 2,
+      "section_count": 134,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AMERICAN GOVERNMENT POLITICS",
+        "INTERNATIONAL RELATIONS"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 26,
+      "section_count": 127,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AAT Placement Documentation",
+        "Child Development",
+        "Child Hlth,Nutri&Safety",
+        "Edu of Exceptional Learners",
+        "EDUCATION EXCEPTIONAL LEARNER"
+      ]
+    },
+    {
+      "prefix": "MSA",
+      "name": "Lessons",
+      "course_count": 32,
+      "section_count": 126,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Brass Lessons I",
+        "Brass Lessons II",
+        "Brass Lessons III",
+        "Brass Lessons IV",
+        "Guitar/Bass Lessons I"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 11,
+      "section_count": 120,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Alcohol, Drugs, and Society",
+        "Am Social Problems",
+        "CULTURAL DIVERSITY",
+        "DECONSTRUCTING SOCIAL PROBLEM",
+        "Human Diversity"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 22,
+      "section_count": 114,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Academic Skills for Success in the U.S.",
+        "Advanced I: Grammar",
+        "Advanced I: Reading and Composition",
+        "Advanced I: Speaking and Listening",
+        "Advanced II: Grammar"
+      ]
+    },
+    {
+      "prefix": "CSIS",
+      "name": "CSIS",
+      "course_count": 23,
+      "section_count": 109,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Web Development",
+        "Assembly Language Programming",
+        "Computer Concepts and Applications",
+        "Computer Hardware, Maintenance, and Troubleshooting",
+        "Cyber Analytics"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 59,
+      "section_count": 108,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Adv Radiographic Proc I",
+        "CAPSTONE & REVIEW I",
+        "CAPSTONE & REVIEW II",
+        "CLINIC & PROFESSIONALISM I",
+        "CLINIC & PROFESSIONALISM II"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 35,
+      "section_count": 99,
+      "colleges": [
+        "east-central-college",
+        "metropolitan-community-college-kansas-city",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support (ACLS)",
+        "Advanced Medical Life Support (AMLS)",
+        "Advanced Patient Assessment",
+        "Airway and Respiratory Management",
+        "Basic Emergency Patient Care"
+      ]
+    },
+    {
+      "prefix": "HRA",
+      "name": "HRA",
+      "course_count": 23,
+      "section_count": 97,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADV COMMERCIAL REFRIGERATION",
+        "ADV HEATING/AIR CONDITIONING",
+        "Advanced Electricity for HVAC",
+        "AIR DISTRIBUTION SYSTEMS",
+        "BASIC REFRIG THEORY & APPS"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 5,
+      "section_count": 96,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Introduction to Critical Thinking",
+        "Introduction to Philosophy",
+        "Logic",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 13,
+      "section_count": 94,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Internship",
+        "ACCOUNTING SOFTWARE APPS",
+        "CO-OPERATIVE ED/INTERNSHIP",
+        "COLLEGE ACCOUNTING, PART I",
+        "COLLEGE ACCOUNTING, PART II"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Ethics",
+      "course_count": 8,
+      "section_count": 93,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Business &amp; Professional Ethics",
+        "Ethics",
+        "INTRO TO ETHICS",
+        "Intro to Philosophy",
+        "Introduction to Philosophy"
+      ]
+    },
+    {
+      "prefix": "ASN",
+      "name": "Nursing",
+      "course_count": 18,
+      "section_count": 89,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADV NURSING - LIFESPAN I",
+        "ADV NURSING - LIFESPAN II",
+        "ADV NURSING - LIFESPAN III",
+        "ADV NURSING-PEDIATRIC CONCEPT",
+        "ADV NURSING-PSY/MENTAL HLTH"
+      ]
+    },
+    {
+      "prefix": "SOCI",
+      "name": "Sociology",
+      "course_count": 2,
+      "section_count": 89,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Contemporary Social Issues",
+        "Sociology"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 17,
+      "section_count": 76,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADULT MED SUR II-I.V. THERAPY",
+        "ADULT MEDICAL-SURGICAL I",
+        "COMMUNITY/MENTAL HEALTH NUR",
+        "Fund Nursing Lab",
+        "FUNDAMENTALS OF NURSING I"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 12,
+      "section_count": 74,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "GUITAR CLASS I",
+        "JAZZ APPRECIATION",
+        "JAZZ ENSEMBLE",
+        "Mus Apprec: Age of Rock&Roll",
+        "Music Appreciation"
+      ]
+    },
+    {
+      "prefix": "READ",
+      "name": "Reading",
+      "course_count": 4,
+      "section_count": 70,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "College Reading",
+        "College Success Skills",
+        "Foundations for Academic Reading I",
+        "Foundations for Academic Reading II"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 5,
+      "section_count": 68,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Economics",
+        "Prin Macroeconomics",
+        "Prin Microeconomics",
+        "PRINCIPLES OF MACROECONOMICS",
+        "PRINCIPLES OF MICROECONOMICS"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 4,
+      "section_count": 65,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "BEGINNING SPANISH I",
+        "Intermediate Spanish",
+        "Spanish Grammar Comp",
+        "Spanish Reading"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 13,
+      "section_count": 64,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Accounting Capstone",
+        "Accounting Information Systems",
+        "Accounting Principles I",
+        "Accounting Principles II",
+        "Accounting Using Spreadsheets"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 25,
+      "section_count": 63,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Baking and Pastry",
+        "Basic Culinary Mthds & Tech",
+        "Beverage Management",
+        "CAKE DECORATING",
+        "CHOCOLATE & SUGARS"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 23,
+      "section_count": 63,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Basic Principles of Disease",
+        "Classification Systems II",
+        "COMPARATIVE HEALTH RECORDS",
+        "Electronic Health Systems",
+        "HEALTH INFORMATION SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "MSC",
+      "name": "MSC",
+      "course_count": 29,
+      "section_count": 62,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Brass Chamber Ensemble",
+        "Chamber Choir",
+        "Class Piano I",
+        "Class Piano II",
+        "Class Piano III"
+      ]
+    },
+    {
+      "prefix": "WELD",
+      "name": "Welding",
+      "course_count": 22,
+      "section_count": 62,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Flux Core Arc Welding I (FCAW) Lab",
+        "Flux Core Arc Welding I (FCAW) Lecture",
+        "Gas Metal Arc Welding I (GMAW) Lab",
+        "Gas Metal Arc Welding I (GMAW) Lecture",
+        "Gas Metal Arc Welding II (GMAW) Lab"
+      ]
+    },
+    {
+      "prefix": "GDT",
+      "name": "Design",
+      "course_count": 17,
+      "section_count": 58,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVERTISING DESIGN",
+        "ANIMATION",
+        "CO-OPERATIVE ED/INTERN",
+        "COMIC BOOK ART & DESIGN",
+        "CREATIVE THINKING"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 10,
+      "section_count": 56,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Administrative Issues in GIS",
+        "Applications in Geographic Information Systems",
+        "Cultural/Human Geography",
+        "Geographic Information Systems Internship",
+        "GIS Database and Design"
+      ]
+    },
+    {
+      "prefix": "INTE",
+      "name": "INTE",
+      "course_count": 24,
+      "section_count": 56,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Industrial Machine Repair",
+        "Advanced Special Problems, Projects, and Capstones",
+        "Communication for Industry",
+        "Electric Motor Control II",
+        "Electric Motor Controls I"
+      ]
+    },
+    {
+      "prefix": "ITI",
+      "name": "ITI",
+      "course_count": 13,
+      "section_count": 54,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED NETWORKING SYSTEMS",
+        "CCNAv7: ENSA",
+        "CCNAv7: INTRO TO NETWORKS",
+        "CCNAv7: SRWE",
+        "CLOUD & DATA CENTER SYSTEMS"
+      ]
+    },
+    {
+      "prefix": "AVI",
+      "name": "Pilot",
+      "course_count": 25,
+      "section_count": 53,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AIR TRAFFIC CONTROL SYSTEM",
+        "AIRCRAFT & ENGINE COMPONENTS",
+        "AIRLINE OPERATIONS",
+        "AVIATION SAFETY",
+        "AVIATION WEATHER"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 18,
+      "section_count": 51,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Diagnosis",
+        "Automatic Transmissions and Transaxles",
+        "Automotive Air Conditioning",
+        "Automotive Braking Systems",
+        "Automotive Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "ECD",
+      "name": "ECD",
+      "course_count": 16,
+      "section_count": 51,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CAPSTONE PRACTICUM IV",
+        "CLASSROOM & BEHAVIORAL MGMT",
+        "CREATIVITY & THE YOUNG CHILD",
+        "CURRICULUM & ASSESSMNT IN ECD",
+        "EARLY CHILDHOOD GROWTH/DEV"
+      ]
+    },
+    {
+      "prefix": "AUM",
+      "name": "AUM",
+      "course_count": 12,
+      "section_count": 50,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED TOPICS AUTO INDUST",
+        "AUTO TRANSM & TRANS AXLE",
+        "BRAKES",
+        "ELECTRICAL I",
+        "ELECTRICAL II"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 5,
+      "section_count": 50,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "INTRO RELIGIONS OF THE WORLD",
+        "INTRO TO NEW TESTAMENT",
+        "INTRO TO OLD TESTAMENT",
+        "Old Testament",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "MUA",
+      "name": "MUA",
+      "course_count": 39,
+      "section_count": 49,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Applied Guitar Advanced Skills",
+        "Applied Guitar I",
+        "Applied Guitar II",
+        "Applied Guitar III",
+        "Applied Guitar IV"
+      ]
+    },
+    {
+      "prefix": "PMT",
+      "name": "PMT",
+      "course_count": 15,
+      "section_count": 48,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADV. BLUEPRINT READING & QC",
+        "ADV. MACHINING PROCESSES I",
+        "ADVANCED CAD/CAM",
+        "Advanced Machining Procedures",
+        "CAD/CAM ESSENTIALS"
+      ]
+    },
+    {
+      "prefix": "EMP",
+      "name": "EMP",
+      "course_count": 15,
+      "section_count": 45,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "3-D ANIMATION",
+        "AUDIO ENGINEERING",
+        "CO-OPERATIVE ED/INTERNSHIP",
+        "DIGITAL SPECIAL EFFECTS",
+        "DIGITAL VIDEO PRODUCTION"
+      ]
+    },
+    {
+      "prefix": "POLS",
+      "name": "Political Science",
+      "course_count": 2,
+      "section_count": 45,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Introduction to International Relations",
+        "Introduction to U.S. National Politics"
+      ]
+    },
+    {
+      "prefix": "ALHS",
+      "name": "ALHS",
+      "course_count": 14,
+      "section_count": 44,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CLINICAL SUPERVISOR SEMINAR",
+        "CMT/INSULIN ADMINISTRATION",
+        "CNA COMPREHENSIVE",
+        "CNA NON-COMPREHENSIVE",
+        "CNA/CMT/INSULIN INSTRUCTOR"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 18,
+      "section_count": 43,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AGRICULTURE BUSINESS MGT",
+        "AGRICULTURE ECONOMICS",
+        "AGRICULTURE EQUIP. OP & MAINT",
+        "ANIMAL SCIENCE",
+        "ENVIRONMENTAL STEWARDSHIP"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 28,
+      "section_count": 43,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Activity Analysis and Therap",
+        "CONDITIONS IN OT I",
+        "CONDITIONS IN OT II",
+        "DOCUMENT & REIMBURSEMENT OTA",
+        "EBP FOR THE OTA I"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 9,
+      "section_count": 43,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Engineering Physics I",
+        "Engineering Physics II",
+        "Foundations of Physical Science with Lab",
+        "General Astronomy",
+        "General Astronomy with Lab"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 7,
+      "section_count": 43,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Beginning Occupational Spanish",
+        "Elementary Spanish I",
+        "Elementary Spanish II",
+        "Intermediate Spanish I",
+        "Intermediate Spanish II"
+      ]
+    },
+    {
+      "prefix": "CRJU",
+      "name": "CRJU",
+      "course_count": 14,
+      "section_count": 42,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Addiction Counseling with Special Populations",
+        "Alcohol and Drug Addiction",
+        "American Corrections",
+        "Community Relations",
+        "Correctional Psychology"
+      ]
+    },
+    {
+      "prefix": "CRM",
+      "name": "CRM",
+      "course_count": 6,
+      "section_count": 42,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CRIMINAL LAW AND THE COURTS",
+        "DIRECTED STUDY",
+        "INST & COMM BASED CORRECTIONS",
+        "INTRO TO CRIMINAL JUSTICE",
+        "INTRODUCTION TO CRIMINOLOGY"
+      ]
+    },
+    {
+      "prefix": "OTHA",
+      "name": "OTHA",
+      "course_count": 20,
+      "section_count": 42,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Applied Neurology",
+        "Assessment and Intervention",
+        "Clinical Conditions",
+        "Documentation Guidelines",
+        "Gerontology"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 41,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Macroeconomics",
+        "Microeconomics"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 8,
+      "section_count": 41,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Children&#39;s Literature for Elementary Teachers",
+        "Education of Exceptional Learners",
+        "Educational Psychology",
+        "Educational Technology",
+        "Foundations of Education in a Diverse Society"
+      ]
+    },
+    {
+      "prefix": "HVAC",
+      "name": "HVAC",
+      "course_count": 9,
+      "section_count": 41,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Commercial Refrigeration",
+        "Electricity for HVAC/R Technicians",
+        "Fundamentals of Refrigeration",
+        "Geo-Thermal &amp; Air Source Heat Pumps",
+        "Principles of Heating, Ventilation, and Air Conditioning"
+      ]
+    },
+    {
+      "prefix": "PTHA",
+      "name": "PTHA",
+      "course_count": 14,
+      "section_count": 41,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Applied Neurology",
+        "Clinical Education I",
+        "Clinical Education II",
+        "Clinical Immersion",
+        "Clinical Seminar"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 24,
+      "section_count": 40,
+      "colleges": [
+        "east-central-college",
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Ambulatory Care Coding - CPT",
+        "Basic Principles of Disease",
+        "Clinical Classification Systems - Diagnostic",
+        "Clinical Classification Systems - PCS",
+        "Clinical Professional Practice"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 15,
+      "section_count": 40,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Accounting Internship",
+        "Advertising",
+        "Bookkeeping",
+        "Business Intern I",
+        "Business Math"
+      ]
+    },
+    {
+      "prefix": "VAT",
+      "name": "Tech",
+      "course_count": 16,
+      "section_count": 40,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Applied Pharmacology",
+        "Applied Radiology Lab",
+        "Clinical Pathological Tech",
+        "Intro To Veterinary Tech",
+        "Lab Animal Tech Lab"
+      ]
+    },
+    {
+      "prefix": "LEA",
+      "name": "LEA",
+      "course_count": 14,
+      "section_count": 39,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Adv. Crim. Invest. for Law Enf",
+        "Criminal Invest. for Law Enfor",
+        "Criminal Law for Law Enforc.",
+        "Ethics/Professionalism for Law",
+        "Firearms for Law Enforc. I"
+      ]
+    },
+    {
+      "prefix": "MEC",
+      "name": "MEC",
+      "course_count": 9,
+      "section_count": 38,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CO-OPERATIVE ED/INTERNSHIP",
+        "FLUID POWER",
+        "INDUSTRIAL ELECTRICITY I",
+        "INDUSTRIAL MOTORS & CONTROLS",
+        "INDUSTRIAL SAFETY"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "PSC",
+      "course_count": 9,
+      "section_count": 38,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Civics Achievement Exam",
+        "Current Political Issues",
+        "Honors US &amp; MO Govt &amp; Const",
+        "International Relations",
+        "Intro to Comparative Politics"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 22,
+      "section_count": 37,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "*Intro Auto Tech",
+        "Adv Electrical Electronics Lab",
+        "Adv Electrical Electronics Sys",
+        "Adv Engine Performance Lab",
+        "Advanced Engine Performance"
+      ]
+    },
+    {
+      "prefix": "HSC",
+      "name": "Medical",
+      "course_count": 4,
+      "section_count": 37,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO HEALTH PROFESSIONS",
+        "Medical Terminology",
+        "MEDICAL TERMINOLOGY",
+        "Nutrition"
+      ]
+    },
+    {
+      "prefix": "SON",
+      "name": "SON",
+      "course_count": 26,
+      "section_count": 37,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ABDOMINAL SONOGRAPHY I",
+        "ABDOMINAL SONOGRAPHY II",
+        "ABDOMINAL SONOGRAPHY LAB I",
+        "ABDOMINAL SONOGRAPHY LAB II",
+        "CAPSTONE I"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 8,
+      "section_count": 36,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AMERICAN SIGN LANGUAGE I",
+        "AMERICAN SIGN LANGUAGE II",
+        "AMERICAN SIGN LANGUAGE III",
+        "AMERICAN SIGN LANGUAGE IV",
+        "CONVERSATIONAL ASL"
+      ]
+    },
+    {
+      "prefix": "CIMM",
+      "name": "CIMM",
+      "course_count": 27,
+      "section_count": 36,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Lathe Operations",
+        "Advanced Mill Operations",
+        "Basic Lathe Operation",
+        "Basic Mill Operation",
+        "Capstone - Chucking"
+      ]
+    },
+    {
+      "prefix": "ELC",
+      "name": "ELC",
+      "course_count": 8,
+      "section_count": 36,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ALT AND RENEWABLE ENERGY",
+        "BASIC POWER GEN & CODE REQ",
+        "ELECT FORMULAS & CIRCUITRY",
+        "INTRO ELECT THEORY & SAFETY",
+        "NEC TO APPARATUS & LOCATIONS"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 7,
+      "section_count": 36,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Directed Studies in Theater",
+        "Elements of Play Production",
+        "Theater Appreciation"
+      ]
+    },
+    {
+      "prefix": "BSRT",
+      "name": "BSRT",
+      "course_count": 22,
+      "section_count": 35,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ACID-BASE PHYSIOLOGY I",
+        "ACID-BASE PHYSIOLOGY II",
+        "CARDIOPULMONARY DISEASE",
+        "CARDIOPULMONARY EQUIPMENT",
+        "CARDIOPULMONARY EQUIPMENT LAB"
+      ]
+    },
+    {
+      "prefix": "DAS",
+      "name": "Dental",
+      "course_count": 13,
+      "section_count": 35,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CHAIRSIDE ASSISTING I",
+        "CHAIRSIDE ASSISTING II",
+        "DENTAL CLINIC PRACTICUM I",
+        "DENTAL CLINIC PRACTICUM II",
+        "DENTAL MATERIALS I"
+      ]
+    },
+    {
+      "prefix": "ETEC",
+      "name": "ETEC",
+      "course_count": 16,
+      "section_count": 35,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Inventor",
+        "Advanced Solidworks",
+        "Applied Statics &amp; Mechanics",
+        "Computer Aided Design II",
+        "Descriptive Geometry"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "FST",
+      "course_count": 15,
+      "section_count": 33,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "BUILDING CONSTRUCTION",
+        "CAPSTONE ASSESSMENT",
+        "DIRECTED STUDY",
+        "EMERGENCY MEDICAL RESPONDER",
+        "FIRE BEHAVIOR AND COMBUSTION"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "HPE",
+      "course_count": 9,
+      "section_count": 33,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Care Prev of Athletic Injuries",
+        "First Aid CPR",
+        "Foundations of Sport Mgmt",
+        "Lifetime Fitness &amp; Wellness",
+        "Personal Health"
+      ]
+    },
+    {
+      "prefix": "HLSC",
+      "name": "Health",
+      "course_count": 2,
+      "section_count": 31,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Anatomy and Physiology for Health Professions",
+        "Introduction to Health Professions"
+      ]
+    },
+    {
+      "prefix": "DDT",
+      "name": "Drafting",
+      "course_count": 12,
+      "section_count": 30,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CIVIL DRAFTING",
+        "CIVIL ENGINEERING DRAFTING",
+        "CO-OPERATIVE ED/INTERNSHIP",
+        "COMMERCIAL ARCHITECT DRAFTING",
+        "DRAFTING & DESIGN CAPSTONE"
+      ]
+    },
+    {
+      "prefix": "PNUR",
+      "name": "PNUR",
+      "course_count": 10,
+      "section_count": 30,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Applied Pharmacology I",
+        "Applied Pharmacology II",
+        "Fundamentals of Practical Nursing",
+        "IV Therapy",
+        "Leadership"
+      ]
+    },
+    {
+      "prefix": "RATE",
+      "name": "RATE",
+      "course_count": 17,
+      "section_count": 30,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Clinical I",
+        "Clinical II",
+        "Clinical III",
+        "Clinical IV",
+        "Clinical V"
+      ]
+    },
+    {
+      "prefix": "TEC",
+      "name": "TEC",
+      "course_count": 4,
+      "section_count": 30,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "APPLIED TECHNICAL MATHEMATICS",
+        "LEADERSHIP IN INDUSTRY",
+        "OCCUPATIONAL SEMINAR",
+        "SPECIAL TOPICS"
+      ]
+    },
+    {
+      "prefix": "ABR",
+      "name": "ABR",
+      "course_count": 11,
+      "section_count": 29,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "DAMAGE REPAIR METAL/WELD CUT",
+        "ESTIMATING & SHOP MANAGEMENT",
+        "NON-STRUCTURAL ANALYSIS I",
+        "NON-STRUCTURAL ANALYSIS II",
+        "PAINT & REFINISH PREPARATION"
+      ]
+    },
+    {
+      "prefix": "CYB",
+      "name": "CYB",
+      "course_count": 8,
+      "section_count": 29,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CO-OPERATIVE EDUCATION/INTERN",
+        "CYBERSECURITY OPERATIONS",
+        "DIGITAL FORENSICS",
+        "ETHICAL HACKING",
+        "FIREWALL ESSENTIALS"
+      ]
+    },
+    {
+      "prefix": "DENA",
+      "name": "Dental",
+      "course_count": 18,
+      "section_count": 29,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Body Structure and Function",
+        "Chairside Assisting I",
+        "Chairside Assisting II",
+        "Clinical Experience I",
+        "Clinical Experience II"
+      ]
+    },
+    {
+      "prefix": "DSL",
+      "name": "Diesel",
+      "course_count": 12,
+      "section_count": 29,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED DIESEL ENGINES",
+        "CAPSTONE/CO-OP/INTERNSHIP",
+        "DIESEL BRAKES",
+        "DIESEL DIAGNOSTICS & REPAIR",
+        "DIESEL ENGINE REPAIR"
+      ]
+    },
+    {
+      "prefix": "EDS",
+      "name": "EDS",
+      "course_count": 15,
+      "section_count": 29,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CO-OP ED/INTERN",
+        "COMMERCIAL DRIVER LICENSE",
+        "COMMERCIAL DRIVER LICENSE LAB",
+        "COMMUNICATION LINE INST.",
+        "DISTRIBUTION SYSTEMS MAINT."
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 12,
+      "section_count": 28,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CABINETMAKING & MILLWORK I",
+        "CO-OPERATIVE ED/INTERNSHIP",
+        "CONCRETE AND FORMS",
+        "CONSTRUCTION CARPENTRY I",
+        "CONSTRUCTION CARPENTRY II"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 20,
+      "section_count": 28,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Best Practices in Youth Work &amp; Development",
+        "Capstone Practicum Experience",
+        "Care and Education of Infants and Toddlers",
+        "Child Care Management",
+        "Child Growth and Development I"
+      ]
+    },
+    {
+      "prefix": "GEOL",
+      "name": "Geology",
+      "course_count": 2,
+      "section_count": 27,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Environmental Geology",
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "SURT",
+      "name": "Surgical",
+      "course_count": 10,
+      "section_count": 27,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Care of the Surgical Patient",
+        "Central Services",
+        "Clinical Experience",
+        "Fundamentals of Surgical Technology I",
+        "Fundamentals of Surgical Technology II"
+      ]
+    },
+    {
+      "prefix": "VRO",
+      "name": "Viking",
+      "course_count": 1,
+      "section_count": 27,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Viking Ready Orientation-12/15"
+      ]
+    },
+    {
+      "prefix": "LEGL",
+      "name": "Legal",
+      "course_count": 16,
+      "section_count": 26,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Constitutional Law",
+        "Criminal Law and Procedure",
+        "Employment Law",
+        "Ethics for the Paralegal",
+        "Intellectual Property"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "Management",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "BAR & BEVERAGE MANAGEMENT",
+        "CULINARY/HOSPITALITY INTERN",
+        "DINING ROOM MANAGEMENT",
+        "EVENT MANAGEMENT & SALES",
+        "FRONT OFFICE PROCEDURES"
+      ]
+    },
+    {
+      "prefix": "PAR",
+      "name": "Paramedic",
+      "course_count": 11,
+      "section_count": 24,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Paramedic Adv Care Term",
+        "Paramedic Advanced Cardiology",
+        "Paramedic Ambulance Operations",
+        "Paramedic Clinic Practicum II",
+        "Paramedic Clinical Practicum I"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Child Health Nutrition Safety",
+        "Curriculum Strat for Preschool",
+        "ECE Administration",
+        "ECE Lab",
+        "ECE Practicum I"
+      ]
+    },
+    {
+      "prefix": "HLT",
+      "name": "Health",
+      "course_count": 5,
+      "section_count": 23,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Health Services Aid I",
+        "Health Services Aid II",
+        "Health Services Aid III",
+        "Health Services Aid IV",
+        "LIFETIME WELLNESS"
+      ]
+    },
+    {
+      "prefix": "RNUR",
+      "name": "Nursing",
+      "course_count": 10,
+      "section_count": 23,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Adult Nursing I",
+        "Adult Nursing II",
+        "Adult Nursing III",
+        "Child-Centered Nursing",
+        "Essential Nursing Concepts"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 2,
+      "section_count": 22,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AFRICA, OCEANIA, AMERICAS ART",
+        "INTRODUCTION TO THE HUMANITIES"
+      ]
+    },
+    {
+      "prefix": "MUE",
+      "name": "College",
+      "course_count": 22,
+      "section_count": 22,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "College Band Advanced Skills",
+        "College Band I",
+        "College Band II",
+        "College Band III",
+        "College Band IV"
+      ]
+    },
+    {
+      "prefix": "PHED",
+      "name": "Fitness",
+      "course_count": 3,
+      "section_count": 22,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Lifetime Fitness I",
+        "Physical Fitness I",
+        "Physical Fitness II"
+      ]
+    },
+    {
+      "prefix": "PNE",
+      "name": "Nursing",
+      "course_count": 16,
+      "section_count": 22,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Capstone PN Clinical Practicum",
+        "Capstone Practical Nursing",
+        "Fund of Nursing Clinical",
+        "Fundamentals of Nursing",
+        "Intro to Nursing Pharmacology"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "Anthropology",
+      "course_count": 3,
+      "section_count": 21,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Cultural Anthropology",
+        "General Anthropology",
+        "Introduction to Archaeology"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 11,
+      "section_count": 21,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Criminal Investigation",
+        "Criminal Justice Internship",
+        "Criminal Law",
+        "Ethics in Criminal Justice",
+        "Intro Crim Justice"
+      ]
+    },
+    {
+      "prefix": "GDES",
+      "name": "Design",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Color Correction",
+        "Digital Design Applications I",
+        "Digital Design Applications II",
+        "Digital Imaging",
+        "Graphic Design File Preparation"
+      ]
+    },
+    {
+      "prefix": "DHY",
+      "name": "Dental",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "COMMUNITY DENTAL HEALTH",
+        "COMMUNITY DENTAL HEALTH II",
+        "DENTAL HYG. PRECLINICAL LAB I",
+        "DENTAL HYGIENE I",
+        "DENTAL HYGIENE I CLINIC"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 9,
+      "section_count": 18,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Circuit Analysis I",
+        "Circuit Analysis Laboratory",
+        "Engineering Design Microcomputer Applications",
+        "Engineering Statistics and Computation",
+        "Introduction to the Engineering Profession"
+      ]
+    },
+    {
+      "prefix": "VETT",
+      "name": "Veterinary",
+      "course_count": 14,
+      "section_count": 18,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Clinical Mathematics for Veterinary Technicians",
+        "Clinical Pathology Techniques I",
+        "Clinical Pathology Techniques II",
+        "Equine Medicine and Management",
+        "Infectious Disease Management"
+      ]
+    },
+    {
+      "prefix": "BHS",
+      "name": "BHS",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CHRONIC HEALTH CARE ISSUES",
+        "CLIENT INTERACTIONS I",
+        "CLIENT INTERACTIONS II",
+        "EVIDENCE BASED TREATMENT",
+        "FAMILY AND YOUTH ISSUES"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "Clinical",
+      "course_count": 14,
+      "section_count": 17,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CLINIC SEMINAR AND REVIEW",
+        "Clinical Chem and Urinalysis",
+        "CLINICAL CHEMISTRY",
+        "Clinical Chemistry Urin Pract",
+        "CLINICAL IMMUNOLOGY"
+      ]
+    },
+    {
+      "prefix": "MRI",
+      "name": "MRI",
+      "course_count": 11,
+      "section_count": 17,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "MR CAPSTONE",
+        "MR INTRO, SAFETY, & CARE",
+        "MR PACTICUM I",
+        "MR PACTICUM II",
+        "MR PACTICUM III"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Social Work",
+        "INTRODUCTION TO SOCIAL WORK",
+        "SOC WELFARE POLICY & SERVICES",
+        "Social Welfare and Policy Serv",
+        "Social Work Lab"
+      ]
+    },
+    {
+      "prefix": "GRY",
+      "name": "World",
+      "course_count": 1,
+      "section_count": 16,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "WORLD GEOGRAPHY I"
+      ]
+    },
+    {
+      "prefix": "EGR",
+      "name": "Engineering",
+      "course_count": 9,
+      "section_count": 15,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "Circuit Analysis I",
+        "Comp Aided Engineering Design",
+        "Engin Mech-Statics",
+        "Engineer Mechanic Dynam",
+        "Engineer Mechanic Static"
+      ]
+    },
+    {
+      "prefix": "OTC",
+      "name": "Navigating",
+      "course_count": 1,
+      "section_count": 15,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "NAVIGATING COLLEGE"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 5,
+      "section_count": 14,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "C++ PROGRAMMING",
+        "COMPUTER ARCHITECTURE",
+        "DATA STRUCTURES",
+        "PYTHON PROGRAMMING I",
+        "PYTHON PROGRAMMING II"
+      ]
+    },
+    {
+      "prefix": "HON",
+      "name": "HON",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "HONORS SEMINAR",
+        "HONORS SERVICE LEARNING",
+        "PTK OFFICER DEVELOPMENT",
+        "SPECIAL TOPICS: HONORS"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 4,
+      "section_count": 14,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CO-OPERATIVE ED/INTERNSHIP",
+        "MANUFACTURING CAPSTONE",
+        "MFG PROCESSES & MATERIALS",
+        "QUALITY IN INDUSTRY"
+      ]
+    },
+    {
+      "prefix": "MUC",
+      "name": "MUC",
+      "course_count": 14,
+      "section_count": 14,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Class Piano I: Beginners",
+        "Class Piano II: Upper Elem",
+        "Class Piano III: Early Interm",
+        "Class Piano IV: Intermediate",
+        "Mus Theo I(Aural)"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Emergency",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Emergency Med Technician I",
+        "Emergency Med Technician II",
+        "EMT Clinical Internship I"
+      ]
+    },
+    {
+      "prefix": "FRN",
+      "name": "French",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "BEGINNING FRENCH I",
+        "French Grammar &amp; Composition",
+        "Intermediate French"
+      ]
+    },
+    {
+      "prefix": "LPN",
+      "name": "Nursing",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Fdn PN II Lec Incl IV Therapy",
+        "Found Practical Nursing I Lab",
+        "Found Practical Nursing I Lec",
+        "Found Practical Nursing II Lab",
+        "Nurs Across Lifespan III Lab"
+      ]
+    },
+    {
+      "prefix": "PRS",
+      "name": "PRS",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "CNC 2 Mill Lab",
+        "CNC 2 Mill Lec",
+        "Geom Dim Tolerance&SPC Lab",
+        "Geom Dim Tolerance&SPC Lec",
+        "Intro CNC Mill&Lathe Lab"
+      ]
+    },
+    {
+      "prefix": "RST",
+      "name": "RST",
+      "course_count": 13,
+      "section_count": 13,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED RESP THERAPY THEORY",
+        "APPL CARDIOPULMONARY PATHOLOGY",
+        "CARDIOPULMONARY DIAGNOSTIC II",
+        "CARDIOPULMONARY DIAGNOSTICS I",
+        "CLINICAL PRACTICUM I"
+      ]
+    },
+    {
+      "prefix": "APT",
+      "name": "APT",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "AIRCRAFT AUXILIARY SYSTEMS",
+        "AIRCRAFT ELECTRICAL SYSTEMS",
+        "AIRCRAFT FLUID SYSTEMS",
+        "AIRCRAFT LANDING SYSTEMS",
+        "AIRFRAME DESIGN & ASSEMBLY"
+      ]
+    },
+    {
+      "prefix": "IND",
+      "name": "IND",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Advanced PLC Lab",
+        "Advanced PLC Lecture",
+        "Intro Manufacturing Processes",
+        "Intro to Electricity Lab",
+        "Intro to Electricity Lec"
+      ]
+    },
+    {
+      "prefix": "PLM",
+      "name": "Plumbing",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "DWV & STORM SYSTEMS/DRAINS",
+        "DWV & WATER SUPPLY",
+        "INTRO TO PLUMBING",
+        "PIPE & FITTINGS",
+        "PLUMBING CODES & APPLICATION"
+      ]
+    },
+    {
+      "prefix": "RSC",
+      "name": "Respiratory",
+      "course_count": 12,
+      "section_count": 12,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Advanced Respiratory Care",
+        "Fund of Respiratory Care",
+        "Neonatal & Pediatric Resp Care",
+        "Resp Equipment & Therapeutics",
+        "Respiratory Care Capstone"
+      ]
+    },
+    {
+      "prefix": "ANHS",
+      "name": "Veterinary",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Animal Care and Sanitation",
+        "Animal Diseases of Canine, Feline, and Exotic Pets",
+        "Introduction to Veterinary Practice Management",
+        "Veterinary Terminology"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "east-central-college",
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Intro Phys Geo Lab",
+        "Intro Phys Geo Lec",
+        "Seminar in Global Studies",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "HVC",
+      "name": "Heating",
+      "course_count": 6,
+      "section_count": 10,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "App Sheet Metal I",
+        "Forced Air Heating I",
+        "Heating and Equip Install I",
+        "Intro to Heating and Cooling",
+        "Refrig Recov/EPA Cert"
+      ]
+    },
+    {
+      "prefix": "LINE",
+      "name": "LINE",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Advanced Pole Climbing",
+        "Conductor Installation and Metering",
+        "Electrical Distribution Systems",
+        "Fusing, Substations and Voltage Regulation",
+        "Installation and Troubleshooting Underground Distribution Systems"
+      ]
+    },
+    {
+      "prefix": "PED",
+      "name": "Varsity",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Fitness Center Orientation",
+        "Soc Aspects of PE & Sports",
+        "Varsity Baseball",
+        "Varsity Soccer",
+        "Varsity Softball"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 10,
+      "section_count": 10,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ANATOMY FOR THE PTA",
+        "BIOPHYS. AGENTS/THERA MASSAGE",
+        "CLINICAL EDUCATION I",
+        "CLINICAL EDUCATION II",
+        "CLINICAL KINESIOLOGY"
+      ]
+    },
+    {
+      "prefix": "RNR",
+      "name": "Nursing",
+      "course_count": 8,
+      "section_count": 10,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Adult Health Nursing I",
+        "Adult Health Nursing I Clin.",
+        "Capstone Prof. Nurs. Practicum",
+        "Introduction to Bridging",
+        "Nursing Transitions and Trends"
+      ]
+    },
+    {
+      "prefix": "SIGN",
+      "name": "American",
+      "course_count": 3,
+      "section_count": 10,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "American Sign Language I",
+        "American Sign Language II",
+        "Deaf Culture"
+      ]
+    },
+    {
+      "prefix": "AGRI",
+      "name": "Science",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Agribusiness Management",
+        "Animal Science",
+        "Global Agriculture",
+        "Introduction to Agribusiness",
+        "Introduction to Agriculture"
+      ]
+    },
+    {
+      "prefix": "ANT",
+      "name": "Anthropology",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "east-central-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CULTURAL ANTHROPOLOGY",
+        "Intro Cult Anthro",
+        "INTRODUCTION TO ANTHROPOLOGY"
+      ]
+    },
+    {
+      "prefix": "GRM",
+      "name": "German",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "jefferson-college",
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY GERMAN I",
+        "ELEMENTARY GERMAN II",
+        "INTERMEDIATE GERMAN II"
+      ]
+    },
+    {
+      "prefix": "JPN",
+      "name": "Japanese",
+      "course_count": 4,
+      "section_count": 9,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY JAPANESE I",
+        "ELEMENTARY JAPANESE II",
+        "INTERMEDIATE JAPANESE I",
+        "INTERMEDIATE JAPANESE II"
+      ]
+    },
+    {
+      "prefix": "LWE",
+      "name": "LWE",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Constitutional Law for Law Enf",
+        "Criminal Invest Law Enforc II",
+        "First Responder for Law Enforc",
+        "Intro to Law Enforcement",
+        "Law Enforcement Skills"
+      ]
+    },
+    {
+      "prefix": "MIL",
+      "name": "Military",
+      "course_count": 5,
+      "section_count": 9,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "BASIC MILITARY SKILLS & TECH",
+        "INTRO BASIC MILITARY SKILLS",
+        "INTRO TO MILITARY SCIENCE",
+        "LEADERSHIP FITNESS",
+        "MILITARY FUNDAMENTALS PRACT"
+      ]
+    },
+    {
+      "prefix": "MTT",
+      "name": "MTT",
+      "course_count": 3,
+      "section_count": 9,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Dimensional Metrology",
+        "Ind Blueprint Reading",
+        "Intro to Metallurgy"
+      ]
+    },
+    {
+      "prefix": "SRG",
+      "name": "Surgical",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Advanced Surgical Procedures",
+        "Clinical Externship II",
+        "Fund of Surgical Technology",
+        "Introduction to Surgical Tech",
+        "Medical-Surgical Terminology"
+      ]
+    },
+    {
+      "prefix": "THR",
+      "name": "Theater",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ACTING I",
+        "INTRODUCTION TO THEATER"
+      ]
+    },
+    {
+      "prefix": "INT",
+      "name": "Technical",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Technical Internship for CIS",
+        "Technical Internship for PMT"
+      ]
+    },
+    {
+      "prefix": "CLSN",
+      "name": "Automotive",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Automotive Refinishing I",
+        "Automotive Refinishing II",
+        "Automotive Welding",
+        "Estimating &amp; Shop Management",
+        "Non-Structural Analysis and Damage Repair I"
+      ]
+    },
+    {
+      "prefix": "CTR",
+      "name": "CTR",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "CT CAPSTONE",
+        "CT IMAGE PRODUCTION",
+        "CT PATIENT CARE",
+        "CT PRACTICUM I",
+        "CT PRACTICUM II"
+      ]
+    },
+    {
+      "prefix": "GUID",
+      "name": "Career",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Career Exploration Seminar"
+      ]
+    },
+    {
+      "prefix": "MDA",
+      "name": "Procedures",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures",
+        "Clinical Procedures",
+        "MDA Clinical Externship",
+        "Medical Ethics for Healthcare",
+        "Medical Laboratory Procedures"
+      ]
+    },
+    {
+      "prefix": "BLDM",
+      "name": "BLDM",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Building Mechanical Systems",
+        "Carpentry: Sheetrock, Siding and Finishes",
+        "Carpentry: Stairs, Flooring and Roofs",
+        "Electrical Safety and Principles",
+        "General Construction Principles and Trade Tools"
+      ]
+    },
+    {
+      "prefix": "CHN",
+      "name": "Chinese",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY CHINESE I",
+        "ELEMENTARY CHINESE II",
+        "INTERMEDIATE CHINESE I",
+        "INTERMEDIATE CHINESE II"
+      ]
+    },
+    {
+      "prefix": "CODE",
+      "name": "Coding",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Classification of Diseases",
+        "Classification of Procedural Coding Systems",
+        "Coding Professional Practicum",
+        "Current Procedural Terminology (CPT) Coding",
+        "Medical Billing"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Elementary French I",
+        "Elementary French II"
+      ]
+    },
+    {
+      "prefix": "FSTE",
+      "name": "Fire",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Fire Behavior and Combustion",
+        "Fire Protection Systems",
+        "Firefighting Strategy and Tactics",
+        "Legal Aspects of the Fire Service",
+        "Occupational Safety and Health for Emergency Services"
+      ]
+    },
+    {
+      "prefix": "KOR",
+      "name": "Korean",
+      "course_count": 4,
+      "section_count": 6,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY KOREAN I",
+        "ELEMENTARY KOREAN II",
+        "INTERMEDIATE KOREAN I",
+        "INTERMEDIATE KOREAN II"
+      ]
+    },
+    {
+      "prefix": "MCM",
+      "name": "Media",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Diversity in the Media",
+        "Intro to Mass Media Comm",
+        "Media Production I",
+        "Media Production II",
+        "Media Production III"
+      ]
+    },
+    {
+      "prefix": "THT",
+      "name": "Acting",
+      "course_count": 3,
+      "section_count": 6,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Acting II",
+        "Beginning Acting",
+        "Theatre Appreciation"
+      ]
+    },
+    {
+      "prefix": "FLIN",
+      "name": "Interpreting",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Fundamentals of Interpreting",
+        "Interpreting Practicum",
+        "Introduction to Interpreting",
+        "Legal Interpreting",
+        "Medical Interpreting"
+      ]
+    },
+    {
+      "prefix": "HONR",
+      "name": "Topic",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Arts, Humanities, Languages and Communications Honors Seminar",
+        "Topic: Heaven and Hell on Earth: Visions of Utopia in Early Modern English Literature"
+      ]
+    },
+    {
+      "prefix": "NMT",
+      "name": "Nuclear",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "BASICS OF NUCLEAR MEDICINE",
+        "CLINICAL PROCEDURES I",
+        "NUC MED PRACTICUM I",
+        "NUCLEAR PHYSICS I",
+        "RADIOPHARMACY I"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary and Renal Anatomy and Physiology",
+        "Fundamentals of Respiratory Care",
+        "Respiratory Care Pharmacology"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "Operating",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "OPERATING ROOM TECHNIQUE I",
+        "OPERATING ROOM TECHNIQUE II",
+        "PHARMACOLOGY FOR SURG TECH",
+        "SURGICAL PROCEDURES I",
+        "SURGICAL PROCEDURES II"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 3,
+      "section_count": 5,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Theatre Appreciation"
+      ]
+    },
+    {
+      "prefix": "ARAB",
+      "name": "Modern",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Elementary Modern Arabic 1",
+        "Elementary Modern Arabic I"
+      ]
+    },
+    {
+      "prefix": "ARB",
+      "name": "Arabic",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY ARABIC I",
+        "ELEMENTARY ARABIC II",
+        "INTERMEDIATE ARABIC I",
+        "INTERMEDIATE ARABIC II"
+      ]
+    },
+    {
+      "prefix": "ARO",
+      "name": "Automation",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ADVANCED AUTOMATION CONTROLS",
+        "INDUSTRIAL ROBOTICS"
+      ]
+    },
+    {
+      "prefix": "BDC",
+      "name": "Building",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "*Building Construction I",
+        "*Building Construction III"
+      ]
+    },
+    {
+      "prefix": "CHIN",
+      "name": "Chinese",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Elementary Chinese I",
+        "Elementary Chinese II"
+      ]
+    },
+    {
+      "prefix": "COLL",
+      "name": "Firstyear",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "First-Year Seminar"
+      ]
+    },
+    {
+      "prefix": "ECH",
+      "name": "ECH",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ANATOMY & PATHOPHYSIOLOGY I",
+        "CARDIOVASCULAR PHYSICS",
+        "ECHOCARDIOGRAPHIC PROCEDURES",
+        "ECHOCARDIOGRAPHY PRACTICUM I"
+      ]
+    },
+    {
+      "prefix": "ITL",
+      "name": "Italian",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY ITALIAN I",
+        "ELEMENTARY ITALIAN II",
+        "INTERMEDIATE ITALIAN I",
+        "INTERMEDIATE ITALIAN II"
+      ]
+    },
+    {
+      "prefix": "PLB",
+      "name": "Phlebotomy",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "INTRODUCTION TO PHLEBOTOMY",
+        "PHLEBOTOMY CLINICAL"
+      ]
+    },
+    {
+      "prefix": "PLMS",
+      "name": "Plumbing",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "PLUMBING CODES I",
+        "PLUMBING CODES II"
+      ]
+    },
+    {
+      "prefix": "RUS",
+      "name": "Russian",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY RUSSIAN I",
+        "ELEMENTARY RUSSIAN II",
+        "INTERMEDIATE RUSSIAN I",
+        "INTERMEDIATE RUSSIAN II"
+      ]
+    },
+    {
+      "prefix": "SOWK",
+      "name": "Social",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Dynamics of Drug and Alcohol Abuse",
+        "Introduction to Social Work"
+      ]
+    },
+    {
+      "prefix": "VRL",
+      "name": "Viking",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "jefferson-college"
+      ],
+      "sample_titles": [
+        "Viking Relaunch"
+      ]
+    },
+    {
+      "prefix": "DESL",
+      "name": "Medium",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Medium &amp; Heavy-Duty Electrical Systems",
+        "Medium &amp; Heavy-Duty Truck Braking &amp; Hydraulic Systems",
+        "Medium &amp; Heavy-Duty Truck Suspension &amp; Steering"
+      ]
+    },
+    {
+      "prefix": "EVR",
+      "name": "Environmental",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Intro Environmental Science"
+      ]
+    },
+    {
+      "prefix": "TES",
+      "name": "Technical",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "TECHNICAL PHYSICS"
+      ]
+    },
+    {
+      "prefix": "CAC",
+      "name": "Strengths",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "STRENGTHS IN CAREERS & BEYOND"
+      ]
+    },
+    {
+      "prefix": "CIV",
+      "name": "Western",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "east-central-college"
+      ],
+      "sample_titles": [
+        "Western Civilization II"
+      ]
+    },
+    {
+      "prefix": "GERM",
+      "name": "German",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Elementary German"
+      ]
+    },
+    {
+      "prefix": "HUMN",
+      "name": "Humanities",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Humanities Past and Present"
+      ]
+    },
+    {
+      "prefix": "JRN",
+      "name": "Journalism",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "INTRO TO JOURNALISM"
+      ]
+    },
+    {
+      "prefix": "LIBR",
+      "name": "Library",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "Introduction to Library &amp; Online Research"
+      ]
+    },
+    {
+      "prefix": "PTG",
+      "name": "Portuguese",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "ozarks-technical-community-college"
+      ],
+      "sample_titles": [
+        "ELEMENTARY PORTUGUESE I"
+      ]
+    },
+    {
+      "prefix": "RTCT",
+      "name": "Radiation",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "metropolitan-community-college-kansas-city"
+      ],
+      "sample_titles": [
+        "CT Radiation Safety"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/ms/subject-vocab.json
+++ b/data/ms/subject-vocab.json
@@ -1,0 +1,966 @@
+{
+  "state": "ms",
+  "generated_at": "2026-05-13T03:53:11.041Z",
+  "subjects": [
+    {
+      "prefix": "HPR",
+      "name": "HPR",
+      "course_count": 20,
+      "section_count": 83,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Health Concep Phys Act/Well",
+        "**Intro to Kin,Health,PE,Rec",
+        "**Pers &amp; Comm Health",
+        "*Prev/Care Athl. Inj.",
+        "Athl Trng Terminology"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 18,
+      "section_count": 80,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Anat &amp; Physiol I w/lab",
+        "**Anat &amp; Physiol II w/lab",
+        "**Anatomy &amp; Physiology I",
+        "**Anatomy &amp; Physiology II",
+        "**Gen Biology I w/lab"
+      ]
+    },
+    {
+      "prefix": "ECT",
+      "name": "ECT",
+      "course_count": 19,
+      "section_count": 77,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Disaster Response &amp; Recovery",
+        "Dynamics of Homeland Security",
+        "Emergency Manag Tech Practicum",
+        "Emergency Personnel Sup",
+        "Emergency Planning"
+      ]
+    },
+    {
+      "prefix": "FFT",
+      "name": "Fire",
+      "course_count": 18,
+      "section_count": 76,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Building Construction",
+        "Comm Risk Management I",
+        "Comm Risk Management II",
+        "Deliver Fire &amp; EM Services",
+        "Disaster Management"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 15,
+      "section_count": 57,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Beginning Algebra",
+        "**Business Calculus I",
+        "**Calculus I",
+        "**Calculus II",
+        "**Calculus III"
+      ]
+    },
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 7,
+      "section_count": 45,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**American Literature I",
+        "**American Literature II",
+        "**English Comp. I",
+        "**English Composition II",
+        "**Enhanced English Comp I"
+      ]
+    },
+    {
+      "prefix": "MUO",
+      "name": "MUO",
+      "course_count": 28,
+      "section_count": 33,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Band I",
+        "Band II",
+        "Band III",
+        "Band IV",
+        "Choir I"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 4,
+      "section_count": 29,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**American (US) History II",
+        "**American (US)History I",
+        "**World Civilization I",
+        "**World Civilization II"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 21,
+      "section_count": 28,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Judgement",
+        "Advanced Neonatal Concepts",
+        "Clinical Judgement in Nursing",
+        "Health Assess &amp; Health Prom",
+        "Intro to Neonatal Concepts"
+      ]
+    },
+    {
+      "prefix": "DTV",
+      "name": "Driving",
+      "course_count": 8,
+      "section_count": 24,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Comm Truck Driving Internship",
+        "Commerc Driving I for Lineman",
+        "Commerc Driving II for Lineman",
+        "Commercial Truck Driving I",
+        "Commercial Truck Driving II"
+      ]
+    },
+    {
+      "prefix": "SPT",
+      "name": "Public",
+      "course_count": 2,
+      "section_count": 23,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Public Speaking I",
+        "**Theater Appreciation"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 11,
+      "section_count": 19,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Chemistry Survey",
+        "**General Chemistry I",
+        "**General Chemistry II",
+        "**Lab, Organic Chemistry I",
+        "**Organic Chemistry I"
+      ]
+    },
+    {
+      "prefix": "COV",
+      "name": "Care",
+      "course_count": 12,
+      "section_count": 19,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Cosmetology Orientation",
+        "Cosmetology Sciences I",
+        "Cosmetology Sciences III",
+        "Cosmo Teacher Training I",
+        "Cosmo Teacher Training II"
+      ]
+    },
+    {
+      "prefix": "LLS",
+      "name": "LLS",
+      "course_count": 4,
+      "section_count": 19,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "College Study Skills",
+        "Orientation",
+        "Self Affirmation"
+      ]
+    },
+    {
+      "prefix": "MUA",
+      "name": "Majors",
+      "course_count": 17,
+      "section_count": 17,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Class Guitar I",
+        "Guitar I for Music Majors",
+        "Guitar I for Non Majors",
+        "Guitar II for Music Majors",
+        "Guitar II for Non-Majors"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**General Physics I",
+        "**General Physics I-A Engineer",
+        "**General Physics II",
+        "**General Physics w/Lab",
+        "**Phys.Sci. I/w Lab"
+      ]
+    },
+    {
+      "prefix": "BOT",
+      "name": "BOT",
+      "course_count": 14,
+      "section_count": 15,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Business Accounting",
+        "**Communication Essentials",
+        "**Medical Insurance Billing",
+        "**Medical Office Concepts",
+        "**Medical Terminology I"
+      ]
+    },
+    {
+      "prefix": "IST",
+      "name": "Programming",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Advanced JAVA Programming",
+        "**Client Side Programming",
+        "**Fund of Data Communications",
+        "**IT Foundations",
+        "**JAVA Programming"
+      ]
+    },
+    {
+      "prefix": "RGT",
+      "name": "RGT",
+      "course_count": 13,
+      "section_count": 15,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Education I",
+        "Clinical Education III",
+        "Clinical Education IV",
+        "Digital Image Analysis",
+        "Ethical/Legal Repsonsibilities"
+      ]
+    },
+    {
+      "prefix": "WLT",
+      "name": "Welding",
+      "course_count": 7,
+      "section_count": 15,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Pipe Welding",
+        "Cutting Processes",
+        "Gas Metal Arc Welding",
+        "Intro to Welding &amp; Safety",
+        "Pipe Welding"
+      ]
+    },
+    {
+      "prefix": "MMT",
+      "name": "MMT",
+      "course_count": 11,
+      "section_count": 13,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Advertising",
+        "**Human Resource Management",
+        "**International Business",
+        "**Internet Concepts",
+        "**Internet Marketing"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 1,
+      "section_count": 13,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**General Psychology"
+      ]
+    },
+    {
+      "prefix": "DHT",
+      "name": "Dental",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Dental Hygiene II",
+        "Dental Anatomy/Embry",
+        "Dental Ethics/Law",
+        "Dental Materials",
+        "Dental Medical Emergencies"
+      ]
+    },
+    {
+      "prefix": "IMM",
+      "name": "Maint",
+      "course_count": 10,
+      "section_count": 12,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Adv Electrical Ind Maint",
+        "Basic Pipefitting",
+        "Electrical Indust Maint I",
+        "Equipment Install &amp; Align",
+        "Fluid Power"
+      ]
+    },
+    {
+      "prefix": "PNV",
+      "name": "Nursing",
+      "course_count": 9,
+      "section_count": 12,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Adult Nursing Concepts &amp; Clini",
+        "Body Structure &amp; Function",
+        "IV Therapy &amp; Pharmacology",
+        "Maternal Child Nursing",
+        "Mental Health Concepts"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Intro. to Sociology I",
+        "**Marriage and Family"
+      ]
+    },
+    {
+      "prefix": "DAT",
+      "name": "Dental",
+      "course_count": 9,
+      "section_count": 11,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Chairside Assisting I",
+        "Chairside Assisting III",
+        "Clinical Experience II",
+        "Dental Assisting Materials",
+        "Dental Assisting Seminar I"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 4,
+      "section_count": 11,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Music Appreciation",
+        "Fundamentals of Music",
+        "Music Theory III",
+        "Music Theory III, Lab"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Biophysical Agents",
+        "Clinical Education I",
+        "Electrotherapy",
+        "Fund Concepts of Physical Ther",
+        "Health Care Experience I"
+      ]
+    },
+    {
+      "prefix": "RCT",
+      "name": "RCT",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary A &amp; P",
+        "Clinical Practice II",
+        "Clinical Practice III",
+        "Patient Assessment &amp; Planning",
+        "Pulmonary Function"
+      ]
+    },
+    {
+      "prefix": "SSP",
+      "name": "Smart",
+      "course_count": 1,
+      "section_count": 10,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Smart Start Pathway (CTE)"
+      ]
+    },
+    {
+      "prefix": "CAT",
+      "name": "Design",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Graphic Design &amp; Production",
+        "*Practical Advertising Design",
+        "Adv Extended (XR) 3D Design",
+        "Basic Advertising Design",
+        "Drawing for Designers I"
+      ]
+    },
+    {
+      "prefix": "CDT",
+      "name": "CDT",
+      "course_count": 8,
+      "section_count": 9,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Child Growth &amp; Development",
+        "**Child Health, Safety &amp; Nutri",
+        "**Classroom Instruction &amp; Prac",
+        "**Creative Arts for Early Educ",
+        "**Develop Differences Early Ed"
+      ]
+    },
+    {
+      "prefix": "CSC",
+      "name": "Computer Science",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Computer Applications I",
+        "**Computer Concepts"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Concepts",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Concepts Airway &amp; Resp Med",
+        "Concepts Cardiovascular Med",
+        "Concepts EMS Operations",
+        "Concepts of Reproductive Med",
+        "EMT - Emergency Medical Tech"
+      ]
+    },
+    {
+      "prefix": "EPY",
+      "name": "Adolescent",
+      "course_count": 2,
+      "section_count": 9,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Human Growth &amp; Develop",
+        "*Adolescent Psych"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "MST",
+      "course_count": 9,
+      "section_count": 9,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Advanced Shop Math",
+        "**Power Machinery I",
+        "**Power Machinery III",
+        "Blueprint Reading",
+        "Computer Numerical Control I"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Art Appreciation",
+        "**Design I",
+        "Drawing I"
+      ]
+    },
+    {
+      "prefix": "CUT",
+      "name": "Culinary",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Culinary Arts Seminar I",
+        "Culinary Arts Seminar III",
+        "Culinary Arts Seminar IV",
+        "Culinary Principles I",
+        "Internatinal Cuisine"
+      ]
+    },
+    {
+      "prefix": "MDT",
+      "name": "MDT",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Multimedia Production",
+        "**Principles of Mass Comm",
+        "Audio Production I",
+        "Basic Editing",
+        "Broadcast Assistantship I"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Coding Systems I",
+        "**Pathopharmacology I",
+        "Health Record Systems",
+        "Health Statistics",
+        "Medical Terminology"
+      ]
+    },
+    {
+      "prefix": "MFL",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Spanish I",
+        "Elementary French I"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 7,
+      "section_count": 7,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Fund of MLT/Phlebotomy",
+        "Hematology II",
+        "Immunohematology",
+        "MLT Chem I",
+        "MLT Chem II"
+      ]
+    },
+    {
+      "prefix": "WBL",
+      "name": "Learning",
+      "course_count": 6,
+      "section_count": 7,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Work Based Learning",
+        "Work-Based Learning"
+      ]
+    },
+    {
+      "prefix": "AHT",
+      "name": "Medical",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Medical Vocabulary"
+      ]
+    },
+    {
+      "prefix": "SUT",
+      "name": "Surgical",
+      "course_count": 6,
+      "section_count": 6,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Fundamentals of Surg Tech",
+        "**Principles of Surg Tech",
+        "**Surgical Anatomy",
+        "**Surgical Microbiology",
+        "Advanced Surgical Procedures**"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Princ. of Acct. I",
+        "**Princ. of Acct. II"
+      ]
+    },
+    {
+      "prefix": "CTE",
+      "name": "Occupational",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Health Professions",
+        "Occupational Math"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 5,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Princ. of Macroeconomics",
+        "**Princ. of Microeconomics"
+      ]
+    },
+    {
+      "prefix": "ELT",
+      "name": "ELT",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "AC/DC Circuits",
+        "Branch Circuit &amp; Ser Ent Cal",
+        "Electrical Drawings &amp; Schemati",
+        "Fundamentals of Electricity",
+        "Residential Wiring"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "Medical",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Procedures I",
+        "Med Assist Seminar I",
+        "Medical Law and Ethics",
+        "Medical Terminology",
+        "Pharmacology for Med Assist"
+      ]
+    },
+    {
+      "prefix": "ULT",
+      "name": "Line",
+      "course_count": 5,
+      "section_count": 5,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Electrical Power",
+        "Fund of Elect for Line Workers",
+        "Overhead, Undergr &amp; Sub Constr",
+        "Pole Climbing",
+        "Safety for Line Workers"
+      ]
+    },
+    {
+      "prefix": "BAD",
+      "name": "Legal",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Legal Environ of Business"
+      ]
+    },
+    {
+      "prefix": "DET",
+      "name": "DET",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Diesel Systems I",
+        "**Electrical/Electronic Sys I",
+        "**Fund of Equip Mechanics",
+        "**Preventative Maint &amp; Service"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "HCA",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Basic Health-Care Assisting",
+        "Body Structure and Function",
+        "Home Health Aid/Homemaker Serv",
+        "Special Care Procedures"
+      ]
+    },
+    {
+      "prefix": "HRT",
+      "name": "HRT",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Culinary Math",
+        "Hospitality Supervision",
+        "Restaurant &amp; Catering Operatio",
+        "Sanitation &amp; Safety"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Intro to Philosophy I",
+        "**Old Testament Survey",
+        "New Testament Survey"
+      ]
+    },
+    {
+      "prefix": "CCT",
+      "name": "Nccer",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "NCCER Core Curriculum"
+      ]
+    },
+    {
+      "prefix": "LEA",
+      "name": "Skills",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Ldrshp/Comm Skills I Rec/PR",
+        "Ldrshp/Comm Skills III Rec/PR",
+        "PTK-Leadership/Org Skills I"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**American National Government"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "**Criminology",
+        "**Intro to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "DDT",
+      "name": "Engineering",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Computer Aided Design II",
+        "Engineering Graphics"
+      ]
+    },
+    {
+      "prefix": "IDT",
+      "name": "American",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "American Sign Language I"
+      ]
+    },
+    {
+      "prefix": "PPV",
+      "name": "Fabrication",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Basic Fabrication Pipe Fitting"
+      ]
+    },
+    {
+      "prefix": "WLV",
+      "name": "Sheilded",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "meridian-community-college"
+      ],
+      "sample_titles": [
+        "Sheilded Metal ARC Welding 1"
+      ]
+    }
+  ],
+  "program_titles": []
+}

--- a/data/oh/subject-vocab.json
+++ b/data/oh/subject-vocab.json
@@ -1,0 +1,3996 @@
+{
+  "state": "oh",
+  "generated_at": "2026-05-13T03:53:11.085Z",
+  "subjects": [
+    {
+      "prefix": "ENG",
+      "name": "English",
+      "course_count": 63,
+      "section_count": 1212,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Academic Writing",
+        "African-American Literature I",
+        "African-American Literature II",
+        "American Literature I",
+        "American Literature II"
+      ]
+    },
+    {
+      "prefix": "BIO",
+      "name": "Biology",
+      "course_count": 71,
+      "section_count": 1115,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "A & P Companion Course",
+        "Anatomy & Physiology 1",
+        "Anatomy & Physiology 2",
+        "Anatomy &amp; Physiology of Domestic Animals I",
+        "Anatomy &amp; Physiology of Domestic Animals II"
+      ]
+    },
+    {
+      "prefix": "MATH",
+      "name": "Mathematics",
+      "course_count": 27,
+      "section_count": 757,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Algebraic and Quantitative Reasoning",
+        "Basic Arithmetic and Pre-Algebra",
+        "Beginning Algebra",
+        "Business Calculus",
+        "Business Probability and Statistics I"
+      ]
+    },
+    {
+      "prefix": "NURS",
+      "name": "Nursing",
+      "course_count": 11,
+      "section_count": 717,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Concepts of Nursing Care for Patients in Community and Behavioral Health Settings",
+        "Concepts of Nursing Care for patients with Acute and Chronic Conditions I",
+        "Concepts of Nursing Care for Patients with Acute Unstable and Chronic Conditions II",
+        "Concepts of Nursing Care for Patients with Complex Conditions",
+        "Concepts of Nursing Care of Childbearing Families and Children"
+      ]
+    },
+    {
+      "prefix": "PSY",
+      "name": "Psychology",
+      "course_count": 38,
+      "section_count": 504,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Abnormal Psychology",
+        "Adolescent Psychology",
+        "Child Growth and Development",
+        "Cross-Cultural Competency for Health Care Providers",
+        "Death and Dying"
+      ]
+    },
+    {
+      "prefix": "MTH",
+      "name": "Mathematics",
+      "course_count": 52,
+      "section_count": 487,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "1st Half Prereq Math Shell (MTH021--MTH023)",
+        "2nd Half Prereq Math Shell (MTH021--MTH025)",
+        "ANALYTIC GEOMETRY AND CAL I B",
+        "ANALYTIC GEOMETRY-CAL I A",
+        "Analytical Geometry and Calculus I"
+      ]
+    },
+    {
+      "prefix": "IT",
+      "name": "IT",
+      "course_count": 46,
+      "section_count": 280,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Topics in Network Security",
+        "ASP.NET Web Programming",
+        "Business Intelligence",
+        "Computer Applications",
+        "Cooperative Field Experience"
+      ]
+    },
+    {
+      "prefix": "SOC",
+      "name": "Sociology",
+      "course_count": 25,
+      "section_count": 259,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "American Cultural Diversity",
+        "Criminology",
+        "Cultural Awareness",
+        "Death and Dying",
+        "Deviance"
+      ]
+    },
+    {
+      "prefix": "MUS",
+      "name": "Music",
+      "course_count": 61,
+      "section_count": 235,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "African-American Music",
+        "Applied Music I",
+        "Applied Music II",
+        "Applied Music III",
+        "Applied Music IV"
+      ]
+    },
+    {
+      "prefix": "BADM",
+      "name": "BADM",
+      "course_count": 23,
+      "section_count": 233,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Human Resources Practices",
+        "Business Communications",
+        "Business Law",
+        "Business Strategies",
+        "Global Commerce and Communication"
+      ]
+    },
+    {
+      "prefix": "NSG",
+      "name": "Nursing",
+      "course_count": 50,
+      "section_count": 228,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Adult Health I",
+        "Adult Health II",
+        "Advanced Health Assess Complex",
+        "Advanced Health Assess Ind/Fam",
+        "Birth to Middle Age Nsg Care"
+      ]
+    },
+    {
+      "prefix": "ESL",
+      "name": "English as a Second Language",
+      "course_count": 13,
+      "section_count": 223,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "English as a Second Language: Basic Grammar for Communication",
+        "English as a Second Language: Basic Reading and Writing",
+        "English as a Second Language: Grammar for Communication I",
+        "English as a Second Language: Grammar for Communication II",
+        "English as a Second Language: Grammar for Communication III"
+      ]
+    },
+    {
+      "prefix": "ART",
+      "name": "Art",
+      "course_count": 32,
+      "section_count": 206,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "2D Design and Color",
+        "3D Foundations",
+        "Art Appreciation",
+        "Art History Survey: Late Renaissance to Present",
+        "Art History Survey: Prehistoric to Renaissance"
+      ]
+    },
+    {
+      "prefix": "CHEM",
+      "name": "Chemistry",
+      "course_count": 16,
+      "section_count": 206,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Essential Skills for General Chemistry",
+        "Everyday Chemistry",
+        "Everyday Chemistry Laboratory",
+        "General Chemistry I",
+        "General Chemistry II"
+      ]
+    },
+    {
+      "prefix": "ACC",
+      "name": "Accounting",
+      "course_count": 48,
+      "section_count": 200,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Accounting Basics for Managers",
+        "Accounting Software and Analytics",
+        "Acct Software App-QuickBooks",
+        "Advanced Accounting",
+        "Auditing"
+      ]
+    },
+    {
+      "prefix": "COMM",
+      "name": "Communication",
+      "course_count": 9,
+      "section_count": 198,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Fundamentals of Interpersonal Communication",
+        "Fundamentals of Speech Communication",
+        "Honors Speech Communication",
+        "Intercultural Communication",
+        "Interpersonal Comm"
+      ]
+    },
+    {
+      "prefix": "MAT",
+      "name": "Mathematics",
+      "course_count": 34,
+      "section_count": 188,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Algebra & Trigonometry",
+        "Applied Algebra/Geometry",
+        "Aviation Mathematics",
+        "Beginning/Intermediate Algebra",
+        "Business Calculus"
+      ]
+    },
+    {
+      "prefix": "MET",
+      "name": "MET",
+      "course_count": 78,
+      "section_count": 183,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "2D AutoCAD",
+        "2nd Yr Spec Topics: MET",
+        "3D Scanning, Reverse Engineering, and Quality Inspection",
+        "3D Solid Modeling",
+        "Additive Manufacturing"
+      ]
+    },
+    {
+      "prefix": "EET",
+      "name": "EET",
+      "course_count": 67,
+      "section_count": 176,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "AC Circuit Analysis",
+        "AC/DC Machines",
+        "Applications Programming for Smart Manufacturing",
+        "Basic Audio Electronics",
+        "Biomedical Design Project"
+      ]
+    },
+    {
+      "prefix": "GEN",
+      "name": "GEN",
+      "course_count": 6,
+      "section_count": 176,
+      "colleges": [
+        "cuyahoga-community-college-district",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration",
+        "First Year Success Seminar",
+        "First-Year Seminar",
+        "Honors in Action Research Project Seminar II",
+        "Personal Development"
+      ]
+    },
+    {
+      "prefix": "COM",
+      "name": "Communication",
+      "course_count": 17,
+      "section_count": 147,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Business Communications",
+        "Directed Research for Capstone",
+        "Effective Speaking",
+        "English Composition",
+        "English Composition II"
+      ]
+    },
+    {
+      "prefix": "MGT",
+      "name": "Management",
+      "course_count": 40,
+      "section_count": 146,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "1st Yr Spec Topics: MGT",
+        "Applications in Business Admin",
+        "Benefits and Compensation",
+        "Business Coaching",
+        "Business Decision Making"
+      ]
+    },
+    {
+      "prefix": "PHIL",
+      "name": "Philosophy",
+      "course_count": 7,
+      "section_count": 129,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Bioethics",
+        "Business Ethics",
+        "Critical Thinking",
+        "Ethics",
+        "Honors Contract in Philosophy"
+      ]
+    },
+    {
+      "prefix": "PHYS",
+      "name": "Physics",
+      "course_count": 8,
+      "section_count": 118,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Astronomy Laboratory",
+        "College Physics I",
+        "College Physics II",
+        "Everyday Physics"
+      ]
+    },
+    {
+      "prefix": "BUS",
+      "name": "Business",
+      "course_count": 15,
+      "section_count": 115,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "1st Yr Ind Proj: BUS",
+        "1st Yr Spec Topics: BUS",
+        "Basic Economics",
+        "Business Administration",
+        "Business Analysis"
+      ]
+    },
+    {
+      "prefix": "HOSP",
+      "name": "HOSP",
+      "course_count": 35,
+      "section_count": 115,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Baking Production and Sales II",
+        "Banquet Management and Production",
+        "Beverage Management",
+        "Contemporary Cuisine",
+        "Convention Management and Meeting Planning"
+      ]
+    },
+    {
+      "prefix": "NUR",
+      "name": "Nursing",
+      "course_count": 30,
+      "section_count": 114,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Adult Health III Clinical",
+        "Adult Health Nursing I",
+        "Adult Health Nursing I Clinical",
+        "Adult Health Nursing I Lab",
+        "Adult Health Nursing II"
+      ]
+    },
+    {
+      "prefix": "SSC",
+      "name": "Student",
+      "course_count": 1,
+      "section_count": 112,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Student Success Seminar"
+      ]
+    },
+    {
+      "prefix": "FYE",
+      "name": "Success",
+      "course_count": 3,
+      "section_count": 105,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "College & Personal Success",
+        "Essentials for College Success",
+        "Success Practice/Applications"
+      ]
+    },
+    {
+      "prefix": "ASL",
+      "name": "American",
+      "course_count": 20,
+      "section_count": 103,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced American Sign Language I",
+        "Advanced ASL 1",
+        "Advanced ASL 2",
+        "American Sign Language I",
+        "American Sign Language II"
+      ]
+    },
+    {
+      "prefix": "AUT",
+      "name": "Automotive",
+      "course_count": 32,
+      "section_count": 101,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Automotive Electronics",
+        "Automotive Aftermarket Vehicle Exterior Modifications",
+        "Automotive Co-op 1",
+        "Automotive Co-op 2",
+        "Automotive Co-op 3"
+      ]
+    },
+    {
+      "prefix": "CHM",
+      "name": "Chemistry",
+      "course_count": 22,
+      "section_count": 101,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Biochemistry I",
+        "Exploring Science and Technology",
+        "Forensic Chemistry",
+        "General Chemistry I",
+        "General Chemistry II"
+      ]
+    },
+    {
+      "prefix": "ISET",
+      "name": "ISET",
+      "course_count": 26,
+      "section_count": 99,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Applied Boiler Technology",
+        "Applied Electricity I",
+        "Applied Electricity II",
+        "Applied National Electric Code",
+        "Commercial Wiring"
+      ]
+    },
+    {
+      "prefix": "HIS",
+      "name": "History",
+      "course_count": 9,
+      "section_count": 98,
+      "colleges": [
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "American Civic Literacy",
+        "American History I",
+        "American History II",
+        "United States History I to 1877",
+        "United States History II from 1877"
+      ]
+    },
+    {
+      "prefix": "ACCT",
+      "name": "Accounting",
+      "course_count": 17,
+      "section_count": 97,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Applied Accounting",
+        "Auditing",
+        "Business Math Applications",
+        "Business Taxation",
+        "Cooperative Field Experience"
+      ]
+    },
+    {
+      "prefix": "HUM",
+      "name": "Humanities",
+      "course_count": 19,
+      "section_count": 92,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Career Exploration: AA/AS",
+        "Crisis Management",
+        "Culture and Belief",
+        "FT Co-op Proj: AA/AS",
+        "History of Rock and Roll"
+      ]
+    },
+    {
+      "prefix": "DMS",
+      "name": "Sonography",
+      "course_count": 30,
+      "section_count": 91,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography I",
+        "Abdominal Sonography II",
+        "Cardiac Diagnostic Procedures",
+        "Concepts of Physics in Diagnostic Sonography",
+        "DMS Instrumentation 1"
+      ]
+    },
+    {
+      "prefix": "FIN",
+      "name": "Finance",
+      "course_count": 19,
+      "section_count": 87,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Business Finance",
+        "Business Finance",
+        "Financial Management",
+        "Financial Markets and Institutions",
+        "Full-time Co-op 1: FIN"
+      ]
+    },
+    {
+      "prefix": "EMT",
+      "name": "Paramedic",
+      "course_count": 11,
+      "section_count": 85,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Anatomy &amp; Physiology for Paramedics",
+        "Cardiopulmonary Resuscitation",
+        "Defensive Driving - EMT",
+        "Emergency Medical Technician",
+        "Emergency Medical Technician - Basic"
+      ]
+    },
+    {
+      "prefix": "HIST",
+      "name": "History",
+      "course_count": 15,
+      "section_count": 81,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "African American History 1877-present",
+        "African American History to 1877",
+        "History of Africa",
+        "History of Civilization I",
+        "History of Civilization II"
+      ]
+    },
+    {
+      "prefix": "RADT",
+      "name": "Radiography",
+      "course_count": 21,
+      "section_count": 77,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Anatomy and Pathology of the Breast",
+        "Clinical Radiography I",
+        "Clinical Radiography II",
+        "Clinical Radiography II-A",
+        "Clinical Radiography II-B"
+      ]
+    },
+    {
+      "prefix": "CUL",
+      "name": "Culinary Arts",
+      "course_count": 31,
+      "section_count": 76,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "2nd Yr Ind Proj: CUL",
+        "Advanced Cookery - Preparation IV",
+        "Advanced Portfolio Management",
+        "Bakery and Pastry - Preparation III",
+        "Catering, Beverage and Food Services"
+      ]
+    },
+    {
+      "prefix": "IMT",
+      "name": "IMT",
+      "course_count": 38,
+      "section_count": 76,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "3D Graphics Animation",
+        "3D Graphics Modeling",
+        "Advanced 3D Graphics Modeling",
+        "ADVANCED COMPOSITING",
+        "Advanced Digital Photography"
+      ]
+    },
+    {
+      "prefix": "HTEC",
+      "name": "Medical",
+      "course_count": 6,
+      "section_count": 75,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Critical Thinking in Healthcare",
+        "Ethics for Health Care Professionals",
+        "Introduction to Medical Terminology",
+        "Introduction to Pharmacology",
+        "Medical Terminology I"
+      ]
+    },
+    {
+      "prefix": "CNST",
+      "name": "CNST",
+      "course_count": 32,
+      "section_count": 74,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "3D Laser Scanning for Land Surveying",
+        "Advanced Construction Safety",
+        "Aerial Surveying",
+        "Basic Survey Practices",
+        "CAD Technology in Construction"
+      ]
+    },
+    {
+      "prefix": "ECON",
+      "name": "Economics",
+      "course_count": 4,
+      "section_count": 74,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Honors Advanced Independent Study in Economics",
+        "Principles of Macroeconomics",
+        "Principles of Microeconomics",
+        "Survey of Economics"
+      ]
+    },
+    {
+      "prefix": "PHY",
+      "name": "Physics",
+      "course_count": 20,
+      "section_count": 74,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Astronomy",
+        "Aviation Physics",
+        "College Physics I with Algebra",
+        "College Physics II with Algebra",
+        "General Physics I"
+      ]
+    },
+    {
+      "prefix": "POL",
+      "name": "Political Science",
+      "course_count": 12,
+      "section_count": 74,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "American Government",
+        "American Government and Civics",
+        "American National Government",
+        "Conflict Resolution and Management",
+        "Constitutional Law"
+      ]
+    },
+    {
+      "prefix": "EMS",
+      "name": "Paramedic",
+      "course_count": 24,
+      "section_count": 72,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "CPR & First Aid",
+        "Emergency Medical Technician",
+        "EMS Anatomy & Physiology",
+        "EMS Capstone",
+        "EMT Theory & Practice"
+      ]
+    },
+    {
+      "prefix": "CSE",
+      "name": "Computer Science",
+      "course_count": 17,
+      "section_count": 70,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        ".Net Development",
+        "Advanced .Net Development",
+        "Advanced C++ Programming",
+        "Advanced Java Programming",
+        "Advanced Python Development"
+      ]
+    },
+    {
+      "prefix": "AMT",
+      "name": "AMT",
+      "course_count": 27,
+      "section_count": 68,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Aircraft Electricity",
+        "Aircraft Landing Gears",
+        "Aircraft Metal Structures",
+        "Aircraft Non-Metal Struc",
+        "Aircraft Orientation"
+      ]
+    },
+    {
+      "prefix": "PHL",
+      "name": "Ethics",
+      "course_count": 3,
+      "section_count": 68,
+      "colleges": [
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Introduction to Ethics",
+        "Medical Ethics"
+      ]
+    },
+    {
+      "prefix": "AUTO",
+      "name": "Automotive",
+      "course_count": 33,
+      "section_count": 65,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Automatic Transmissions",
+        "Automotive Alignment, Steering and Suspension",
+        "Automotive Braking Systems",
+        "Automotive Electrical Fundamentals",
+        "Automotive Electrical Systems"
+      ]
+    },
+    {
+      "prefix": "MKT",
+      "name": "Marketing",
+      "course_count": 22,
+      "section_count": 65,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Advertising & PR",
+        "Comprehensive Sales Techniques",
+        "Customer Relations",
+        "Digital Marketing"
+      ]
+    },
+    {
+      "prefix": "ITD",
+      "name": "Computer",
+      "course_count": 5,
+      "section_count": 63,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Computer Applications - -Windows and Concepts",
+        "Computer Applications - Word",
+        "Computer Applications for Professionals",
+        "Digital Project Management",
+        "Microsoft Outlook"
+      ]
+    },
+    {
+      "prefix": "CCR",
+      "name": "CCR",
+      "course_count": 31,
+      "section_count": 61,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Technology",
+        "Annotation for Digital Reporting",
+        "Court Procedures",
+        "Court Reporting Technology",
+        "Digital Reporting Technology"
+      ]
+    },
+    {
+      "prefix": "CJ",
+      "name": "Criminal Justice",
+      "course_count": 23,
+      "section_count": 60,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Assets Protection",
+        "Community Intervention Resources",
+        "Community Oriented Policing",
+        "Community Supervision and Aftercare",
+        "Computers in Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "HIT",
+      "name": "Health Information Technology",
+      "course_count": 31,
+      "section_count": 60,
+      "colleges": [
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "ALTERNATVE HLTH RECS AND REGST",
+        "Clinical Classification Systems III",
+        "Clinical Classifications Systems II",
+        "CLINICAL CLASSIFICATNS SYS I",
+        "Clinical Data Analysis"
+      ]
+    },
+    {
+      "prefix": "ESCI",
+      "name": "Physical",
+      "course_count": 10,
+      "section_count": 58,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Earth",
+        "Earth Laboratory",
+        "Geology of the National Parks",
+        "Introduction to Ocean Studies",
+        "Lab in Geology of the National Parks"
+      ]
+    },
+    {
+      "prefix": "PST",
+      "name": "PST",
+      "course_count": 20,
+      "section_count": 58,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Arboriculture",
+        "Arboriculture Practices",
+        "Deciduous Woody Landscape Plants",
+        "Equipment Operations and Safety",
+        "Evergreens, Groundcovers, and Herbaceous Landscape Plants"
+      ]
+    },
+    {
+      "prefix": "EDU",
+      "name": "Education",
+      "course_count": 22,
+      "section_count": 57,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Child Development",
+        "Children with Exceptionalities",
+        "Community and Family-based Programs",
+        "Early Childhood Education Practicum and Seminar",
+        "Educational Psychology"
+      ]
+    },
+    {
+      "prefix": "OTA",
+      "name": "OTA",
+      "course_count": 33,
+      "section_count": 57,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Anatomy and Path I for OTA",
+        "Clinical Applications I",
+        "Clinical Applications II",
+        "Developmental Aspects in OT",
+        "Developmental Clinical Experience"
+      ]
+    },
+    {
+      "prefix": "CET",
+      "name": "CET",
+      "course_count": 38,
+      "section_count": 56,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "1st Yr Ind Proj: CET",
+        "Advanced Revit Electrical",
+        "Advanced Revit Mechanical",
+        "Arch Design: Revit Arch",
+        "Arch Drafting & CAD"
+      ]
+    },
+    {
+      "prefix": "MLT",
+      "name": "MLT",
+      "course_count": 34,
+      "section_count": 55,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced MLT Applications",
+        "Clinical Chem/Urinalysis",
+        "Clinical Chemistry",
+        "Clinical Microbiology",
+        "Fundamentals of Laboratory Techniques"
+      ]
+    },
+    {
+      "prefix": "MA",
+      "name": "Medical",
+      "course_count": 29,
+      "section_count": 54,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "1st Yr Ind Proj: Ma",
+        "1st Yr Spec Topics: MA",
+        "Admin, Coding & Billing",
+        "Administrative Procedures for the Medical Office",
+        "Administrative Procedures Laboratory"
+      ]
+    },
+    {
+      "prefix": "IDS",
+      "name": "Critical",
+      "course_count": 2,
+      "section_count": 53,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "College and Career Success Skills",
+        "Critical Analysis"
+      ]
+    },
+    {
+      "prefix": "MCH",
+      "name": "MCH",
+      "course_count": 9,
+      "section_count": 53,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Comprehensive Med Term",
+        "ECG 1",
+        "Healthcare Informatics",
+        "Medical Terminology 1",
+        "Medical Terminology 2"
+      ]
+    },
+    {
+      "prefix": "RAT",
+      "name": "Recording",
+      "course_count": 18,
+      "section_count": 53,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Audio Recording Field Experience",
+        "Audio Signal Processing",
+        "Audio Transducers",
+        "Concert Technical Production",
+        "Digital Audio Mixing"
+      ]
+    },
+    {
+      "prefix": "ITNT",
+      "name": "Network",
+      "course_count": 7,
+      "section_count": 52,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Linux Administration",
+        "Network Administration I",
+        "Network Administration II",
+        "Network Security Fundamentals",
+        "Networking Capstone"
+      ]
+    },
+    {
+      "prefix": "BHS",
+      "name": "BHS",
+      "course_count": 16,
+      "section_count": 51,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Cardiac Life Support",
+        "Applied Functional Anatomy",
+        "Certified Nurse Aide Training",
+        "CPR",
+        "CPR Renewal"
+      ]
+    },
+    {
+      "prefix": "MST",
+      "name": "Welding",
+      "course_count": 11,
+      "section_count": 51,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "3G and 4G Welding Certification Exam Preparatory",
+        "6G Welding Certification Examination Preparatory",
+        "Basic Pumps",
+        "Blueprint Reading",
+        "Gas Tungsten Arc Welding"
+      ]
+    },
+    {
+      "prefix": "MT",
+      "name": "Massage",
+      "course_count": 17,
+      "section_count": 51,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Massage Therapy",
+        "Advanced Massage Therapy Clinic",
+        "Applied Musculo-Skeletal Anatomy",
+        "Business Practices for Massage Therapists",
+        "Comprehensive Massage Therapy"
+      ]
+    },
+    {
+      "prefix": "CFS",
+      "name": "CFS",
+      "course_count": 23,
+      "section_count": 50,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "CFS Colloquium",
+        "Chem Analysis of Food",
+        "Computer Crime and Investigation",
+        "Cyber Defense Fundamentals",
+        "Cyber Forensics and Data Recovery"
+      ]
+    },
+    {
+      "prefix": "PSC",
+      "name": "Government",
+      "course_count": 9,
+      "section_count": 50,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Comparative Government and Politics",
+        "Exploring the Solar System",
+        "Government &amp; Legal Ethics",
+        "Introduction to Law and Legal System",
+        "Introduction to Political Thought"
+      ]
+    },
+    {
+      "prefix": "ANTH",
+      "name": "ANTH",
+      "course_count": 4,
+      "section_count": 49,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Archaeology",
+        "Cultural Anthropology",
+        "Human Evolution",
+        "Peoples and Cultures of the World"
+      ]
+    },
+    {
+      "prefix": "SUR",
+      "name": "SUR",
+      "course_count": 30,
+      "section_count": 49,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "CAD & Civil 3D Software",
+        "Construction Layout",
+        "Control Surveying",
+        "Dendrology 1",
+        "Full-time Co-op 1: LS"
+      ]
+    },
+    {
+      "prefix": "HIM",
+      "name": "Health Information Management",
+      "course_count": 32,
+      "section_count": 47,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Medical Coding",
+        "Clinical Abstracting",
+        "Coding with CPT (Current Procedural Terminology)",
+        "Coding with ICD-10-CM",
+        "Coding with ICD-10-PCS"
+      ]
+    },
+    {
+      "prefix": "LAW",
+      "name": "LAW",
+      "course_count": 16,
+      "section_count": 47,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Bankruptcy",
+        "Basic Police Academy",
+        "Business Law",
+        "Employment & Admin Law",
+        "Family & Probate Law"
+      ]
+    },
+    {
+      "prefix": "SWK",
+      "name": "Social",
+      "course_count": 14,
+      "section_count": 47,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Crisis Intervention",
+        "Group Processes",
+        "Human Behavior in the Social Environment",
+        "Human Services Case Mgmt",
+        "Intro to Social Work"
+      ]
+    },
+    {
+      "prefix": "THEA",
+      "name": "Theatre",
+      "course_count": 13,
+      "section_count": 47,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Acting I",
+        "Acting II",
+        "Acting III",
+        "Acting IV",
+        "Advanced Rehearsal Performance"
+      ]
+    },
+    {
+      "prefix": "VC",
+      "name": "VC",
+      "course_count": 7,
+      "section_count": 47,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Graphic Design and Illustration",
+        "History of Graphic Design",
+        "Individual Projects",
+        "Portfolio Preparation",
+        "Typography I"
+      ]
+    },
+    {
+      "prefix": "VT",
+      "name": "Veterinary",
+      "course_count": 19,
+      "section_count": 47,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Animal Health and Disease",
+        "Avian and Exotic Animal Med",
+        "Dentistry for Veterinary Technicians",
+        "Introduction to Veterinary Technology",
+        "Pharmacology for Veterinary Technicians"
+      ]
+    },
+    {
+      "prefix": "HLTH",
+      "name": "Personal",
+      "course_count": 4,
+      "section_count": 46,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "CPR-AED for Healthcare Professionals",
+        "Personal Health Education",
+        "Standard First Aid and Personal Safety",
+        "Women&#39;s Health Issues"
+      ]
+    },
+    {
+      "prefix": "PE",
+      "name": "PE",
+      "course_count": 10,
+      "section_count": 46,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Adapted Physical Education",
+        "Aqua Fitness",
+        "Meditation Techniques",
+        "Personal Fitness",
+        "Personal Strength Development"
+      ]
+    },
+    {
+      "prefix": "PL",
+      "name": "PL",
+      "course_count": 21,
+      "section_count": 45,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Alternative Dispute Resolution",
+        "Bankruptcy and Debtor/Creditor Law",
+        "Business Organizations",
+        "Business Transactions",
+        "Civil Procedure"
+      ]
+    },
+    {
+      "prefix": "IM",
+      "name": "IM",
+      "course_count": 18,
+      "section_count": 44,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Business Document Formatting",
+        "Computer Applications",
+        "Document Proofing/Editing",
+        "Full-time Co-op 1: IM",
+        "Full-time Co-op 2: IM"
+      ]
+    },
+    {
+      "prefix": "WET",
+      "name": "Welding",
+      "course_count": 10,
+      "section_count": 44,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Codes and Procedures",
+        "GMAW and GTAW Welding Theory",
+        "GMAW Welding Lab",
+        "GTAW Welding Lab",
+        "Inspection"
+      ]
+    },
+    {
+      "prefix": "FILM",
+      "name": "Media",
+      "course_count": 18,
+      "section_count": 43,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Crew and Set Operations",
+        "Advanced Independent Study in Film and Media Arts",
+        "Applied Integrated Media (AIM) I: Real World Pre-production",
+        "Applied Integrated Media (AIM) II: Real World Production and Post-Production for Motion Media",
+        "Cinematography II"
+      ]
+    },
+    {
+      "prefix": "NET",
+      "name": "NET",
+      "course_count": 13,
+      "section_count": 42,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "CCNA Phase 2",
+        "CCNA Phase 3",
+        "Firewall and Network Security",
+        "Introduction to Computer Networking",
+        "Microsoft Client Operating System"
+      ]
+    },
+    {
+      "prefix": "PNC",
+      "name": "Nursing",
+      "course_count": 6,
+      "section_count": 41,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Nursing 2",
+        "Nursing 3",
+        "Nursing 4",
+        "Nursing I",
+        "Pharmacology 2"
+      ]
+    },
+    {
+      "prefix": "CIT",
+      "name": "Computer Information Technology",
+      "course_count": 16,
+      "section_count": 40,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Career Prep: ET/IT",
+        "CIS Capstone",
+        "Computer Security and Forensics",
+        "Database",
+        "Databases and Client/Server Programming"
+      ]
+    },
+    {
+      "prefix": "MARK",
+      "name": "Marketing",
+      "course_count": 6,
+      "section_count": 40,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Digital Marketing Design",
+        "Principles of Advertising",
+        "Principles of Marketing",
+        "Salesmanship and Promotional Strategies",
+        "Social Media Content Strategies and Analytics"
+      ]
+    },
+    {
+      "prefix": "AIT",
+      "name": "AIT",
+      "course_count": 13,
+      "section_count": 38,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CNC PROGRAMMING",
+        "Advanced Machine Tools",
+        "Automated Welding and Fabrication",
+        "Basic Machines",
+        "CAD/CAM"
+      ]
+    },
+    {
+      "prefix": "ARL",
+      "name": "ARL",
+      "course_count": 15,
+      "section_count": 38,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "ADVANCED CNC OPERATIONS",
+        "Basic Metrology",
+        "CNC MACHING CTR PRG EIA FRMT",
+        "CNC TRNG CTR PROG EIA FORMAT",
+        "COMPRESSOR DOC INTEGRATION"
+      ]
+    },
+    {
+      "prefix": "PTAT",
+      "name": "Physical",
+      "course_count": 17,
+      "section_count": 38,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Acute Care Physical Therapy",
+        "Clinical Pathophysiology &amp; Pharmacology",
+        "Clinical Practicum I",
+        "Clinical Practicum II",
+        "Field Experience I"
+      ]
+    },
+    {
+      "prefix": "ECED",
+      "name": "Early Childhood Education",
+      "course_count": 12,
+      "section_count": 37,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Administration and Leadership in Early Childhood",
+        "Child Behavior and Guidance",
+        "Creative Development in an Integrated Curriculum",
+        "Early Childhood Education Student Teaching Practicum",
+        "Early Childhood Education Student Teaching Seminar"
+      ]
+    },
+    {
+      "prefix": "AOT",
+      "name": "AOT",
+      "course_count": 20,
+      "section_count": 36,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Administrative Procedures and Systems",
+        "AOT PRACTICUM",
+        "Database Applications-Microsoft Access",
+        "Digital Technologies",
+        "Document Development and Website Maintenance"
+      ]
+    },
+    {
+      "prefix": "DENT",
+      "name": "DENT",
+      "course_count": 18,
+      "section_count": 36,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Community Oral Health I",
+        "Community Oral Health II",
+        "Current Concepts in Dental Materials",
+        "Dental Anatomy, Histology &amp; Embryology",
+        "Dental Hygiene Fundamentals"
+      ]
+    },
+    {
+      "prefix": "ECO",
+      "name": "Economics",
+      "course_count": 4,
+      "section_count": 36,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Macroeconomics",
+        "Microeconomics"
+      ]
+    },
+    {
+      "prefix": "SES",
+      "name": "Exercise",
+      "course_count": 15,
+      "section_count": 36,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Exercise Testing and Prescription",
+        "Advanced Training Concepts and Techniques",
+        "Essentials of Sports Injury Care",
+        "Exercise and Movement Anatomy",
+        "Exercise for Special Populations"
+      ]
+    },
+    {
+      "prefix": "INTD",
+      "name": "Interior",
+      "course_count": 16,
+      "section_count": 35,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Architectural Drafting for Interiors I",
+        "Architectural Drafting for Interiors II",
+        "Architectural Materials and Methods",
+        "Color and Textile Studio",
+        "Digital Presentation I"
+      ]
+    },
+    {
+      "prefix": "MJS",
+      "name": "Media",
+      "course_count": 8,
+      "section_count": 35,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Black Media",
+        "Broadcast and Multimedia Journalism",
+        "Digital Media Writing",
+        "Film Appreciation",
+        "Independent Study/Research in Media and Journalism Studies"
+      ]
+    },
+    {
+      "prefix": "DHY",
+      "name": "Dental",
+      "course_count": 26,
+      "section_count": 34,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Anesthesia and Pain Control",
+        "CLINICAL DENTAL HYG I",
+        "CLINICAL DENTAL HYG III",
+        "Clinical Dental Hygiene IA",
+        "Clinical Dental Hygiene II"
+      ]
+    },
+    {
+      "prefix": "PIP",
+      "name": "PIP",
+      "course_count": 33,
+      "section_count": 33,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Controls and Backflow",
+        "Advanced Layout and Pipe Threading and Grooving",
+        "Advanced Steam and Hydronic Systems and Service",
+        "Backflow and Medical Gas",
+        "Balance of Heating, Ventilation, and Air Conditioning Systems and Fuel Oil Heat"
+      ]
+    },
+    {
+      "prefix": "SPAN",
+      "name": "Spanish",
+      "course_count": 4,
+      "section_count": 33,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Beginning Spanish Language and Culture II",
+        "Beginning Spanish Language and Cultures I",
+        "Intermediate Spanish Language and Culture I",
+        "Intermediate Spanish Language and Cultures II"
+      ]
+    },
+    {
+      "prefix": "AVP",
+      "name": "AVP",
+      "course_count": 16,
+      "section_count": 32,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "2nd Yr Spec Topics: AVP",
+        "After Effects",
+        "Alternate Editing Platfor",
+        "Audio Editing & Mixing",
+        "Audio Production"
+      ]
+    },
+    {
+      "prefix": "HVC",
+      "name": "Hvac",
+      "course_count": 10,
+      "section_count": 31,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Chiller Operations",
+        "HVAC DESIGN &amp; APPLICATION",
+        "HVAC Electrical Systems and Applications",
+        "HVAC Field InstallationTechniques and Procedures",
+        "HVAC PRINCIPLES I"
+      ]
+    },
+    {
+      "prefix": "LH",
+      "name": "LH",
+      "course_count": 16,
+      "section_count": 31,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Arboriculture",
+        "Full-time Co-op 1: LH",
+        "Full-time Co-op 2: LH",
+        "Herbaceous Plants",
+        "Hort Occupations"
+      ]
+    },
+    {
+      "prefix": "BTA",
+      "name": "BTA",
+      "course_count": 29,
+      "section_count": 30,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "A2L Refrigerants",
+        "Advanced Fitting",
+        "Advanced Fitting/Welding",
+        "Advanced Welding",
+        "Basic Electricity"
+      ]
+    },
+    {
+      "prefix": "PN",
+      "name": "Concepts",
+      "course_count": 4,
+      "section_count": 30,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "PN Concepts 1",
+        "PN Concepts 2",
+        "PN Concepts 3",
+        "PN Role Transition"
+      ]
+    },
+    {
+      "prefix": "RCT",
+      "name": "RCT",
+      "course_count": 24,
+      "section_count": 30,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Respiratory Care Procedures Lab",
+        "AIRWAY MANAGEMENT PROCED",
+        "Airway Mgmt Procedures Lab",
+        "Cardiopulmonary Anatomy and Physiology",
+        "Critical Care"
+      ]
+    },
+    {
+      "prefix": "ECE",
+      "name": "Early Childhood Education",
+      "course_count": 14,
+      "section_count": 29,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Assessment/Observation",
+        "CDA 1",
+        "CDA 2",
+        "Child Health/Safety/Nutrition",
+        "Classroom Management"
+      ]
+    },
+    {
+      "prefix": "HS",
+      "name": "Services",
+      "course_count": 14,
+      "section_count": 29,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Crisis Intervention and Child Abuse Issues",
+        "Diagnostic Tools and Legal Considerations",
+        "Ethics in Chemical Dependency",
+        "Family Theory and Services",
+        "Foundation of Substance Abuse, Addiction, and Group Work"
+      ]
+    },
+    {
+      "prefix": "REL",
+      "name": "Religion",
+      "course_count": 5,
+      "section_count": 29,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "African-American Religious Experience",
+        "Comparative World Religions",
+        "Introduction to Religious Studies",
+        "Religious Traditions of Western Christianity",
+        "World Religions"
+      ]
+    },
+    {
+      "prefix": "CHE",
+      "name": "Chemistry",
+      "course_count": 10,
+      "section_count": 28,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "1st Yr Spec Topics: CHE",
+        "Basic Chemistry",
+        "Bio-Organic Chemistry",
+        "Everyday Chemistry",
+        "Fundamentals of Chemistry"
+      ]
+    },
+    {
+      "prefix": "EVT",
+      "name": "EVT",
+      "course_count": 20,
+      "section_count": 28,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Air Pollution Control",
+        "Environ Risk Assessment",
+        "Environmental Chemistry",
+        "Environmental Mapping",
+        "Environmental Mgmt"
+      ]
+    },
+    {
+      "prefix": "ITP",
+      "name": "Information Technology Programming",
+      "course_count": 21,
+      "section_count": 28,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Deaf Culture, History & Rights",
+        "Deaf Plus Interpreting",
+        "Ed Interpreting Practicum",
+        "Educational Interpreting",
+        "Fingerspelling and Numbers"
+      ]
+    },
+    {
+      "prefix": "BT",
+      "name": "Business",
+      "course_count": 12,
+      "section_count": 27,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Business Spreadsheets (Excel)",
+        "Advanced Word Processing",
+        "Business Database Systems (Access)",
+        "Business Spreadsheets (Excel)",
+        "Business Technologies Capstone"
+      ]
+    },
+    {
+      "prefix": "CJS",
+      "name": "CJS",
+      "course_count": 8,
+      "section_count": 27,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Corrections",
+        "Criminal Law in the United States",
+        "Criminal Procedure",
+        "Criminology",
+        "Introduction to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "END",
+      "name": "END",
+      "course_count": 15,
+      "section_count": 27,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Basic Evoked Potentials",
+        "Cardiopulmonary Anatomy and Physiology",
+        "Electroneurodiagnostic Capstone",
+        "END Directed Practice I",
+        "END Directed Practice II"
+      ]
+    },
+    {
+      "prefix": "MIL",
+      "name": "Military",
+      "course_count": 1,
+      "section_count": 27,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Special Topics in Military"
+      ]
+    },
+    {
+      "prefix": "OTAT",
+      "name": "OTAT",
+      "course_count": 15,
+      "section_count": 27,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Clinical Skills for the Occupational Therapy Assistant",
+        "Field Experience",
+        "Fundamentals of Developmental Disabilities",
+        "Fundamentals of Physical Dysfunction",
+        "Fundamentals of Psychosocial Dysfunction"
+      ]
+    },
+    {
+      "prefix": "RESP",
+      "name": "Respiratory",
+      "course_count": 15,
+      "section_count": 27,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Acid-Base and Hemodynamics",
+        "Basic Therapeutic Procedures",
+        "Cardiopulmonary Assessment and Pulmonary Diseases",
+        "Cardiopulmonary Physiology",
+        "Introduction to Mechanical Ventilation"
+      ]
+    },
+    {
+      "prefix": "PTA",
+      "name": "PTA",
+      "course_count": 22,
+      "section_count": 26,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Clinical Application I",
+        "Clinical Experience II",
+        "Clinical Experience III",
+        "Data Collection",
+        "Data Collection Lab"
+      ]
+    },
+    {
+      "prefix": "SPE",
+      "name": "Effective",
+      "course_count": 2,
+      "section_count": 26,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Effective Speaking",
+        "Interpersonal Communication"
+      ]
+    },
+    {
+      "prefix": "VCPH",
+      "name": "Photography",
+      "course_count": 13,
+      "section_count": 26,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Commercial Studio Techniques II",
+        "Commercial Studio Techniques III",
+        "Digital Imaging I",
+        "Digital Imaging II",
+        "Digital Video for Photographers"
+      ]
+    },
+    {
+      "prefix": "MAS",
+      "name": "Massage",
+      "course_count": 12,
+      "section_count": 25,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Clinical Operations",
+        "Massage Therapy Anatomy and Physiology I",
+        "Massage Therapy Anatomy and Physiology II",
+        "Massage Therapy I",
+        "Massage Therapy II"
+      ]
+    },
+    {
+      "prefix": "NETC",
+      "name": "Coop",
+      "course_count": 12,
+      "section_count": 25,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Full-time Co-op 1: NETC",
+        "Full-time Co-op 2: NETC",
+        "Full-time Co-op 3: NETC",
+        "Information Risk Management",
+        "Intro to Cybersecurity"
+      ]
+    },
+    {
+      "prefix": "AGR",
+      "name": "AGR",
+      "course_count": 17,
+      "section_count": 23,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college",
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "AGR Technology Capstone",
+        "Agricultural Mechanics",
+        "Agronomy and Soil Science",
+        "Fall Production",
+        "Farm Ecology Management"
+      ]
+    },
+    {
+      "prefix": "CPT",
+      "name": "CPT",
+      "course_count": 19,
+      "section_count": 23,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Animation I",
+        "C# Programming and .NET5",
+        "Cisco CCNA 2SRW",
+        "Cisco CCNA Enterprise I",
+        "Computer Apps in the Workplace"
+      ]
+    },
+    {
+      "prefix": "DET",
+      "name": "DET",
+      "course_count": 8,
+      "section_count": 23,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "AutoCAD Inventor with 3D Printing and Scanning",
+        "Basic AutoCAD",
+        "CUSTOMIZING AUTOCAD",
+        "Engineering Drawing",
+        "GEOMETRIC DIM AND TOL"
+      ]
+    },
+    {
+      "prefix": "SPN",
+      "name": "Spanish",
+      "course_count": 4,
+      "section_count": 23,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Elementary Spanish 1",
+        "Elementary Spanish 2",
+        "Elementary Spanish I",
+        "Elementary Spanish II"
+      ]
+    },
+    {
+      "prefix": "WDD",
+      "name": "Development",
+      "course_count": 9,
+      "section_count": 23,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Active Server Page Development",
+        "Advanced Cascading Style Sheets",
+        "Advanced Web Design",
+        "ASP.Net MVC Development",
+        "Content Management System Design and Development"
+      ]
+    },
+    {
+      "prefix": "CDL",
+      "name": "Commercial",
+      "course_count": 4,
+      "section_count": 22,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Commercial Driver&#39;s License - Class A - Advanced Operations and Maintenance",
+        "Commercial Driver&#39;s License - Class A - Safe Operation and Control",
+        "Commercial Truck Advanced Safe Operation and Control",
+        "Introduction to Truck Operations and Maintenance"
+      ]
+    },
+    {
+      "prefix": "CPDM",
+      "name": "Cpdm",
+      "course_count": 10,
+      "section_count": 22,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Preparation: CPDM",
+        "CPDM Capstone",
+        "Full-time Co-op 1: CPDM",
+        "Full-time Co-op 2: CPDM",
+        "Full-time Co-op 3: CPDM"
+      ]
+    },
+    {
+      "prefix": "DLS",
+      "name": "Digital",
+      "course_count": 1,
+      "section_count": 22,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Digital Literacy and Applications"
+      ]
+    },
+    {
+      "prefix": "GRD",
+      "name": "GRD",
+      "course_count": 13,
+      "section_count": 22,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "2D Graphics: Vector",
+        "Analysis & Conceptualization",
+        "Applied 2D Graphics: GRD",
+        "Beginning 2D: Bitmap",
+        "Design Principles"
+      ]
+    },
+    {
+      "prefix": "HST",
+      "name": "History",
+      "course_count": 7,
+      "section_count": 22,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Afr Amer Hist to 1877",
+        "American Hist since 1877",
+        "American History Since 1877",
+        "American History to 1877",
+        "Western Civ to 1648"
+      ]
+    },
+    {
+      "prefix": "PAS",
+      "name": "Coop",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Adv Pastry/Buffet Design",
+        "Artisan Bread Baking",
+        "Celebration Cakes",
+        "Full-time Co-op 1: PAS",
+        "Full-time Co-op 2: PAS"
+      ]
+    },
+    {
+      "prefix": "REF",
+      "name": "REF",
+      "course_count": 11,
+      "section_count": 22,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Air Conditioning Systems",
+        "Electricity for HVAC I",
+        "Electricity for HVAC II",
+        "Electronics for HVAC",
+        "Heating Systems I"
+      ]
+    },
+    {
+      "prefix": "TEM",
+      "name": "TEM",
+      "course_count": 9,
+      "section_count": 22,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Elec Ladder Diagrams",
+        "Electrical Systems",
+        "Industrial Electricity",
+        "Industrial Sensors",
+        "Motor Controls"
+      ]
+    },
+    {
+      "prefix": "CIS",
+      "name": "Computer Information Systems",
+      "course_count": 9,
+      "section_count": 21,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Data Analysis and Visualization",
+        "Advanced Help Desk",
+        "Advanced Topics in data Analysis",
+        "DATA ACQUISITION AND ANALYSIS",
+        "Data Analysis and Decision Making"
+      ]
+    },
+    {
+      "prefix": "DMT",
+      "name": "DMT",
+      "course_count": 10,
+      "section_count": 21,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Design",
+        "Digital Creation and Editing",
+        "Digital Video Production II",
+        "Interactive Media",
+        "Introduction to Digital Video Production"
+      ]
+    },
+    {
+      "prefix": "FST",
+      "name": "FST",
+      "course_count": 10,
+      "section_count": 21,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "1st Yr Spec Topics: FST",
+        "Building Construction",
+        "Career Firefighter",
+        "Emerg Services Principles",
+        "Emergency Vehicle Ops"
+      ]
+    },
+    {
+      "prefix": "MED",
+      "name": "Medical",
+      "course_count": 12,
+      "section_count": 21,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Medical Assisting",
+        "Introduction to Medical Assisting Lab",
+        "Medical Assisting Practicum",
+        "Medical Assisting Procedures I",
+        "Medical Assisting Procedures I Lab"
+      ]
+    },
+    {
+      "prefix": "HLT",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 20,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Healthcare Professional Prep"
+      ]
+    },
+    {
+      "prefix": "NETA",
+      "name": "Neta",
+      "course_count": 12,
+      "section_count": 20,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Computer Virtualization",
+        "Full-time Co-op 1: NETA",
+        "Full-time Co-op 2: NETA",
+        "Full-time Co-op 3: NETA",
+        "IT Support Desk Concepts"
+      ]
+    },
+    {
+      "prefix": "UPP",
+      "name": "UPP",
+      "course_count": 20,
+      "section_count": 20,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Hydronic Heating and Cooling Systems Piping",
+        "Advanced Plumbing and Pipefitting Mathematical Applications",
+        "Advanced Plumbing Code and Backflow Test",
+        "Air Conditioning and Heat Pumps and Variable Frequency Drives",
+        "Basic Refrigeration and Electricity"
+      ]
+    },
+    {
+      "prefix": "VCIM",
+      "name": "Design",
+      "course_count": 13,
+      "section_count": 20,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "2D Animation",
+        "Game Design I: Introduction to Game Design",
+        "Game Design II: Game Engines",
+        "Game Design III: Game Design Studio",
+        "Game Design IV-Game Publishing"
+      ]
+    },
+    {
+      "prefix": "AAD",
+      "name": "AAD",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Auto Electricity",
+        "Auto Engines",
+        "Automotive Power Train I",
+        "Drivability",
+        "Fuel and Emission Systems"
+      ]
+    },
+    {
+      "prefix": "DAS",
+      "name": "Dental",
+      "course_count": 10,
+      "section_count": 19,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Dental Assisting Materials",
+        "Dental Assisting Radiography",
+        "DENTAL ASSISTING SPECIALTY",
+        "Dental Assisting Techniques I",
+        "Dental Assisting Techniques II"
+      ]
+    },
+    {
+      "prefix": "DIET",
+      "name": "Nutrition",
+      "course_count": 4,
+      "section_count": 19,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Basic Nutrition",
+        "Dietary Managers Field Experience",
+        "Nutrition for Dental Hygiene",
+        "Sports Nutrition"
+      ]
+    },
+    {
+      "prefix": "EVS",
+      "name": "EVS",
+      "course_count": 3,
+      "section_count": 19,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Env Sci: Ecology & Ecosys",
+        "Env Science: Conservation",
+        "Environmental Geology"
+      ]
+    },
+    {
+      "prefix": "HRM",
+      "name": "Coop",
+      "course_count": 9,
+      "section_count": 19,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Food & Bev Cost Control",
+        "Full-time Co-op 1: HOSP",
+        "Full-time Co-op 2: HOSP",
+        "Hospitality Careers",
+        "Part-time Co-op 1: HOSP"
+      ]
+    },
+    {
+      "prefix": "SURT",
+      "name": "SURT",
+      "course_count": 13,
+      "section_count": 19,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Clinical Experience I",
+        "Clinical Experience II",
+        "Clinical Experience III",
+        "Clinical Experience IV",
+        "Clinical Experience: Sterile Processing"
+      ]
+    },
+    {
+      "prefix": "BREW",
+      "name": "Coop",
+      "course_count": 12,
+      "section_count": 18,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Brewing Microbiology",
+        "Brewing Production",
+        "Brewing Quality Control",
+        "Brewing Sanitation/Safety",
+        "Foundations of Craft Beer"
+      ]
+    },
+    {
+      "prefix": "HSV",
+      "name": "Services",
+      "course_count": 7,
+      "section_count": 18,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Counseling & Interviewing",
+        "Family Theory & Services",
+        "HSV Practicum 1",
+        "HSV Practicum 2",
+        "Human Services Group Work"
+      ]
+    },
+    {
+      "prefix": "NMED",
+      "name": "Nuclear",
+      "course_count": 18,
+      "section_count": 18,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Immunology and Pathophysiology for Sectional Imaging",
+        "Molecular and Fusion Imaging with Pharmacology",
+        "Nuclear Medicine Computers, Math, and Statistics",
+        "Nuclear Medicine Field Experience I",
+        "Nuclear Medicine Field Experience II"
+      ]
+    },
+    {
+      "prefix": "ROB",
+      "name": "Robotics",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Emerging Technologies in Robotics",
+        "Introduction to Robotics",
+        "Robotic Programming",
+        "Robotics Maintenance PM & Networking",
+        "Servo Systems"
+      ]
+    },
+    {
+      "prefix": "SGE",
+      "name": "Game",
+      "course_count": 8,
+      "section_count": 18,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "2D GAME DESIGN AND DEVELP",
+        "3D Game Design and Development",
+        "Advanced Gaming and Simulation Topics",
+        "Assets for Games",
+        "Game Design"
+      ]
+    },
+    {
+      "prefix": "WGS",
+      "name": "Women",
+      "course_count": 5,
+      "section_count": 18,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Honors Introduction to Women&#39;s and Gender Studies",
+        "Introduction to Women&#39;s and Gender Studies",
+        "Women and Politics",
+        "Women in the World",
+        "Women Writers on the Experiences of Women"
+      ]
+    },
+    {
+      "prefix": "GEOG",
+      "name": "Geography",
+      "course_count": 5,
+      "section_count": 17,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Africans in the Americas",
+        "Environmental Geography",
+        "Introduction to Geography",
+        "Regional Geography of the United States and Canada",
+        "World Regional Geography"
+      ]
+    },
+    {
+      "prefix": "MFG",
+      "name": "MFG",
+      "course_count": 3,
+      "section_count": 17,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Materials",
+        "Print Reading for Industry",
+        "Safety"
+      ]
+    },
+    {
+      "prefix": "WLD",
+      "name": "Welding",
+      "course_count": 12,
+      "section_count": 17,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Full-time Co-op 1: WLD",
+        "Full-time Co-op 2: WLD",
+        "Fundamentals of Welding",
+        "GTAW Welding",
+        "Part-time Co-op 1: WLD"
+      ]
+    },
+    {
+      "prefix": "ADC",
+      "name": "ADC",
+      "course_count": 5,
+      "section_count": 16,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Addict Treatment Ethics",
+        "Addiction Counseling",
+        "Drugs in Society",
+        "Dual Diagnosis",
+        "Relapse Prevention"
+      ]
+    },
+    {
+      "prefix": "CPD",
+      "name": "CPD",
+      "course_count": 3,
+      "section_count": 16,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "DATA MODELING AND DATABSE DSGN",
+        "Microsoft SQL Server Database Administration",
+        "Structured Query Language"
+      ]
+    },
+    {
+      "prefix": "EMET",
+      "name": "EMET",
+      "course_count": 12,
+      "section_count": 16,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Electro-Mechanical CAD",
+        "Energy Efficiency/Audits",
+        "Full-time Co-op 1: EMET",
+        "Full-time Co-op 2: EMET",
+        "Full-time Co-op 3: EMET"
+      ]
+    },
+    {
+      "prefix": "ST",
+      "name": "Surgical",
+      "course_count": 7,
+      "section_count": 16,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Adv Surgical Procedures 1",
+        "Adv Surgical Procedures 2",
+        "Intro to Surgical Tech",
+        "ST Clinical Skills 2",
+        "ST Directed Practice 1"
+      ]
+    },
+    {
+      "prefix": "VCGD",
+      "name": "Design",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advertising and Design",
+        "Brand Identity Design",
+        "Graphic Design Studio",
+        "Information Graphic Design",
+        "Package Design"
+      ]
+    },
+    {
+      "prefix": "VCIL",
+      "name": "Illustration",
+      "course_count": 6,
+      "section_count": 16,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "3D Design",
+        "3D Motion",
+        "Illustration for Story",
+        "Illustration I",
+        "Illustration II"
+      ]
+    },
+    {
+      "prefix": "DANC",
+      "name": "Dance",
+      "course_count": 4,
+      "section_count": 15,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Ballet I",
+        "Dance Appreciation",
+        "Dance Fundamentals",
+        "Hip-Hop Dance I"
+      ]
+    },
+    {
+      "prefix": "DT",
+      "name": "Nutrition",
+      "course_count": 11,
+      "section_count": 15,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Community Nutrition",
+        "Cultural Food Production",
+        "Dietetic Prof Practices",
+        "DT Dir Prac: Food Serv",
+        "DT Directed Practice 2"
+      ]
+    },
+    {
+      "prefix": "SDE",
+      "name": "First",
+      "course_count": 1,
+      "section_count": 15,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "First Year Experience"
+      ]
+    },
+    {
+      "prefix": "WEB",
+      "name": "WEB",
+      "course_count": 10,
+      "section_count": 15,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Animated Web Content",
+        "Applied 2D Graphics: WEB",
+        "Full-time Co-op 1: WEB",
+        "Part-time Co-op 1: WEB",
+        "Part-time Co-op 2: WEB"
+      ]
+    },
+    {
+      "prefix": "ENT",
+      "name": "ENT",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Entrepreneurship",
+        "Global Entrepreneurialship",
+        "Managing Entrepreneurial Growth"
+      ]
+    },
+    {
+      "prefix": "PHI",
+      "name": "Philosophy",
+      "course_count": 2,
+      "section_count": 14,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Ethics",
+        "Intro to Philosophy"
+      ]
+    },
+    {
+      "prefix": "RAD",
+      "name": "RAD",
+      "course_count": 9,
+      "section_count": 14,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Clinical Education II-RAD",
+        "Clinical Education III-RAD",
+        "Computed Tomography Procedures",
+        "Intro to Rad Imaging",
+        "Prin of Computed Tomography"
+      ]
+    },
+    {
+      "prefix": "RE",
+      "name": "Real",
+      "course_count": 3,
+      "section_count": 14,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "RE Appraisal/Finance",
+        "Real Estate Law",
+        "Real Estate Principles"
+      ]
+    },
+    {
+      "prefix": "RT",
+      "name": "RT",
+      "course_count": 8,
+      "section_count": 14,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Cardiopulmonary A&P",
+        "Intro to Respiratory Care",
+        "Mechanical Ventilation",
+        "RC Advanced Critical Care",
+        "RC Clinical Practice 2"
+      ]
+    },
+    {
+      "prefix": "ATMT",
+      "name": "Manufacturing",
+      "course_count": 8,
+      "section_count": 13,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Field Experience",
+        "Machine Operations I",
+        "Machine Tool Theory",
+        "Manufacturing Skills I",
+        "Manufacturing Tech Skills I"
+      ]
+    },
+    {
+      "prefix": "EDUC",
+      "name": "Education",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Educational Technology",
+        "Human Diversity in Education",
+        "Individuals with Exceptionalities",
+        "Introduction to Education"
+      ]
+    },
+    {
+      "prefix": "GER",
+      "name": "Beginning",
+      "course_count": 4,
+      "section_count": 13,
+      "colleges": [
+        "cuyahoga-community-college-district",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Beginning German I",
+        "Beginning German II",
+        "Introduction to Gerontology",
+        "Psychological Aspect of Aging"
+      ]
+    },
+    {
+      "prefix": "LDR",
+      "name": "Leadership",
+      "course_count": 7,
+      "section_count": 13,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Ethical Leadership",
+        "Inclusive Leadership",
+        "Intro to Leadership",
+        "Leading Teams",
+        "Practicing Positive Leadership"
+      ]
+    },
+    {
+      "prefix": "LEN",
+      "name": "LEN",
+      "course_count": 10,
+      "section_count": 13,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Community Relations",
+        "Corrections",
+        "Criminology",
+        "Introduction to Criminal Justice",
+        "Investigation Techniques"
+      ]
+    },
+    {
+      "prefix": "MRT",
+      "name": "MRT",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Advertising",
+        "Marketing",
+        "Marketing Research",
+        "Principles of Selling",
+        "Public Relations"
+      ]
+    },
+    {
+      "prefix": "PBA",
+      "name": "Coop",
+      "course_count": 6,
+      "section_count": 13,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Full-time Co-op 1: PBA",
+        "Full-time Co-op 2: PBA",
+        "Part-time Co-op 1: PBA",
+        "Part-time Co-op 2: PBA",
+        "Part-time Co-op 3: PBA"
+      ]
+    },
+    {
+      "prefix": "UST",
+      "name": "Urban",
+      "course_count": 3,
+      "section_count": 13,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "History of Cleveland",
+        "Introduction to Urban Studies",
+        "Urban Cultures"
+      ]
+    },
+    {
+      "prefix": "CAD",
+      "name": "CAD",
+      "course_count": 2,
+      "section_count": 12,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "CAD I",
+        "CAD II"
+      ]
+    },
+    {
+      "prefix": "LP",
+      "name": "Phlebotomy",
+      "course_count": 3,
+      "section_count": 12,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Advanced Phlebotomy Seminar",
+        "Introduction to Blood Collection",
+        "Laboratory Phlebotomy Practicum"
+      ]
+    },
+    {
+      "prefix": "NTR",
+      "name": "Nutrition",
+      "course_count": 4,
+      "section_count": 12,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Food Operations",
+        "Food Operations Lab",
+        "Introduction to Medical Nutrition Therapy",
+        "Nutrition for Health"
+      ]
+    },
+    {
+      "prefix": "RES",
+      "name": "Respiratory",
+      "course_count": 8,
+      "section_count": 12,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Advanced Clinical Experience I",
+        "Cardiopulmonary Anat and Phys",
+        "Clinical Experience II",
+        "Respiratory Care Pharmacology",
+        "Respiratory Care Procedures I"
+      ]
+    },
+    {
+      "prefix": "JCR",
+      "name": "Skill",
+      "course_count": 6,
+      "section_count": 11,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "JCR Internship",
+        "Legal Terminology",
+        "Realtime Theory II",
+        "Skill Building II",
+        "Skill Building IV"
+      ]
+    },
+    {
+      "prefix": "PLS",
+      "name": "Political Science",
+      "course_count": 1,
+      "section_count": 11,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "American Government"
+      ]
+    },
+    {
+      "prefix": "TOY",
+      "name": "Toyota",
+      "course_count": 11,
+      "section_count": 11,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Toyota T-TEN",
+        "Toyota Automatic Transmission",
+        "Toyota Automotive Braking Systems",
+        "Toyota Electrical Systems I",
+        "Toyota Electrical Systems II"
+      ]
+    },
+    {
+      "prefix": "CMT",
+      "name": "Coop",
+      "course_count": 6,
+      "section_count": 9,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Analytical Chemistry",
+        "Chemical Technology 1",
+        "Full-time Co-op 1: CMT",
+        "Full-time Co-op 2: CMT",
+        "Part-time Co-op 2: CMT"
+      ]
+    },
+    {
+      "prefix": "HTD",
+      "name": "Hlth",
+      "course_count": 7,
+      "section_count": 9,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Health Independent Study-Surgical Technology",
+        "HLTH INDEP STUDY-DENTL HYGIENE",
+        "HLTH INDEP STUDY-MED LAB",
+        "HLTH INDEP STUDY-OCC THERAPY",
+        "HLTH INDEP STUDY-RESPIRATORY"
+      ]
+    },
+    {
+      "prefix": "CDC",
+      "name": "Chemical",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "CHEM DEP:ASSESSMT AND TRTMT PL",
+        "Chemical Dependency and Ethics",
+        "Chemical Dependency and Prevention",
+        "Chemical Dependency and the Family",
+        "FUND OF CHEM DEP PRACT I"
+      ]
+    },
+    {
+      "prefix": "DMSC",
+      "name": "Sonography",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "CV Internship 1",
+        "CV Internship 2",
+        "CV Sonography",
+        "CV Sonography Scan Lab 1",
+        "CV Sonography Scan Lab 3"
+      ]
+    },
+    {
+      "prefix": "DMSG",
+      "name": "Sonography",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Abdominal Sonography 2",
+        "GI Internship 1",
+        "GI Internship 2",
+        "GI Sonography",
+        "GI Sonography Scan Lab 1"
+      ]
+    },
+    {
+      "prefix": "DTR",
+      "name": "Nutrition",
+      "course_count": 8,
+      "section_count": 8,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Community Nutrition",
+        "Community Nutrition Directed Practice",
+        "DIETARY SYSTEMS",
+        "LIFE CYCLE NUTRITION",
+        "Medical Nutrition and Professionalism Directed Practice"
+      ]
+    },
+    {
+      "prefix": "EXS",
+      "name": "Exercise",
+      "course_count": 4,
+      "section_count": 8,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Anatomy of Exercise",
+        "Anatomy of Exercise Lab",
+        "Exercise Applications",
+        "Exercise Applications Lab"
+      ]
+    },
+    {
+      "prefix": "FOC",
+      "name": "Focus",
+      "course_count": 1,
+      "section_count": 8,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "FOCUS"
+      ]
+    },
+    {
+      "prefix": "GEO",
+      "name": "Geography",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Cultural Geography",
+        "Physical Geology",
+        "World Geo: Amer/Eur/Aus"
+      ]
+    },
+    {
+      "prefix": "HPE",
+      "name": "HPE",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Cycle",
+        "First Aid and Safety",
+        "Yoga"
+      ]
+    },
+    {
+      "prefix": "LIT",
+      "name": "Literature",
+      "course_count": 6,
+      "section_count": 8,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college",
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Children's Literature",
+        "Introduction to Literature",
+        "Literature of Graphic Novels",
+        "Shakespeare",
+        "The Short Story"
+      ]
+    },
+    {
+      "prefix": "MMC",
+      "name": "Shop",
+      "course_count": 2,
+      "section_count": 8,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Shop Math",
+        "Special Topics: MMC"
+      ]
+    },
+    {
+      "prefix": "SCI",
+      "name": "Science",
+      "course_count": 3,
+      "section_count": 8,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Special Topics in Science I",
+        "Special Topics in Science II",
+        "Special Topics In Science III"
+      ]
+    },
+    {
+      "prefix": "UT",
+      "name": "Construction",
+      "course_count": 5,
+      "section_count": 8,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Aerial Construction",
+        "Equipment Operations I",
+        "Equipment Operations II",
+        "Underground Construction I",
+        "Underground Construction II"
+      ]
+    },
+    {
+      "prefix": "DTN",
+      "name": "Nutrition",
+      "course_count": 1,
+      "section_count": 7,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Principles of Nutrition"
+      ]
+    },
+    {
+      "prefix": "ECN",
+      "name": "Economics",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Macro Economics",
+        "Micro Economics"
+      ]
+    },
+    {
+      "prefix": "EST",
+      "name": "EST",
+      "course_count": 3,
+      "section_count": 7,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Electrical Circuits &amp; Devices",
+        "Power Generation &amp; Grid Technology",
+        "Switchgear, Transmission, and Controls"
+      ]
+    },
+    {
+      "prefix": "SPH",
+      "name": "Beginning",
+      "course_count": 2,
+      "section_count": 7,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Beginning Spanish I",
+        "Beginning Spanish II"
+      ]
+    },
+    {
+      "prefix": "SRG",
+      "name": "Practice",
+      "course_count": 5,
+      "section_count": 7,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Directed Practice I",
+        "Directed Practice II",
+        "Intro to STP for the SRG",
+        "Surgical Procedures II",
+        "Theory and Fundamentals"
+      ]
+    },
+    {
+      "prefix": "AIN",
+      "name": "Artificial",
+      "course_count": 1,
+      "section_count": 6,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Introduction to Artificial Intelligence"
+      ]
+    },
+    {
+      "prefix": "HNR",
+      "name": "Orientation",
+      "course_count": 2,
+      "section_count": 6,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "1st Yr Spec Topics: HRN",
+        "Orientation to Honors"
+      ]
+    },
+    {
+      "prefix": "OAD",
+      "name": "OAD",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Advanced Database",
+        "Advanced Spreadsheets",
+        "Advanced Word Processing",
+        "Personal and Professional Development"
+      ]
+    },
+    {
+      "prefix": "PNS",
+      "name": "Nursing",
+      "course_count": 4,
+      "section_count": 5,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Adult Medical-Surgical Nursing",
+        "Foundations of Practical NSG",
+        "Maternal Child Nursing",
+        "PN-Issues and Trends"
+      ]
+    },
+    {
+      "prefix": "CTU",
+      "name": "Construction",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Construction Safety",
+        "Cooperative Work Experience",
+        "Utility Construction Practices",
+        "Utility Location & Print Reading"
+      ]
+    },
+    {
+      "prefix": "CULT",
+      "name": "Issues",
+      "course_count": 1,
+      "section_count": 4,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Issues in Human Diversity"
+      ]
+    },
+    {
+      "prefix": "DMA",
+      "name": "Practice",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Dietary Systems Directed Practice",
+        "Food Operations Directed Practice",
+        "Nutrition Management Directed Practice"
+      ]
+    },
+    {
+      "prefix": "ENV",
+      "name": "Environmental Science",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "james-a-rhodes-state-college",
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "OSHA 30 HOUR GENERAL INDUSTRY",
+        "OSHA Regulations and Safety"
+      ]
+    },
+    {
+      "prefix": "FREN",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Beginning French I",
+        "Beginning French II"
+      ]
+    },
+    {
+      "prefix": "FRN",
+      "name": "French",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Elementary French 1",
+        "Elementary French 2"
+      ]
+    },
+    {
+      "prefix": "HSP",
+      "name": "Hospitality",
+      "course_count": 4,
+      "section_count": 4,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Co-op Work Experience",
+        "Control Cost in Hospitality",
+        "Food Preparation I",
+        "Introduction to Hospitality Management"
+      ]
+    },
+    {
+      "prefix": "IET",
+      "name": "IET",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Computer Numerical Controls",
+        "Dimensional Metrology and Inspection I",
+        "Industrial Management Concepts"
+      ]
+    },
+    {
+      "prefix": "SET",
+      "name": "Programming",
+      "course_count": 2,
+      "section_count": 4,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "C Programming 1",
+        "C Programming 2"
+      ]
+    },
+    {
+      "prefix": "STP",
+      "name": "Sterile",
+      "course_count": 3,
+      "section_count": 4,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Directed Prac. Ster.Proc.",
+        "Sterile Processing I",
+        "Sterile Processing II"
+      ]
+    },
+    {
+      "prefix": "EBE",
+      "name": "Cooperative",
+      "course_count": 1,
+      "section_count": 3,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Cooperative Education Seminar"
+      ]
+    },
+    {
+      "prefix": "ENGR",
+      "name": "Engineering",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Engineering 1",
+        "Intro to Engineering 2"
+      ]
+    },
+    {
+      "prefix": "ESET",
+      "name": "ESET",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Electronics",
+        "ESET Capstone",
+        "Microcontrollers"
+      ]
+    },
+    {
+      "prefix": "HCA",
+      "name": "Health",
+      "course_count": 3,
+      "section_count": 3,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Health Care Finance",
+        "Health Care Systems & Resources",
+        "Intro to Health Care Admin"
+      ]
+    },
+    {
+      "prefix": "MID",
+      "name": "Drawing",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Career Preparation: MID",
+        "Drawing for MID"
+      ]
+    },
+    {
+      "prefix": "QCT",
+      "name": "Quality",
+      "course_count": 2,
+      "section_count": 3,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Process Improvement and Lean Manufacturing",
+        "Quality Assurance"
+      ]
+    },
+    {
+      "prefix": "AIM",
+      "name": "Artificial",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Intro to Artificial Intel",
+        "Intro to Machine Learining"
+      ]
+    },
+    {
+      "prefix": "CRJ",
+      "name": "Criminal Justice",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Intro to Criminal Justice"
+      ]
+    },
+    {
+      "prefix": "FMS",
+      "name": "Robotics",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Basic Robotics & Mechatronics",
+        "CAM/CNC Machining I"
+      ]
+    },
+    {
+      "prefix": "HJS",
+      "name": "Human",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Human Services and Justice Studies Practicum and Seminar"
+      ]
+    },
+    {
+      "prefix": "LAC",
+      "name": "Academy",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Basic Law Academy I",
+        "Basic Law Academy II"
+      ]
+    },
+    {
+      "prefix": "MMO",
+      "name": "Mechanical",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Additive Mfg Applications",
+        "Mechanical Machining"
+      ]
+    },
+    {
+      "prefix": "PSET",
+      "name": "Power",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Power Systems Capstone",
+        "Power Systems Foundations"
+      ]
+    },
+    {
+      "prefix": "RUSS",
+      "name": "Beginning",
+      "course_count": 2,
+      "section_count": 2,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Beginning Russian I",
+        "Beginning Russian II"
+      ]
+    },
+    {
+      "prefix": "THE",
+      "name": "Theatre",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "History of Theater"
+      ]
+    },
+    {
+      "prefix": "TPI",
+      "name": "Process",
+      "course_count": 1,
+      "section_count": 2,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Process Control 1"
+      ]
+    },
+    {
+      "prefix": "AVI",
+      "name": "Unmanned",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Unmanned Aerial Systems Basic"
+      ]
+    },
+    {
+      "prefix": "BMT",
+      "name": "Biomed",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Biomed Instrumentation 1"
+      ]
+    },
+    {
+      "prefix": "CSA",
+      "name": "Computer",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Computer Repair 1"
+      ]
+    },
+    {
+      "prefix": "CST",
+      "name": "Communication Studies",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "MODELING AND SIMULATION"
+      ]
+    },
+    {
+      "prefix": "DIS",
+      "name": "Interpreting",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Interpreting I"
+      ]
+    },
+    {
+      "prefix": "DPH",
+      "name": "Photography",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "stark-state-college"
+      ],
+      "sample_titles": [
+        "Photography Portfolio"
+      ]
+    },
+    {
+      "prefix": "GLG",
+      "name": "Physical",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Physical Geology"
+      ]
+    },
+    {
+      "prefix": "HCT",
+      "name": "Health",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Health Care Tech Capstone"
+      ]
+    },
+    {
+      "prefix": "ITAL",
+      "name": "Beginning",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cuyahoga-community-college-district"
+      ],
+      "sample_titles": [
+        "Beginning Italian Language and Culture I"
+      ]
+    },
+    {
+      "prefix": "NDR",
+      "name": "Dispute",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "Intro Dispute Resolution"
+      ]
+    },
+    {
+      "prefix": "PET",
+      "name": "Plastics",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "terra-state-community-college"
+      ],
+      "sample_titles": [
+        "Introduction to Plastics"
+      ]
+    },
+    {
+      "prefix": "PGM",
+      "name": "Project",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Project Management Principles"
+      ]
+    },
+    {
+      "prefix": "SCM",
+      "name": "Supply",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "james-a-rhodes-state-college"
+      ],
+      "sample_titles": [
+        "Supply Chain Mgt Principles"
+      ]
+    },
+    {
+      "prefix": "TC",
+      "name": "Spec",
+      "course_count": 1,
+      "section_count": 1,
+      "colleges": [
+        "cincinnati-state-technical-and-community-college"
+      ],
+      "sample_titles": [
+        "2nd Yr Spec Topics: TC"
+      ]
+    }
+  ],
+  "program_titles": []
+}


### PR DESCRIPTION
## Summary

Two quick wins from the data completeness audit:

**AL prereqs (new):** Aggregated 369 prereq entries from existing course section data. Previously `prereqs.json` didn't exist despite 3,036/8,883 sections having prereq data embedded.

**Subject vocab for 8 states (new):** Built `subject-vocab.json` for AL, FL, IA, KY, MI, MO, MS, OH — all had course data but no subject vocab. 1,628 total subjects across 8 states.

| State | Subjects |
|-------|----------|
| AL | 117 |
| FL | 261 |
| IA | 105 |
| KY | 190 |
| MI | 432 |
| MO | 201 |
| MS | 65 |
| OH | 257 |

## Test plan
- [ ] Verify AL prereqs render on `/al` course pages
- [ ] Verify subject search works on `/al`, `/fl`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)