### PR TITLE
fix(bls): correct OEWS data-type codes + ingest 2024 wage data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ NEXT_PUBLIC_ADSENSE_ID=ca-pub-xxxxxxxxxxxxxxxx
 # Used by scripts/lib/college-scorecard.ts to fetch per-college metrics.
 # See issue #392.
 COLLEGE_SCORECARD_API_KEY=
+
+# BLS Public Data API key — registered tier, 500 queries/day (vs 25/day unauth).
+# Used by scripts/ingest-bls.ts to refresh state-level OEWS wage data.
+# Sign up free + instant at: https://data.bls.gov/registrationEngine/
+BLS_API_KEY=

--- a/data/bls/wages.json
+++ b/data/bls/wages.json
@@ -1,0 +1,1358 @@
+{
+  "fetchedAt": "2026-05-13T14:08:54.073Z",
+  "year": 2024,
+  "byState": {
+    "va": {
+      "111021": {
+        "employment": 99710,
+        "meanAnnualWage": 140090,
+        "medianAnnualWage": 121530
+      },
+      "132011": {
+        "employment": 50220,
+        "meanAnnualWage": 95650,
+        "medianAnnualWage": 84190
+      },
+      "151232": {
+        "employment": 20300,
+        "meanAnnualWage": 70690,
+        "medianAnnualWage": 63420
+      },
+      "173026": {
+        "employment": 1180,
+        "meanAnnualWage": 68380,
+        "medianAnnualWage": 64170
+      },
+      "252011": {
+        "employment": 12030,
+        "meanAnnualWage": 42300,
+        "medianAnnualWage": 37320
+      },
+      "271024": {
+        "employment": 5500,
+        "meanAnnualWage": 75060,
+        "medianAnnualWage": 70060
+      },
+      "291141": {
+        "employment": 77420,
+        "meanAnnualWage": 90930,
+        "medianAnnualWage": 88820
+      },
+      "333051": {
+        "employment": 19400,
+        "meanAnnualWage": 70330,
+        "medianAnnualWage": 65110
+      },
+      "493023": {
+        "employment": 17740,
+        "meanAnnualWage": 58900,
+        "medianAnnualWage": 56320
+      },
+      "514121": {
+        "employment": 10690,
+        "meanAnnualWage": 58250,
+        "medianAnnualWage": 57350
+      }
+    },
+    "nc": {
+      "111021": {
+        "employment": 72250,
+        "meanAnnualWage": 125540,
+        "medianAnnualWage": 99190
+      },
+      "132011": {
+        "employment": 46420,
+        "meanAnnualWage": 91240,
+        "medianAnnualWage": 80490
+      },
+      "151232": {
+        "employment": 21730,
+        "meanAnnualWage": 60890,
+        "medianAnnualWage": 58660
+      },
+      "173026": {
+        "employment": 2110,
+        "meanAnnualWage": 67580,
+        "medianAnnualWage": 65960
+      },
+      "252011": {
+        "employment": 16820,
+        "meanAnnualWage": 33620,
+        "medianAnnualWage": 30980
+      },
+      "271024": {
+        "employment": 7210,
+        "meanAnnualWage": 61010,
+        "medianAnnualWage": 50600
+      },
+      "291141": {
+        "employment": 108510,
+        "meanAnnualWage": 86270,
+        "medianAnnualWage": 81860
+      },
+      "333051": {
+        "employment": 21650,
+        "meanAnnualWage": 60520,
+        "medianAnnualWage": 58030
+      },
+      "493023": {
+        "employment": 25260,
+        "meanAnnualWage": 52930,
+        "medianAnnualWage": 48530
+      },
+      "514121": {
+        "employment": 12020,
+        "meanAnnualWage": 53340,
+        "medianAnnualWage": 49860
+      }
+    },
+    "sc": {
+      "111021": {
+        "employment": 39170,
+        "meanAnnualWage": 118180,
+        "medianAnnualWage": 99340
+      },
+      "132011": {
+        "employment": 15250,
+        "meanAnnualWage": 84260,
+        "medianAnnualWage": 73180
+      },
+      "151232": {
+        "employment": 10510,
+        "meanAnnualWage": 55360,
+        "medianAnnualWage": 50500
+      },
+      "173026": {
+        "employment": 2180,
+        "meanAnnualWage": 70540,
+        "medianAnnualWage": 69250
+      },
+      "252011": {
+        "employment": 3270,
+        "meanAnnualWage": 37960,
+        "medianAnnualWage": 33260
+      },
+      "271024": {
+        "employment": 1990,
+        "meanAnnualWage": 58160,
+        "medianAnnualWage": 56180
+      },
+      "291141": {
+        "employment": 50300,
+        "meanAnnualWage": 84930,
+        "medianAnnualWage": 79900
+      },
+      "333051": {
+        "employment": 12820,
+        "meanAnnualWage": 60140,
+        "medianAnnualWage": 58020
+      },
+      "493023": {
+        "employment": 13950,
+        "meanAnnualWage": 49060,
+        "medianAnnualWage": 45950
+      },
+      "514121": {
+        "employment": 7600,
+        "meanAnnualWage": 50900,
+        "medianAnnualWage": 49120
+      }
+    },
+    "dc": {
+      "111021": {
+        "employment": 36060,
+        "meanAnnualWage": 178210,
+        "medianAnnualWage": 167270
+      },
+      "132011": {
+        "employment": 9600,
+        "meanAnnualWage": 116580,
+        "medianAnnualWage": 103030
+      },
+      "151232": {
+        "employment": 3690,
+        "meanAnnualWage": 79040,
+        "medianAnnualWage": 76880
+      },
+      "173026": {
+        "employment": null,
+        "meanAnnualWage": null,
+        "medianAnnualWage": null
+      },
+      "252011": {
+        "employment": 2770,
+        "meanAnnualWage": 59420,
+        "medianAnnualWage": 45090
+      },
+      "271024": {
+        "employment": 1280,
+        "meanAnnualWage": 95050,
+        "medianAnnualWage": 90710
+      },
+      "291141": {
+        "employment": 9790,
+        "meanAnnualWage": 109240,
+        "medianAnnualWage": 104550
+      },
+      "333051": {
+        "employment": 4830,
+        "meanAnnualWage": 91310,
+        "medianAnnualWage": 88330
+      },
+      "493023": {
+        "employment": 270,
+        "meanAnnualWage": 68550,
+        "medianAnnualWage": 71030
+      },
+      "514121": {
+        "employment": 330,
+        "meanAnnualWage": 66140,
+        "medianAnnualWage": 58700
+      }
+    },
+    "md": {
+      "111021": {
+        "employment": 91810,
+        "meanAnnualWage": 129700,
+        "medianAnnualWage": 105320
+      },
+      "132011": {
+        "employment": 25630,
+        "meanAnnualWage": 95950,
+        "medianAnnualWage": 84890
+      },
+      "151232": {
+        "employment": 10820,
+        "meanAnnualWage": 69260,
+        "medianAnnualWage": 62200
+      },
+      "173026": {
+        "employment": 670,
+        "meanAnnualWage": 82670,
+        "medianAnnualWage": 78800
+      },
+      "252011": {
+        "employment": 7960,
+        "meanAnnualWage": 45990,
+        "medianAnnualWage": 38560
+      },
+      "271024": {
+        "employment": 3880,
+        "meanAnnualWage": 71460,
+        "medianAnnualWage": 66290
+      },
+      "291141": {
+        "employment": 48980,
+        "meanAnnualWage": 96650,
+        "medianAnnualWage": 96830
+      },
+      "333051": {
+        "employment": 9420,
+        "meanAnnualWage": 81660,
+        "medianAnnualWage": 77440
+      },
+      "493023": {
+        "employment": 14310,
+        "meanAnnualWage": 59070,
+        "medianAnnualWage": 57560
+      },
+      "514121": {
+        "employment": 3190,
+        "meanAnnualWage": 59800,
+        "medianAnnualWage": 56420
+      }
+    },
+    "ga": {
+      "111021": {
+        "employment": 111240,
+        "meanAnnualWage": 127450,
+        "medianAnnualWage": 99800
+      },
+      "132011": {
+        "employment": 45000,
+        "meanAnnualWage": 92050,
+        "medianAnnualWage": 80100
+      },
+      "151232": {
+        "employment": 26900,
+        "meanAnnualWage": 63250,
+        "medianAnnualWage": 57160
+      },
+      "173026": {
+        "employment": 2020,
+        "meanAnnualWage": 66040,
+        "medianAnnualWage": 60790
+      },
+      "252011": {
+        "employment": 11230,
+        "meanAnnualWage": 45760,
+        "medianAnnualWage": 42330
+      },
+      "271024": {
+        "employment": 5410,
+        "meanAnnualWage": 62340,
+        "medianAnnualWage": 57860
+      },
+      "291141": {
+        "employment": 97410,
+        "meanAnnualWage": 91960,
+        "medianAnnualWage": 86560
+      },
+      "333051": {
+        "employment": 21540,
+        "meanAnnualWage": 57970,
+        "medianAnnualWage": 56350
+      },
+      "493023": {
+        "employment": 24000,
+        "meanAnnualWage": 55440,
+        "medianAnnualWage": 48800
+      },
+      "514121": {
+        "employment": 14030,
+        "meanAnnualWage": 49960,
+        "medianAnnualWage": 48000
+      }
+    },
+    "de": {
+      "111021": {
+        "employment": 4740,
+        "meanAnnualWage": 165580,
+        "medianAnnualWage": 136900
+      },
+      "132011": {
+        "employment": 6120,
+        "meanAnnualWage": 95150,
+        "medianAnnualWage": 84560
+      },
+      "151232": {
+        "employment": 2220,
+        "meanAnnualWage": 66010,
+        "medianAnnualWage": 62280
+      },
+      "173026": {
+        "employment": null,
+        "meanAnnualWage": null,
+        "medianAnnualWage": null
+      },
+      "252011": {
+        "employment": 2090,
+        "meanAnnualWage": 33590,
+        "medianAnnualWage": 31380
+      },
+      "271024": {
+        "employment": 420,
+        "meanAnnualWage": 58540,
+        "medianAnnualWage": 56160
+      },
+      "291141": {
+        "employment": 13260,
+        "meanAnnualWage": 95450,
+        "medianAnnualWage": 92610
+      },
+      "333051": {
+        "employment": 1790,
+        "meanAnnualWage": 85350,
+        "medianAnnualWage": 83230
+      },
+      "493023": {
+        "employment": 1840,
+        "meanAnnualWage": 54740,
+        "medianAnnualWage": 50350
+      },
+      "514121": {
+        "employment": 510,
+        "meanAnnualWage": 61310,
+        "medianAnnualWage": 56510
+      }
+    },
+    "tn": {
+      "111021": {
+        "employment": 66610,
+        "meanAnnualWage": 129040,
+        "medianAnnualWage": 102850
+      },
+      "132011": {
+        "employment": 26890,
+        "meanAnnualWage": 82310,
+        "medianAnnualWage": 75500
+      },
+      "151232": {
+        "employment": 11010,
+        "meanAnnualWage": 58830,
+        "medianAnnualWage": 54420
+      },
+      "173026": {
+        "employment": 2290,
+        "meanAnnualWage": 61590,
+        "medianAnnualWage": 59700
+      },
+      "252011": {
+        "employment": 4890,
+        "meanAnnualWage": 41080,
+        "medianAnnualWage": 35980
+      },
+      "271024": {
+        "employment": 4190,
+        "meanAnnualWage": 58710,
+        "medianAnnualWage": 51740
+      },
+      "291141": {
+        "employment": 67990,
+        "meanAnnualWage": 82010,
+        "medianAnnualWage": 79030
+      },
+      "333051": {
+        "employment": 13780,
+        "meanAnnualWage": 60280,
+        "medianAnnualWage": 59410
+      },
+      "493023": {
+        "employment": 16390,
+        "meanAnnualWage": 51880,
+        "medianAnnualWage": 47460
+      },
+      "514121": {
+        "employment": 12610,
+        "meanAnnualWage": 49420,
+        "medianAnnualWage": 47280
+      }
+    },
+    "ny": {
+      "111021": {
+        "employment": 210890,
+        "meanAnnualWage": 169610,
+        "medianAnnualWage": 129990
+      },
+      "132011": {
+        "employment": 111860,
+        "meanAnnualWage": 115490,
+        "medianAnnualWage": 101780
+      },
+      "151232": {
+        "employment": 41260,
+        "meanAnnualWage": 70420,
+        "medianAnnualWage": 63910
+      },
+      "173026": {
+        "employment": 3910,
+        "meanAnnualWage": 68650,
+        "medianAnnualWage": 66830
+      },
+      "252011": {
+        "employment": 25180,
+        "meanAnnualWage": 50050,
+        "medianAnnualWage": 45580
+      },
+      "271024": {
+        "employment": 16730,
+        "meanAnnualWage": 81020,
+        "medianAnnualWage": 74530
+      },
+      "291141": {
+        "employment": 204120,
+        "meanAnnualWage": 110490,
+        "medianAnnualWage": 105600
+      },
+      "333051": {
+        "employment": 54360,
+        "meanAnnualWage": 86880,
+        "medianAnnualWage": 93050
+      },
+      "493023": {
+        "employment": 31790,
+        "meanAnnualWage": 57650,
+        "medianAnnualWage": 51650
+      },
+      "514121": {
+        "employment": 7810,
+        "meanAnnualWage": 60700,
+        "medianAnnualWage": 57230
+      }
+    },
+    "ri": {
+      "111021": {
+        "employment": 9060,
+        "meanAnnualWage": 139150,
+        "medianAnnualWage": 122040
+      },
+      "132011": {
+        "employment": 5980,
+        "meanAnnualWage": 97210,
+        "medianAnnualWage": 90040
+      },
+      "151232": {
+        "employment": 2050,
+        "meanAnnualWage": 63390,
+        "medianAnnualWage": 59420
+      },
+      "173026": {
+        "employment": 130,
+        "meanAnnualWage": 65180,
+        "medianAnnualWage": 64750
+      },
+      "252011": {
+        "employment": 1470,
+        "meanAnnualWage": 38400,
+        "medianAnnualWage": 36040
+      },
+      "271024": {
+        "employment": 820,
+        "meanAnnualWage": 70570,
+        "medianAnnualWage": 64190
+      },
+      "291141": {
+        "employment": 10760,
+        "meanAnnualWage": 99770,
+        "medianAnnualWage": 99960
+      },
+      "333051": {
+        "employment": 1780,
+        "meanAnnualWage": 75090,
+        "medianAnnualWage": 77280
+      },
+      "493023": {
+        "employment": 2390,
+        "meanAnnualWage": 53000,
+        "medianAnnualWage": 50690
+      },
+      "514121": {
+        "employment": 2350,
+        "meanAnnualWage": 61480,
+        "medianAnnualWage": 57000
+      }
+    },
+    "vt": {
+      "111021": {
+        "employment": 7260,
+        "meanAnnualWage": 110950,
+        "medianAnnualWage": 93290
+      },
+      "132011": {
+        "employment": 2770,
+        "meanAnnualWage": 85300,
+        "medianAnnualWage": 76990
+      },
+      "151232": {
+        "employment": 2000,
+        "meanAnnualWage": 68640,
+        "medianAnnualWage": 68170
+      },
+      "173026": {
+        "employment": 90,
+        "meanAnnualWage": 67030,
+        "medianAnnualWage": 63700
+      },
+      "252011": {
+        "employment": 1480,
+        "meanAnnualWage": 46490,
+        "medianAnnualWage": 44760
+      },
+      "271024": {
+        "employment": 470,
+        "meanAnnualWage": 68440,
+        "medianAnnualWage": 62180
+      },
+      "291141": {
+        "employment": 7240,
+        "meanAnnualWage": 92710,
+        "medianAnnualWage": 85150
+      },
+      "333051": {
+        "employment": 1080,
+        "meanAnnualWage": 68220,
+        "medianAnnualWage": 63690
+      },
+      "493023": {
+        "employment": 1730,
+        "meanAnnualWage": 55510,
+        "medianAnnualWage": 50010
+      },
+      "514121": {
+        "employment": 340,
+        "meanAnnualWage": 56560,
+        "medianAnnualWage": 57520
+      }
+    },
+    "ct": {
+      "111021": {
+        "employment": 46780,
+        "meanAnnualWage": 160220,
+        "medianAnnualWage": 130230
+      },
+      "132011": {
+        "employment": 16590,
+        "meanAnnualWage": 95930,
+        "medianAnnualWage": 89630
+      },
+      "151232": {
+        "employment": 9220,
+        "meanAnnualWage": 70680,
+        "medianAnnualWage": 68800
+      },
+      "173026": {
+        "employment": 820,
+        "meanAnnualWage": 68210,
+        "medianAnnualWage": 64820
+      },
+      "252011": {
+        "employment": 6190,
+        "meanAnnualWage": 48570,
+        "medianAnnualWage": 43160
+      },
+      "271024": {
+        "employment": 1980,
+        "meanAnnualWage": 71760,
+        "medianAnnualWage": 65360
+      },
+      "291141": {
+        "employment": 39020,
+        "meanAnnualWage": 103670,
+        "medianAnnualWage": 101590
+      },
+      "333051": {
+        "employment": 6500,
+        "meanAnnualWage": 83210,
+        "medianAnnualWage": 82820
+      },
+      "493023": {
+        "employment": 6630,
+        "meanAnnualWage": 57940,
+        "medianAnnualWage": 56220
+      },
+      "514121": {
+        "employment": 2030,
+        "meanAnnualWage": 66330,
+        "medianAnnualWage": 64520
+      }
+    },
+    "me": {
+      "111021": {
+        "employment": 15100,
+        "meanAnnualWage": 109540,
+        "medianAnnualWage": 96740
+      },
+      "132011": {
+        "employment": 4020,
+        "meanAnnualWage": 84990,
+        "medianAnnualWage": 77680
+      },
+      "151232": {
+        "employment": 2630,
+        "meanAnnualWage": 58660,
+        "medianAnnualWage": 56050
+      },
+      "173026": {
+        "employment": 230,
+        "meanAnnualWage": 70760,
+        "medianAnnualWage": 64790
+      },
+      "252011": {
+        "employment": 1430,
+        "meanAnnualWage": 40780,
+        "medianAnnualWage": 37070
+      },
+      "271024": {
+        "employment": 590,
+        "meanAnnualWage": 59100,
+        "medianAnnualWage": 53490
+      },
+      "291141": {
+        "employment": 16280,
+        "meanAnnualWage": 87440,
+        "medianAnnualWage": 82860
+      },
+      "333051": {
+        "employment": 1930,
+        "meanAnnualWage": 68100,
+        "medianAnnualWage": 65330
+      },
+      "493023": {
+        "employment": 3230,
+        "meanAnnualWage": 53920,
+        "medianAnnualWage": 49390
+      },
+      "514121": {
+        "employment": 1950,
+        "meanAnnualWage": 58680,
+        "medianAnnualWage": 58340
+      }
+    },
+    "pa": {
+      "111021": {
+        "employment": 168110,
+        "meanAnnualWage": 121150,
+        "medianAnnualWage": 100400
+      },
+      "132011": {
+        "employment": 54440,
+        "meanAnnualWage": 85200,
+        "medianAnnualWage": 77330
+      },
+      "151232": {
+        "employment": 29220,
+        "meanAnnualWage": 60530,
+        "medianAnnualWage": 58130
+      },
+      "173026": {
+        "employment": 1990,
+        "meanAnnualWage": 64200,
+        "medianAnnualWage": 59590
+      },
+      "252011": {
+        "employment": 23190,
+        "meanAnnualWage": 35250,
+        "medianAnnualWage": 34250
+      },
+      "271024": {
+        "employment": 8280,
+        "meanAnnualWage": 61600,
+        "medianAnnualWage": 52990
+      },
+      "291141": {
+        "employment": 146840,
+        "meanAnnualWage": 90830,
+        "medianAnnualWage": 87610
+      },
+      "333051": {
+        "employment": 24280,
+        "meanAnnualWage": 83130,
+        "medianAnnualWage": 86350
+      },
+      "493023": {
+        "employment": 29020,
+        "meanAnnualWage": 52690,
+        "medianAnnualWage": 49790
+      },
+      "514121": {
+        "employment": 16060,
+        "meanAnnualWage": 53210,
+        "medianAnnualWage": 50860
+      }
+    },
+    "nj": {
+      "111021": {
+        "employment": 63940,
+        "meanAnnualWage": 182010,
+        "medianAnnualWage": 149990
+      },
+      "132011": {
+        "employment": 43540,
+        "meanAnnualWage": 113110,
+        "medianAnnualWage": 101340
+      },
+      "151232": {
+        "employment": 19930,
+        "meanAnnualWage": 70620,
+        "medianAnnualWage": 65810
+      },
+      "173026": {
+        "employment": 900,
+        "meanAnnualWage": 67040,
+        "medianAnnualWage": 62780
+      },
+      "252011": {
+        "employment": 17990,
+        "meanAnnualWage": 52770,
+        "medianAnnualWage": 46570
+      },
+      "271024": {
+        "employment": 5870,
+        "meanAnnualWage": 74200,
+        "medianAnnualWage": 66600
+      },
+      "291141": {
+        "employment": 95150,
+        "meanAnnualWage": 106990,
+        "medianAnnualWage": 102730
+      },
+      "333051": {
+        "employment": 21620,
+        "meanAnnualWage": 93290,
+        "medianAnnualWage": 89030
+      },
+      "493023": {
+        "employment": 16820,
+        "meanAnnualWage": 59270,
+        "medianAnnualWage": 57290
+      },
+      "514121": {
+        "employment": 3300,
+        "meanAnnualWage": 64500,
+        "medianAnnualWage": 59630
+      }
+    },
+    "nh": {
+      "111021": {
+        "employment": 21180,
+        "meanAnnualWage": 142560,
+        "medianAnnualWage": 107060
+      },
+      "132011": {
+        "employment": 7820,
+        "meanAnnualWage": 89850,
+        "medianAnnualWage": 82830
+      },
+      "151232": {
+        "employment": 3400,
+        "meanAnnualWage": 69070,
+        "medianAnnualWage": 64850
+      },
+      "173026": {
+        "employment": 540,
+        "meanAnnualWage": 69360,
+        "medianAnnualWage": 66080
+      },
+      "252011": {
+        "employment": 2340,
+        "meanAnnualWage": 39660,
+        "medianAnnualWage": 37500
+      },
+      "271024": {
+        "employment": 680,
+        "meanAnnualWage": 62370,
+        "medianAnnualWage": 57310
+      },
+      "291141": {
+        "employment": 16580,
+        "meanAnnualWage": 94620,
+        "medianAnnualWage": 96830
+      },
+      "333051": {
+        "employment": 2550,
+        "meanAnnualWage": 70060,
+        "medianAnnualWage": 67620
+      },
+      "493023": {
+        "employment": 4510,
+        "meanAnnualWage": 58710,
+        "medianAnnualWage": 58460
+      },
+      "514121": {
+        "employment": 1040,
+        "meanAnnualWage": 60080,
+        "medianAnnualWage": 57700
+      }
+    },
+    "ma": {
+      "111021": {
+        "employment": 105350,
+        "meanAnnualWage": 154280,
+        "medianAnnualWage": 123850
+      },
+      "132011": {
+        "employment": 45520,
+        "meanAnnualWage": 102030,
+        "medianAnnualWage": 96580
+      },
+      "151232": {
+        "employment": 19570,
+        "meanAnnualWage": 76040,
+        "medianAnnualWage": 75670
+      },
+      "173026": {
+        "employment": 1970,
+        "meanAnnualWage": 70810,
+        "medianAnnualWage": 71370
+      },
+      "252011": {
+        "employment": 15380,
+        "meanAnnualWage": 48630,
+        "medianAnnualWage": 45030
+      },
+      "271024": {
+        "employment": 4890,
+        "meanAnnualWage": 80030,
+        "medianAnnualWage": 76370
+      },
+      "291141": {
+        "employment": 90190,
+        "meanAnnualWage": 112610,
+        "medianAnnualWage": 101970
+      },
+      "333051": {
+        "employment": 17000,
+        "meanAnnualWage": 80790,
+        "medianAnnualWage": 78610
+      },
+      "493023": {
+        "employment": 12390,
+        "meanAnnualWage": 59620,
+        "medianAnnualWage": 57470
+      },
+      "514121": {
+        "employment": 3080,
+        "meanAnnualWage": 64380,
+        "medianAnnualWage": 61710
+      }
+    },
+    "wv": {
+      "111021": {
+        "employment": 16070,
+        "meanAnnualWage": 100160,
+        "medianAnnualWage": 80490
+      },
+      "132011": {
+        "employment": 5310,
+        "meanAnnualWage": 78150,
+        "medianAnnualWage": 74520
+      },
+      "151232": {
+        "employment": 1840,
+        "meanAnnualWage": 58790,
+        "medianAnnualWage": 54850
+      },
+      "173026": {
+        "employment": 100,
+        "meanAnnualWage": 70150,
+        "medianAnnualWage": 62820
+      },
+      "252011": {
+        "employment": 2380,
+        "meanAnnualWage": 35160,
+        "medianAnnualWage": 29610
+      },
+      "271024": {
+        "employment": 540,
+        "meanAnnualWage": 43870,
+        "medianAnnualWage": 36870
+      },
+      "291141": {
+        "employment": 21740,
+        "meanAnnualWage": 80650,
+        "medianAnnualWage": 79990
+      },
+      "333051": {
+        "employment": 3130,
+        "meanAnnualWage": 54930,
+        "medianAnnualWage": 54570
+      },
+      "493023": {
+        "employment": 4450,
+        "meanAnnualWage": 42700,
+        "medianAnnualWage": 36320
+      },
+      "514121": {
+        "employment": 2280,
+        "meanAnnualWage": 52720,
+        "medianAnnualWage": 47000
+      }
+    },
+    "fl": {
+      "111021": {
+        "employment": 249620,
+        "meanAnnualWage": 128610,
+        "medianAnnualWage": 100750
+      },
+      "132011": {
+        "employment": 90880,
+        "meanAnnualWage": 87360,
+        "medianAnnualWage": 78470
+      },
+      "151232": {
+        "employment": 48780,
+        "meanAnnualWage": 62410,
+        "medianAnnualWage": 58120
+      },
+      "173026": {
+        "employment": 2480,
+        "meanAnnualWage": 57870,
+        "medianAnnualWage": 52620
+      },
+      "252011": {
+        "employment": 34940,
+        "meanAnnualWage": 34830,
+        "medianAnnualWage": 34270
+      },
+      "271024": {
+        "employment": 14010,
+        "meanAnnualWage": 62750,
+        "medianAnnualWage": 57900
+      },
+      "291141": {
+        "employment": 218100,
+        "meanAnnualWage": 88200,
+        "medianAnnualWage": 82850
+      },
+      "333051": {
+        "employment": 48340,
+        "meanAnnualWage": 83850,
+        "medianAnnualWage": 76190
+      },
+      "493023": {
+        "employment": 46090,
+        "meanAnnualWage": 53090,
+        "medianAnnualWage": 48520
+      },
+      "514121": {
+        "employment": 16390,
+        "meanAnnualWage": 52570,
+        "medianAnnualWage": 49430
+      }
+    },
+    "ky": {
+      "111021": {
+        "employment": 58570,
+        "meanAnnualWage": 96350,
+        "medianAnnualWage": 77150
+      },
+      "132011": {
+        "employment": 12180,
+        "meanAnnualWage": 77450,
+        "medianAnnualWage": 72220
+      },
+      "151232": {
+        "employment": 8280,
+        "meanAnnualWage": 55370,
+        "medianAnnualWage": 51630
+      },
+      "173026": {
+        "employment": 1190,
+        "meanAnnualWage": 65510,
+        "medianAnnualWage": 63430
+      },
+      "252011": {
+        "employment": 6780,
+        "meanAnnualWage": 35240,
+        "medianAnnualWage": 29980
+      },
+      "271024": {
+        "employment": 1910,
+        "meanAnnualWage": 53540,
+        "medianAnnualWage": 50330
+      },
+      "291141": {
+        "employment": 48170,
+        "meanAnnualWage": 83900,
+        "medianAnnualWage": 79910
+      },
+      "333051": {
+        "employment": 7090,
+        "meanAnnualWage": 59460,
+        "medianAnnualWage": 60230
+      },
+      "493023": {
+        "employment": 10910,
+        "meanAnnualWage": 45440,
+        "medianAnnualWage": 39940
+      },
+      "514121": {
+        "employment": 7360,
+        "meanAnnualWage": 51320,
+        "medianAnnualWage": 49260
+      }
+    },
+    "al": {
+      "111021": {
+        "employment": 32370,
+        "meanAnnualWage": 134790,
+        "medianAnnualWage": 106330
+      },
+      "132011": {
+        "employment": 25420,
+        "meanAnnualWage": 80760,
+        "medianAnnualWage": 71070
+      },
+      "151232": {
+        "employment": 7430,
+        "meanAnnualWage": 51960,
+        "medianAnnualWage": 48860
+      },
+      "173026": {
+        "employment": 830,
+        "meanAnnualWage": 64140,
+        "medianAnnualWage": 59860
+      },
+      "252011": {
+        "employment": 6610,
+        "meanAnnualWage": 30920,
+        "medianAnnualWage": 27630
+      },
+      "271024": {
+        "employment": 2010,
+        "meanAnnualWage": 53630,
+        "medianAnnualWage": 48130
+      },
+      "291141": {
+        "employment": 53340,
+        "meanAnnualWage": 74970,
+        "medianAnnualWage": 71040
+      },
+      "333051": {
+        "employment": 12060,
+        "meanAnnualWage": 55330,
+        "medianAnnualWage": 53850
+      },
+      "493023": {
+        "employment": 9920,
+        "meanAnnualWage": 49770,
+        "medianAnnualWage": 45710
+      },
+      "514121": {
+        "employment": 12570,
+        "meanAnnualWage": 49440,
+        "medianAnnualWage": 47170
+      }
+    },
+    "ms": {
+      "111021": {
+        "employment": 14530,
+        "meanAnnualWage": 112540,
+        "medianAnnualWage": 88290
+      },
+      "132011": {
+        "employment": 6940,
+        "meanAnnualWage": 74620,
+        "medianAnnualWage": 64170
+      },
+      "151232": {
+        "employment": 3220,
+        "meanAnnualWage": 50540,
+        "medianAnnualWage": 46690
+      },
+      "173026": {
+        "employment": 340,
+        "meanAnnualWage": 65960,
+        "medianAnnualWage": 57370
+      },
+      "252011": {
+        "employment": 3130,
+        "meanAnnualWage": 29720,
+        "medianAnnualWage": 26620
+      },
+      "271024": {
+        "employment": 920,
+        "meanAnnualWage": 57070,
+        "medianAnnualWage": 45260
+      },
+      "291141": {
+        "employment": 29400,
+        "meanAnnualWage": 79470,
+        "medianAnnualWage": 74470
+      },
+      "333051": {
+        "employment": 7590,
+        "meanAnnualWage": 45450,
+        "medianAnnualWage": 45610
+      },
+      "493023": {
+        "employment": 6410,
+        "meanAnnualWage": 46010,
+        "medianAnnualWage": 38070
+      },
+      "514121": {
+        "employment": 6570,
+        "meanAnnualWage": 51360,
+        "medianAnnualWage": 49490
+      }
+    },
+    "oh": {
+      "111021": {
+        "employment": 146860,
+        "meanAnnualWage": 117950,
+        "medianAnnualWage": 94990
+      },
+      "132011": {
+        "employment": 51840,
+        "meanAnnualWage": 86040,
+        "medianAnnualWage": 77640
+      },
+      "151232": {
+        "employment": 22090,
+        "meanAnnualWage": 58690,
+        "medianAnnualWage": 53500
+      },
+      "173026": {
+        "employment": 6200,
+        "meanAnnualWage": 65790,
+        "medianAnnualWage": 63690
+      },
+      "252011": {
+        "employment": 18840,
+        "meanAnnualWage": 35060,
+        "medianAnnualWage": 32760
+      },
+      "271024": {
+        "employment": 7010,
+        "meanAnnualWage": 58930,
+        "medianAnnualWage": 55140
+      },
+      "291141": {
+        "employment": 138360,
+        "meanAnnualWage": 86110,
+        "medianAnnualWage": 81250
+      },
+      "333051": {
+        "employment": 24050,
+        "meanAnnualWage": 76200,
+        "medianAnnualWage": 77050
+      },
+      "493023": {
+        "employment": 22950,
+        "meanAnnualWage": 51540,
+        "medianAnnualWage": 47010
+      },
+      "514121": {
+        "employment": 20110,
+        "meanAnnualWage": 52210,
+        "medianAnnualWage": 49410
+      }
+    },
+    "mi": {
+      "111021": {
+        "employment": 86000,
+        "meanAnnualWage": 124310,
+        "medianAnnualWage": 99660
+      },
+      "132011": {
+        "employment": 43910,
+        "meanAnnualWage": 85460,
+        "medianAnnualWage": 77720
+      },
+      "151232": {
+        "employment": 21970,
+        "meanAnnualWage": 58550,
+        "medianAnnualWage": 56110
+      },
+      "173026": {
+        "employment": 5800,
+        "meanAnnualWage": 66190,
+        "medianAnnualWage": 62040
+      },
+      "252011": {
+        "employment": 10790,
+        "meanAnnualWage": 39070,
+        "medianAnnualWage": 36720
+      },
+      "271024": {
+        "employment": 5990,
+        "meanAnnualWage": 57150,
+        "medianAnnualWage": 52600
+      },
+      "291141": {
+        "employment": 104210,
+        "meanAnnualWage": 90580,
+        "medianAnnualWage": 85670
+      },
+      "333051": {
+        "employment": 16290,
+        "meanAnnualWage": 71380,
+        "medianAnnualWage": 74420
+      },
+      "493023": {
+        "employment": 20650,
+        "meanAnnualWage": 53960,
+        "medianAnnualWage": 48840
+      },
+      "514121": {
+        "employment": 13640,
+        "meanAnnualWage": 52780,
+        "medianAnnualWage": 48930
+      }
+    },
+    "ia": {
+      "111021": {
+        "employment": 33560,
+        "meanAnnualWage": 100750,
+        "medianAnnualWage": 80620
+      },
+      "132011": {
+        "employment": 13970,
+        "meanAnnualWage": 80540,
+        "medianAnnualWage": 74290
+      },
+      "151232": {
+        "employment": 6370,
+        "meanAnnualWage": 58780,
+        "medianAnnualWage": 56710
+      },
+      "173026": {
+        "employment": 690,
+        "meanAnnualWage": 65570,
+        "medianAnnualWage": 60330
+      },
+      "252011": {
+        "employment": 5570,
+        "meanAnnualWage": 34190,
+        "medianAnnualWage": 29790
+      },
+      "271024": {
+        "employment": 2230,
+        "meanAnnualWage": 51830,
+        "medianAnnualWage": 47560
+      },
+      "291141": {
+        "employment": 33480,
+        "meanAnnualWage": 77780,
+        "medianAnnualWage": 76960
+      },
+      "333051": {
+        "employment": 5110,
+        "meanAnnualWage": 75390,
+        "medianAnnualWage": 73900
+      },
+      "493023": {
+        "employment": 8060,
+        "meanAnnualWage": 53110,
+        "medianAnnualWage": 48400
+      },
+      "514121": {
+        "employment": 9250,
+        "meanAnnualWage": 52280,
+        "medianAnnualWage": 49450
+      }
+    },
+    "mo": {
+      "111021": {
+        "employment": 105210,
+        "meanAnnualWage": 101060,
+        "medianAnnualWage": 77410
+      },
+      "132011": {
+        "employment": 25340,
+        "meanAnnualWage": 80160,
+        "medianAnnualWage": 73210
+      },
+      "151232": {
+        "employment": 15570,
+        "meanAnnualWage": 57640,
+        "medianAnnualWage": 52730
+      },
+      "173026": {
+        "employment": 850,
+        "meanAnnualWage": 77370,
+        "medianAnnualWage": 75000
+      },
+      "252011": {
+        "employment": 5980,
+        "meanAnnualWage": 38230,
+        "medianAnnualWage": 35120
+      },
+      "271024": {
+        "employment": 3700,
+        "meanAnnualWage": 56450,
+        "medianAnnualWage": 50900
+      },
+      "291141": {
+        "employment": 74270,
+        "meanAnnualWage": 81950,
+        "medianAnnualWage": 79770
+      },
+      "333051": {
+        "employment": 12750,
+        "meanAnnualWage": 63640,
+        "medianAnnualWage": 60720
+      },
+      "493023": {
+        "employment": 16810,
+        "meanAnnualWage": 51120,
+        "medianAnnualWage": 46710
+      },
+      "514121": {
+        "employment": 10270,
+        "meanAnnualWage": 53100,
+        "medianAnnualWage": 49460
+      }
+    }
+  }
+}

