### PR TITLE
feat(nav): add Programs index page + global header link

### DIFF
--- a/app/[state]/programs/page.tsx
+++ b/app/[state]/programs/page.tsx
@@ -1,0 +1,206 @@
+/**
+ * State-level programs index — `/[state]/programs`.
+ *
+ * Lists every program that qualifies for the state with a one-line
+ * description and section/college count, each linking to the dedicated
+ * `/[state]/program/[slug]` comparison hub.
+ *
+ * Closes priority #5 of issue #413's internal-link audit. Pairs with the
+ * "Programs" link added to the global header — every page on the site
+ * now reaches the per-program comparison views in two clicks
+ * (any-page → header "Programs" → state index → program hub).
+ *
+ * ISR cadence matches the per-program page (7 days).
+ */
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getAllStates, isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
+import { PROGRAMS } from "@/lib/programs/registry";
+import {
+  loadProgramData,
+  qualifies,
+  getQualifyingProgramSlugs,
+} from "@/lib/programs";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export const revalidate = 604800; // 7 days
+
+type PageProps = {
+  params: Promise<{ state: string }>;
+};
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  return getAllStates().map((s) => ({ state: s.slug }));
+}
+
+function siteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"
+  );
+}
+
+export async function generateMetadata(
+  props: PageProps,
+): Promise<Metadata> {
+  const { state } = await props.params;
+  if (!isValidState(state)) return { title: "Not Found" };
+  const config = requireStateConfig(state);
+  const slugs = await getQualifyingProgramSlugs(state);
+
+  const title = `Programs at ${config.name} Community Colleges — Earnings, Transfer, and Course Comparison`;
+  const description = `Compare ${slugs.length} program${slugs.length === 1 ? "" : "s"} across ${config.systemName} community colleges. Side-by-side awards-per-year, graduate earnings, and transfer details for popular majors at every CC in ${config.name}.`;
+  const canonical = `${siteUrl()}/${state}/programs`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      `${config.name} community college programs`,
+      `${config.name} community college majors`,
+      `${config.systemName} programs`,
+      ...config.branding.metaKeywords,
+    ],
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      siteName: config.branding.siteName,
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+interface ProgramRow {
+  slug: string;
+  name: string;
+  description: string;
+  totalSections: number;
+  totalColleges: number;
+}
+
+export default async function StateProgramsIndexPage(props: PageProps) {
+  const { state } = await props.params;
+  if (!isValidState(state)) notFound();
+  const config = requireStateConfig(state);
+
+  // Walk every curated program; only include ones that qualify in this
+  // state. Reuses loadProgramData + qualifies() so we match exactly what
+  // the per-program page shows (no chance of linking to a 404).
+  const rows: ProgramRow[] = (
+    await Promise.all(
+      PROGRAMS.map(async (def) => {
+        const data = await loadProgramData(state, def.slug).catch(() => null);
+        if (!data || !qualifies(data)) return null;
+        return {
+          slug: def.slug,
+          name: def.name,
+          description: def.description,
+          totalSections: data.totalSections,
+          totalColleges: data.totalColleges,
+        } satisfies ProgramRow;
+      }),
+    )
+  )
+    .filter((r): r is ProgramRow => r !== null)
+    .sort((a, b) => b.totalSections - a.totalSections);
+
+  if (rows.length === 0) notFound();
+
+  const url = siteUrl();
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "@id": `${url}/${state}/programs#itemlist`,
+    name: `Programs at ${config.name} community colleges`,
+    numberOfItems: rows.length,
+    url: `${url}/${state}/programs`,
+    isPartOf: { "@id": `${url}/#website` },
+    itemListElement: rows.map((r, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "EducationalOccupationalProgram",
+        name: `${r.name} programs at ${config.name} community colleges`,
+        url: `${url}/${state}/program/${r.slug}`,
+        description: r.description,
+      },
+    })),
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Breadcrumbs
+          siteUrl={url}
+          items={[
+            { name: config.branding.siteName, href: `/${state}` },
+            { name: "Programs", href: `/${state}/programs` },
+          ]}
+        />
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
+            Programs at {config.name} community colleges
+          </h1>
+          <p className="text-gray-600 dark:text-slate-400 mt-2 max-w-3xl">
+            {rows.length} program{rows.length === 1 ? "" : "s"} across{" "}
+            {config.systemName}. Click any program to compare every college
+            offering it, including median graduate earnings from the federal
+            College Scorecard and per-college section counts for the current
+            term.
+          </p>
+        </header>
+
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {rows.map((r) => (
+            <li key={r.slug}>
+              <Link
+                href={`/${state}/program/${r.slug}`}
+                className="block rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 hover:border-teal-300 dark:hover:border-teal-600 transition-colors h-full"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <h2 className="text-lg font-semibold text-teal-700 dark:text-teal-300">
+                    {r.name}
+                  </h2>
+                  <span className="text-xs text-gray-500 dark:text-slate-400 tabular-nums whitespace-nowrap">
+                    {r.totalColleges} college{r.totalColleges === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-gray-600 dark:text-slate-400 line-clamp-3">
+                  {r.description}
+                </p>
+                <p className="mt-2 text-xs text-gray-500 dark:text-slate-400">
+                  {r.totalSections} section{r.totalSections === 1 ? "" : "s"}{" "}
+                  this term
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-8 text-sm text-gray-500 dark:text-slate-400">
+          Don&rsquo;t see a program?{" "}
+          <Link
+            href={`/${state}/colleges`}
+            className="underline hover:text-teal-700 dark:hover:text-teal-400"
+          >
+            Browse every {config.name} community college
+          </Link>{" "}
+          to see its full degree catalog directly.
+        </p>
+      </div>
+    </>
+  );
+}
+

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,6 +13,10 @@ const NAV_ITEMS = [
   { path: "/transfer", label: "Transfer" },
   { path: "/plan", label: "Semester Planner" },
   { path: "/colleges", label: "All Colleges" },
+  // Programs index — every page in the site links here so the
+  // /[state]/program/[slug] comparison hubs (federal earnings data, awards
+  // counts) are one click away regardless of entry point. See #413.
+  { path: "/programs", label: "Programs" },
   { path: "/about", label: "About" },
 ];
 


### PR DESCRIPTION
Closes priority #5 of the link audit at #413.

## What changes for someone using the site

Every page on the site now has a **"Programs" link in the header**, alongside Find a Course, Schedule Builder, All Colleges, etc. Clicking it lands on a new state-aware index at `/[state]/programs` that lists every qualifying program for that state — Nursing, Business Administration, Computer Science, etc. — each with:

- A short description of what's covered
- Section count this term
- College count
- Click-through to the per-program comparison hub (the one with federal earnings data, awards/yr, per-college breakdown)

So a student who arrives on any page (a blog post, a college page, a course page, anywhere on the site) is now **two clicks away from the full grid of program comparison hubs** that #410's Tier 2 work built. Before this PR they were one click from one program via the state landing page's pill row, but had to manually navigate to discover the full set.

Concrete check on NC: [`/nc/programs`](https://communitycollegepath.com/nc/programs) lists all 15 qualifying NC programs sorted by section count, each linking to its `/nc/program/[slug]` hub.

## What changes on the technical front

- **`app/[state]/programs/page.tsx`** (new) — server component, ISR 7 days. Walks every PROGRAM in `lib/programs/registry.ts`, calls `loadProgramData()` + `qualifies()` to filter (reusing the same gate the per-program detail pages use, so the index never links to a target that 404s). Sorts by total section count. Renders an `EducationalOccupationalProgram` ItemList JSON-LD for SEO.
- **`components/Header.tsx`** — `NAV_ITEMS` gains `{ path: "/programs", label: "Programs" }`. The existing template wraps that path with the current state slug, so no per-state logic needed.

No new data files, no API calls. Pure rendering of the existing program registry + already-cached `loadProgramData` calls.

## Why this matters for the link graph

Before this PR, inbound link sources to the program hubs were:

| Source | Quality |
|---|---|
| State landing page pill row | one path, 16 programs splitting the equity 16 ways |
| Sibling-program pills on each program page | weak (only between hubs) |
| College page "Top programs" (#417) | strong but only from college pages |
| Subject page banner (#417) | strong from prefix-matching subject pages |
| Course detail breadcrumb (#419) | strong from each course page |
| Adjacent-state program pills (#419) | weak (only between hubs again) |

After this PR, **every page on the site** also gets a "Programs" header link → state index → individual program hub. That triples the inbound paths and gives crawlers a clean hub-and-spoke navigation pattern to follow.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Local render on `/nc/programs`: 15 qualifying programs render, all link to valid /nc/program/[slug] hubs
- [x] Header "Programs" link appears on the home page state landing and links to /nc/programs
- [ ] After merge + Vercel deploy: visit any prod page (e.g. a blog post or course page) and confirm the header has "Programs" with the correct state prefix
- [ ] Spot-check a state where some programs don't qualify (e.g., a smaller state) — index should show fewer rows, no broken links

## Remaining from #413

Only #6 (content depth on program pages: intro paragraph / career-path FAQ / BLS salary context) is left. That's the biggest SEO push — would convert ranking improvements into actual traffic. Tracked as a future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)