--- a/scripts/ingest-bls.ts
+++ b/scripts/ingest-bls.ts
@@ -13,10 +13,16 @@
  *   OEUS370000000000029114101 → annual employment count
  *   OEUS370000000000029114109 → annual median wage
  *
- * Data type codes:
+ * Data type codes (verified empirically against NC RN data — BLS docs
+ * disagree across sources, so trust the actual returned values):
  *   01 = Employment count
+ *   03 = Hourly mean wage
  *   04 = Annual mean wage
- *   09 = Annual median wage
+ *   08 = Hourly median wage
+ *   09 = Hourly 75th percentile wage
+ *   13 = Annual median wage   ← what we want for the page tile
+ *   14 = Annual 75th percentile wage
+ *   15 = Annual 90th percentile wage
  *
  * National data: BLS publishes national-level OEWS but the public-API
  * series prefix is not the obvious "OEUN" or "OEUS00" — both probe as
@@ -33,8 +39,15 @@
 import fs from "fs";
 import { PROGRAMS } from "@/lib/programs/registry";
 import { getAllStates } from "@/lib/states/registry";
+import { loadEnv } from "./lib/load-env";
+
+loadEnv();
 
 const BLS_API = "https://api.bls.gov/publicAPI/v2/timeseries/data/";
+// Registered API key bumps the daily cap from 25 → 500 queries and lets
+// the response include current-year revisions. Optional; the script
+// falls back to unauthenticated requests when unset.
+const BLS_API_KEY = process.env.BLS_API_KEY ?? "";
 
 interface BlsResponse {
   status: string;
@@ -68,10 +81,12 @@ function fipsForState(slug: string): string | null {
 }
 
 async function fetchBls(seriesIds: string[]): Promise<BlsResponse> {
+  const body: Record<string, unknown> = { seriesid: seriesIds };
+  if (BLS_API_KEY) body.registrationkey = BLS_API_KEY;
   const res = await fetch(BLS_API, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ seriesid: seriesIds }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`BLS API HTTP ${res.status}`);
   return (await res.json()) as BlsResponse;
@@ -99,7 +114,8 @@ async function main(): Promise<void> {
   // unauthenticated daily cap. Employment + mean are nice-to-haves we
   // can add later if we register a BLS API key (free, instant, 500/day).
   console.log(
-    `Fetching BLS OEWS state median wages: ${states.length} states × ${socs.length} SOCs`,
+    `Fetching BLS OEWS state median wages: ${states.length} states × ${socs.length} SOCs` +
+      (BLS_API_KEY ? " (registered tier, 500/day)" : " (unauth tier, 25/day)"),
   );
 
   const byState: WagesFile["byState"] = {};
@@ -116,19 +132,25 @@ async function main(): Promise<void> {
 
   let latestYear = 0;
 
-  // Build the full series list, then batch.
+  // Build the full series list, then batch. With a registered API key
+  // the daily budget is 500 queries; fetch employment (01), annual mean
+  // wage (04), AND annual median wage (13) per (state, SOC) — 3× the
+  // unauth scope. Without a key, fall back to median-only to stay
+  // under the 25/day unauth cap.
+  const dataTypes = BLS_API_KEY ? ["01", "04", "13"] : ["13"];
   const seriesList: Array<{ id: string; state: string; soc: string; dt: string }> = [];
   for (const state of states) {
     const fips = fipsForState(state.slug);
     if (!fips) continue;
     for (const soc of socs) {
-      // Median wage only — see comment above re: 25/day cap.
-      seriesList.push({
-        id: stateSeriesId(fips, soc, "09"),
-        state: state.slug,
-        soc,
-        dt: "09",
-      });
+      for (const dt of dataTypes) {
+        seriesList.push({
+          id: stateSeriesId(fips, soc, dt),
+          state: state.slug,
+          soc,
+          dt,
+        });
+      }
     }
   }
 
@@ -161,7 +183,7 @@ async function main(): Promise<void> {
       const stats = byState[meta.state][meta.soc];
       if (meta.dt === "01") stats.employment = value;
       else if (meta.dt === "04") stats.meanAnnualWage = value;
-      else if (meta.dt === "09") stats.medianAnnualWage = value;
+      else if (meta.dt === "13") stats.medianAnnualWage = value;
       got++;
     }
     console.log(`${got} values`);


### PR DESCRIPTION
## What changes for someone using the site

The "Career outlook" tile on every program page now shows **real state-level median wage data** from the federal Bureau of Labor Statistics. PR #432 wired the tile up but the data ingest had two blockers (rate-limited daily cap, and a wrong OEWS data-type code). Both fixed here.

Concrete examples from the new data:

| Page | State median wage |
|---|---|
| [/nc/program/nursing](https://communitycollegepath.com/nc/program/nursing) | \$81,860 |
| [/nc/program/welding](https://communitycollegepath.com/nc/program/welding) | \$49,860 |
| [/va/program/accounting](https://communitycollegepath.com/va/program/accounting) | \$84,190 |
| [/ma/program/computer-science](https://communitycollegepath.com/ma/program/computer-science) | \$75,670 |

Each page also gets the comparison line — e.g. \"North Carolina's typical pay for this occupation is about 11% below the typical state — common for lower cost-of-living states, but worth weighing against tuition savings.\"

Transfer-track programs (psychology, math, history, english, biology, liberal-arts) correctly omit the section, since wage data for an SOC like \"Psychologists\" doesn't reflect what a CC associate-degree grad actually earns.

## What changes on the technical front

**Two bugs fixed in `scripts/ingest-bls.ts`:**

1. **Wrong OEWS data-type code.** I had `09` mapped to annual median, but BLS's actual OEWS encoding makes `09` the **hourly 75th percentile** — which is why NC RN showed up as \"\$47.46\" (~$47/hour, not $47k/year). The correct code is **`13`** (annual median wage). For NC RN that's $81,860 — plausible against BLS' own consumer-facing pages.

   Comment in the script now includes the verified code map so the next person doesn't have to re-probe:

   ```
   01 = Employment count
   03 = Hourly mean wage
   04 = Annual mean wage
   08 = Hourly median wage
   09 = Hourly 75th percentile wage
   13 = Annual median wage   ← what we want for the page tile
   14 = Annual 75th percentile wage
   15 = Annual 90th percentile wage
   ```

2. **API key handling.** The unauth tier (25 queries/day) is too tight; the ingest needs ~32 query batches when fetching employment + mean + median across 26 states × 10 SOCs. Script now reads `BLS_API_KEY` from `.env.local` (registered tier = 500/day) and falls back gracefully to median-only when no key is set.

**Data file: `data/bls/wages.json`** (new, ~1,400 lines). 2024 OEWS release. 258 of 260 (state, SOC) pairs populated; 2 suppressed by BLS due to small state cohorts. Each pair carries employment count, annual mean wage, and annual median wage.

**`.env.example`** documents the new `BLS_API_KEY` var with a sign-up URL.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Local ingest with key: 780/780 series fetched in 32 batches, all numbers plausible
- [x] Local render `/nc/program/nursing`: Career Outlook section shows \$81,860 + \"below the typical state\" framing
- [x] Local render `/nc/program/welding`: shows \$49,860
- [x] Transfer-track programs (e.g., `/nc/program/history`) correctly omit the section
- [ ] After merge + Vercel deploy: confirm Career Outlook tiles render on prod with the right numbers

## Note on the API key

The `BLS_API_KEY` value goes in Vercel's environment variables (Project Settings → Environment Variables) so the registered tier is available at scrape time. I added it locally to `.env.local` (gitignored, never committed); production needs the same value set in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)