### PR TITLE
feat(prereqs): catalog prereq scrapers for KY, ME, MS

### DIFF
--- a/data/ky/prereqs.json
+++ b/data/ky/prereqs.json
@@ -1,0 +1,10388 @@
+{
+  "ACC 201": {
+    "text": "Quantitative Reasoning College-Readiness or Consent of the Instructor",
+    "courses": []
+  },
+  "ACC 202": {
+    "text": "ACC 201 or ACT 101 and ACT 102",
+    "courses": [
+      "ACC 201",
+      "ACT 101",
+      "ACT 102"
+    ]
+  },
+  "ACH 150": {
+    "text": "ACH 100 or consent of instructor",
+    "courses": [
+      "ACH 100"
+    ]
+  },
+  "ACH 180": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "ACH 198": {
+    "text": "Completion of a minimum of 12 hours in Architectural Technology (ACH) courses with a minimum cumulative GPA of 2.0 in all courses",
+    "courses": []
+  },
+  "ACH 200": {
+    "text": "ACH 150 and ACH 185/ACH 195 or consent of instructor",
+    "courses": [
+      "ACH 150",
+      "ACH 185",
+      "ACH 195"
+    ]
+  },
+  "ACH 225": {
+    "text": "ACH 175 and MAH 125, or Consent of instructor",
+    "courses": [
+      "ACH 175",
+      "MAH 125"
+    ]
+  },
+  "ACH 250": {
+    "text": "ACH 200 or consent of instructor",
+    "courses": [
+      "ACH 200"
+    ]
+  },
+  "ACH 260": {
+    "text": "ACH 110 and ACH 200 or equivalent",
+    "courses": [
+      "ACH 110",
+      "ACH 200"
+    ]
+  },
+  "ACH 275": {
+    "text": "ACH 175 and MAT 125, or Consent of instructor",
+    "courses": [
+      "ACH 175",
+      "MAT 125"
+    ]
+  },
+  "ACH 280": {
+    "text": "ACH 195, or Consent of instructor",
+    "courses": [
+      "ACH 195"
+    ]
+  },
+  "ACH 290": {
+    "text": "ACH 150 and ACH 160, or Consent of instructor",
+    "courses": [
+      "ACH 150",
+      "ACH 160"
+    ]
+  },
+  "ACH 291": {
+    "text": "ACH 150, ACH 160 and ACH 161, or Consent of instructor",
+    "courses": [
+      "ACH 150",
+      "ACH 160",
+      "ACH 161"
+    ]
+  },
+  "ACH 292": {
+    "text": "ACH 290 or Consent of instructor",
+    "courses": [
+      "ACH 290"
+    ]
+  },
+  "ACH 293": {
+    "text": "ACH 100 or Consent of instructor",
+    "courses": [
+      "ACH 100"
+    ]
+  },
+  "ACH 294": {
+    "text": "ACH 150, ACH 160, ACH 161, or Consent of instructor",
+    "courses": [
+      "ACH 150",
+      "ACH 160",
+      "ACH 161"
+    ]
+  },
+  "ACH 295": {
+    "text": "ACH 195 or Consent of instructor",
+    "courses": [
+      "ACH 195"
+    ]
+  },
+  "ACH 297": {
+    "text": "ACH 150 and MAT 125; or Consent of instructor",
+    "courses": [
+      "ACH 150",
+      "MAT 125"
+    ]
+  },
+  "ACH 298": {
+    "text": "ACH 150 and ACH 195 or Consent of instructor",
+    "courses": [
+      "ACH 150",
+      "ACH 195"
+    ]
+  },
+  "ACR 130": {
+    "text": "ACR 102 with a grade of C or greater",
+    "courses": [
+      "ACR 102"
+    ]
+  },
+  "ACR 131": {
+    "text": "ACR 102 with a grade of C or greater",
+    "courses": [
+      "ACR 102"
+    ]
+  },
+  "ACR 198": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "ACR 200": {
+    "text": "(ACR 100 and ACR 101) with a grade of C or greater",
+    "courses": [
+      "ACR 100",
+      "ACR 101"
+    ]
+  },
+  "ACR 201": {
+    "text": "(ACR 100 and ACR 101) with a grade of C or greater",
+    "courses": [
+      "ACR 100",
+      "ACR 101"
+    ]
+  },
+  "ACR 206": {
+    "text": "ACR 102 and ACR 103",
+    "courses": [
+      "ACR 102",
+      "ACR 103"
+    ]
+  },
+  "ACR 207": {
+    "text": "(ACR 100 and ACR 101 and ACR 102 and ACR 103) or Consent of the Instructor",
+    "courses": [
+      "ACR 100",
+      "ACR 101",
+      "ACR 102",
+      "ACR 103"
+    ]
+  },
+  "ACR 208": {
+    "text": "ACR 100 and ACR 101 and ACR 102 and ACR 103",
+    "courses": [
+      "ACR 100",
+      "ACR 101",
+      "ACR 102",
+      "ACR 103"
+    ]
+  },
+  "ACR 210": {
+    "text": "(ACR 100 and ACR 102) with a grade of C or greater",
+    "courses": [
+      "ACR 100",
+      "ACR 102"
+    ]
+  },
+  "ACR 237": {
+    "text": "ACR 100 and (ACR 102 or comparable electrical course) and 10 semester credit hours of Building Controls Technician technical electives or consent of instructor",
+    "courses": [
+      "ACR 100",
+      "ACR 102"
+    ]
+  },
+  "ACR 238": {
+    "text": "ACR 237 or consent of instructor",
+    "courses": [
+      "ACR 237"
+    ]
+  },
+  "ACR 250": {
+    "text": "(ACR 100 & ACR 101) with a grade of C or greater",
+    "courses": [
+      "ACR 100",
+      "ACR 101"
+    ]
+  },
+  "ACR 251": {
+    "text": "(ACR 100 & ACR 101) with a grade of C or greater",
+    "courses": [
+      "ACR 100",
+      "ACR 101"
+    ]
+  },
+  "ACR 260": {
+    "text": "ACR 102 and103 or EET 154 and 155 or ETT 112 and 113 or IMT 110 and 111 or Consent of the instructor",
+    "courses": [
+      "ACR 102",
+      "EET 154",
+      "ETT 112",
+      "IMT 110"
+    ]
+  },
+  "ACR 262": {
+    "text": "ACR 102 and 103 or EET 154 and 155 or ETT 112 and 113 or IMT 110 and 111 or Consent of the instructor",
+    "courses": [
+      "ACR 102",
+      "EET 154",
+      "ETT 112",
+      "IMT 110"
+    ]
+  },
+  "ACR 270": {
+    "text": "[(ACR 100 and ACR 102) with a grade of C or greater] or Permission of Instructor",
+    "courses": [
+      "ACR 100",
+      "ACR 102"
+    ]
+  },
+  "ACR 271": {
+    "text": "[(ACR 100 and ACR 102) with a grade of C or greater] or Permission of Instructor",
+    "courses": [
+      "ACR 100",
+      "ACR 102"
+    ]
+  },
+  "ACR 291": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "ACR 293": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "ACR 295": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "ACR 298": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "ACR 299": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "ACT 102": {
+    "text": "ACT 101",
+    "courses": [
+      "ACT 101"
+    ]
+  },
+  "ACT 277": {
+    "text": "ACC 202",
+    "courses": [
+      "ACC 202"
+    ]
+  },
+  "ACT 279": {
+    "text": "ACC 201 or ACT 101 and ACT 102 or concurrent enrollment in ACT 102",
+    "courses": [
+      "ACC 201",
+      "ACT 101",
+      "ACT 102"
+    ]
+  },
+  "ACT 281": {
+    "text": "One semester of college accounting or consent of instructor",
+    "courses": []
+  },
+  "ACT 286": {
+    "text": "ACC 201 or ACT 101 and ACT 102",
+    "courses": [
+      "ACC 201",
+      "ACT 101",
+      "ACT 102"
+    ]
+  },
+  "ACT 290": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "ACT 295": {
+    "text": "ACT 281 or consent of instructor",
+    "courses": [
+      "ACT 281"
+    ]
+  },
+  "ADX 151": {
+    "text": "ADX 150",
+    "courses": [
+      "ADX 150"
+    ]
+  },
+  "AEG 102": {
+    "text": "MAT 126 or Higher Quantitative Reasoning Course",
+    "courses": [
+      "MAT 126"
+    ]
+  },
+  "AEG 103": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 104": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 201": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 202": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 203": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 220": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 230": {
+    "text": "AEG 101",
+    "courses": [
+      "AEG 101"
+    ]
+  },
+  "AEG 290": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "AET 114": {
+    "text": "AET 110 or consent of instructor",
+    "courses": [
+      "AET 110"
+    ]
+  },
+  "AET 190": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "AET 250": {
+    "text": "AET 190",
+    "courses": [
+      "AET 190"
+    ]
+  },
+  "AET 270": {
+    "text": "EET 276 and EET 277",
+    "courses": [
+      "EET 276",
+      "EET 277"
+    ]
+  },
+  "AFS 113": {
+    "text": "AFS 111",
+    "courses": [
+      "AFS 111"
+    ]
+  },
+  "AFS 211": {
+    "text": "AFS 111, 113 or PAS approval",
+    "courses": [
+      "AFS 111"
+    ]
+  },
+  "AFS 213": {
+    "text": "AFS 111, 113 or PAS approval",
+    "courses": [
+      "AFS 111"
+    ]
+  },
+  "AGR 130": {
+    "text": "MAT 55 or equivalent placement level",
+    "courses": [
+      "MAT 55"
+    ]
+  },
+  "AGR 155": {
+    "text": "AGR 135",
+    "courses": [
+      "AGR 135"
+    ]
+  },
+  "AGR 180": {
+    "text": "(AGR 150 and AGR 140) or Consent of Instructor",
+    "courses": [
+      "AGR 140",
+      "AGR 150"
+    ]
+  },
+  "AGR 190": {
+    "text": "(AGR 125 and AGR 180 and AGR 170) or Consent of Instructor",
+    "courses": [
+      "AGR 125",
+      "AGR 170",
+      "AGR 180"
+    ]
+  },
+  "AGR 200": {
+    "text": "AGR 180 and AGR 190",
+    "courses": [
+      "AGR 180",
+      "AGR 190"
+    ]
+  },
+  "AGR 210": {
+    "text": "AGR 240",
+    "courses": [
+      "AGR 240"
+    ]
+  },
+  "AGR 215": {
+    "text": "AGR 250",
+    "courses": [
+      "AGR 250"
+    ]
+  },
+  "AGR 225": {
+    "text": "AGR 250",
+    "courses": [
+      "AGR 250"
+    ]
+  },
+  "AGR 245": {
+    "text": "AGR 250",
+    "courses": [
+      "AGR 250"
+    ]
+  },
+  "AGR 280": {
+    "text": "AGR 240",
+    "courses": [
+      "AGR 240"
+    ]
+  },
+  "AGR 285": {
+    "text": "AGR 101",
+    "courses": [
+      "AGR 101"
+    ]
+  },
+  "AGR 290": {
+    "text": "AGR 240",
+    "courses": [
+      "AGR 240"
+    ]
+  },
+  "AIT 1001": {
+    "text": "Reading and Mathematics assessment exam scores above KCTCS developmental placement level or successful completion of prescribed developmental courses or consent of instructor",
+    "courses": []
+  },
+  "AIT 1002": {
+    "text": "AIT 1001 or Consent of Instructor",
+    "courses": [
+      "AIT 1001"
+    ]
+  },
+  "AIT 1003": {
+    "text": "Reading and Mathematics assessment exam scores above KCTCS developmental placement level or successful completion of prescribed developmental courses or consent of instructor",
+    "courses": []
+  },
+  "AIT 1101": {
+    "text": "AIT 100 or 1001 or consent of instructor",
+    "courses": [
+      "AIT 100"
+    ]
+  },
+  "AIT 1102": {
+    "text": "AIT 100 or AIT 1003 or consent of instructor",
+    "courses": [
+      "AIT 100",
+      "AIT 1003"
+    ]
+  },
+  "AIT 120": {
+    "text": "AIT 110 or AIT 1101 or consent of instructor",
+    "courses": [
+      "AIT 110",
+      "AIT 1101"
+    ]
+  },
+  "AIT 1201": {
+    "text": "AIT 110 or AIT 1101 or consent of instructor",
+    "courses": [
+      "AIT 110",
+      "AIT 1101"
+    ]
+  },
+  "AIT 1301": {
+    "text": "AIT 110 or AIT 1101 or consent of instructor",
+    "courses": [
+      "AIT 110",
+      "AIT 1101"
+    ]
+  },
+  "AIT 1302": {
+    "text": "AIT 1301 or consent of instructor",
+    "courses": [
+      "AIT 1301"
+    ]
+  },
+  "AIT 1401": {
+    "text": "AIT 110 or AIT 1101 or consent of instructor",
+    "courses": [
+      "AIT 110",
+      "AIT 1101"
+    ]
+  },
+  "AIT 1402": {
+    "text": "AIT 110 or AIT 1102 or consent of instructor",
+    "courses": [
+      "AIT 110",
+      "AIT 1102"
+    ]
+  },
+  "AIT 1403": {
+    "text": "AIT 110 or AIT 1102 or consent of instructor",
+    "courses": [
+      "AIT 110",
+      "AIT 1102"
+    ]
+  },
+  "AIT 1501": {
+    "text": "AIT 140 or AIT 1401 or consent of instructor",
+    "courses": [
+      "AIT 140",
+      "AIT 1401"
+    ]
+  },
+  "AIT 1502": {
+    "text": "AIT 1402 or consent of instructor",
+    "courses": [
+      "AIT 1402"
+    ]
+  },
+  "AIT 1503": {
+    "text": "AIT 1403 or consent of instructor",
+    "courses": [
+      "AIT 1403"
+    ]
+  },
+  "AIT 160": {
+    "text": "Reading assessment scores above KCTCS development placement level or successful completion of prescribed developmental courses",
+    "courses": []
+  },
+  "AIT 2001": {
+    "text": "AIT 130 or Consent of Instructor",
+    "courses": [
+      "AIT 130"
+    ]
+  },
+  "AIT 2002": {
+    "text": "AIT 130 or Consent of Instructor",
+    "courses": [
+      "AIT 130"
+    ]
+  },
+  "AIT 210": {
+    "text": "Reading and Mathematics assessment exam scores above KCTCS developmental placement level or successful completion of prescribed developmental courses, and AIT 110 or consent of instructor",
+    "courses": [
+      "AIT 110"
+    ]
+  },
+  "AIT 2101": {
+    "text": "AIT 1101 or consent of instructor",
+    "courses": [
+      "AIT 1101"
+    ]
+  },
+  "AIT 2102": {
+    "text": "Reading and Mathematics assessment exam scores above KCTCS developmental placement level or successful completion of prescribed developmental courses or consent of instructor",
+    "courses": []
+  },
+  "AIT 2103": {
+    "text": "Reading and Mathematics assessment exam scores above KCTCS developmental placement level or successful completion of prescribed developmental courses or consent of instructor",
+    "courses": []
+  },
+  "AIT 235": {
+    "text": "AIT 135",
+    "courses": [
+      "AIT 135"
+    ]
+  },
+  "AIT 245": {
+    "text": "AIT 145. AIT 245",
+    "courses": [
+      "AIT 145"
+    ]
+  },
+  "AIT 2710": {
+    "text": "AIT 140 or AIT 1401 or consent of instructor",
+    "courses": [
+      "AIT 140",
+      "AIT 1401"
+    ]
+  },
+  "AIT 273": {
+    "text": "AIT 271 or AIT 2711 or consent of instructor",
+    "courses": [
+      "AIT 271",
+      "AIT 2711"
+    ]
+  },
+  "AIT 275": {
+    "text": "AIT 271 or AIT 2710 or consent of instructor",
+    "courses": [
+      "AIT 271",
+      "AIT 2710"
+    ]
+  },
+  "AIT 277": {
+    "text": "AIT 275 or consent of instructor",
+    "courses": [
+      "AIT 275"
+    ]
+  },
+  "AIT 280": {
+    "text": "AIT 273 and AIT 277 or consent of instructor",
+    "courses": [
+      "AIT 273",
+      "AIT 277"
+    ]
+  },
+  "ANA 209": {
+    "text": "Introductory biology or zoology",
+    "courses": []
+  },
+  "ANT 220": {
+    "text": "ACT, COMPASS, or ASSET scores for college level reading OR completion of developmental reading courses",
+    "courses": []
+  },
+  "ANT 223": {
+    "text": "ACT, COMPASS, or ASSET scores for college level reading or completion of developmental reading courses",
+    "courses": []
+  },
+  "ANT 231": {
+    "text": "ANT 230",
+    "courses": [
+      "ANT 230"
+    ]
+  },
+  "ANT 235": {
+    "text": "ACT, COMPASS, or ASSET scores for college level reading OR completion of developmental reading courses",
+    "courses": []
+  },
+  "APS 201": {
+    "text": "Completion of national/state certified apprenticeship program",
+    "courses": []
+  },
+  "APT 102": {
+    "text": "Test at MAT126 eligible or MAT 65 or Consent of Instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "APT 104": {
+    "text": "Test at MAT126 eligible or MAT 65 or Consent of Instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "APT 106": {
+    "text": "Test at MAT126 eligible or MAT 65 or Consent of Instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "APT 108": {
+    "text": "Test at MAT126 eligible or MAT 65 or Consent of Instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "APT 142": {
+    "text": "APT 108 with a grade of \"C\" or greater OR Instructor Consent",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 144": {
+    "text": "APT 108 with a grade of C or greater or Permission of Instructor",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 146": {
+    "text": "APT 108 with a grade of C or greater or Permission of Instructor",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 148": {
+    "text": "APT 108 with a grade of C or greater or Permission of Instructor",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 154": {
+    "text": "APT 108 with a grade of C or greater",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 156": {
+    "text": "APT 108 with a grade of C or greater",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 158": {
+    "text": "APT 108 or Consent of Instructor",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 159": {
+    "text": "APT 108 or Consent of Instructor",
+    "courses": [
+      "APT 108"
+    ]
+  },
+  "APT 202": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "APT 204": {
+    "text": "APT 148 with a grade of C or greater",
+    "courses": [
+      "APT 148"
+    ]
+  },
+  "APT 251": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "APT 258": {
+    "text": "APT 158, APT 159, EET 150, EET 151, OR EGY 170",
+    "courses": [
+      "APT 158",
+      "APT 159",
+      "EET 150",
+      "EET 151",
+      "EGY 170"
+    ]
+  },
+  "APT 259": {
+    "text": "APT 158, APT 159, EET 150, EET 151",
+    "courses": [
+      "APT 158",
+      "APT 159",
+      "EET 150",
+      "EET 151"
+    ]
+  },
+  "APT 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "ART 105": {
+    "text": "English and Reading assessment exam scores above the developmental placement level or the successful completion of prescribed developmental course(s)",
+    "courses": []
+  },
+  "ART 106": {
+    "text": "English and Reading assessment exam scores above the developmental placement level or the successful completion of prescribed developmental course(s)",
+    "courses": []
+  },
+  "ART 108": {
+    "text": "RDG 185, ENC 91",
+    "courses": [
+      "ENC 91",
+      "RDG 185"
+    ]
+  },
+  "ART 109": {
+    "text": "English and Reading assessment exam scores above the developmental placement level or the successful completion of prescribed developmental course(s)",
+    "courses": []
+  },
+  "ART 204": {
+    "text": "(English and Reading assessment exam scores above the developmental placement level or the successful completion of prescribed developmental course (s)) or Consent of Instructor",
+    "courses": []
+  },
+  "ART 205": {
+    "text": "Current placement scores for college level- reading established by KCTCS, or completion of RDG 30 or RDG185, and ENC 91",
+    "courses": [
+      "ENC 91",
+      "RDG 30"
+    ]
+  },
+  "ART 210": {
+    "text": "ART 110",
+    "courses": [
+      "ART 110"
+    ]
+  },
+  "ART 211": {
+    "text": "ART 110",
+    "courses": [
+      "ART 110"
+    ]
+  },
+  "ART 220": {
+    "text": "ART 110 or Consent of Instructor",
+    "courses": [
+      "ART 110"
+    ]
+  },
+  "ART 221": {
+    "text": "ART 220",
+    "courses": [
+      "ART 220"
+    ]
+  },
+  "ART 232": {
+    "text": "ART 231 or Consent of Instructor",
+    "courses": [
+      "ART 231"
+    ]
+  },
+  "ART 241": {
+    "text": "ART 240",
+    "courses": [
+      "ART 240"
+    ]
+  },
+  "ART 251": {
+    "text": "ART 110 & ART 112, or consent of instructor",
+    "courses": [
+      "ART 110",
+      "ART 112"
+    ]
+  },
+  "ART 252": {
+    "text": "ART 251 or consent of instructor",
+    "courses": [
+      "ART 251"
+    ]
+  },
+  "ART 253": {
+    "text": "ART 251 or consent of instructor",
+    "courses": [
+      "ART 251"
+    ]
+  },
+  "ART 254": {
+    "text": "ART 251 or consent of instructor",
+    "courses": [
+      "ART 251"
+    ]
+  },
+  "ART 260": {
+    "text": "ART 110, ART130",
+    "courses": [
+      "ART 110"
+    ]
+  },
+  "ART 261": {
+    "text": "ART 260 or consent of instructor",
+    "courses": [
+      "ART 260"
+    ]
+  },
+  "ART 270": {
+    "text": "(ART 110 and ART 120) or consent of instructor",
+    "courses": [
+      "ART 110",
+      "ART 120"
+    ]
+  },
+  "ART 271": {
+    "text": "ART 270 or permission of instructor",
+    "courses": [
+      "ART 270"
+    ]
+  },
+  "ART 282": {
+    "text": "ART 281 or permission of instructor",
+    "courses": [
+      "ART 281"
+    ]
+  },
+  "ART 290": {
+    "text": "9 credits of ART 100 / 200 level classes or permission of instructor",
+    "courses": [
+      "ART 100"
+    ]
+  },
+  "ART 299": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "ASL 102U": {
+    "text": "ASL 101 with a minimum grade of C or permission of instructor",
+    "courses": [
+      "ASL 101"
+    ]
+  },
+  "ASL 104": {
+    "text": "ASL 103 or permission of the instructor",
+    "courses": [
+      "ASL 103"
+    ]
+  },
+  "ASL 201U": {
+    "text": "ASL 102 with a minimum grade of C or permission of instructor",
+    "courses": [
+      "ASL 102"
+    ]
+  },
+  "ASL 202U": {
+    "text": "ASL 201 with a minimum grade of C or permission of instructor",
+    "courses": [
+      "ASL 201"
+    ]
+  },
+  "ASL 203": {
+    "text": "ASL 104 or permission of instructor",
+    "courses": [
+      "ASL 104"
+    ]
+  },
+  "ASL 204": {
+    "text": "ASL 203 or permission of instructor",
+    "courses": [
+      "ASL 203"
+    ]
+  },
+  "AST 101": {
+    "text": "College Readiness in Writing and Reading",
+    "courses": []
+  },
+  "AST 155": {
+    "text": "MT65 and ENC91 or equivalent as determined by KCTCS placement examination",
+    "courses": []
+  },
+  "AST 191": {
+    "text": "College Readiness in Math, Writing, and Reading",
+    "courses": []
+  },
+  "AST 192": {
+    "text": "College Readiness in Math, Writing, and Reading",
+    "courses": []
+  },
+  "AST 195": {
+    "text": "College readiness in math, writing, and reading",
+    "courses": []
+  },
+  "ATE 109": {
+    "text": "Computer Literacy or Consent of Instructor",
+    "courses": []
+  },
+  "ATE 201": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 203": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 205": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 207": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 211": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 213": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 215": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 217": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 221": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 223": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 225": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 227": {
+    "text": "((ATE 101 and ATE 103 and ATE 105 and ATE 107 and ATE 109) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ATE 101",
+      "ATE 103",
+      "ATE 105",
+      "ATE 107",
+      "ATE 109"
+    ]
+  },
+  "ATE 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "AUT 111": {
+    "text": "AUT 110",
+    "courses": [
+      "AUT 110"
+    ]
+  },
+  "AUT 131": {
+    "text": "AUT 130",
+    "courses": [
+      "AUT 130"
+    ]
+  },
+  "AUT 141": {
+    "text": "AUT 140",
+    "courses": [
+      "AUT 140"
+    ]
+  },
+  "AUT 143": {
+    "text": "AUT 142",
+    "courses": [
+      "AUT 142"
+    ]
+  },
+  "AUT 161": {
+    "text": "AUT 160",
+    "courses": [
+      "AUT 160"
+    ]
+  },
+  "AUT 181": {
+    "text": "AUT 180",
+    "courses": [
+      "AUT 180"
+    ]
+  },
+  "AUT 198": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "AUT 199": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "AUT 241": {
+    "text": "AUT 240",
+    "courses": [
+      "AUT 240"
+    ]
+  },
+  "AUT 275": {
+    "text": "ADX 120 and ADX 121 and ADX 260 and ADX 261",
+    "courses": [
+      "ADX 120",
+      "ADX 121",
+      "ADX 260",
+      "ADX 261"
+    ]
+  },
+  "AUT 276": {
+    "text": "ADX 120 and ADX 121 and ADX 260 and ADX 261",
+    "courses": [
+      "ADX 120",
+      "ADX 121",
+      "ADX 260",
+      "ADX 261"
+    ]
+  },
+  "AUT 290": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "AUT 291": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "AUT 298": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "AUT 299": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "BAS 110": {
+    "text": "Computer Literacy or Consent of Instructor",
+    "courses": []
+  },
+  "BAS 120": {
+    "text": "Completion of or concurrent enrollment in MAT 65 or higher level math or Consent of Instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "BAS 125": {
+    "text": "Placement scores for college level reading or completion of developmental reading courses",
+    "courses": []
+  },
+  "BAS 126": {
+    "text": "BAS 125",
+    "courses": [
+      "BAS 125"
+    ]
+  },
+  "BAS 170": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 200": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 212": {
+    "text": "MAT 105 or MAT 110 or Consent of Instructor",
+    "courses": [
+      "MAT 105",
+      "MAT 110"
+    ]
+  },
+  "BAS 256": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 270": {
+    "text": "(CIT 105 Introduction to Computers, Sophomore Standing, and Business Administration Program Students only) or Consent of Instructor",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "BAS 274": {
+    "text": "BAS 160 and BAS 283 or Consent of Instructor",
+    "courses": [
+      "BAS 160",
+      "BAS 283"
+    ]
+  },
+  "BAS 280": {
+    "text": "Sophomore Standing or Consent of Instructor",
+    "courses": []
+  },
+  "BAS 282": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 283": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 284": {
+    "text": "(BAS 160 and BAS 283) or prior supervisory experience",
+    "courses": [
+      "BAS 160",
+      "BAS 283"
+    ]
+  },
+  "BAS 289": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 290": {
+    "text": "BAS 283 or Consent of Instructor",
+    "courses": [
+      "BAS 283"
+    ]
+  },
+  "BAS 293": {
+    "text": "BAS 160 or Consent of Instructor",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "BAS 294": {
+    "text": "BAS 212 or Consent of Instructor",
+    "courses": [
+      "BAS 212"
+    ]
+  },
+  "BAS 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "BBT 100": {
+    "text": "MAT 65 or Equivalent Placement Level or Consent of Instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "BBT 101": {
+    "text": "BBT 100 or Consent of Instructor",
+    "courses": [
+      "BBT 100"
+    ]
+  },
+  "BBT 201": {
+    "text": "BBT 200 or Consent of Instructor",
+    "courses": [
+      "BBT 200"
+    ]
+  },
+  "BBT 220": {
+    "text": "ELT 120",
+    "courses": [
+      "ELT 120"
+    ]
+  },
+  "BBT 289": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "BIO 113": {
+    "text": "BIO 112 (If a student taking the courses concurrently fails or withdraws from BIO 112, they may continue to complete and earn credit for BIO 113 with instructor's consent)",
+    "courses": [
+      "BIO 112"
+    ]
+  },
+  "BIO 121": {
+    "text": "BIO 120 or BIO 124",
+    "courses": [
+      "BIO 120",
+      "BIO 124"
+    ]
+  },
+  "BIO 122": {
+    "text": "High school biology recommended",
+    "courses": []
+  },
+  "BIO 135": {
+    "text": "Minimum ACT Composite score 16 (or KCTCS determined equivalency); OR completion with \"C\" or better of any college biology or chemistry course; OR ACT of 13-15 with co-requisite OR supplemental instruction; OR consent of instructor",
+    "courses": []
+  },
+  "BIO 137": {
+    "text": "College readiness in math, reading, and English; OR successful completion (C or better) of a college biology or chemistry course; OR consent of instructor for enrollment in co-requisite supplemental instruction; OR consent of instructor",
+    "courses": []
+  },
+  "BIO 137S": {
+    "text": "Consent of BIO 137 Instructor",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "BIO 139": {
+    "text": "BIO 137",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "BIO 140": {
+    "text": "BIO 112 or consent of instructor",
+    "courses": [
+      "BIO 112"
+    ]
+  },
+  "BIO 141": {
+    "text": "BIO 112 or consent of instructor",
+    "courses": [
+      "BIO 112"
+    ]
+  },
+  "BIO 142": {
+    "text": "BIO 112 or consent of instructor",
+    "courses": [
+      "BIO 112"
+    ]
+  },
+  "BIO 143": {
+    "text": "BIO 112 or consent of instructor",
+    "courses": [
+      "BIO 112"
+    ]
+  },
+  "BIO 145": {
+    "text": "BIO 144 - Insect Biology",
+    "courses": [
+      "BIO 144"
+    ]
+  },
+  "BIO 148U": {
+    "text": "Math ACT of 23 or above or MA 109, past or current enrollment in CHE 105",
+    "courses": [
+      "CHE 105",
+      "MA 109"
+    ]
+  },
+  "BIO 150": {
+    "text": "(CHE 170 or concurrent enrollment) or consent of instructor",
+    "courses": [
+      "CHE 170"
+    ]
+  },
+  "BIO 151": {
+    "text": "BIO 150 or Concurrent enrollment",
+    "courses": [
+      "BIO 150"
+    ]
+  },
+  "BIO 152": {
+    "text": "BIO 150 or consent of instructor",
+    "courses": [
+      "BIO 150"
+    ]
+  },
+  "BIO 153": {
+    "text": "BIO 152 or concurrent",
+    "courses": [
+      "BIO 152"
+    ]
+  },
+  "BIO 155": {
+    "text": "MT65 and ENC91or equivalent as determined by KCTCS placement examination",
+    "courses": []
+  },
+  "BIO 155U": {
+    "text": "Math ACT of 23 or above or MA 109, past or current enrollment in CHE 105 (KCTCS equivalents: MA 109=MAT 150; CHE 105=CHE 170)",
+    "courses": [
+      "CHE 105",
+      "CHE 170",
+      "MA 109",
+      "MAT 150"
+    ]
+  },
+  "BIO 209": {
+    "text": "One unit of chemistry or consent of instructor",
+    "courses": []
+  },
+  "BIO 225": {
+    "text": "BIO 137 and BIO 139 or equivalent",
+    "courses": [
+      "BIO 137",
+      "BIO 139"
+    ]
+  },
+  "BIO 226": {
+    "text": "BIO 112 or consent of instructor",
+    "courses": [
+      "BIO 112"
+    ]
+  },
+  "BIO 227": {
+    "text": "BIO 114 or BIO 150 or consent of instructor",
+    "courses": [
+      "BIO 114",
+      "BIO 150"
+    ]
+  },
+  "BIO 295": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "BIO 299": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "BRX 210": {
+    "text": "BRX 110 with a grade of C or greater or Consent of Instructor",
+    "courses": [
+      "BRX 110"
+    ]
+  },
+  "BRX 2202": {
+    "text": "BRX 2201 or Consent of Instructor",
+    "courses": [
+      "BRX 2201"
+    ]
+  },
+  "BTN 105": {
+    "text": "MAT 65 or equivalent as determined by KCTCS examination",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "BTN 110": {
+    "text": "One semester of college biology with lab or college chemistry with lab or consent of instructor",
+    "courses": []
+  },
+  "BTN 115": {
+    "text": "Completion of BTN 201 and BTN 202 with a grade of C or better, or permission of program coordinator",
+    "courses": [
+      "BTN 201",
+      "BTN 202"
+    ]
+  },
+  "BTN 120": {
+    "text": "Completion of BTN 201 and BTN 202 with a grade of C or better, or permission of program coordinator",
+    "courses": [
+      "BTN 201",
+      "BTN 202"
+    ]
+  },
+  "BTN 125": {
+    "text": "Completion of, or concurrent enrollment in BTN 201 and BTN 202",
+    "courses": [
+      "BTN 201",
+      "BTN 202"
+    ]
+  },
+  "BTN 126": {
+    "text": "Completion of BTN 125 with a grade of C or better or permission of program coordinator",
+    "courses": [
+      "BTN 125"
+    ]
+  },
+  "BTN 160": {
+    "text": "BTN 201 and BTN 202 with a grade of C or better, or permission of the program coordinator",
+    "courses": [
+      "BTN 201",
+      "BTN 202"
+    ]
+  },
+  "BTN 201": {
+    "text": "A semester of college biology with lab or college chemistry with lab or consent of instructor",
+    "courses": []
+  },
+  "BTN 202": {
+    "text": "BTN 201",
+    "courses": [
+      "BTN 201"
+    ]
+  },
+  "BTN 210": {
+    "text": "(BTN 110 with a grade of C or better) or consent of instructor",
+    "courses": [
+      "BTN 110"
+    ]
+  },
+  "BTN 220": {
+    "text": "(BTN 110 with a grade of C or better) or consent of instructor",
+    "courses": [
+      "BTN 110"
+    ]
+  },
+  "BTN 225": {
+    "text": "Completion of BTN 201 and BTN 202 with a grade of C or better, or permission of the program coordinator",
+    "courses": [
+      "BTN 201",
+      "BTN 202"
+    ]
+  },
+  "BTN 295": {
+    "text": "Permission of instructor",
+    "courses": []
+  },
+  "BTN 298": {
+    "text": "Completion of BTN 201 and BTN 202 with a C or better, or permission of program coordinator",
+    "courses": [
+      "BTN 201",
+      "BTN 202"
+    ]
+  },
+  "BTN 299": {
+    "text": "Permission of instructor",
+    "courses": []
+  },
+  "BTS 100": {
+    "text": "RDG 30 or equivalent based on KCTCS placement exam",
+    "courses": [
+      "RDG 30"
+    ]
+  },
+  "BTS 110": {
+    "text": "RDG 30 or equivalent based on KCTCS placement exam",
+    "courses": [
+      "RDG 30"
+    ]
+  },
+  "BTS 120": {
+    "text": "AIT 1101with a grade of C or better",
+    "courses": []
+  },
+  "BTS 125": {
+    "text": "BTS 120 with a grade of C or better",
+    "courses": [
+      "BTS 120"
+    ]
+  },
+  "BTS 130": {
+    "text": "BTS 100, BTS 110 and AIT 1101(each with a grade of C or better)",
+    "courses": [
+      "AIT 1101",
+      "BTS 100",
+      "BTS 110"
+    ]
+  },
+  "BTS 140": {
+    "text": "PHY 171",
+    "courses": [
+      "PHY 171"
+    ]
+  },
+  "BTS 170": {
+    "text": "BTS 125",
+    "courses": [
+      "BTS 125"
+    ]
+  },
+  "BTS 200": {
+    "text": "BTS 125 with a grade of C or better",
+    "courses": [
+      "BTS 125"
+    ]
+  },
+  "BTS 210": {
+    "text": "BIO 135, BTS 110, BTS 125, and BTS 140 (each with a grade of C or better)",
+    "courses": [
+      "BIO 135",
+      "BTS 110",
+      "BTS 125",
+      "BTS 140"
+    ]
+  },
+  "BTS 220": {
+    "text": "BIO 135 with a grade of C or better BTS 110 with a grade of C or better BTS 125 with a grade of C or better BTS 140 with a grade of C or better",
+    "courses": [
+      "BIO 135",
+      "BTS 110",
+      "BTS 125",
+      "BTS 140"
+    ]
+  },
+  "BTS 230": {
+    "text": "BTS 130 with a grade of C or better",
+    "courses": [
+      "BTS 130"
+    ]
+  },
+  "BTS 250": {
+    "text": "CIT 160",
+    "courses": [
+      "CIT 160"
+    ]
+  },
+  "BTS 260": {
+    "text": "BIO 135, BTS 110, BTS 125, BTS 140 and BTS 230 (each with a grade of C or better)",
+    "courses": [
+      "BIO 135",
+      "BTS 110",
+      "BTS 125",
+      "BTS 140",
+      "BTS 230"
+    ]
+  },
+  "BTS 270": {
+    "text": "BIO 135, BTS 125, and BTS 140 (each with a grade of C or better)",
+    "courses": [
+      "BIO 135",
+      "BTS 125",
+      "BTS 140"
+    ]
+  },
+  "BTS 275": {
+    "text": "BTS 270 and BTS 230(each with a grade of C or better)",
+    "courses": [
+      "BTS 230",
+      "BTS 270"
+    ]
+  },
+  "BTS 280": {
+    "text": "BIO 135, BTS 125, and BTS 140 (each with a grade of C or better)",
+    "courses": [
+      "BIO 135",
+      "BTS 125",
+      "BTS 140"
+    ]
+  },
+  "BTS 285": {
+    "text": "BTS 280 and BTS 230 (both with a grade of C or better)",
+    "courses": [
+      "BTS 230",
+      "BTS 280"
+    ]
+  },
+  "BTS 290": {
+    "text": "BTS 200, BTS 220, and BTS 230 (each with a grade of C or better)",
+    "courses": [
+      "BTS 200",
+      "BTS 220",
+      "BTS 230"
+    ]
+  },
+  "CAD 112": {
+    "text": "CAD 102 with a grade of C or better or Approval of Instructor",
+    "courses": [
+      "CAD 102"
+    ]
+  },
+  "CAD 120": {
+    "text": "CAD 100 or CAD 103 with a grade of C or better or approval of the Instructor",
+    "courses": [
+      "CAD 100",
+      "CAD 103"
+    ]
+  },
+  "CAD 130": {
+    "text": "CAD 112 with a grade of C or better or approval of Instructor",
+    "courses": [
+      "CAD 112"
+    ]
+  },
+  "CAD 150": {
+    "text": "CAD 100 or CAD 103 with a grade of C or better or approval of the Instructor",
+    "courses": [
+      "CAD 100",
+      "CAD 103"
+    ]
+  },
+  "CAD 200": {
+    "text": "CAD 100 or CAD 103 with a grade of C or better or approval of the Instructor",
+    "courses": [
+      "CAD 100",
+      "CAD 103"
+    ]
+  },
+  "CAD 212": {
+    "text": "CAD 100 or CAD 103 with a grade of C or better or approval of the Instructor",
+    "courses": [
+      "CAD 100",
+      "CAD 103"
+    ]
+  },
+  "CAD 220": {
+    "text": "CAD 120 with a grade of C or better or approval of Instructor",
+    "courses": [
+      "CAD 120"
+    ]
+  },
+  "CAD 222": {
+    "text": "CAD 100 with a grade of C or better or approval of Instructor",
+    "courses": [
+      "CAD 100"
+    ]
+  },
+  "CAD 230": {
+    "text": "CAD 120 with a grade of C or better or approval of Instructor",
+    "courses": [
+      "CAD 120"
+    ]
+  },
+  "CAD 240": {
+    "text": "CAD 100 with a grade of C or better or approval of the Instructor",
+    "courses": [
+      "CAD 100"
+    ]
+  },
+  "CAD 252": {
+    "text": "CAD 120 with a grade of C or better or Approval of the Instructor",
+    "courses": [
+      "CAD 120"
+    ]
+  },
+  "CAD 262": {
+    "text": "CAD 120 with a grade of C or better or approval of the Instructor",
+    "courses": [
+      "CAD 120"
+    ]
+  },
+  "CAD 292": {
+    "text": "Approval of instructor",
+    "courses": []
+  },
+  "CAD 293": {
+    "text": "Approval of Program Coordinator",
+    "courses": []
+  },
+  "CAD 298": {
+    "text": "Approval of Program Coordinator",
+    "courses": []
+  },
+  "CAD 299": {
+    "text": "Approval of Program Coordinator",
+    "courses": []
+  },
+  "CAR 198": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CAR 2012": {
+    "text": "CAR 2002",
+    "courses": [
+      "CAR 2002"
+    ]
+  },
+  "CAR 298": {
+    "text": "ISX 100 and/or Permission from program Instructor",
+    "courses": [
+      "ISX 100"
+    ]
+  },
+  "CAR 299": {
+    "text": "ISX 100 and/or permission from program Instructor",
+    "courses": [
+      "ISX 100"
+    ]
+  },
+  "CDH 110": {
+    "text": "Graduate or current enrollment in Commission on Dental Accreditation (CODA) accredited dental hygiene program or KCTCS dental assisting program or a certified dental assistant or a registered dental assistant with 5 years experience OR consent of CDHC Program Coordinator",
+    "courses": []
+  },
+  "CDH 115": {
+    "text": "Graduate or current enrollment in Commission on Dental Accreditation (CODA) accredited dental hygiene program or KCTCS dental assisting program or a certified dental assistant or a registered dental assistant with 5 years experience or consent of CDHC Program Coordinator",
+    "courses": []
+  },
+  "CDH 125": {
+    "text": "Graduate or current enrollment in Commission on Dental Accreditation (CODA) accredited dental hygiene program or KCTCS dental assisting program or a certified dental assistant or a registered dental assistant with 5 years experience or consent of CDHC Program Coordinator",
+    "courses": []
+  },
+  "CDH 220": {
+    "text": "Graduate or current enrollment in Commission on Dental Accreditation (CODA) accredited dental hygiene program or KCTCS dental assisting program or a certified dental assistant or a registered dental assistant with 5 years experience or consent of CDHC Program Coordinator",
+    "courses": []
+  },
+  "CDH 245": {
+    "text": "Graduate or current enrollment in Commission on Dental Accreditation (CODA) accredited dental hygiene program or KCTCS dental assisting program or a certified dental assistant or a registered dental assistant with 5 years experience or consent of CDHC Program Coordinator",
+    "courses": []
+  },
+  "CET 150": {
+    "text": "CAD 100",
+    "courses": [
+      "CAD 100"
+    ]
+  },
+  "CET 200": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CET 210": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CET 220": {
+    "text": "SMT 110 or Consent of Instructor",
+    "courses": [
+      "SMT 110"
+    ]
+  },
+  "CET 260": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CET 280": {
+    "text": "CET 150 or Consent of Instructor",
+    "courses": [
+      "CET 150"
+    ]
+  },
+  "CHE 120": {
+    "text": "(Math ACT 18 or higher) OR (Completion of quantitative reasoning co-requisite course)",
+    "courses": []
+  },
+  "CHE 125": {
+    "text": "CHE 120",
+    "courses": [
+      "CHE 120"
+    ]
+  },
+  "CHE 130": {
+    "text": "(Math ACT 19 or higher) OR (Completion of MAT 85, MAT 110, MAT 116, MAT 126, or MAT 150 with a grade of \"C\" or better)",
+    "courses": [
+      "MAT 110",
+      "MAT 116",
+      "MAT 126",
+      "MAT 150",
+      "MAT 85"
+    ]
+  },
+  "CHE 135": {
+    "text": "CHE 130 concurrent enrollment OR CHE 130 with a grade of \"C\" or better",
+    "courses": [
+      "CHE 130"
+    ]
+  },
+  "CHE 140": {
+    "text": "(Math ACT 19 or higher) OR (Completion of MAT 85, MAT 110, MAT 116, MAT 126, or MAT 150 with a grade of \"C\" or better)",
+    "courses": [
+      "MAT 110",
+      "MAT 116",
+      "MAT 126",
+      "MAT 150",
+      "MAT 85"
+    ]
+  },
+  "CHE 145": {
+    "text": "CHE 140",
+    "courses": [
+      "CHE 140"
+    ]
+  },
+  "CHE 150": {
+    "text": "CHE 140 with a grade of C or better Lecture: 3 credits (45 contact hours)",
+    "courses": [
+      "CHE 140"
+    ]
+  },
+  "CHE 155": {
+    "text": "CHE 140 and CHE 145",
+    "courses": [
+      "CHE 140",
+      "CHE 145"
+    ]
+  },
+  "CHE 170": {
+    "text": "(ACT math score of 22) OR (College Algebra or higher with \"C\" or better) OR (CHE 130 OR CHE 140 with a grade of \"C\" or better) OR (Appropriate score on chemistry placement exam)",
+    "courses": [
+      "CHE 130",
+      "CHE 140"
+    ]
+  },
+  "CHE 175": {
+    "text": "CHE 170",
+    "courses": [
+      "CHE 170"
+    ]
+  },
+  "CHE 180": {
+    "text": "(CHE 170 with a grade of \"C\" or better) AND (Completion of College Algebra Readiness course or higher with a grade of \"C\" or better)",
+    "courses": [
+      "CHE 170"
+    ]
+  },
+  "CHE 185": {
+    "text": "CHE 175 with a grade of C or better",
+    "courses": [
+      "CHE 175"
+    ]
+  },
+  "CHE 270": {
+    "text": "CHE 180 with a grade of C or better",
+    "courses": [
+      "CHE 180"
+    ]
+  },
+  "CHE 275": {
+    "text": "CHE 185 with a grade of C or better",
+    "courses": [
+      "CHE 185"
+    ]
+  },
+  "CHE 280": {
+    "text": "CHE 270 with a grade of C or better",
+    "courses": [
+      "CHE 270"
+    ]
+  },
+  "CHE 285": {
+    "text": "CHE 275 with a grade of C or better",
+    "courses": [
+      "CHE 275"
+    ]
+  },
+  "CHE 290": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "CHE 295": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "CIT 105": {
+    "text": "Reading Placement Level of \"Reading Corequisite or Reading Course\" as outlined in the KCTCS Assessment and Placement Policy or above or completion of 12 credit hours of college-level courses with a 2.0 or better GPA",
+    "courses": []
+  },
+  "CIT 1051": {
+    "text": "RDG 20 OR Consent of Instructor",
+    "courses": [
+      "RDG 20"
+    ]
+  },
+  "CIT 111": {
+    "text": "(CIT 105 and Quantitative Reasoning College-Readiness) orConsent of Instructor",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "CIT 120": {
+    "text": "Quantitative Reasoning College-Readiness or Consent of Instructor",
+    "courses": []
+  },
+  "CIT 124": {
+    "text": "CIT 105 or IMD 100 or Consent of Instructor",
+    "courses": [
+      "CIT 105",
+      "IMD 100"
+    ]
+  },
+  "CIT 125": {
+    "text": "CIT 105 OR Consent of Instructor",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "CIT 130": {
+    "text": "CIT 105 or OST 105 or IMD 100 or Consent of Instructor",
+    "courses": [
+      "CIT 105",
+      "IMD 100",
+      "OST 105"
+    ]
+  },
+  "CIT 140": {
+    "text": "CIT 120 and (CIT 150 or CIT 155) or Consent of Instructor",
+    "courses": [
+      "CIT 120",
+      "CIT 150",
+      "CIT 155"
+    ]
+  },
+  "CIT 142": {
+    "text": "CIT 120 or Consent of Instructor",
+    "courses": [
+      "CIT 120"
+    ]
+  },
+  "CIT 143": {
+    "text": "CIT 120 OR Consent of Instructor",
+    "courses": [
+      "CIT 120"
+    ]
+  },
+  "CIT 144": {
+    "text": "CIT 120 or Consent of Instructor",
+    "courses": [
+      "CIT 120"
+    ]
+  },
+  "CIT 146": {
+    "text": "CIT 120 OR Consent of Instructor",
+    "courses": [
+      "CIT 120"
+    ]
+  },
+  "CIT 148": {
+    "text": "CIT 120 or Consent of Instructor",
+    "courses": [
+      "CIT 120"
+    ]
+  },
+  "CIT 149": {
+    "text": "CIT 120 or Consent of Instructor",
+    "courses": [
+      "CIT 120"
+    ]
+  },
+  "CIT 150": {
+    "text": "CIT 105 or Consent of Instructor",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "CIT 151": {
+    "text": "Digital Literacy or Consent of Instructor",
+    "courses": []
+  },
+  "CIT 152": {
+    "text": "CIT 150 or Consent of Instructor",
+    "courses": [
+      "CIT 150"
+    ]
+  },
+  "CIT 155": {
+    "text": "CIT 105 or Consent of Instructor",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "CIT 157": {
+    "text": "CIT 105 OR Consent of Instructor",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "CIT 160": {
+    "text": "Quantitative Reasoning College-Readiness or Consent of Instructor",
+    "courses": []
+  },
+  "CIT 161": {
+    "text": "Quantitative Reasoning College-Readiness or Consent of Instructor",
+    "courses": []
+  },
+  "CIT 167": {
+    "text": "CIT 161 or Consent of Instructor",
+    "courses": [
+      "CIT 161"
+    ]
+  },
+  "CIT 170": {
+    "text": "[(CIT 105 or OST 105 or IMD 100) and Quantitative Reasoning College-Readiness] or Consent of Instructor",
+    "courses": [
+      "CIT 105",
+      "IMD 100",
+      "OST 105"
+    ]
+  },
+  "CIT 171": {
+    "text": "(CIT 120 and CIT 170) or Consent of Instructor",
+    "courses": [
+      "CIT 120",
+      "CIT 170"
+    ]
+  },
+  "CIT 180": {
+    "text": "(CIT 160 OR CIT 161) or Consent of Instructor",
+    "courses": [
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 182": {
+    "text": "CIT 180 or Consent of Instructor",
+    "courses": [
+      "CIT 180"
+    ]
+  },
+  "CIT 184": {
+    "text": "CIT 180 or Consent of Instructor",
+    "courses": [
+      "CIT 180"
+    ]
+  },
+  "CIT 201": {
+    "text": "[CIT 167 and (CIT 214 or CIT 217 or CIT262)] or Consent of Instructor",
+    "courses": [
+      "CIT 167",
+      "CIT 214",
+      "CIT 217"
+    ]
+  },
+  "CIT 203": {
+    "text": "[CIT 167 and (CIT 214 or CIT 217 or CIT 262)] or Consent of Instructor",
+    "courses": [
+      "CIT 167",
+      "CIT 214",
+      "CIT 217",
+      "CIT 262"
+    ]
+  },
+  "CIT 204": {
+    "text": "CIT 203 or Consent of Instructor",
+    "courses": [
+      "CIT 203"
+    ]
+  },
+  "CIT 205": {
+    "text": "(CIT 201 and CIT 203) or consent of instructor",
+    "courses": [
+      "CIT 201",
+      "CIT 203"
+    ]
+  },
+  "CIT 206": {
+    "text": "CIT 170 and (CIT 161 or CIT 160), or consent of the instructor",
+    "courses": [
+      "CIT 160",
+      "CIT 161",
+      "CIT 170"
+    ]
+  },
+  "CIT 207": {
+    "text": "CIT 206 or consent of instructor",
+    "courses": [
+      "CIT 206"
+    ]
+  },
+  "CIT 208": {
+    "text": "CIT 206 or consent of instructor",
+    "courses": [
+      "CIT 206"
+    ]
+  },
+  "CIT 212": {
+    "text": "CIT 167 OR Consent of Instructor",
+    "courses": [
+      "CIT 167"
+    ]
+  },
+  "CIT 213": {
+    "text": "(CIT 111 AND (CIT 160 OR CIT 161)) OR Consent of Instructor",
+    "courses": [
+      "CIT 111",
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 217": {
+    "text": "[CIT 111 and (CIT 160 or CIT 161)] or Consent of Instructor",
+    "courses": [
+      "CIT 111",
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 219": {
+    "text": "(CIT 160 OR CIT 161OR CIT162) OR Consent of Instructor",
+    "courses": [
+      "CIT 160"
+    ]
+  },
+  "CIT 221": {
+    "text": "CIT 105 or IMD 100 or Consent of Instructor",
+    "courses": [
+      "CIT 105",
+      "IMD 100"
+    ]
+  },
+  "CIT 222": {
+    "text": "CIT/IMD 221 or Consent of Instructor",
+    "courses": [
+      "IMD 221"
+    ]
+  },
+  "CIT 223": {
+    "text": "CIT/IMD 124 AND CIT/IMD 222 OR Consent of Instructor",
+    "courses": [
+      "IMD 124",
+      "IMD 222"
+    ]
+  },
+  "CIT 225": {
+    "text": "CIT 125 or Consent of Instructor",
+    "courses": [
+      "CIT 125"
+    ]
+  },
+  "CIT 227": {
+    "text": "(CIT111 AND an Approved Level I Networking Course) OR Consent of Instructor",
+    "courses": []
+  },
+  "CIT 228": {
+    "text": "CIT 227 OR Consent of Instructor",
+    "courses": [
+      "CIT 227"
+    ]
+  },
+  "CIT 229": {
+    "text": "CIT 125 OR Consent of Instructor",
+    "courses": [
+      "CIT 125"
+    ]
+  },
+  "CIT 232": {
+    "text": "CIT 111 OR Consent of Instructor",
+    "courses": [
+      "CIT 111"
+    ]
+  },
+  "CIT 234": {
+    "text": "CIT 130 OR Consent of Instructor",
+    "courses": [
+      "CIT 130"
+    ]
+  },
+  "CIT 236": {
+    "text": "CIT 130 OR Consent of Instructor",
+    "courses": [
+      "CIT 130"
+    ]
+  },
+  "CIT 237": {
+    "text": "CIT 146 OR Consent of Instructor",
+    "courses": [
+      "CIT 146"
+    ]
+  },
+  "CIT 238": {
+    "text": "CIT 149 or INF 120 or Consent of Instructor",
+    "courses": [
+      "CIT 149",
+      "INF 120"
+    ]
+  },
+  "CIT 242": {
+    "text": "CIT 142 OR Consent of Instructor",
+    "courses": [
+      "CIT 142"
+    ]
+  },
+  "CIT 243": {
+    "text": "CIT 143 OR Consent of Instructor",
+    "courses": [
+      "CIT 143"
+    ]
+  },
+  "CIT 244": {
+    "text": "CIT 144 OR Consent of Instructor",
+    "courses": [
+      "CIT 144"
+    ]
+  },
+  "CIT 248": {
+    "text": "CIT 148 or Consent of Instructor",
+    "courses": [
+      "CIT 148"
+    ]
+  },
+  "CIT 249": {
+    "text": "CIT 149 OR Consent of Instructor",
+    "courses": [
+      "CIT 149"
+    ]
+  },
+  "CIT 251": {
+    "text": "CIT 151 or Consent of Instructor",
+    "courses": [
+      "CIT 151"
+    ]
+  },
+  "CIT 253": {
+    "text": "((CIT 150 OR CIT 155 OR CIT 157) AND CIT 170 AND Approved Level I Programming Language) OR Consent of Instructor",
+    "courses": [
+      "CIT 150",
+      "CIT 155",
+      "CIT 157",
+      "CIT 170"
+    ]
+  },
+  "CIT 255": {
+    "text": "[(CIT 150 OR CIT 155 OR CIT 157) AND (CIT 214 OR CIT 228 OR CIT 262) AND CIT 219 OR Consent of Instructor",
+    "courses": [
+      "CIT 150",
+      "CIT 155",
+      "CIT 157",
+      "CIT 214",
+      "CIT 219",
+      "CIT 228",
+      "CIT 262"
+    ]
+  },
+  "CIT 257": {
+    "text": "CIT 253 or Co-Requisite of CIT 255 or Consent of Instructor",
+    "courses": [
+      "CIT 253",
+      "CIT 255"
+    ]
+  },
+  "CIT 258": {
+    "text": "CIT 253 or Co-Requisite of CIT 255 or Consent of Instructor",
+    "courses": [
+      "CIT 253",
+      "CIT 255"
+    ]
+  },
+  "CIT 260": {
+    "text": "CIT 160 OR CIT 161 OR Consent of Instructor",
+    "courses": [
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 261": {
+    "text": "(CIT 111 AND (CIT 160 OR CIT 161)) or Consent of Instructor",
+    "courses": [
+      "CIT 111",
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 262": {
+    "text": "(CIT 111 and (CIT 160 or CIT 161)) or Consent of Instructor",
+    "courses": [
+      "CIT 111",
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 264": {
+    "text": "CIT 262 OR Consent of Instructor",
+    "courses": [
+      "CIT 262"
+    ]
+  },
+  "CIT 267": {
+    "text": "CIT 228 OR Consent of Instructor",
+    "courses": [
+      "CIT 228"
+    ]
+  },
+  "CIT 270": {
+    "text": "CIT 160 or CIT 161 or Consent of Instructor",
+    "courses": [
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 271": {
+    "text": "CIT 171 OR Consent of Instructor",
+    "courses": [
+      "CIT 171"
+    ]
+  },
+  "CIT 273": {
+    "text": "CIT/IMD 124 AND CIT/IMD 222 OR Consent of Instructor",
+    "courses": [
+      "IMD 124",
+      "IMD 222"
+    ]
+  },
+  "CIT 274": {
+    "text": "CIT/IMD 223 AND CIT/IMD 273 or Consent of Instructor",
+    "courses": [
+      "IMD 223",
+      "IMD 273"
+    ]
+  },
+  "CIT 275": {
+    "text": "CIT 160 or CIT 161 or Consent of Instructor",
+    "courses": [
+      "CIT 160",
+      "CIT 161"
+    ]
+  },
+  "CIT 279": {
+    "text": "CIT 275 or Consent of Instructor",
+    "courses": [
+      "CIT 275"
+    ]
+  },
+  "CIT 284": {
+    "text": "CIT 180 OR Consent of Instructor",
+    "courses": [
+      "CIT 180"
+    ]
+  },
+  "CIT 286": {
+    "text": "(CIT 180 AND CIT 228) OR Consent of Instructor",
+    "courses": [
+      "CIT 180",
+      "CIT 228"
+    ]
+  },
+  "CIT 287": {
+    "text": "CIT 167 OR CIT 212 OR Consent of Instructor",
+    "courses": [
+      "CIT 167",
+      "CIT 212"
+    ]
+  },
+  "CIT 288": {
+    "text": "(CIT 180 AND Level 1 Network Technologies Specialization Sequence) OR Consent of Instructor",
+    "courses": [
+      "CIT 180"
+    ]
+  },
+  "CIT 290": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CIT 291": {
+    "text": "36 credit hours of CIT Courses OR Consent of Instructor",
+    "courses": []
+  },
+  "CIT 293": {
+    "text": "(Sophomore Standing and 18 credit hours of CIT courses) or Consent of Instructor",
+    "courses": []
+  },
+  "CIT 295": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CIT 297": {
+    "text": "Sophomore Standing AND 18 credit hours of CIT courses) OR Consent of Instructor",
+    "courses": [
+      "AND 18"
+    ]
+  },
+  "CIT 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CMM 112": {
+    "text": "(CMM 110 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 110"
+    ]
+  },
+  "CMM 120": {
+    "text": "((CMM 110 and 112) or (CMM 114) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 110",
+      "CMM 114"
+    ]
+  },
+  "CMM 122": {
+    "text": "(CMM 120 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 120"
+    ]
+  },
+  "CMM 124": {
+    "text": "((CMM 110 and CMM 112) or (CMM 114) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 110",
+      "CMM 112",
+      "CMM 114"
+    ]
+  },
+  "CMM 134": {
+    "text": "((CMM 110 and CMM 112) or CMM 114) with a grade of C or greater] or Consent of Instructor",
+    "courses": [
+      "CMM 110",
+      "CMM 112",
+      "CMM 114"
+    ]
+  },
+  "CMM 138": {
+    "text": "((CMM 110 and CMM 112) or (CMM 114) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 110",
+      "CMM 112",
+      "CMM 114"
+    ]
+  },
+  "CMM 210": {
+    "text": "((CMM 122 or 124) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 122"
+    ]
+  },
+  "CMM 212": {
+    "text": "(CMM 210 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 210"
+    ]
+  },
+  "CMM 214": {
+    "text": "((CMM 122 or CMM 124) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 122",
+      "CMM 124"
+    ]
+  },
+  "CMM 220": {
+    "text": "((CMM 130 and CMM 132) or (CMM 134) and (CMM 212 or CMM 214) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 130",
+      "CMM 132",
+      "CMM 134",
+      "CMM 212",
+      "CMM 214"
+    ]
+  },
+  "CMM 222": {
+    "text": "(CMM 212 or CMM 214 with a Grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 212",
+      "CMM 214"
+    ]
+  },
+  "CMM 224": {
+    "text": "(CMM 134 and (CMM 212 or CMM 214) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 134",
+      "CMM 212",
+      "CMM 214"
+    ]
+  },
+  "CMM 230": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CMM 2301": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CMM 2302": {
+    "text": "CMM 2301 or Consent of Instructor",
+    "courses": [
+      "CMM 2301"
+    ]
+  },
+  "CMM 234": {
+    "text": "((CMM 130 and CMM 132) or (CMM 134 or CMM 138) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 130",
+      "CMM 132",
+      "CMM 134",
+      "CMM 138"
+    ]
+  },
+  "CMM 240": {
+    "text": "((CMM 130 and CMM 132) or (CMM 134 or CMM 138) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 130",
+      "CMM 132",
+      "CMM 134",
+      "CMM 138"
+    ]
+  },
+  "CMM 2401": {
+    "text": "((CMM 130 and CMM 132) or (CMM 134) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 130",
+      "CMM 132",
+      "CMM 134"
+    ]
+  },
+  "CMM 2402": {
+    "text": "((CMM 130 and CMM 132) or (CMM 134 or CMM 138) and (CMM 2401) with a Grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "CMM 130",
+      "CMM 132",
+      "CMM 134",
+      "CMM 138",
+      "CMM 2401"
+    ]
+  },
+  "CMM 244": {
+    "text": "((CMM 2301 and CMM 2302) or (CMM 230) with a grade of C or greater) or consent of instructor",
+    "courses": [
+      "CMM 230",
+      "CMM 2301",
+      "CMM 2302"
+    ]
+  },
+  "CMM 298": {
+    "text": "Permission of the Instructor",
+    "courses": []
+  },
+  "CMM 299": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "COE 199": {
+    "text": "Completion of at least 12 credit hours in the Associate in Applied Science Degree, diploma or certificate program of study and/or marketable skills in the area in which the student in enrolled, and minimum cumulative grade point average (GPA) of 2.0",
+    "courses": []
+  },
+  "COED 198": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "COM 181": {
+    "text": "Current KCTCS placement scores for college level reading and writing or Consent of Instructor",
+    "courses": []
+  },
+  "COM 205": {
+    "text": "Current KCTCS placement scores for College level reading and writing, or Consent of Instructor",
+    "courses": []
+  },
+  "COM 249": {
+    "text": "Current KCTCS placement scores for College level reading and writing, or Consent of Instructor",
+    "courses": []
+  },
+  "COM 252": {
+    "text": "Current KCTCS placement scores for college level reading and writing, or consent of instructor",
+    "courses": []
+  },
+  "COM 254": {
+    "text": "Current KCTCS placement scores for college level reading and writing, or consent of instructor",
+    "courses": []
+  },
+  "COM 281": {
+    "text": "Current KCTCS placement scores for college level reading and writing, or consent of instructor",
+    "courses": []
+  },
+  "COM 287": {
+    "text": "COM 181",
+    "courses": [
+      "COM 181"
+    ]
+  },
+  "COM 299": {
+    "text": "COM 181 or COM 252 or consent of instructor",
+    "courses": [
+      "COM 181",
+      "COM 252"
+    ]
+  },
+  "COS 107": {
+    "text": "Cosmetologist License, one year work experience, apprentice cosmetologist instructor's permit",
+    "courses": []
+  },
+  "COS 108": {
+    "text": "High school diploma or equivalent",
+    "courses": []
+  },
+  "COS 109": {
+    "text": "High school diploma or equivalent",
+    "courses": []
+  },
+  "COS 117": {
+    "text": "Cosmetologist License, one year work experience, apprentice cosmetologist instructor's permit",
+    "courses": []
+  },
+  "COS 118": {
+    "text": "Successful completion of COS 114 or COS 108 & COS 109",
+    "courses": [
+      "COS 108",
+      "COS 109",
+      "COS 114"
+    ]
+  },
+  "COS 119": {
+    "text": "Successful completion COS 114 or COS 108 & COS 109",
+    "courses": [
+      "COS 108",
+      "COS 109",
+      "COS 114"
+    ]
+  },
+  "COS 135": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "COS 146": {
+    "text": "COS 136 or Instructor permission",
+    "courses": [
+      "COS 136"
+    ]
+  },
+  "COS 170": {
+    "text": "Cosmetologist's license, one year work experience, and Apprentice Cosmetologists' Instructor's permit",
+    "courses": []
+  },
+  "COS 222": {
+    "text": "COS 114, 116, 218 or consent of instructor",
+    "courses": [
+      "COS 114"
+    ]
+  },
+  "COS 228": {
+    "text": "Successful completion of COS 116 or COS 118 & COS 119",
+    "courses": [
+      "COS 116",
+      "COS 118",
+      "COS 119"
+    ]
+  },
+  "COS 229": {
+    "text": "Successful completion of COS 116 or COS 118 & COS 119",
+    "courses": [
+      "COS 116",
+      "COS 118",
+      "COS 119"
+    ]
+  },
+  "COS 235": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "COS 238": {
+    "text": "Successful completion of COS 218 or COS 228 & COS 229",
+    "courses": [
+      "COS 218",
+      "COS 228",
+      "COS 229"
+    ]
+  },
+  "COS 239": {
+    "text": "Successful completion of COS 218 or COS 228 & COS 229",
+    "courses": [
+      "COS 218",
+      "COS 228",
+      "COS 229"
+    ]
+  },
+  "CRJ 100": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 102": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 107": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 108": {
+    "text": "CRJ 107 and (Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "CRJ 107",
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 110": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 201": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 202": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 203": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 204": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 208": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 210": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 211": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90) AND (CRJ 100 or Consent of Instructor)",
+    "courses": [
+      "CRJ 100",
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 215": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 216": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 217": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 218": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90) AND CRJ 100 or CRJ 215 or Consent of Instructor",
+    "courses": [
+      "CRJ 100",
+      "CRJ 215",
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 219": {
+    "text": "CRJ 215 and (Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "CRJ 215",
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 220": {
+    "text": "Completion of an approved Computer Literacy Course with a grade of C or greater, or computer literacy demonstrated by competency exam; AND (Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 222": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 224": {
+    "text": "CRJ 204 and MAT 110 and (Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "CRJ 204",
+      "ENC 90",
+      "ENC 91",
+      "MAT 110",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 225": {
+    "text": "CRJ 215 and (Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "CRJ 215",
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 230": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 231": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 240": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 245": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 277": {
+    "text": "If yes, list: (Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 279": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 290": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90) AND Sophomore Standing and completion of at least 12 semester hours of Criminal Justice work",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRJ 295": {
+    "text": "(CRJ 100 and CRJ 202 and CRJ 204 and CRJ 216 and CRJ 217) and/or consent of Program Coordinator",
+    "courses": [
+      "CRJ 100",
+      "CRJ 202",
+      "CRJ 204",
+      "CRJ 216",
+      "CRJ 217"
+    ]
+  },
+  "CRJ 296": {
+    "text": "CRJ 100, PSY 110",
+    "courses": [
+      "CRJ 100",
+      "PSY 110"
+    ]
+  },
+  "CRJ 299": {
+    "text": "(Current placement scores for RDG 30 or higher or completion of RDG 20) and (Current placement scores for ENC 91 or higher or completion of ENC 90)",
+    "courses": [
+      "ENC 90",
+      "ENC 91",
+      "RDG 20",
+      "RDG 30"
+    ]
+  },
+  "CRT 131": {
+    "text": "CRT 130",
+    "courses": [
+      "CRT 130"
+    ]
+  },
+  "CRT 151": {
+    "text": "CRT 150",
+    "courses": [
+      "CRT 150"
+    ]
+  },
+  "CRT 198": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CRT 231": {
+    "text": "CRT 230",
+    "courses": [
+      "CRT 230"
+    ]
+  },
+  "CRT 251": {
+    "text": "CRT 250",
+    "courses": [
+      "CRT 250"
+    ]
+  },
+  "CRT 291": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CRT 298": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CRT 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "CS 215U": {
+    "text": "CS 115, 221 or equivalent",
+    "courses": [
+      "CS 115"
+    ]
+  },
+  "CS 216U": {
+    "text": "CS215",
+    "courses": []
+  },
+  "CS 217U": {
+    "text": "CS 215",
+    "courses": [
+      "CS 215"
+    ]
+  },
+  "CS 218U": {
+    "text": "CS 215",
+    "courses": [
+      "CS 215"
+    ]
+  },
+  "CS 275U": {
+    "text": "MA 113 and CS 115",
+    "courses": [
+      "CS 115",
+      "MA 113"
+    ]
+  },
+  "CUL 190": {
+    "text": "CUL 100 and CUL 125 or consent of instructor",
+    "courses": [
+      "CUL 100",
+      "CUL 125"
+    ]
+  },
+  "CUL 195": {
+    "text": "CUL 100 and CUL 125 or consent of instructor",
+    "courses": [
+      "CUL 100",
+      "CUL 125"
+    ]
+  },
+  "CUL 220": {
+    "text": "CUL 195",
+    "courses": [
+      "CUL 195"
+    ]
+  },
+  "CUL 225": {
+    "text": "CUL 195",
+    "courses": [
+      "CUL 195"
+    ]
+  },
+  "CUL 235": {
+    "text": "CUL 100, CUL 125, CUL 190, CUL 195, or Instructor Approval",
+    "courses": [
+      "CUL 100",
+      "CUL 125",
+      "CUL 190",
+      "CUL 195"
+    ]
+  },
+  "CUL 240": {
+    "text": "CUL 100 and CUL 125",
+    "courses": [
+      "CUL 100",
+      "CUL 125"
+    ]
+  },
+  "CUL 250": {
+    "text": "CUL 190 and CUL 195 or Consent of instructor",
+    "courses": [
+      "CUL 190",
+      "CUL 195"
+    ]
+  },
+  "CUL 260": {
+    "text": "CUL 100 and CUL 125",
+    "courses": [
+      "CUL 100",
+      "CUL 125"
+    ]
+  },
+  "CUL 280": {
+    "text": "A mathematics placement score above the score range for MAT 65 or successful completion of the prescribed developmental course(s) or consent of the instructor",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "CUL 290": {
+    "text": "(CUL 190, CUL 195, and CUL 240) or Consent of Instructor",
+    "courses": [
+      "CUL 190",
+      "CUL 195",
+      "CUL 240"
+    ]
+  },
+  "CUL 295": {
+    "text": "All Technical Core Courses as outlined in the current Culinary Arts Curriculum",
+    "courses": []
+  },
+  "CUL 298": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "CUL 299": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "CYS 130": {
+    "text": "CYS 101 or Consent of Instructor",
+    "courses": [
+      "CYS 101"
+    ]
+  },
+  "CYS 140": {
+    "text": "College Readiness in Math or Consent of Instructor",
+    "courses": []
+  },
+  "CYS 145": {
+    "text": "MAT 150 OR Consent of Instructor",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "CYS 150": {
+    "text": "MAT 150 or Consent of Instructor",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "CYS 202": {
+    "text": "ENG 101 or consent of instructor",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "CYS 231": {
+    "text": "CYS 145 or consent of instructor",
+    "courses": [
+      "CYS 145"
+    ]
+  },
+  "CYS 234": {
+    "text": "(CYS 130 and CYS 145) or Consent of Instructor",
+    "courses": [
+      "CYS 130",
+      "CYS 145"
+    ]
+  },
+  "CYS 245": {
+    "text": "(CYS 145 and MAT 150) or Consent of Instructor",
+    "courses": [
+      "CYS 145",
+      "MAT 150"
+    ]
+  },
+  "CYS 247": {
+    "text": "CYS 245 or Consent of Instructor",
+    "courses": [
+      "CYS 245"
+    ]
+  },
+  "CYS 248": {
+    "text": "CYS 245 or Consent of Instructor",
+    "courses": [
+      "CYS 245"
+    ]
+  },
+  "CYS 249": {
+    "text": "CYS 245 or Consent of Instructor",
+    "courses": [
+      "CYS 245"
+    ]
+  },
+  "CYS 250": {
+    "text": "(CYS 150 and MAT 150) or Consent of Instructor",
+    "courses": [
+      "CYS 150",
+      "MAT 150"
+    ]
+  },
+  "CYS 251": {
+    "text": "((CIT 149 and CIT 249) or (CS 115 and CS 215) or (INF 120 and INF 260) or (CIT 142 and CIT 242) or (CIT 143 and CIT 243)) or Consent of Instructor",
+    "courses": [
+      "CIT 142",
+      "CIT 143",
+      "CIT 149",
+      "CIT 242",
+      "CIT 243",
+      "CIT 249",
+      "CS 115",
+      "CS 215",
+      "INF 120",
+      "INF 260"
+    ]
+  },
+  "CYS 255": {
+    "text": "(MAT 150 and (CYS 250 or CYS 251)) or Consent of Instructor",
+    "courses": [
+      "CYS 250",
+      "CYS 251",
+      "MAT 150"
+    ]
+  },
+  "CYS 258": {
+    "text": "CYS 101",
+    "courses": [
+      "CYS 101"
+    ]
+  },
+  "CYS 265": {
+    "text": "(CYS 130 and CYS 245) or Consent of Instructor",
+    "courses": [
+      "CYS 130",
+      "CYS 245"
+    ]
+  },
+  "CYS 266": {
+    "text": "(CYS 130 and CYS 245) or Consent of Instructor",
+    "courses": [
+      "CYS 130",
+      "CYS 245"
+    ]
+  },
+  "CYS 270": {
+    "text": "(CYS 140 and CYS 150) or Consent of Instructor",
+    "courses": [
+      "CYS 140",
+      "CYS 150"
+    ]
+  },
+  "CYS 285": {
+    "text": "(MAT 150 and CYS 101) or Consent of Instructor",
+    "courses": [
+      "CYS 101",
+      "MAT 150"
+    ]
+  },
+  "CYS 299": {
+    "text": "Completion of 18 hours of CYS core or Consent of Instructor",
+    "courses": []
+  },
+  "DAH 101": {
+    "text": "Admission into the Integrated Dental Assisting or Dental Hygiene Program",
+    "courses": []
+  },
+  "DAH 121": {
+    "text": "Admission into the Integrated Dental Assisting or Dental Hygiene Program",
+    "courses": []
+  },
+  "DAH 124": {
+    "text": "Admission into the Integrated Dental Assisting or Dental Hygiene Program",
+    "courses": []
+  },
+  "DAH 131": {
+    "text": "Dental Assisting: Minimum grade of \"C\" in DAH 101, DAH 121, DAH 124, DAH 135, DAS 125, and DAS 130; Dental Hygiene: Minimum grade of \"C\" in DAH 101, DAH 121, DAH 124, DAH 135, and DHG 120",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DAS 125",
+      "DAS 130",
+      "DHG 120"
+    ]
+  },
+  "DAH 135": {
+    "text": "Admission into the Integrated Dental Assisting or Dental Hygiene Program",
+    "courses": []
+  },
+  "DAH 235": {
+    "text": "Dental Assisting: Minimum grade of \"C\" in DAH 101, DAH 121, DAH 135, DAH 124, DAS 125 and DAS 130; Dental Hygiene: Minimum grade of \"C\" in DHG 220 and DHG 226",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DAS 125",
+      "DAS 130",
+      "DHG 220",
+      "DHG 226"
+    ]
+  },
+  "DAS 125": {
+    "text": "Admission into the Dental Assisting Integrated program",
+    "courses": []
+  },
+  "DAS 130": {
+    "text": "Admission into the Dental Assisting Integrated program",
+    "courses": []
+  },
+  "DAS 225": {
+    "text": "Dental Assisting: Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, DAS 125, and DAS 130",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DAS 125",
+      "DAS 130"
+    ]
+  },
+  "DAS 230": {
+    "text": "Minimum grade of \"C\" in DAH 101, DAH 121, DAH 124, DAH 135, DAS 125, and DAS 130",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DAS 125",
+      "DAS 130"
+    ]
+  },
+  "DAS 245": {
+    "text": "Dental Assisting: Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, DAS 125, and DAS 130",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DAS 125",
+      "DAS 130"
+    ]
+  },
+  "DAS 250": {
+    "text": "Dental Assisting: Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, DAS 125, and DAS 130",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DAS 125",
+      "DAS 130"
+    ]
+  },
+  "DHG 120": {
+    "text": "Admission into the Dental Hygiene Integrated Program",
+    "courses": []
+  },
+  "DHG 130": {
+    "text": "Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, and DHG 120",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DHG 120"
+    ]
+  },
+  "DHG 132": {
+    "text": "Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, and DHG 120",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DHG 120"
+    ]
+  },
+  "DHG 134": {
+    "text": "Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, and DHG 120",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DHG 120"
+    ]
+  },
+  "DHG 136": {
+    "text": "Minimum grade of C in DAH 101, DAH 121, DAH 124, DAH 135, and DHG 120",
+    "courses": [
+      "DAH 101",
+      "DAH 121",
+      "DAH 124",
+      "DAH 135",
+      "DHG 120"
+    ]
+  },
+  "DHG 220": {
+    "text": "Minimum grade of C in DAH 131, DHG 130, DHG 132, DHG 134, and DHG 136",
+    "courses": [
+      "DAH 131",
+      "DHG 130",
+      "DHG 132",
+      "DHG 134",
+      "DHG 136"
+    ]
+  },
+  "DHG 221": {
+    "text": "Minimum grade of C in DAH 131, DHG 130, DHG 132, DHG 134, DHG 136, and current enrollment in the Dental Hygiene Integrated Program",
+    "courses": [
+      "DAH 131",
+      "DHG 130",
+      "DHG 132",
+      "DHG 134",
+      "DHG 136"
+    ]
+  },
+  "DHG 226": {
+    "text": "Minimum grade of C in DAH 131, DHG 130, DHG 132, DHG 134, and DHG 136",
+    "courses": [
+      "DAH 131",
+      "DHG 130",
+      "DHG 132",
+      "DHG 134",
+      "DHG 136"
+    ]
+  },
+  "DHG 228": {
+    "text": "Minimum grade of C in DAH 131, DHG 130, DHG 132, DHG 134, DHG 136, and current enrollment in the Dental Hygiene Integrated Program",
+    "courses": [
+      "DAH 131",
+      "DHG 130",
+      "DHG 132",
+      "DHG 134",
+      "DHG 136"
+    ]
+  },
+  "DHG 230": {
+    "text": "Minimum grade of C in DHG 220 and DHG 226",
+    "courses": [
+      "DHG 220",
+      "DHG 226"
+    ]
+  },
+  "DHG 238": {
+    "text": "Minimum grade of C in DHG 220 and DHG 226",
+    "courses": [
+      "DHG 220",
+      "DHG 226"
+    ]
+  },
+  "DHP 120": {
+    "text": "Acceptance into the Dental Hygiene Program; Computer Literacy or equivalency; and CPR certification",
+    "courses": []
+  },
+  "DHP 122": {
+    "text": "Acceptance into the Dental Hygiene Program; Computer Literacy or equivalent; and CPR certification",
+    "courses": []
+  },
+  "DHP 123": {
+    "text": "Acceptance into Dental Hygiene Program; digital literacy is defined by KCTCS or equivalent; and CPR certification",
+    "courses": []
+  },
+  "DHP 124": {
+    "text": "Acceptance into the Dental Hygiene Program; digital literacy as defined by KCTCS or equivalent; and CPR certification",
+    "courses": []
+  },
+  "DHP 130": {
+    "text": "DHP 120, DHP 122, DHP 123, DHP 124 and (BIO 225 or BIO 226, or equivalent) all with a minimum grade of C",
+    "courses": [
+      "BIO 225",
+      "BIO 226",
+      "DHP 120",
+      "DHP 122",
+      "DHP 123",
+      "DHP 124"
+    ]
+  },
+  "DHP 132": {
+    "text": "DHP 120, DHP 122, DHP 123, DHP 124 and (BIO 225 or 226 or equivalent) all with a minimum grade of C",
+    "courses": [
+      "BIO 225",
+      "DHP 120",
+      "DHP 122",
+      "DHP 123",
+      "DHP 124"
+    ]
+  },
+  "DHP 135": {
+    "text": "DHP 120, DHP 122, DHP 123, DHP 124, and (BIO 225 or BIO 226, or equivalent) all with a minimum grade of C",
+    "courses": [
+      "BIO 225",
+      "BIO 226",
+      "DHP 120",
+      "DHP 122",
+      "DHP 123",
+      "DHP 124"
+    ]
+  },
+  "DHP 136": {
+    "text": "DHP 120, DHP 122, DHP 123, DHP 124, and (BIO 225 or BIO 226, or equivalent) all with a minimum grade of C",
+    "courses": [
+      "BIO 225",
+      "BIO 226",
+      "DHP 120",
+      "DHP 122",
+      "DHP 123",
+      "DHP 124"
+    ]
+  },
+  "DHP 220": {
+    "text": "DHP 130, DHP 132, DHP 135 and DHP 136 all with a minimum grade of C",
+    "courses": [
+      "DHP 130",
+      "DHP 132",
+      "DHP 135",
+      "DHP 136"
+    ]
+  },
+  "DHP 222": {
+    "text": "DHP 130, DHP 132, DHP 135, and DHP 136 all with a minimum grade of C",
+    "courses": [
+      "DHP 130",
+      "DHP 132",
+      "DHP 135",
+      "DHP 136"
+    ]
+  },
+  "DHP 226": {
+    "text": "DHP 130, DHP 132, DHP 135 and DHP 136 all with a minimum grade of C",
+    "courses": [
+      "DHP 130",
+      "DHP 132",
+      "DHP 135",
+      "DHP 136"
+    ]
+  },
+  "DHP 229": {
+    "text": "DHP 130, DHP 132, DHP 135 and DHP 136 all with a minimum grade of C",
+    "courses": [
+      "DHP 130",
+      "DHP 132",
+      "DHP 135",
+      "DHP 136"
+    ]
+  },
+  "DHP 230": {
+    "text": "DHP 220, DHP 222, DHP 226, and DHP 229 all with a minimum grade of C",
+    "courses": [
+      "DHP 220",
+      "DHP 222",
+      "DHP 226",
+      "DHP 229"
+    ]
+  },
+  "DHP 235": {
+    "text": "DHP 220, DHP 222, DHP 226, and DHP 229 all with a minimum grade of C",
+    "courses": [
+      "DHP 220",
+      "DHP 222",
+      "DHP 226",
+      "DHP 229"
+    ]
+  },
+  "DHP 238": {
+    "text": "DHP 220, DHP 222, DHP 226 and DHP 229 all with a minimum grade of C",
+    "courses": [
+      "DHP 220",
+      "DHP 222",
+      "DHP 226",
+      "DHP 229"
+    ]
+  },
+  "DIT 112": {
+    "text": "DIT 110 or ADX 150",
+    "courses": [
+      "ADX 150",
+      "DIT 110"
+    ]
+  },
+  "DIT 113": {
+    "text": "DIT 111 or ADX 151",
+    "courses": [
+      "ADX 151",
+      "DIT 111"
+    ]
+  },
+  "DIT 161": {
+    "text": "DIT 160",
+    "courses": [
+      "DIT 160"
+    ]
+  },
+  "DIT 198": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "DIT 199": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "DLC 101": {
+    "text": "RDG 20 OR Consent of Instructor",
+    "courses": [
+      "RDG 20"
+    ]
+  },
+  "DMI 102": {
+    "text": "Admission to the radiography program",
+    "courses": []
+  },
+  "DMI 106": {
+    "text": "Admission to the radiography program",
+    "courses": []
+  },
+  "DMI 108": {
+    "text": "Admission to the Radiography Program AND BIO 137",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "DMI 110": {
+    "text": "Admission to the radiography program",
+    "courses": []
+  },
+  "DMI 112": {
+    "text": "Admission to the Radiography Program AND MAT 150 or higher-level quantitative reasoning course",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "DMI 115": {
+    "text": "DMI 106 and DMI 108",
+    "courses": [
+      "DMI 106",
+      "DMI 108"
+    ]
+  },
+  "DMI 118": {
+    "text": "DMI 108",
+    "courses": [
+      "DMI 108"
+    ]
+  },
+  "DMI 120": {
+    "text": "DMI 110",
+    "courses": [
+      "DMI 110"
+    ]
+  },
+  "DMI 128": {
+    "text": "DMI 108 & DMI 118",
+    "courses": [
+      "DMI 108",
+      "DMI 118"
+    ]
+  },
+  "DMI 130": {
+    "text": "DMI 120",
+    "courses": [
+      "DMI 120"
+    ]
+  },
+  "DMI 212": {
+    "text": "DMI 112",
+    "courses": [
+      "DMI 112"
+    ]
+  },
+  "DMI 220": {
+    "text": "DMI 130",
+    "courses": [
+      "DMI 130"
+    ]
+  },
+  "DMI 222": {
+    "text": "DMI 108 & DMI 118",
+    "courses": [
+      "DMI 108",
+      "DMI 118"
+    ]
+  },
+  "DMI 224": {
+    "text": "DMI 112",
+    "courses": [
+      "DMI 112"
+    ]
+  },
+  "DMI 226": {
+    "text": "DMI 108, DMI 118, and DMI 128",
+    "courses": [
+      "DMI 108",
+      "DMI 118",
+      "DMI 128"
+    ]
+  },
+  "DMI 228": {
+    "text": "Final semester in the radiography program",
+    "courses": []
+  },
+  "DMI 230": {
+    "text": "DMI 220",
+    "courses": [
+      "DMI 220"
+    ]
+  },
+  "DMS 109": {
+    "text": "Admission to Diagnostic Medical Sonography program; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 111": {
+    "text": "Admission to Diagnostic Medical Sonography program; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 115": {
+    "text": "Admission to Diagnostic Medical Sonography program; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 116": {
+    "text": "Admission to Diagnostic Medical Sonography Program; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 117": {
+    "text": "Admission to Diagnostic Medical Sonography program; Computer Literacy; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 118": {
+    "text": "Admission to Diagnostic Medical Sonography program; Computer Literacy; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 119": {
+    "text": "Consent of Program Coordinator",
+    "courses": []
+  },
+  "DMS 126": {
+    "text": "Admission to Diagnostic Medical Sonography program; NAA 100 or equivalent; CPR Certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 136": {
+    "text": "DMS 117 with minimum \"C\" grade",
+    "courses": [
+      "DMS 117"
+    ]
+  },
+  "DMS 146": {
+    "text": "Admission to Diagnostic Medical Sonography program; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 147": {
+    "text": "Admission to the Diagnostic Medical Sonography program; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 204": {
+    "text": "Consent of Program Coordinator",
+    "courses": []
+  },
+  "DMS 206": {
+    "text": "Admission to Diagnostic Medical Sonography Program; Computer Literacy; NAA 100 or equivalent; CPR certification",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "DMS 207": {
+    "text": "DMS 146 with a minimum \"C\" grade or Consent of Program Coordinator",
+    "courses": [
+      "DMS 146"
+    ]
+  },
+  "DMS 216": {
+    "text": "DMS 207 with a minimum \"C\" grade or Consent of Program Coordinator",
+    "courses": [
+      "DMS 207"
+    ]
+  },
+  "DMS 218": {
+    "text": "DMS 109, or DMS 111 with a minimum \"C\" grade, or Consent of Program Coordinator",
+    "courses": [
+      "DMS 109",
+      "DMS 111"
+    ]
+  },
+  "DMS 219": {
+    "text": "DMS 115 or DMS 116 with a minimum \"C\" grade, or Consent of Program Coordinator",
+    "courses": [
+      "DMS 115",
+      "DMS 116"
+    ]
+  },
+  "DMS 230": {
+    "text": "DMS 126 with minimum \"C\" grade",
+    "courses": [
+      "DMS 126"
+    ]
+  },
+  "DMS 236": {
+    "text": "DMS 136 with minimum \"C\" grade",
+    "courses": [
+      "DMS 136"
+    ]
+  },
+  "DMS 237": {
+    "text": "Minimum \"C\" grade in DMS 136 and DMS 236",
+    "courses": [
+      "DMS 136",
+      "DMS 236"
+    ]
+  },
+  "DMS 240": {
+    "text": "DMS 230 with Minimum \"C\" grade",
+    "courses": [
+      "DMS 230"
+    ]
+  },
+  "DMS 241": {
+    "text": "DMS 147 or Consent of Program Coordinator",
+    "courses": [
+      "DMS 147"
+    ]
+  },
+  "DMS 243": {
+    "text": "DMS 241 with a minimum ''C'' grade or Consent of Program Coordinator",
+    "courses": [
+      "DMS 241"
+    ]
+  },
+  "DMS 246": {
+    "text": "DMS 207 with minimum \"C\" grade or Consent of Program Coordinator",
+    "courses": [
+      "DMS 207"
+    ]
+  },
+  "DMS 249": {
+    "text": "DMS 248 with minimum \"C\" grade or Consent of Program Coordinator",
+    "courses": [
+      "DMS 248"
+    ]
+  },
+  "DMS 255": {
+    "text": "Minimum \"C\" grade in (DMS 119 and DMS 240) or Consent of Program Coordinator",
+    "courses": [
+      "DMS 119",
+      "DMS 240"
+    ]
+  },
+  "DMS 260": {
+    "text": "Minimum \"C\" grade in (DMS 119 and DMS 240) or consent of Program Coordinator",
+    "courses": [
+      "DMS 119",
+      "DMS 240"
+    ]
+  },
+  "DPT 102": {
+    "text": "CIT 105, demonstration of digital literacy competency by exam or certificate, or other approved course with digital literacy status",
+    "courses": [
+      "CIT 105"
+    ]
+  },
+  "DPT 104": {
+    "text": "DPT 100",
+    "courses": [
+      "DPT 100"
+    ]
+  },
+  "DPT 150": {
+    "text": "DPT 100 or DPT 102",
+    "courses": [
+      "DPT 100",
+      "DPT 102"
+    ]
+  },
+  "DPT 203": {
+    "text": "DPT 100",
+    "courses": [
+      "DPT 100"
+    ]
+  },
+  "DPT 210": {
+    "text": "DPT 100, CIT 105",
+    "courses": [
+      "CIT 105",
+      "DPT 100"
+    ]
+  },
+  "DPT 212": {
+    "text": "DPT 150",
+    "courses": [
+      "DPT 150"
+    ]
+  },
+  "DPT 220": {
+    "text": "DPT 100, DPT 150, DPT 201, DPT 203",
+    "courses": [
+      "DPT 100",
+      "DPT 150",
+      "DPT 201",
+      "DPT 203"
+    ]
+  },
+  "DPT 280": {
+    "text": "DPT 100 or DPT 102",
+    "courses": [
+      "DPT 100",
+      "DPT 102"
+    ]
+  },
+  "DPT 281": {
+    "text": "DPT 100, DPT 150",
+    "courses": [
+      "DPT 100",
+      "DPT 150"
+    ]
+  },
+  "DPT 285": {
+    "text": "DPT 100, DPT 150, DPT 281",
+    "courses": [
+      "DPT 100",
+      "DPT 150",
+      "DPT 281"
+    ]
+  },
+  "DPT 290": {
+    "text": "DPT 100, DPT 104, DPT 150, DPT 203, DPT 280",
+    "courses": [
+      "DPT 100",
+      "DPT 104",
+      "DPT 150",
+      "DPT 203",
+      "DPT 280"
+    ]
+  },
+  "EDM 270": {
+    "text": "EDP 202 and EDU 201",
+    "courses": [
+      "EDP 202",
+      "EDU 201"
+    ]
+  },
+  "EDP 202": {
+    "text": "PSY 100 or PSY 110",
+    "courses": [
+      "PSY 100",
+      "PSY 110"
+    ]
+  },
+  "EDP 203": {
+    "text": "EDP 202 with an earned grade of C or higher",
+    "courses": [
+      "EDP 202"
+    ]
+  },
+  "EDP 260": {
+    "text": "EDP 202",
+    "courses": [
+      "EDP 202"
+    ]
+  },
+  "EDU 140": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "EDU 201": {
+    "text": "ENG 101 or consent of instructor",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "EDU 240": {
+    "text": "ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "EDU 260U": {
+    "text": "EDU250/EDU201 or consent of instructor",
+    "courses": []
+  },
+  "EDU 270": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "EDU 291": {
+    "text": "EDU 201 and EDP 202",
+    "courses": [
+      "EDP 202",
+      "EDU 201"
+    ]
+  },
+  "EE 210U": {
+    "text": "MAT 185 Calculus II (C or better)",
+    "courses": [
+      "MAT 185"
+    ]
+  },
+  "EET 110": {
+    "text": "Basic physics/electricity courses are recommended but not required",
+    "courses": []
+  },
+  "EET 116": {
+    "text": "EET 110 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 110"
+    ]
+  },
+  "EET 118": {
+    "text": "EET 110 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 110"
+    ]
+  },
+  "EET 122": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 123": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 124": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 127": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "EET 130": {
+    "text": "EET 122 and EET 123 or EET 124",
+    "courses": [
+      "EET 122",
+      "EET 123",
+      "EET 124"
+    ]
+  },
+  "EET 131": {
+    "text": "EET 130",
+    "courses": [
+      "EET 130"
+    ]
+  },
+  "EET 132": {
+    "text": "EET 122 and EET 123 or EET 124",
+    "courses": [
+      "EET 122",
+      "EET 123",
+      "EET 124"
+    ]
+  },
+  "EET 150": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 151": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 153": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 154": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 155": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 198": {
+    "text": "Consent of Electrical Technology program advisor(s)",
+    "courses": []
+  },
+  "EET 201": {
+    "text": "EET 200 Robotic Systems I",
+    "courses": [
+      "EET 200"
+    ]
+  },
+  "EET 202": {
+    "text": "EET 201 Robotic Systems II or IMT 200 Industrial Robotics and Robotic Maintenance",
+    "courses": [
+      "EET 201",
+      "IMT 200"
+    ]
+  },
+  "EET 203": {
+    "text": "EET 201 Robotic Systems II or IMT 200 Industrial Robotics and Robotic Maintenance",
+    "courses": [
+      "EET 201",
+      "IMT 200"
+    ]
+  },
+  "EET 248": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 249": {
+    "text": "Consent of instructor and EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 250": {
+    "text": "ELT 110 or EET 119 with minimum grade of \"C\" or consent of Electrical Technology Program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 251": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 252": {
+    "text": "Consent of Instructor or EET 154",
+    "courses": [
+      "EET 154"
+    ]
+  },
+  "EET 254": {
+    "text": "(ELT 110 OR EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 255": {
+    "text": "(ELT 110 OR EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 259": {
+    "text": "EET 251 or EET 248 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 248",
+      "EET 251"
+    ]
+  },
+  "EET 264": {
+    "text": "(ELT 110 OR EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 265": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 266": {
+    "text": "(ELT 110 OR ELT 119 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "ELT 110",
+      "ELT 119"
+    ]
+  },
+  "EET 267": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 268": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 269": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 270": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 271": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of the Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 272": {
+    "text": "EET 270 OR EET 264 OR EET 268 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 264",
+      "EET 268",
+      "EET 270"
+    ]
+  },
+  "EET 273": {
+    "text": "EET 271 or EET 265 or EET 269 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 265",
+      "EET 269",
+      "EET 271"
+    ]
+  },
+  "EET 274": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 275": {
+    "text": "(ELT 110 or EET 119) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 276": {
+    "text": "EET 270 or EET 268 or EET 274 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 268",
+      "EET 270",
+      "EET 274"
+    ]
+  },
+  "EET 277": {
+    "text": "EET 271 or EET 269 or EET 275 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 269",
+      "EET 271",
+      "EET 275"
+    ]
+  },
+  "EET 280": {
+    "text": "EET 276 and EET 277 with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 276",
+      "EET 277"
+    ]
+  },
+  "EET 281": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "EET 285": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "EET 286": {
+    "text": "(EET 276) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 276"
+    ]
+  },
+  "EET 287": {
+    "text": "(EET 277) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 277"
+    ]
+  },
+  "EET 288": {
+    "text": "EET 260 or EET 261 or EET 263 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 260",
+      "EET 261",
+      "EET 263"
+    ]
+  },
+  "EET 289": {
+    "text": "EET 260 or EET 261 or EET 263 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 260",
+      "EET 261",
+      "EET 263"
+    ]
+  },
+  "EET 290": {
+    "text": "(EET 276 and EET 277) with a minimum grade of \"C\" or consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 276",
+      "EET 277"
+    ]
+  },
+  "EET 292": {
+    "text": "EET 119 or ELT 110 with a minimum grade of \"C\"",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "EET 295": {
+    "text": "(ELT110 or EET119 and EET154 and EET155 and EET252 and EET253 or EET 254 and EET 255 and EET250) or electrical experience and consent of Electrical Technology program advisor(s)",
+    "courses": [
+      "EET 254",
+      "EET 255"
+    ]
+  },
+  "EET 298": {
+    "text": "Consent of Electrical Technology program advisor(s)",
+    "courses": []
+  },
+  "EET 299": {
+    "text": "Consent of Electrical Technology program advisor(s)",
+    "courses": []
+  },
+  "EGR 101U": {
+    "text": "Enrolled in the College of Engineering or MA ACT of at least 23 or equivalent",
+    "courses": []
+  },
+  "EGY 120": {
+    "text": "(ELT 110 and ETT 110) or (electrical experience and consent of instructor)",
+    "courses": [
+      "ELT 110",
+      "ETT 110"
+    ]
+  },
+  "EGY 170": {
+    "text": "(ELT 110 and EET 150 and EET 151) or (electrical experience and consent of instructor)",
+    "courses": [
+      "EET 150",
+      "EET 151",
+      "ELT 110"
+    ]
+  },
+  "EGY 220": {
+    "text": "(ELT 110 and EET 154 and EET 155 and EET 252 and EET 253 and EET 250) or (electrical experience and consent of instructor)",
+    "courses": [
+      "EET 154",
+      "EET 155",
+      "EET 250",
+      "EET 252",
+      "EET 253",
+      "ELT 110"
+    ]
+  },
+  "EGY 230": {
+    "text": "(ELT 110 and EET 154 and EET 155 and EET 252 and EET 253 and EET 250) or (electrical experience and consent of instructor)",
+    "courses": [
+      "EET 154",
+      "EET 155",
+      "EET 250",
+      "EET 252",
+      "EET 253",
+      "ELT 110"
+    ]
+  },
+  "EGY 240": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "EGY 250": {
+    "text": "ELT110 or consent of instructor",
+    "courses": []
+  },
+  "ELT 103": {
+    "text": "Current Placement Scores for College Level Quantitative Reasoning or Consent of Instructor",
+    "courses": []
+  },
+  "ELT 110": {
+    "text": "MAT 61 or equivalent placement level or Consent of Instructor",
+    "courses": [
+      "MAT 61"
+    ]
+  },
+  "ELT 114": {
+    "text": "(ELT 110 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ELT 110"
+    ]
+  },
+  "ELT 115": {
+    "text": "(EET 119 or ELT 110 with a grade of \"C\" or greater) or Consent of Instructor",
+    "courses": [
+      "EET 119",
+      "ELT 110"
+    ]
+  },
+  "ELT 120": {
+    "text": "MAT 61 or equivalent placement level or Consent of Instructor",
+    "courses": [
+      "MAT 61"
+    ]
+  },
+  "ELT 201": {
+    "text": "(MAT 150 and MAT 155 or MAT 110) or consent of instructor",
+    "courses": [
+      "MAT 110",
+      "MAT 150",
+      "MAT 155"
+    ]
+  },
+  "ELT 210": {
+    "text": "(ELT 110 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ELT 110"
+    ]
+  },
+  "ELT 214": {
+    "text": "(ELT 210 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ELT 210"
+    ]
+  },
+  "ELT 220": {
+    "text": "(ELT 120 with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "ELT 120"
+    ]
+  },
+  "ELT 222": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "ELT 224": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "ELT 232": {
+    "text": "(Computer literacy course or demonstrate competency) or consent of instructor",
+    "courses": []
+  },
+  "ELT 234": {
+    "text": "(Computer literacy course or demonstrate competency) or consent of instructor",
+    "courses": []
+  },
+  "ELT 240": {
+    "text": "(ELT 220 and ELT 214) or Consent of Instructor",
+    "courses": [
+      "ELT 214",
+      "ELT 220"
+    ]
+  },
+  "ELT 244": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "ELT 249": {
+    "text": "ELT 115",
+    "courses": [
+      "ELT 115"
+    ]
+  },
+  "ELT 250": {
+    "text": "ELT 244 or Consent of instructor",
+    "courses": [
+      "ELT 244"
+    ]
+  },
+  "ELT 260": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "ELT 289": {
+    "text": "(ELT 120 and ELT 210) or Consent of Instructor",
+    "courses": [
+      "ELT 120",
+      "ELT 210"
+    ]
+  },
+  "ELT 290": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "EM 221": {
+    "text": "MA 213",
+    "courses": [
+      "MA 213"
+    ]
+  },
+  "EMS 105": {
+    "text": "Minimum ACT Reading Score of 15 or Consent of Instructor",
+    "courses": []
+  },
+  "EMS 120": {
+    "text": "EMS 105 or FIR 230 or current unrestricted certification or validated National Registry status as EMT eligible and concurrent enrollment in EMS 121",
+    "courses": [
+      "EMS 105",
+      "EMS 121",
+      "FIR 230"
+    ]
+  },
+  "EMS 121": {
+    "text": "EMS 120",
+    "courses": [
+      "EMS 120"
+    ]
+  },
+  "EMS 125": {
+    "text": "Successful completion of EMS 120 and EMS 121",
+    "courses": [
+      "EMS 120",
+      "EMS 121"
+    ]
+  },
+  "EMS 130": {
+    "text": "Successful completion of EMS 120, EMS 121, and EMS 125",
+    "courses": [
+      "EMS 120",
+      "EMS 121",
+      "EMS 125"
+    ]
+  },
+  "EMS 150": {
+    "text": "Reading, English, and Mathematics assessment exam scores above KCTCS developmental level or successful completion of the prescribed developmental courses",
+    "courses": []
+  },
+  "EMS 175": {
+    "text": "Currently certified at a minimum of an Emergency Medical Technician by the Kentucky Board of Emergency Medical Services or the NREMT",
+    "courses": []
+  },
+  "EMS 200": {
+    "text": "EMS 105 or FRS 2061 or current unrestricted state certification or validated National Registry status as EMT eligible AND Program Admission AND AHS 115 or CLA 131 or Consent of Instructor AND BIO 135 or Consent of Instructor",
+    "courses": [
+      "AHS 115",
+      "BIO 135",
+      "CLA 131",
+      "EMS 105",
+      "FRS 2061"
+    ]
+  },
+  "EMS 201": {
+    "text": "FRS 2061, EMS 105, unrestricted certification or validated National Registry status as EMT eligible, and Program Admission OR consent of instructor",
+    "courses": [
+      "EMS 105",
+      "FRS 2061"
+    ]
+  },
+  "EMS 202": {
+    "text": "FRS 2061, EMS 105, unrestricted certification or validated National Registry status as EMT eligible and Program Admission OR consent of instructor",
+    "courses": [
+      "EMS 105",
+      "FRS 2061"
+    ]
+  },
+  "EMS 203": {
+    "text": "FRS 2061, EMS 105, unrestricted certification or validated National Registry status as EMT eligible and Program Admission or consent of instructor",
+    "courses": [
+      "EMS 105",
+      "FRS 2061"
+    ]
+  },
+  "EMS 204": {
+    "text": "FRS 2061, EMS 105, unrestricted certification or validated National Registry status as EMT eligible and Program Admission OR consent of instructor",
+    "courses": [
+      "EMS 105",
+      "FRS 2061"
+    ]
+  },
+  "EMS 205": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 206": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 207": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 208": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 2081": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 2082": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 209": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 210": {
+    "text": "EMS 200",
+    "courses": [
+      "EMS 200"
+    ]
+  },
+  "EMS 212": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 213": {
+    "text": "Emergency Medical Technician or consent of instructor",
+    "courses": []
+  },
+  "EMS 215": {
+    "text": "EMS 211",
+    "courses": [
+      "EMS 211"
+    ]
+  },
+  "EMS 220": {
+    "text": "EMS 210 and EMS 211",
+    "courses": [
+      "EMS 210",
+      "EMS 211"
+    ]
+  },
+  "EMS 225": {
+    "text": "EMS 215",
+    "courses": [
+      "EMS 215"
+    ]
+  },
+  "EMS 235": {
+    "text": "EMS 225",
+    "courses": [
+      "EMS 225"
+    ]
+  },
+  "EMS 250": {
+    "text": "EMS 240",
+    "courses": [
+      "EMS 240"
+    ]
+  },
+  "EMS 260": {
+    "text": "EMS 250",
+    "courses": [
+      "EMS 250"
+    ]
+  },
+  "EMS 275": {
+    "text": "EMS 225",
+    "courses": [
+      "EMS 225"
+    ]
+  },
+  "EMS 285": {
+    "text": "EMS 275",
+    "courses": [
+      "EMS 275"
+    ]
+  },
+  "EMS 2851": {
+    "text": "EMS 275",
+    "courses": [
+      "EMS 275"
+    ]
+  },
+  "EMS 2852": {
+    "text": "EMS 2851",
+    "courses": [
+      "EMS 2851"
+    ]
+  },
+  "ENC 90": {
+    "text": "Placement by KCTCS assessment and placement policy",
+    "courses": []
+  },
+  "ENC 91": {
+    "text": "Placement by KCTCS Assessment and Placement policy",
+    "courses": []
+  },
+  "ENC 96": {
+    "text": "Placement by KCTCS Assessment and Placement Policy",
+    "courses": []
+  },
+  "ENG 101": {
+    "text": "Placement by KCTCS Assessment and Placement Policy",
+    "courses": []
+  },
+  "ENG 102": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 105": {
+    "text": "ACT English score of 25 or COMPASS English score of 95 and ACT Reading score of 20 or COMPASS reading score of 90",
+    "courses": []
+  },
+  "ENG 115": {
+    "text": "College Readiness in English without corequisite supplemental instruction or successful completion of ENG 101 or Consent of Instructor",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 135": {
+    "text": "English ACT 18 and Reading ACT 20 OR completion of transitional reading and writing",
+    "courses": []
+  },
+  "ENG 203": {
+    "text": "[ENG 101 and (ENG 102 or Consent of Instructor)] or ENG 105",
+    "courses": [
+      "ENG 101",
+      "ENG 102",
+      "ENG 105"
+    ]
+  },
+  "ENG 204": {
+    "text": "[ENG 101 and (ENG 102 or Consent of Instructor)] or ENG 105",
+    "courses": [
+      "ENG 101",
+      "ENG 102",
+      "ENG 105"
+    ]
+  },
+  "ENG 207": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 208": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 221": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 222": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 230": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 231": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 232": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 233": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 234": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 251": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 252": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 261": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 262": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 264": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 270": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 271": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 281": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 299": {
+    "text": "ENG 101 or consent of instructor",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "EQM 120": {
+    "text": "EQM 100 or consent of instructor",
+    "courses": [
+      "EQM 100"
+    ]
+  },
+  "EQS 112": {
+    "text": "Department Consent",
+    "courses": []
+  },
+  "EQS 113": {
+    "text": "EQS 112 and consent of the instructor",
+    "courses": [
+      "EQS 112"
+    ]
+  },
+  "EQS 115": {
+    "text": "EQS 110 OR Consent of Instructor",
+    "courses": [
+      "EQS 110"
+    ]
+  },
+  "EQS 125": {
+    "text": "EQS 110 OR Consent of Instructor",
+    "courses": [
+      "EQS 110"
+    ]
+  },
+  "EQS 200": {
+    "text": "EQS 110 or permission of instructor",
+    "courses": [
+      "EQS 110"
+    ]
+  },
+  "EQS 223": {
+    "text": "EQS 104",
+    "courses": [
+      "EQS 104"
+    ]
+  },
+  "EQS 225": {
+    "text": "EQS 222 and permission of instructor",
+    "courses": [
+      "EQS 222"
+    ]
+  },
+  "EQS 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "ESL 110U": {
+    "text": "KCTCS assessment instrument scores as shown in Mandatory Placement policy",
+    "courses": []
+  },
+  "ESL 120U": {
+    "text": "KCTCS Assessment instrument scores as shown in Mandatory Placement policy",
+    "courses": []
+  },
+  "ESL 130U": {
+    "text": "KCTCS assessment instrument scores as shown in Mandatory Placement policy",
+    "courses": []
+  },
+  "ESL 52": {
+    "text": "ESL 51",
+    "courses": [
+      "ESL 51"
+    ]
+  },
+  "ESL 53": {
+    "text": "ESL 52 or placement test",
+    "courses": [
+      "ESL 52"
+    ]
+  },
+  "ESL 63": {
+    "text": "ESL 62 or placement test",
+    "courses": [
+      "ESL 62"
+    ]
+  },
+  "ESL 71": {
+    "text": "Placement According to KCTCS Assessment and Placement Policy",
+    "courses": []
+  },
+  "ESL 72": {
+    "text": "Currently appropriate assessment scores and a writing sample or completion of ESL 71",
+    "courses": [
+      "ESL 71"
+    ]
+  },
+  "ESL 81": {
+    "text": "Placement According to KCTCS Assessment and Placement Policy",
+    "courses": []
+  },
+  "ESL 82": {
+    "text": "Currently appropriate assessment scores or completion of ESL 81",
+    "courses": [
+      "ESL 81"
+    ]
+  },
+  "ESL 91": {
+    "text": "placement test",
+    "courses": []
+  },
+  "EST 141": {
+    "text": "EST 140",
+    "courses": [
+      "EST 140"
+    ]
+  },
+  "EST 161": {
+    "text": "If yes, list: EST 160 Hydrologic Geology or approval of the Environmental Science Technology Program Coordinator",
+    "courses": [
+      "EST 160"
+    ]
+  },
+  "EST 170": {
+    "text": "EST 150 or consent of instructor",
+    "courses": [
+      "EST 150"
+    ]
+  },
+  "EST 220": {
+    "text": "(EST 140 or EST 150) and EST 160, CHE 170, and CHE 175 or consent of instructor",
+    "courses": [
+      "CHE 170",
+      "CHE 175",
+      "EST 140",
+      "EST 150",
+      "EST 160"
+    ]
+  },
+  "EST 230": {
+    "text": "CHE 170, CHE 175, and EST 220",
+    "courses": [
+      "CHE 170",
+      "CHE 175",
+      "EST 220"
+    ]
+  },
+  "EST 240": {
+    "text": "[(EST 140 and EST 141) or EST 150] and Digital Literacy Course (OST 105 or CAD 100 or IMD 100 or CIT 105) or consent of instructor",
+    "courses": [
+      "CAD 100",
+      "CIT 105",
+      "EST 140",
+      "EST 141",
+      "EST 150",
+      "IMD 100",
+      "OST 105"
+    ]
+  },
+  "EST 250": {
+    "text": "EST 150 and EST 160, or consent of instructor",
+    "courses": [
+      "EST 150",
+      "EST 160"
+    ]
+  },
+  "EST 260": {
+    "text": "CHE 170, CHE 175, EST 170",
+    "courses": [
+      "CHE 170",
+      "CHE 175",
+      "EST 170"
+    ]
+  },
+  "EST 270": {
+    "text": "EST 220, EST 240, and EST 250 or consent of instructor",
+    "courses": [
+      "EST 220",
+      "EST 240",
+      "EST 250"
+    ]
+  },
+  "EST 290": {
+    "text": "Consent of EST Program Coordinator",
+    "courses": []
+  },
+  "EX 196": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "FAM 252": {
+    "text": "3.0 credit hours of social or behavioral science or consent of instructor",
+    "courses": []
+  },
+  "FAM 253": {
+    "text": "3.0 credit hours in social or behavioral science or consent of instructor",
+    "courses": []
+  },
+  "FAM 255": {
+    "text": "3.0 credit hours of social or behavioral science or consent of instructor",
+    "courses": []
+  },
+  "FIR 105": {
+    "text": "FIR 101, FIR 102, FIR 103, FIR 104",
+    "courses": [
+      "FIR 101",
+      "FIR 102",
+      "FIR 103",
+      "FIR 104"
+    ]
+  },
+  "FIR 198": {
+    "text": "FIR 105 or Instructor Consent",
+    "courses": [
+      "FIR 105"
+    ]
+  },
+  "FIR 202": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "FIR 203": {
+    "text": "FIR 202 or Instructor Consent",
+    "courses": [
+      "FIR 202"
+    ]
+  },
+  "FIR 206": {
+    "text": "FIR 205 or Instructor Consent",
+    "courses": [
+      "FIR 205"
+    ]
+  },
+  "FIR 207": {
+    "text": "FIR 206 or Instructor Consent",
+    "courses": [
+      "FIR 206"
+    ]
+  },
+  "FIR 208": {
+    "text": "FIR 207 or Instructor Consent",
+    "courses": [
+      "FIR 207"
+    ]
+  },
+  "FIR 212": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "FIR 213": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "FIR 220": {
+    "text": "FIR 106 or FIR 1062 Hazardous Material Operations",
+    "courses": [
+      "FIR 106",
+      "FIR 1062"
+    ]
+  },
+  "FIR 225": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "FIR 230": {
+    "text": "Minimum ACT Reading Score of 15 or Consent of Instructor",
+    "courses": []
+  },
+  "FIR 240": {
+    "text": "FIR 106 or FIR 1061 or Instructor Consent",
+    "courses": [
+      "FIR 106",
+      "FIR 1061"
+    ]
+  },
+  "FIR 261": {
+    "text": "FIR 260 or Instructor Consent",
+    "courses": [
+      "FIR 260"
+    ]
+  },
+  "FIR 262": {
+    "text": "FIR 260 or Instructor Consent",
+    "courses": [
+      "FIR 260"
+    ]
+  },
+  "FIR 263": {
+    "text": "FIR 260 or Consent of Instructor",
+    "courses": [
+      "FIR 260"
+    ]
+  },
+  "FIR 264": {
+    "text": "FIR 260 Or Instructor Consent",
+    "courses": [
+      "FIR 260"
+    ]
+  },
+  "FIR 265": {
+    "text": "FIR 260 or Instructor Consent",
+    "courses": [
+      "FIR 260"
+    ]
+  },
+  "FIR 280": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "FIR 281": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "FIR 282": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "FLM 210": {
+    "text": "(FLM 112 AND FLM 122 AND FLM 132 AND FLM 140) OR Consent of Instructor",
+    "courses": [
+      "FLM 112",
+      "FLM 122",
+      "FLM 132",
+      "FLM 140"
+    ]
+  },
+  "FLM 260": {
+    "text": "(FLM 112 AND FLM 122 AND FLM 132 AND FLM 140) OR Consent of Instructor",
+    "courses": [
+      "FLM 112",
+      "FLM 122",
+      "FLM 132",
+      "FLM 140"
+    ]
+  },
+  "FLM 261": {
+    "text": "FLM 112 AND FLM 122 AND FLM 132 AND FLM 140 AND FLM 260",
+    "courses": [
+      "FLM 112",
+      "FLM 122",
+      "FLM 132",
+      "FLM 140",
+      "FLM 260"
+    ]
+  },
+  "FLM 291": {
+    "text": "(FLM 112 AND FLM 122 AND FLM 132 AND FLM 140) or Consent of Instructor",
+    "courses": [
+      "FLM 112",
+      "FLM 122",
+      "FLM 132",
+      "FLM 140"
+    ]
+  },
+  "FLS 210U": {
+    "text": "Basic proficiency in the language and departmental approval",
+    "courses": []
+  },
+  "FRE 102": {
+    "text": "FRE 101 or consent of the department, instructor and/or placement test",
+    "courses": [
+      "FRE 101"
+    ]
+  },
+  "FRE 202": {
+    "text": "FRE 201 or three years of high school French and placement test",
+    "courses": [
+      "FRE 201"
+    ]
+  },
+  "FRM 100": {
+    "text": "Students must be 21 years of age",
+    "courses": []
+  },
+  "FRM 110": {
+    "text": "Students must be 21 years of age, and FRM 100 or consent of instructor",
+    "courses": [
+      "FRM 100"
+    ]
+  },
+  "FRM 120": {
+    "text": "Students must be 21 years of age & FRM 100",
+    "courses": [
+      "FRM 100"
+    ]
+  },
+  "FRM 130": {
+    "text": "Students must be 21 years of age, FRM 100 & FRM 110",
+    "courses": [
+      "FRM 100",
+      "FRM 110"
+    ]
+  },
+  "FRM 140": {
+    "text": "Students must be 21 years of age, FRM 100 & FRM 110",
+    "courses": [
+      "FRM 100",
+      "FRM 110"
+    ]
+  },
+  "FRM 150": {
+    "text": "Students must be 21 years of age, FRM 100 & FRM 110",
+    "courses": [
+      "FRM 100",
+      "FRM 110"
+    ]
+  },
+  "FRM 160": {
+    "text": "Students must be 21 years of age, FRM 100 & FRM 110",
+    "courses": [
+      "FRM 100",
+      "FRM 110"
+    ]
+  },
+  "FWT 130": {
+    "text": "FWT 120 and proof of valid second class (or higher) medical certificate",
+    "courses": [
+      "FWT 120"
+    ]
+  },
+  "FWT 140": {
+    "text": "FWT 120 and FWT 130",
+    "courses": [
+      "FWT 120",
+      "FWT 130"
+    ]
+  },
+  "FWT 150": {
+    "text": "FWT 120, FWT 130, and FWT 140",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140"
+    ]
+  },
+  "FWT 160": {
+    "text": "FWT 120, FWT 130, FWT 140 and FWT 150",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150"
+    ]
+  },
+  "FWT 170": {
+    "text": "FWT 120, FWT 130, FWT 140, FWT 150, and FWT 160",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160"
+    ]
+  },
+  "FWT 171": {
+    "text": "FWT 120, FWT 130, FWT 140, FWT 150, FWT 160, and FWT 170",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160",
+      "FWT 170"
+    ]
+  },
+  "FWT 172": {
+    "text": "FWT 120, FWT 130, FWT 140, FWT 150, FWT 160, FWT 170, and FWT 171",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160",
+      "FWT 170",
+      "FWT 171"
+    ]
+  },
+  "FWT 173": {
+    "text": "FWT 120, FWT 130, FWT 140, FWT 150, FWT 160 FWT 170 and FWT 171",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160",
+      "FWT 170",
+      "FWT 171"
+    ]
+  },
+  "FWT 180": {
+    "text": "FWT 120 (or Private Pilot Certificate), FWT 130, FWT 140, FWT 150, FWT 160, FWT 170, FWT 171, and FWT 172 or FWT 173",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160",
+      "FWT 170",
+      "FWT 171",
+      "FWT 172",
+      "FWT 173"
+    ]
+  },
+  "FWT 190": {
+    "text": "FWT 120, FWT 130, FWT 140, FWT 150, FWT 160, FWT 170, FWT 171, FWT 180, and FWT 172 or FWT 173",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160",
+      "FWT 170",
+      "FWT 171",
+      "FWT 172",
+      "FWT 173",
+      "FWT 180"
+    ]
+  },
+  "FWT 191": {
+    "text": "FWT 120, FWT 130, FWT 140, FWT 150, FWT 160, FWT 170, FWT 171, FWT 180 and FWT 190 and FWT 172 or FWT 173",
+    "courses": [
+      "FWT 120",
+      "FWT 130",
+      "FWT 140",
+      "FWT 150",
+      "FWT 160",
+      "FWT 170",
+      "FWT 171",
+      "FWT 172",
+      "FWT 173",
+      "FWT 180",
+      "FWT 190"
+    ]
+  },
+  "GEN 225": {
+    "text": "GE 175 or Consent of Instructor",
+    "courses": [
+      "GE 175"
+    ]
+  },
+  "GEO 131": {
+    "text": "GEO 130",
+    "courses": [
+      "GEO 130"
+    ]
+  },
+  "GEO 251": {
+    "text": "GEO 130 or consent of instructor",
+    "courses": [
+      "GEO 130"
+    ]
+  },
+  "GEO 299": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "GER 102": {
+    "text": "GER 101 or consent of the department, instructor and/or placement test",
+    "courses": [
+      "GER 101"
+    ]
+  },
+  "GER 201": {
+    "text": "GER 102, or equivalent or placement test",
+    "courses": [
+      "GER 102"
+    ]
+  },
+  "GER 202": {
+    "text": "GER 201 or equivalent or placement test",
+    "courses": [
+      "GER 201"
+    ]
+  },
+  "GIS 145": {
+    "text": "CIT 125 or consent of instructor",
+    "courses": [
+      "CIT 125"
+    ]
+  },
+  "GIS 255": {
+    "text": "CIT 125 or consent of instructor",
+    "courses": [
+      "CIT 125"
+    ]
+  },
+  "GIS 260": {
+    "text": "CIT 125 or consent of instructor",
+    "courses": [
+      "CIT 125"
+    ]
+  },
+  "GLY 101": {
+    "text": "GLY 111",
+    "courses": [
+      "GLY 111"
+    ]
+  },
+  "GLY 114": {
+    "text": "GLY 110",
+    "courses": [
+      "GLY 110"
+    ]
+  },
+  "GLY 131": {
+    "text": "GLY 130",
+    "courses": [
+      "GLY 130"
+    ]
+  },
+  "HEO 130": {
+    "text": "DIT 103",
+    "courses": [
+      "DIT 103"
+    ]
+  },
+  "HEO 131": {
+    "text": "DIT 103",
+    "courses": [
+      "DIT 103"
+    ]
+  },
+  "HEO 132": {
+    "text": "DIT 103",
+    "courses": [
+      "DIT 103"
+    ]
+  },
+  "HEO 133": {
+    "text": "DIT 103",
+    "courses": [
+      "DIT 103"
+    ]
+  },
+  "HEO 134": {
+    "text": "DIT 103",
+    "courses": [
+      "DIT 103"
+    ]
+  },
+  "HFL 130": {
+    "text": "HFL 100",
+    "courses": [
+      "HFL 100"
+    ]
+  },
+  "HFL 140": {
+    "text": "HFL 100",
+    "courses": [
+      "HFL 100"
+    ]
+  },
+  "HFL 150": {
+    "text": "HFL 100",
+    "courses": [
+      "HFL 100"
+    ]
+  },
+  "HFL 230": {
+    "text": "HFL 130",
+    "courses": [
+      "HFL 130"
+    ]
+  },
+  "HFL 240": {
+    "text": "HFL 140",
+    "courses": [
+      "HFL 140"
+    ]
+  },
+  "HFL 250": {
+    "text": "HFL 150",
+    "courses": [
+      "HFL 150"
+    ]
+  },
+  "HFL 270": {
+    "text": "HFL 260 Healthcare Facilities Leadership Capstone I",
+    "courses": [
+      "HFL 260"
+    ]
+  },
+  "HFT 102": {
+    "text": "HFT 101 and Proof of valid Second Class (or higher) Medical Certificate",
+    "courses": [
+      "HFT 101"
+    ]
+  },
+  "HFT 103": {
+    "text": "HFT 101",
+    "courses": [
+      "HFT 101"
+    ]
+  },
+  "HFT 104": {
+    "text": "HFT 101, HFT 102, and HFT 103",
+    "courses": [
+      "HFT 101",
+      "HFT 102",
+      "HFT 103"
+    ]
+  },
+  "HFT 105": {
+    "text": "HFT 101 or Private Pilot Certificate",
+    "courses": [
+      "HFT 101"
+    ]
+  },
+  "HFT 106": {
+    "text": "HFT 101, HFT 102, HFT 103, HFT 104, and HFT 105",
+    "courses": [
+      "HFT 101",
+      "HFT 102",
+      "HFT 103",
+      "HFT 104",
+      "HFT 105"
+    ]
+  },
+  "HFT 210": {
+    "text": "HFT 101 (or Private Pilot Certificate), HFT 102, HFT 103, HFT 104, HFT 105, HFT 106",
+    "courses": [
+      "HFT 101",
+      "HFT 102",
+      "HFT 103",
+      "HFT 104",
+      "HFT 105",
+      "HFT 106"
+    ]
+  },
+  "HFT 220": {
+    "text": "HFT 101, HFT 102, HFT 103, HFT 104, HFT 105, HFT 106, HFT 210",
+    "courses": [
+      "HFT 101",
+      "HFT 102",
+      "HFT 103",
+      "HFT 104",
+      "HFT 105",
+      "HFT 106",
+      "HFT 210"
+    ]
+  },
+  "HFT 299": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "HIS 271": {
+    "text": "Sophomore standing",
+    "courses": []
+  },
+  "HIS 296": {
+    "text": "Sophomore standing or consent of instructor",
+    "courses": []
+  },
+  "HIS 299": {
+    "text": "Sophomore standing or Consent of Instructor",
+    "courses": []
+  },
+  "HIT 100": {
+    "text": "Admission to the Health Information Technology Program or Medical Record Coding Specialist Certificate or Release of Information Data Specialist Certificate or by special permission of the Program Coordinator and Computer Literacy",
+    "courses": []
+  },
+  "HIT 105": {
+    "text": "[HIT 100 and (BIO 135 or BIO 137) and (CLA 131 or AHS 115 or MIT 103)]",
+    "courses": [
+      "AHS 115",
+      "BIO 135",
+      "BIO 137",
+      "CLA 131",
+      "HIT 100",
+      "MIT 103"
+    ]
+  },
+  "HIT 109": {
+    "text": "HIT 105",
+    "courses": [
+      "HIT 105"
+    ]
+  },
+  "HIT 110": {
+    "text": "Admission to the Health Information Technology Program or Medical Record Coding Specialist Certificate or Release of Information Data Specialist or by special permission of the Program Coordinator",
+    "courses": []
+  },
+  "HIT 112": {
+    "text": "Admission to the Health Information Technology Program or Medical Record Coding Certificate or by special permission of the Program Coordinator",
+    "courses": []
+  },
+  "HIT 200": {
+    "text": "Admission to the Health Information Technology Program or Medical Record Coding Specialist Certificate or by special permission of the Program Coordinator and (HIT 109 and HIT 110 and HIT 112)",
+    "courses": [
+      "HIT 109",
+      "HIT 110",
+      "HIT 112"
+    ]
+  },
+  "HIT 202": {
+    "text": "Admission to the Health Information Technology Program or Medical Record Coding Specialist Certificate or by special permission of the Program Coordinator",
+    "courses": []
+  },
+  "HIT 205": {
+    "text": "HIT 109 and HIT 110",
+    "courses": [
+      "HIT 109",
+      "HIT 110"
+    ]
+  },
+  "HIT 207": {
+    "text": "HIT 109 and HIT 202",
+    "courses": [
+      "HIT 109",
+      "HIT 202"
+    ]
+  },
+  "HIT 211": {
+    "text": "HIT 109 and HIT 110",
+    "courses": [
+      "HIT 109",
+      "HIT 110"
+    ]
+  },
+  "HIT 215": {
+    "text": "HIT 200 and HIT 202 and HIT 205",
+    "courses": [
+      "HIT 200",
+      "HIT 202",
+      "HIT 205"
+    ]
+  },
+  "HIT 2151": {
+    "text": "HIT 200 and HIT 202 and HIT 205",
+    "courses": [
+      "HIT 200",
+      "HIT 202",
+      "HIT 205"
+    ]
+  },
+  "HIT 2152": {
+    "text": "HIT 200 and HIT 202 and HIT 205",
+    "courses": [
+      "HIT 200",
+      "HIT 202",
+      "HIT 205"
+    ]
+  },
+  "HMS 103": {
+    "text": "(HMS 101 and HMS 102 with a grade of \"C\" or better) or Consent of Instructor",
+    "courses": [
+      "HMS 101",
+      "HMS 102"
+    ]
+  },
+  "HMS 104": {
+    "text": "HMS103 with a grade of \"C\" or better or Consent of Instructor",
+    "courses": []
+  },
+  "HMS 200": {
+    "text": "PSY 110 or Consent of Instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "HMS 211": {
+    "text": "PSY 110 or Consent of Instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "HMS 212": {
+    "text": "PSY 110 or Consent of Instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "HMS 235": {
+    "text": "PSY 110 or Consent of Instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "HMS 245": {
+    "text": "NAA 100 or MNA 100, PSY 110 and HMS 103 with a grade of \"C\" or better or consent of instructor",
+    "courses": [
+      "HMS 103",
+      "MNA 100",
+      "NAA 100",
+      "PSY 110"
+    ]
+  },
+  "HMS 248": {
+    "text": "HMS 104 or Consent of Instructor",
+    "courses": [
+      "HMS 104"
+    ]
+  },
+  "HMS 251": {
+    "text": "HMS 101, HMS 102, HMS 103, HMS 104 or Consent of Instructor",
+    "courses": [
+      "HMS 101",
+      "HMS 102",
+      "HMS 103",
+      "HMS 104"
+    ]
+  },
+  "HNR 101": {
+    "text": "Admission in the Honors program",
+    "courses": []
+  },
+  "HRS 200": {
+    "text": "Superior academic ability as demonstrated by tests, classwork, and interviews",
+    "courses": []
+  },
+  "HST 122": {
+    "text": "BIO 137 or BIO 135",
+    "courses": [
+      "BIO 135",
+      "BIO 137"
+    ]
+  },
+  "HUM 230": {
+    "text": "ENG 102 or ENG 105 or consent of instructor",
+    "courses": [
+      "ENG 102",
+      "ENG 105"
+    ]
+  },
+  "HUM 250": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUM 251": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "IEC 170": {
+    "text": "IEC 101 or IEC 102 or IEC 130 or permission of IECE program coordinator",
+    "courses": [
+      "IEC 101",
+      "IEC 102",
+      "IEC 130"
+    ]
+  },
+  "IEC 180": {
+    "text": "IEC 101 or IEC 102 or IEC 130 or permission of IECE program coordinator",
+    "courses": [
+      "IEC 101",
+      "IEC 102",
+      "IEC 130"
+    ]
+  },
+  "IEC 200": {
+    "text": "IEC 101 or IEC 130 or permission of the IECE program coordinator",
+    "courses": [
+      "IEC 101",
+      "IEC 130"
+    ]
+  },
+  "IEC 216": {
+    "text": "IEC 180 or permission of the IECE program coordinator",
+    "courses": [
+      "IEC 180"
+    ]
+  },
+  "IEC 221": {
+    "text": "IEC 180 or permission of the IECE program coordinator",
+    "courses": [
+      "IEC 180"
+    ]
+  },
+  "IEC 235": {
+    "text": "IEC 180 or permission of the IECE program coordinator",
+    "courses": [
+      "IEC 180"
+    ]
+  },
+  "IEC 246": {
+    "text": "IEC 180 or permission of IECE program coordinator",
+    "courses": [
+      "IEC 180"
+    ]
+  },
+  "IEC 295": {
+    "text": "Program Coordinator's Approval",
+    "courses": []
+  },
+  "IET 121": {
+    "text": "MAT 126 or higher-level math course",
+    "courses": [
+      "MAT 126"
+    ]
+  },
+  "IET 202": {
+    "text": "IET 121, or EET 119, or ELT 110 or (IMT 110 and IMT 111)",
+    "courses": [
+      "EET 119",
+      "ELT 110",
+      "IET 121",
+      "IMT 110",
+      "IMT 111"
+    ]
+  },
+  "IET 204": {
+    "text": "[IET 121 or ELT 110 or EET 119 or (IMT 110 and IMT 111) with a minimum letter grade of \"C\"] and [IET 202 or (EET 270 and 271) or (IMT 220 and 221) with a minimum letter grade of \"C\"] or consent of Integrated Engineering Technology program coordinator",
+    "courses": [
+      "EET 119",
+      "EET 270",
+      "ELT 110",
+      "IET 121",
+      "IET 202",
+      "IMT 110",
+      "IMT 111",
+      "IMT 220"
+    ]
+  },
+  "IEX 293": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "IEX 295": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "IFM 111": {
+    "text": "Computer Literacy or consent of instructor",
+    "courses": []
+  },
+  "IFM 211": {
+    "text": "Computer Literacy",
+    "courses": []
+  },
+  "IFM 215": {
+    "text": "Digital Literacy or Consent of Instructor",
+    "courses": []
+  },
+  "IFM 225": {
+    "text": "Computer Literacy",
+    "courses": []
+  },
+  "IMD 124": {
+    "text": "CIT 105 or IMD 100 or Consent of Instructor",
+    "courses": [
+      "CIT 105",
+      "IMD 100"
+    ]
+  },
+  "IMD 127": {
+    "text": "IMD 115 or concurrent or consent of instructor",
+    "courses": [
+      "IMD 115"
+    ]
+  },
+  "IMD 165": {
+    "text": "CIT124/IMD 124 or CIT 221/IMD 221",
+    "courses": [
+      "CIT 221",
+      "IMD 124",
+      "IMD 221"
+    ]
+  },
+  "IMD 180": {
+    "text": "IMD 133 OR Consent of Instructor",
+    "courses": [
+      "IMD 133"
+    ]
+  },
+  "IMD 221": {
+    "text": "CIT 105 or IMD 100 or Consent of Instructor",
+    "courses": [
+      "CIT 105",
+      "IMD 100"
+    ]
+  },
+  "IMD 222": {
+    "text": "CIT 221 or IMD 221 or Consent of Instructor",
+    "courses": [
+      "CIT 221",
+      "IMD 221"
+    ]
+  },
+  "IMD 223": {
+    "text": "CIT/IMD 124 AND CIT/IMD 222 or Consent of Instructor",
+    "courses": [
+      "IMD 124",
+      "IMD 222"
+    ]
+  },
+  "IMD 226": {
+    "text": "IMD 126 and IMD 127 and IMD 128",
+    "courses": [
+      "IMD 126",
+      "IMD 127",
+      "IMD 128"
+    ]
+  },
+  "IMD 228": {
+    "text": "IMD 115 and IMD 128",
+    "courses": [
+      "IMD 115",
+      "IMD 128"
+    ]
+  },
+  "IMD 229": {
+    "text": "IMD 127",
+    "courses": [
+      "IMD 127"
+    ]
+  },
+  "IMD 240": {
+    "text": "IMD 133 or consent of instructor",
+    "courses": [
+      "IMD 133"
+    ]
+  },
+  "IMD 255": {
+    "text": "IMD 250 or consent of instructor",
+    "courses": [
+      "IMD 250"
+    ]
+  },
+  "IMD 258": {
+    "text": "IMD 250 or consent of instructor",
+    "courses": [
+      "IMD 250"
+    ]
+  },
+  "IMD 270": {
+    "text": "sophomore status & preparing for job search",
+    "courses": []
+  },
+  "IMD 271": {
+    "text": "Consent of Instructor, 2.0 GPA, IMD 270 and the completion of 9 additional credit hours of IMD course work",
+    "courses": [
+      "IMD 270"
+    ]
+  },
+  "IMD 273": {
+    "text": "CIT/IMD 124 AND CIT/IMD 222 or Consent of Instructor",
+    "courses": [
+      "IMD 124",
+      "IMD 222"
+    ]
+  },
+  "IMD 274": {
+    "text": "((CIT 223 or IMD 223) AND (CIT 273 or IMD 273)) or Consent of Instructor",
+    "courses": [
+      "CIT 223",
+      "CIT 273",
+      "IMD 223",
+      "IMD 273"
+    ]
+  },
+  "IMD 277": {
+    "text": "(IMD 115 and IMD 126 and IMD 127and IMD 128) or consent of instructor",
+    "courses": [
+      "IMD 115",
+      "IMD 126",
+      "IMD 128"
+    ]
+  },
+  "IMD 280": {
+    "text": "(IMD 127 and IMD 128 and IMD 185 and IMD 226) or Consent of Instructor",
+    "courses": [
+      "IMD 127",
+      "IMD 128",
+      "IMD 185",
+      "IMD 226"
+    ]
+  },
+  "IMG 100": {
+    "text": "Admissions to the radiography program and BIO 139 with a minimum grade of \"C\"",
+    "courses": [
+      "BIO 139"
+    ]
+  },
+  "IMG 101": {
+    "text": "Admissions to the radiography program and BIO 139 with a minimum grade of \"C\"",
+    "courses": [
+      "BIO 139"
+    ]
+  },
+  "IMG 104": {
+    "text": "BIO 137 with a minimum grade of C",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "IMG 106": {
+    "text": "BIO 137",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "IMG 108": {
+    "text": "BIO 137",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "IMG 109": {
+    "text": "BIO 137",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "IMG 110": {
+    "text": "IMG 100 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 100"
+    ]
+  },
+  "IMG 111": {
+    "text": "IMG 101 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 101"
+    ]
+  },
+  "IMG 114": {
+    "text": "IMG 104, IMG 106, IMG 108 and IMG 109",
+    "courses": [
+      "IMG 104",
+      "IMG 106",
+      "IMG 108",
+      "IMG 109"
+    ]
+  },
+  "IMG 116": {
+    "text": "IMG 104, IMG 106, IMG 108 and IMG 109",
+    "courses": [
+      "IMG 104",
+      "IMG 106",
+      "IMG 108",
+      "IMG 109"
+    ]
+  },
+  "IMG 118": {
+    "text": "IMG 104, IMG 106, IMG 108 and IMG 109",
+    "courses": [
+      "IMG 104",
+      "IMG 106",
+      "IMG 108",
+      "IMG 109"
+    ]
+  },
+  "IMG 119": {
+    "text": "IMG 104, IMG 106, IMG 108 and IMG 109",
+    "courses": [
+      "IMG 104",
+      "IMG 106",
+      "IMG 108",
+      "IMG 109"
+    ]
+  },
+  "IMG 201": {
+    "text": "IMG 111 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 111"
+    ]
+  },
+  "IMG 209": {
+    "text": "IMG 114, IMG 116, IMG 118 and IMG 119",
+    "courses": [
+      "IMG 114",
+      "IMG 116",
+      "IMG 118",
+      "IMG 119"
+    ]
+  },
+  "IMG 210": {
+    "text": "IMG 201 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 201"
+    ]
+  },
+  "IMG 211": {
+    "text": "IMG 201 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 201"
+    ]
+  },
+  "IMG 214": {
+    "text": "IMG 209",
+    "courses": [
+      "IMG 209"
+    ]
+  },
+  "IMG 216": {
+    "text": "IMG 209",
+    "courses": [
+      "IMG 209"
+    ]
+  },
+  "IMG 219": {
+    "text": "IMG 209",
+    "courses": [
+      "IMG 209"
+    ]
+  },
+  "IMG 220": {
+    "text": "IMG 210 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 210"
+    ]
+  },
+  "IMG 221": {
+    "text": "IMG 211 with a minimum grade of \"C\"",
+    "courses": [
+      "IMG 211"
+    ]
+  },
+  "IMG 224": {
+    "text": "IMG 214 and IMG 216 and IMG 219",
+    "courses": [
+      "IMG 214",
+      "IMG 216",
+      "IMG 219"
+    ]
+  },
+  "IMG 226": {
+    "text": "IMG 214 and IMG 216 and IMG 219",
+    "courses": [
+      "IMG 214",
+      "IMG 216",
+      "IMG 219"
+    ]
+  },
+  "IMG 228": {
+    "text": "IMG 214, IMG 216 and IMG 219",
+    "courses": [
+      "IMG 214",
+      "IMG 216",
+      "IMG 219"
+    ]
+  },
+  "IMG 229": {
+    "text": "IMG 214, IMG 216 and IMG 219",
+    "courses": [
+      "IMG 214",
+      "IMG 216",
+      "IMG 219"
+    ]
+  },
+  "IMG 230": {
+    "text": "((IMG 201 or IMG 216 or DMI 130) with a minimum grade of C) or consent of instructor defined by enrollment in an accredited Nuclear Medicine program or enrollment in second year of an accredited Radiography program or ARRT registry or NMTCB registry",
+    "courses": [
+      "DMI 130",
+      "IMG 201",
+      "IMG 216"
+    ]
+  },
+  "IMG 240": {
+    "text": "((IMG 201 or IMG 216 or DMI 130) with a minimum grade of C) or consent of instructor defined by enrollment in an accredited Nuclear Medicine program or enrollment in second year of an accredited Radiography program or ARRT registry or NMTCB registry",
+    "courses": [
+      "DMI 130",
+      "IMG 201",
+      "IMG 216"
+    ]
+  },
+  "IMG 250": {
+    "text": "((IMG 201 or IMG 216 or DMI 130) with a minimum grade of C) or consent of instructor defined by enrollment in an accredited Nuclear Medicine program or enrollment in second year of an accredited Radiography program or ARRT registry or NMTCB registry",
+    "courses": [
+      "DMI 130",
+      "IMG 201",
+      "IMG 216"
+    ]
+  },
+  "IMG 255": {
+    "text": "((IMG 201 or IMG 216 or DMI 130) with a minimum grade of C) or consent of instructor defined by enrollment in an accredited Nuclear Medicine program or enrollment in second year of an accredited Radiography program or ARRT registry or NMTCB registry",
+    "courses": [
+      "DMI 130",
+      "IMG 201",
+      "IMG 216"
+    ]
+  },
+  "IMG 260": {
+    "text": "((IMG 201 or IMG 216 or DMI 130) with a minimum grade of C) or consent of instructor defined by enrollment in an accredited Nuclear Medicine program or enrollment in second year of an accredited Radiography program or ARRT registry or NMTCB registry",
+    "courses": [
+      "DMI 130",
+      "IMG 201",
+      "IMG 216"
+    ]
+  },
+  "IMG 265": {
+    "text": "((IMG 201 or IMG 216 or DMI 130) with a minimum grade of C) or consent of instructor defined by enrollment in an accredited Nuclear Medicine program or enrollment in second year of an accredited Radiography program or ARRT registry or NMTCB registry",
+    "courses": [
+      "DMI 130",
+      "IMG 201",
+      "IMG 216"
+    ]
+  },
+  "IMG 285": {
+    "text": "ARRT registered as a Radiographer or Nuclear Medicine Technologist, or NMTCB registered as a Nuclear Medicine Technologist, and Kentucky radiography license or a provisional license as a nuclear medicine technologist to perform CT",
+    "courses": []
+  },
+  "IMG 295": {
+    "text": "IMG 255 and IMG 265",
+    "courses": [
+      "IMG 255",
+      "IMG 265"
+    ]
+  },
+  "IMT 120": {
+    "text": "Permission of the instructor",
+    "courses": []
+  },
+  "IMT 198": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "IMT 199": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "IMT 200": {
+    "text": "IMT 110 and IMT 111 or Consent of Instructor",
+    "courses": [
+      "IMT 110",
+      "IMT 111"
+    ]
+  },
+  "IMT 220": {
+    "text": "IMT 110, & IMT 111",
+    "courses": [
+      "IMT 110",
+      "IMT 111"
+    ]
+  },
+  "IMT 221": {
+    "text": "(IMT 110 and IMT 111) or consent of instructor",
+    "courses": [
+      "IMT 110",
+      "IMT 111"
+    ]
+  },
+  "IMT 222": {
+    "text": "(IMT 110 and IMT 111 and IMT 220 and IMT 221) or consent of instructor",
+    "courses": [
+      "IMT 110",
+      "IMT 111",
+      "IMT 220",
+      "IMT 221"
+    ]
+  },
+  "IMT 223": {
+    "text": "(IMT 110 and IMT 111 and IMT 220 and IMT 221) or consent of instructor",
+    "courses": [
+      "IMT 110",
+      "IMT 111",
+      "IMT 220",
+      "IMT 221"
+    ]
+  },
+  "IMT 230": {
+    "text": "IMT 240",
+    "courses": [
+      "IMT 240"
+    ]
+  },
+  "IMT 231": {
+    "text": "[(IMT 110 and 111) or IMT 130 and 131) with a grade of C or greater] or Consent of Instructor",
+    "courses": [
+      "IMT 110",
+      "IMT 130"
+    ]
+  },
+  "IMT 250": {
+    "text": "(IMT 150 and 151) with a grade of \"C\" or greater or consent of instructor",
+    "courses": [
+      "IMT 150"
+    ]
+  },
+  "IMT 251": {
+    "text": "(IMT 150 and 151) with a grade of \"C\" or greater or consent of instructor",
+    "courses": [
+      "IMT 150"
+    ]
+  },
+  "IMT 260": {
+    "text": "IMT 100 and IMT 101 and [(IMT 115 & IMT 116) or (MTT 114) or (MTT 110 & MTT 112)] or consent of instructor",
+    "courses": [
+      "IMT 100",
+      "IMT 101",
+      "IMT 115",
+      "IMT 116",
+      "MTT 110",
+      "MTT 112",
+      "MTT 114"
+    ]
+  },
+  "IMT 280": {
+    "text": "((IMT 220 and IMT221with a grade of \"C\" or greater) or (equivalent) or Consent of Instructor)",
+    "courses": [
+      "IMT 220"
+    ]
+  },
+  "IMT 281": {
+    "text": "(IMT 220 and 221) with a grade of C or greater) or Consent of Instructor",
+    "courses": [
+      "IMT 220"
+    ]
+  },
+  "IMT 282": {
+    "text": "IMT 280 or ELT 250 or EET 276 and EET 277 or Consent of Instructor",
+    "courses": [
+      "EET 276",
+      "EET 277",
+      "ELT 250",
+      "IMT 280"
+    ]
+  },
+  "IMT 289": {
+    "text": "((BRX 120 or ELT 102) and FPX 100 and FPX 101 and IMT 100 and IMT 101 and IMT 110 and IMT 111 and IMT 150 and 151 and IMT 220 and IMT 221) or consent of instructor",
+    "courses": [
+      "BRX 120",
+      "ELT 102",
+      "FPX 100",
+      "FPX 101",
+      "IMT 100",
+      "IMT 101",
+      "IMT 110",
+      "IMT 111",
+      "IMT 150",
+      "IMT 220",
+      "IMT 221"
+    ]
+  },
+  "IMT 290": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "IRW 100": {
+    "text": "Placement by KCTCS Assessment and Placement Policy for either Reading or English",
+    "courses": []
+  },
+  "IRW 85": {
+    "text": "Placement by KCTCS Assessment and Placement Policy",
+    "courses": []
+  },
+  "IRW 95": {
+    "text": "Placement by KCTCS Assessment and Placement Policy",
+    "courses": []
+  },
+  "JOU 204": {
+    "text": "JOU 101 or Consent of Instructor",
+    "courses": [
+      "JOU 101"
+    ]
+  },
+  "JPN 102": {
+    "text": "JPN 101 or equivalent",
+    "courses": [
+      "JPN 101"
+    ]
+  },
+  "JPN 201": {
+    "text": "JPN 102/RAE 121 or equivalent",
+    "courses": [
+      "JPN 102",
+      "RAE 121"
+    ]
+  },
+  "JPN 202": {
+    "text": "JPN 201",
+    "courses": [
+      "JPN 201"
+    ]
+  },
+  "KHP 136": {
+    "text": "Completion of comparable service course or demonstrated competency",
+    "courses": []
+  },
+  "KHP 225": {
+    "text": "BIO 135 or MSG 100 (or consent of instructor)",
+    "courses": [
+      "BIO 135",
+      "MSG 100"
+    ]
+  },
+  "KHP 235": {
+    "text": "BIO 135 or MSG 100",
+    "courses": [
+      "BIO 135",
+      "MSG 100"
+    ]
+  },
+  "KMA 100": {
+    "text": "[(MNA 100 or NAA 100 or NAA 125) and six months of work experience as a Kentucky Medicaid Nurse Aide] or Consent of instructor",
+    "courses": [
+      "MNA 100",
+      "NAA 100",
+      "NAA 125"
+    ]
+  },
+  "KMA 200": {
+    "text": "(MNA 100 or NAA 100 or HST 104 or NAA 125 and KMA) and is listed on the Kentucky Board of Nursing registry as a CMA I / KMA",
+    "courses": [
+      "HST 104",
+      "MNA 100",
+      "NAA 100",
+      "NAA 125"
+    ]
+  },
+  "LOM 101": {
+    "text": "LOM 100",
+    "courses": [
+      "LOM 100"
+    ]
+  },
+  "LOM 102": {
+    "text": "LOM 100",
+    "courses": [
+      "LOM 100"
+    ]
+  },
+  "LOM 180": {
+    "text": "Digital literacy or consent of instructor",
+    "courses": []
+  },
+  "LOM 202": {
+    "text": "LOM 102",
+    "courses": [
+      "LOM 102"
+    ]
+  },
+  "LOM 210": {
+    "text": "LOM 100 Introduction to Logistics Management",
+    "courses": [
+      "LOM 100"
+    ]
+  },
+  "MA 111U": {
+    "text": "Two years of high school algebra and a Math ACT score of 19 or above, or MA 108, or math placement test",
+    "courses": [
+      "MA 108"
+    ]
+  },
+  "MA 113U": {
+    "text": "Math ACT of 27 or above, or math SAT of 620 or above, or a grade of C or better in MA 109 (UK) and MA 112 (UK), or a grade of C or better in MA 110 (UK), or consent of the department",
+    "courses": [
+      "MA 109",
+      "MA 110",
+      "MA 112"
+    ]
+  },
+  "MA 162U": {
+    "text": "MA 109 (UK) or equivalent",
+    "courses": [
+      "MA 109"
+    ]
+  },
+  "MA 213U": {
+    "text": "A grade of C or better in MA 114 (UK) or equivalent",
+    "courses": [
+      "MA 114"
+    ]
+  },
+  "MA 214U": {
+    "text": "MA 213 or equivalent",
+    "courses": [
+      "MA 213"
+    ]
+  },
+  "MAI 105": {
+    "text": "Acceptance into the Medical Assisting program or Consent of Medical Assisting Coordinator/Director",
+    "courses": []
+  },
+  "MAI 120": {
+    "text": "Acceptance into the Medical Assisting Program or consent of Medical Assisting Coordinator/Director",
+    "courses": []
+  },
+  "MAI 125": {
+    "text": "Admission in Medical Assisting Program or Program Coordinator Permission",
+    "courses": []
+  },
+  "MAI 140": {
+    "text": "Acceptance into the Medical Assisting Program or Consent of Medical Assisting Coordinator/Director",
+    "courses": []
+  },
+  "MAI 150": {
+    "text": "Acceptance into the Medical Assisting Program or Consent of Medical Assisting Coordinator/Director",
+    "courses": []
+  },
+  "MAI 155": {
+    "text": "Admission in Medical Assisting Program or Program Coordinator Permission",
+    "courses": []
+  },
+  "MAI 162": {
+    "text": "Admission in Medical Assisting Program or Program Coordinator Permission",
+    "courses": []
+  },
+  "MAI 170": {
+    "text": "Acceptance into the Medical Assisting Program or Consent of Medical Assisting Coordinator/Director",
+    "courses": []
+  },
+  "MAI 200": {
+    "text": "(BIO 135 or BIO 137 and BIO 139) and (AHS 115 or AHS 120 or MIT 103) or Consent of Medical Assisting Coordinator/Director",
+    "courses": [
+      "AHS 115",
+      "AHS 120",
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "MIT 103"
+    ]
+  },
+  "MAI 220": {
+    "text": "MAI 120 with a grade of \"C\" or greater or Consent of Medical Assisting Coordinator/Director",
+    "courses": [
+      "MAI 120"
+    ]
+  },
+  "MAI 230": {
+    "text": "Acceptance into the Medical Assisting Program or Consent of Medical Assisting Coordinator/Director",
+    "courses": []
+  },
+  "MAI 240": {
+    "text": "MAI 140 with a grade of \"C\" or greater OR Consent of Program Coordinator",
+    "courses": [
+      "MAI 140"
+    ]
+  },
+  "MAI 262": {
+    "text": "MAI 162 with a \"C\" or higher",
+    "courses": [
+      "MAI 162"
+    ]
+  },
+  "MAI 265": {
+    "text": "Acceptance to the Medical Assisting Program and (BIO 135 or BIO 137 and BIO 139) and (AHS 115 or CLA 131 or MIT 103) with a grade of \"C\" or better, or Consent of Medical Assisting Program Coordinator/Director",
+    "courses": [
+      "AHS 115",
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "CLA 131",
+      "MIT 103"
+    ]
+  },
+  "MAI 270": {
+    "text": "(MAI 170 and (BIO 135 or BIO 137 and BIO 139) and (AHS 115 or AHS 120 or CLA 131 or MIT 103) with a grade of \"C\" or better) or Consent of Medical Assisting Program Coordinator/Director",
+    "courses": [
+      "AHS 115",
+      "AHS 120",
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "CLA 131",
+      "MAI 170",
+      "MIT 103"
+    ]
+  },
+  "MAI 281": {
+    "text": "Consent of Medical Assisting Program Coordinator/Director",
+    "courses": []
+  },
+  "MAI 284": {
+    "text": "MAI 281 and Consent of Medical Assisting Program Coordinator/Director",
+    "courses": [
+      "MAI 281"
+    ]
+  },
+  "MAI 289": {
+    "text": "Consent of Program Coordinator",
+    "courses": []
+  },
+  "MAI 299": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "MAT 100": {
+    "text": "Concurrent enrollment in MAT 150",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "MAT 105": {
+    "text": "1) MAT 61, MAT 62, MAT 65, MAT 71, MAT 75, or MAT 85; 2) Completion of MAT 55 and concurrent enrollment in MAT 105S; OR 3) KCTCS placement policy",
+    "courses": [
+      "MAT 105S",
+      "MAT 55",
+      "MAT 61",
+      "MAT 62",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75",
+      "MAT 85",
+      "OR 3"
+    ]
+  },
+  "MAT 11": {
+    "text": "KCTCS Placement Exam",
+    "courses": []
+  },
+  "MAT 110": {
+    "text": "MAT 61, MAT 62, MAT 65, MAT 71, MAT 75, or MAT 85 OR Completion of MAT 55 and concurrent enrollment in MAT 110S OR KCTCS placement policy",
+    "courses": [
+      "MAT 110S",
+      "MAT 55",
+      "MAT 61",
+      "MAT 62",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75",
+      "MAT 85"
+    ]
+  },
+  "MAT 116": {
+    "text": "MAT 61, MAT 62, MAT 65, MAT 71, MAT 75, or MAT 85 OR Completion of MAT 55 and concurrent enrollment in MAT 116S OR KCTCS placement policy",
+    "courses": [
+      "MAT 116S",
+      "MAT 55",
+      "MAT 61",
+      "MAT 62",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75",
+      "MAT 85"
+    ]
+  },
+  "MAT 126": {
+    "text": "MAT 61, MAT 65, MAT 71, MAT 75, or MAT 85, OR Completion of MAT 55 and concurrent enrollment in MAT 126S, OR KCTCS placement policy",
+    "courses": [
+      "MAT 126S",
+      "MAT 55",
+      "MAT 61",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75",
+      "MAT 85"
+    ]
+  },
+  "MAT 141": {
+    "text": "College Readiness or concurrent enrollment in MAT 141-S or MAT 61 or MAT 65 or MAT 71 or MAT 75",
+    "courses": [
+      "MAT 61",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75"
+    ]
+  },
+  "MAT 146": {
+    "text": "Math ACT score of 19 or above OR Successful completion of MAT 61, MAT 65, MAT 71, MAT 75, MAT 85, MAT 126, or equivalent OR KCTCS placement policy including concurrent enrollment in MAT 146S as appropriate",
+    "courses": [
+      "MAT 126",
+      "MAT 146S",
+      "MAT 61",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75",
+      "MAT 85"
+    ]
+  },
+  "MAT 150": {
+    "text": "1) Math ACT score of 22 or above; 2) Math ACT score of 19 -21 with concurrent MAT 100 workshop; 3) Successful completion of MAT 61, MAT 65, or MAT 75 with concurrent MAT 100 workshop; 4) Successful completion of MAT 71, MAT 85, MAT 126, or equivalent; or 5) KCTCS placement exam recommendation",
+    "courses": [
+      "MAT 100",
+      "MAT 126",
+      "MAT 61",
+      "MAT 65",
+      "MAT 71",
+      "MAT 75",
+      "MAT 85"
+    ]
+  },
+  "MAT 151": {
+    "text": "College Readiness in Mathematics",
+    "courses": []
+  },
+  "MAT 154": {
+    "text": "Completion of MAT 71 or MAT 150 or a college intermediate algebra course or two years of high school algebra",
+    "courses": [
+      "MAT 150",
+      "MAT 71"
+    ]
+  },
+  "MAT 155": {
+    "text": "Math ACT score of 22 or above OR Math ACT score of 19-21 with concurrent MAT150 OR Successful completion of Intermediate Algebra, MAT 71, MAT 126, MAT 150, or equivalent OR Placement exam recommendation",
+    "courses": [
+      "MAT 126",
+      "MAT 150",
+      "MAT 71"
+    ]
+  },
+  "MAT 160": {
+    "text": "Math ACT score of 23 or above, placement exam recommendation, or consent of instructor",
+    "courses": []
+  },
+  "MAT 161": {
+    "text": "ACT Math of 22 or MAT 71 or MAT 85 OR KCTCS placement policy and concurrent enrollment in MAT 161-S OR Completion of MAT 61 and concurrent enrollment in MAT 161-S",
+    "courses": [
+      "MAT 61",
+      "MAT 71",
+      "MAT 85"
+    ]
+  },
+  "MAT 165": {
+    "text": "MAT 150 or MAT 161 or equivalent",
+    "courses": [
+      "MAT 150",
+      "MAT 161"
+    ]
+  },
+  "MAT 170": {
+    "text": "Successful completion of MAT 150 or Math ACT 27 or above",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "MAT 171": {
+    "text": "ACT Mathematics score of 23 or equivalent, or MAT 71 or MAT 85",
+    "courses": [
+      "MAT 71",
+      "MAT 85"
+    ]
+  },
+  "MAT 174": {
+    "text": "MATH ACT score of 27 or above, or MAT 150 and MAT 154, or MAT 159, or consent of instructor",
+    "courses": [
+      "MAT 150",
+      "MAT 154",
+      "MAT 159"
+    ]
+  },
+  "MAT 175": {
+    "text": "College Algebra and Trigonometry, or equivalent, with grades of \"C\" or higher OR Math ACT 27 or above OR Placement exam recommendation OR Consent of instructor",
+    "courses": []
+  },
+  "MAT 184": {
+    "text": "MAT 174 with a grade of C or above",
+    "courses": [
+      "MAT 174"
+    ]
+  },
+  "MAT 185": {
+    "text": "Calculus I, or equivalent, with grade of \"C\" or higher, or consent of the instructor",
+    "courses": []
+  },
+  "MAT 205": {
+    "text": "MAT 141 or MAT 146 or MAT 150 or MAT 151 or MAT 161 or equivalent, with a minimum grade of \"C\"",
+    "courses": [
+      "MAT 141",
+      "MAT 146",
+      "MAT 150",
+      "MAT 151",
+      "MAT 161"
+    ]
+  },
+  "MAT 206": {
+    "text": "MAT 141 or MAT 146 or MAT 150 or MAT 151 or MAT 161 or equivalent with a minimum grade of \"C\"",
+    "courses": [
+      "MAT 141",
+      "MAT 146",
+      "MAT 150",
+      "MAT 151",
+      "MAT 161"
+    ]
+  },
+  "MAT 213": {
+    "text": "Successful completion of Calculus II",
+    "courses": []
+  },
+  "MAT 214": {
+    "text": "Successful completion of Calculus III with Linear Algebra",
+    "courses": []
+  },
+  "MAT 261": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "MAT 275": {
+    "text": "MAT185 or equivalent, or Consent of instructor",
+    "courses": []
+  },
+  "MAT 285": {
+    "text": "MAT275 or Consent of instructor",
+    "courses": []
+  },
+  "MAT 61": {
+    "text": "KCTCS Placement Policy",
+    "courses": []
+  },
+  "MAT 65": {
+    "text": "MAT 55 or KCTCS placement examination",
+    "courses": [
+      "MAT 55"
+    ]
+  },
+  "MAT 71": {
+    "text": "KCTCS placement examination",
+    "courses": []
+  },
+  "MAT 75": {
+    "text": "MAT 55 or equivalent as determined by KCTCS placement examination",
+    "courses": [
+      "MAT 55"
+    ]
+  },
+  "MAT 85": {
+    "text": "MAT 65 or MAT 75 or KCTCS placement examination",
+    "courses": [
+      "MAT 65",
+      "MAT 75"
+    ]
+  },
+  "MBS 110": {
+    "text": "((AHS 109 or BIO 130 or 135 or (BIO 137 and BIO 139) and (AHS 115 or MIT 103) and Computer Literacy and MBS 100) with a grade of C or better) or consent",
+    "courses": [
+      "AHS 109",
+      "AHS 115",
+      "BIO 130",
+      "BIO 137",
+      "BIO 139",
+      "MBS 100",
+      "MIT 103"
+    ]
+  },
+  "MBS 120": {
+    "text": "((AHS 109 or BIO 130 or 135 or (BIO 137 and BIO 139) and (AHS 115 or CLA 131 or OST 103) and Computer Literacy and MBS 100) with a grade of C or better) or consent",
+    "courses": [
+      "AHS 109",
+      "AHS 115",
+      "BIO 130",
+      "BIO 137",
+      "BIO 139",
+      "CLA 131",
+      "MBS 100",
+      "OST 103"
+    ]
+  },
+  "MBS 199": {
+    "text": "(MBS 110 and MBS 120) or Consent",
+    "courses": [
+      "MBS 110",
+      "MBS 120"
+    ]
+  },
+  "ME 220": {
+    "text": "PHY 231",
+    "courses": [
+      "PHY 231"
+    ]
+  },
+  "MES 110": {
+    "text": "(COMPASS Scores of Pre- Alg-31; Reading-70; English-39) or (ACT Score of 19 in Math and Reading and 18 in English)",
+    "courses": []
+  },
+  "MES 120": {
+    "text": "(COMPASS Scores of Pre- Alg-31; Reading-70; English-39) or (ACT Score of 19 in Math and Reading and 18 in English)",
+    "courses": []
+  },
+  "MES 130": {
+    "text": "(COMPASS Scores of Pre- Alg-31; Reading-70; English-39) or (ACT Score of 19 in Math and Reading and 18 in English) Lecture: 3.0 credits (45 contact hours)",
+    "courses": []
+  },
+  "MES 150": {
+    "text": "(COMPASS Scores of Pre-Alg-31; Reading-70; English-39) or (ACT Score of 19 in Math and Reading and 18 in English) Lecture: 3.0 credits (45 contact hours)",
+    "courses": []
+  },
+  "MFG 125": {
+    "text": "ENGT 110 and at least five other hours of approved technical electives (see Manufacturing Engineering Technology technical elective list) or consent of instructor",
+    "courses": [
+      "ENGT 110"
+    ]
+  },
+  "MFG 130": {
+    "text": "MFG125 Fundamentals of Mechatronics A or consent of instructor",
+    "courses": []
+  },
+  "MFG 135": {
+    "text": "ELT 110 or consent of instructor",
+    "courses": [
+      "ELT 110"
+    ]
+  },
+  "MFG 295": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "MGT 210": {
+    "text": "BAS 160",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "MGT 256": {
+    "text": "BAS 160",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "MGT 258": {
+    "text": "BAS 160",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "MGT 292": {
+    "text": "MGT 283 or BAS 283",
+    "courses": [
+      "BAS 283",
+      "MGT 283"
+    ]
+  },
+  "MIT 104": {
+    "text": "MIT 103 or AHS 115 or Consent of MIT Faculty",
+    "courses": [
+      "AHS 115",
+      "MIT 103"
+    ]
+  },
+  "MIT 106": {
+    "text": "Computer Literacy course and OST 110 and ENG 101 and (AHS 115 or MIT 103)",
+    "courses": [
+      "AHS 115",
+      "ENG 101",
+      "MIT 103",
+      "OST 110"
+    ]
+  },
+  "MIT 204": {
+    "text": "MIT 104, BIO 135 or Equivalent",
+    "courses": [
+      "BIO 135",
+      "MIT 104"
+    ]
+  },
+  "MIT 205": {
+    "text": "MIT 204 or MBS 120 or consent of MIT Faculty",
+    "courses": [
+      "MBS 120",
+      "MIT 204"
+    ]
+  },
+  "MIT 217": {
+    "text": "OST 110 or CIT 105 or OST 105 or consent of MIT Faculty",
+    "courses": [
+      "CIT 105",
+      "OST 105",
+      "OST 110"
+    ]
+  },
+  "MIT 219": {
+    "text": "MIT 205 or consent of MIT Faculty",
+    "courses": [
+      "MIT 205"
+    ]
+  },
+  "MIT 224": {
+    "text": "MIT 230, MIT 217, MIT 104, or consent of MIT Faculty",
+    "courses": [
+      "MIT 104",
+      "MIT 217",
+      "MIT 230"
+    ]
+  },
+  "MIT 227": {
+    "text": "MIT 104 and MIT 217 or consent of MIT Faculty",
+    "courses": [
+      "MIT 104",
+      "MIT 217"
+    ]
+  },
+  "MIT 228": {
+    "text": "MIT 217 or Consent of MIT Faculty",
+    "courses": [
+      "MIT 217"
+    ]
+  },
+  "MIT 230": {
+    "text": "Computer Literacy Course or consent of MIT Faculty",
+    "courses": []
+  },
+  "MIT 240": {
+    "text": "(ENG 101 AND MIT 103 AND (BIO 135 OR (BIO 137 AND BIO 139))) Or consent of MIT Faculty",
+    "courses": [
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "ENG 101",
+      "MIT 103"
+    ]
+  },
+  "MIT 241": {
+    "text": "MIT 240 or consent of MIT Faculty",
+    "courses": [
+      "MIT 240"
+    ]
+  },
+  "MIT 295": {
+    "text": "Consent of MIT Faculty",
+    "courses": []
+  },
+  "MKT 290": {
+    "text": "BAS 282/MKT 282",
+    "courses": [
+      "BAS 282",
+      "MKT 282"
+    ]
+  },
+  "MKT 293": {
+    "text": "BAS 291/MKT 291",
+    "courses": [
+      "BAS 291",
+      "MKT 291"
+    ]
+  },
+  "MKT 295": {
+    "text": "BAS 160",
+    "courses": [
+      "BAS 160"
+    ]
+  },
+  "MLT 101": {
+    "text": "Admission into the MLT program or permission of the MLT Program Director or MLT Clinical Coordinator",
+    "courses": []
+  },
+  "MLT 112": {
+    "text": "Admission into the MLT program or permission of the MLT program director/coordinator",
+    "courses": []
+  },
+  "MLT 115": {
+    "text": "Admission into the MLT program or permission of MLT program director/coordinator",
+    "courses": []
+  },
+  "MLT 205": {
+    "text": "[(MLT 101 and MLT 119) or BIO 225 with a grade of \"C\" or greater]; admission into the MLT program; permission by MLT program director/coordinator",
+    "courses": [
+      "BIO 225",
+      "MLT 101",
+      "MLT 119"
+    ]
+  },
+  "MLT 206": {
+    "text": "Admitted into the MLT program; permission of the MLT program director/coordinator",
+    "courses": []
+  },
+  "MLT 207": {
+    "text": "Admission into the MLT program or permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": []
+  },
+  "MLT 208": {
+    "text": "MLT 207 with a grade of \"C\" or better or permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": [
+      "MLT 207"
+    ]
+  },
+  "MLT 215": {
+    "text": "MLT 101 with a grade of \"C\" or greater or admission into the MLT program or permission by MLT program coordinator",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 216": {
+    "text": "MLT 215 with a grade of \"C\" or greater; permission by MLT program director/coordinator",
+    "courses": [
+      "MLT 215"
+    ]
+  },
+  "MLT 217": {
+    "text": "Admission into the MLT program or permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": []
+  },
+  "MLT 218": {
+    "text": "A grade of C or better in MLT 217 or permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": [
+      "MLT 217"
+    ]
+  },
+  "MLT 225": {
+    "text": "MLT 101with a grade of \"C\" or greater; admission into the MLT program; permission by MLT program director/coordinator",
+    "courses": []
+  },
+  "MLT 226": {
+    "text": "MLT 225 or Permission by MLT Program Director/Coordinator",
+    "courses": [
+      "MLT 225"
+    ]
+  },
+  "MLT 227": {
+    "text": "MLT 115 with a grade of \"C\" or greater and admission into the MLT program or permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": [
+      "MLT 115"
+    ]
+  },
+  "MLT 233": {
+    "text": "(MLT 101 with a grade of \"C\" or greater and admission into the MLT program) or MLT Program Coordinator/Director",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 234": {
+    "text": "MLT 101 with a grade of \"C\" or greater; permission by MLT program director/coordinator",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 247": {
+    "text": "Admission into MLT program or permission of the MLT Clinical Coordinator/MLT Program Director",
+    "courses": []
+  },
+  "MLT 248": {
+    "text": "MLT 247 with a grade of \"C\" or greater or permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": [
+      "MLT 247"
+    ]
+  },
+  "MLT 278": {
+    "text": "MLT 101 with a grade of \"C\" or better or Admission into MLT program; or permission by MLT program director/coordinator",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 2781": {
+    "text": "MLT 101 with a grade of \"C\" or greater or admission into the program",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 2782": {
+    "text": "MLT 2781 with a grade of \"C\" or greater",
+    "courses": [
+      "MLT 2781"
+    ]
+  },
+  "MLT 279": {
+    "text": "MLT 101 with a grade of \"C\" or better or Admission into MLT program or permission by MLT Program Director/Coordinator",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 2791": {
+    "text": "MLT 101 with a grade of \"C\" or greater; or admission to the MLT program",
+    "courses": [
+      "MLT 101"
+    ]
+  },
+  "MLT 2792": {
+    "text": "MLT 2791 with a grade of \"C\" or greater",
+    "courses": [
+      "MLT 2791"
+    ]
+  },
+  "MOR 100": {
+    "text": "AHS 109 and AHS 115 with a grade of C or better",
+    "courses": [
+      "AHS 109",
+      "AHS 115"
+    ]
+  },
+  "MOR 115": {
+    "text": "AHS 109 and AHS 115 with a grade of C or better",
+    "courses": [
+      "AHS 109",
+      "AHS 115"
+    ]
+  },
+  "MOR 117": {
+    "text": "MOR 100 and MOR 115 with a grade of C or better",
+    "courses": [
+      "MOR 100",
+      "MOR 115"
+    ]
+  },
+  "MOR 119": {
+    "text": "MOR 100 and MOR 115 with a grade of C or better",
+    "courses": [
+      "MOR 100",
+      "MOR 115"
+    ]
+  },
+  "MRN 100": {
+    "text": "Instructor consent",
+    "courses": []
+  },
+  "MRN 200": {
+    "text": "MRN 100",
+    "courses": [
+      "MRN 100"
+    ]
+  },
+  "MSG 100": {
+    "text": "AHS 115",
+    "courses": [
+      "AHS 115"
+    ]
+  },
+  "MSG 110": {
+    "text": "MSG 100 and MSG 125 or MSG 126 and 127",
+    "courses": [
+      "MSG 100",
+      "MSG 125",
+      "MSG 126"
+    ]
+  },
+  "MSG 125": {
+    "text": "MSG 100",
+    "courses": [
+      "MSG 100"
+    ]
+  },
+  "MSG 126": {
+    "text": "MSG 100",
+    "courses": [
+      "MSG 100"
+    ]
+  },
+  "MSG 127": {
+    "text": "MSG 100",
+    "courses": [
+      "MSG 100"
+    ]
+  },
+  "MSG 135": {
+    "text": "MSG 100, MSG 110, MSG 125 or MSG 126 and MSG 127",
+    "courses": [
+      "MSG 100",
+      "MSG 110",
+      "MSG 125",
+      "MSG 126",
+      "MSG 127"
+    ]
+  },
+  "MSG 136": {
+    "text": "MSG 100, MSG 125 or MSG 126 and MSG 127",
+    "courses": [
+      "MSG 100",
+      "MSG 125",
+      "MSG 126",
+      "MSG 127"
+    ]
+  },
+  "MSG 137": {
+    "text": "MSG 100, MSG 125, or (MSG 126 and MSG 127)",
+    "courses": [
+      "MSG 100",
+      "MSG 125",
+      "MSG 126",
+      "MSG 127"
+    ]
+  },
+  "MSG 205": {
+    "text": "MSG 100, 110, 125, 135, and 205",
+    "courses": [
+      "MSG 100"
+    ]
+  },
+  "MSG 210": {
+    "text": "MSG 205",
+    "courses": [
+      "MSG 205"
+    ]
+  },
+  "MSG 215": {
+    "text": "MSG 100, 110, 125, 135, 205, and 220",
+    "courses": [
+      "MSG 100"
+    ]
+  },
+  "MSG 220": {
+    "text": "MSG 125 or MSG 126 and MSG 127; and MSG 135 or MSG 136 and MSG 137",
+    "courses": [
+      "MSG 125",
+      "MSG 126",
+      "MSG 127",
+      "MSG 135",
+      "MSG 136",
+      "MSG 137"
+    ]
+  },
+  "MSG 232": {
+    "text": "MSG 136 and MSG 137",
+    "courses": [
+      "MSG 136",
+      "MSG 137"
+    ]
+  },
+  "MSG 234": {
+    "text": "MSG 232",
+    "courses": [
+      "MSG 232"
+    ]
+  },
+  "MSG 286": {
+    "text": "MSG 100, MSG 110, MSG 126, and MSG 136",
+    "courses": [
+      "MSG 100",
+      "MSG 110",
+      "MSG 126",
+      "MSG 136"
+    ]
+  },
+  "MST 200": {
+    "text": "FPX 100, FPX 101",
+    "courses": [
+      "FPX 100",
+      "FPX 101"
+    ]
+  },
+  "MST 201": {
+    "text": "FPX 100, FPX 101",
+    "courses": [
+      "FPX 100",
+      "FPX 101"
+    ]
+  },
+  "MST 204": {
+    "text": "FPX 100, FPX 101",
+    "courses": [
+      "FPX 100",
+      "FPX 101"
+    ]
+  },
+  "MST 205": {
+    "text": "FPX 100, FPX 101",
+    "courses": [
+      "FPX 100",
+      "FPX 101"
+    ]
+  },
+  "MST 206": {
+    "text": "(ENGT 110 and FPX 100) or Consent of Instructor",
+    "courses": [
+      "ENGT 110",
+      "FPX 100"
+    ]
+  },
+  "MST 207": {
+    "text": "(ENGT 111 and ENGT 113 and FPX 101) or Consent of Instructor",
+    "courses": [
+      "ENGT 111",
+      "ENGT 113",
+      "FPX 101"
+    ]
+  },
+  "MSY 115": {
+    "text": "MSY 105 with a grade of C or higher or Consent of Instructor",
+    "courses": [
+      "MSY 105"
+    ]
+  },
+  "MSY 198": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "MSY 199": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "MSY 205": {
+    "text": "[(MSY 105 and MSY 115 with a grade of \"C\" or higher] or Consent of Instructor",
+    "courses": [
+      "MSY 105",
+      "MSY 115"
+    ]
+  },
+  "MSY 215": {
+    "text": "[(MSY 105 and MSY 115 and MSY 205) with a grade of \"C\" or higher] or Consent of Instructor",
+    "courses": [
+      "MSY 105",
+      "MSY 115",
+      "MSY 205"
+    ]
+  },
+  "MSY 225": {
+    "text": "MSY 205 with a grade of \"C\" or higher or Consent of Instructor",
+    "courses": [
+      "MSY 205"
+    ]
+  },
+  "MSY 235": {
+    "text": "MSY 205 with a grade of \"C\" or higher or Consent of Instructor",
+    "courses": [
+      "MSY 205"
+    ]
+  },
+  "MSY 245": {
+    "text": "MSY 105 with a grade of \"C\" or higher or Consent of Instructor",
+    "courses": [
+      "MSY 105"
+    ]
+  },
+  "MSY 257": {
+    "text": "MSY 105 with a grade of \"C\" or higher or Consent of Instructor",
+    "courses": [
+      "MSY 105"
+    ]
+  },
+  "MSY 275": {
+    "text": "MSY 205 with a grade of C or higher or Consent of Instructor",
+    "courses": [
+      "MSY 205"
+    ]
+  },
+  "MSY 298": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "MSY 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "MUC 190U": {
+    "text": "Audition and permission of the instructor",
+    "courses": []
+  },
+  "MUP 101": {
+    "text": "Satisfactory audition and/or approval of instructor",
+    "courses": []
+  },
+  "MUP 102": {
+    "text": "Satisfactory audition and/or approval of instructor",
+    "courses": []
+  },
+  "MUP 201": {
+    "text": "Satisfactory audition and/or approval of instructor",
+    "courses": []
+  },
+  "MUS 120": {
+    "text": "MUS 174 or Consent of Instructor",
+    "courses": [
+      "MUS 174"
+    ]
+  },
+  "MUS 151": {
+    "text": "MUS 150",
+    "courses": [
+      "MUS 150"
+    ]
+  },
+  "MUS 152": {
+    "text": "MUS 151",
+    "courses": [
+      "MUS 151"
+    ]
+  },
+  "MUS 153": {
+    "text": "MUS 152",
+    "courses": [
+      "MUS 152"
+    ]
+  },
+  "MUS 155": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "MUS 173": {
+    "text": "MUS 172",
+    "courses": [
+      "MUS 172"
+    ]
+  },
+  "MUS 192": {
+    "text": "Audition and consent of instructor",
+    "courses": []
+  },
+  "MUS 261": {
+    "text": "MUS 260",
+    "courses": [
+      "MUS 260"
+    ]
+  },
+  "MUS 299": {
+    "text": "MUS 100 or consent of the instructor",
+    "courses": [
+      "MUS 100"
+    ]
+  },
+  "NAA 115": {
+    "text": "((MNA 100 or NAA 100) with a grade of \"C\" or above within one year) or Active Status on the Kentucky Nurse Aide Registry (in good standing)) or consent of instructor",
+    "courses": [
+      "MNA 100",
+      "NAA 100"
+    ]
+  },
+  "NIP 116": {
+    "text": "Admission to the Integrated Nursing Program and proof of active status on the Kentucky Nurse Aid Registry; completion with \"C\" or better in BIO 137, PSY 110, ENG101",
+    "courses": [
+      "BIO 137",
+      "PSY 110"
+    ]
+  },
+  "NIP 126": {
+    "text": "Completion with a grade of \"C\" or better in NIP 116 and BIO 139",
+    "courses": [
+      "BIO 139",
+      "NIP 116"
+    ]
+  },
+  "NIP 140": {
+    "text": "Completion with a grade of \"C\" or better in NIP126",
+    "courses": []
+  },
+  "NIP 141": {
+    "text": "Completion with a grade of \"C\" or better in NIP 126 and AHS 100 or PSY 223",
+    "courses": [
+      "AHS 100",
+      "NIP 126",
+      "PSY 223"
+    ]
+  },
+  "NIP 212": {
+    "text": "Completion with grade of \"C\" or better in NIP 126 and AHS 100 or PSY 223; if entering as a PN, successful completion of a Practical Nursing program curriculum and proof of active unencumbered Kentucky or Compact State Practical Nurse Licensure",
+    "courses": [
+      "AHS 100",
+      "NIP 126",
+      "PSY 223"
+    ]
+  },
+  "NIP 216": {
+    "text": "Completion with a grade C or better in NIP 212 and Quantitative Reasoning (must meet AA or AS requirements)",
+    "courses": [
+      "NIP 212"
+    ]
+  },
+  "NIP 217": {
+    "text": "Completion with a grade of \"C\" or better in NIP 212 and Quantitative Reasoning for AA or AS requirements and Heritage/Humanities",
+    "courses": [
+      "NIP 212"
+    ]
+  },
+  "NIP 220": {
+    "text": "Completion with grade of \"C\" or better in NIP 211 and MAT 150",
+    "courses": [
+      "MAT 150",
+      "NIP 211"
+    ]
+  },
+  "NMI 100": {
+    "text": "Admission to the NMI program with MAT 150, ENG 101, BIO 137, CHE 140/CHE 145 and PHY 171 or consent of instructor",
+    "courses": [
+      "BIO 137",
+      "CHE 140",
+      "CHE 145",
+      "ENG 101",
+      "MAT 150",
+      "PHY 171"
+    ]
+  },
+  "NMI 102": {
+    "text": "Admission to the NMI program with MAT 150, ENG 101, BIO 137, CHE 140/CHE 145 and PHY 171 or consent of instructor",
+    "courses": [
+      "BIO 137",
+      "CHE 140",
+      "CHE 145",
+      "ENG 101",
+      "MAT 150",
+      "PHY 171"
+    ]
+  },
+  "NMI 109": {
+    "text": "Admission to the NMI program and successful completion of NMI 102",
+    "courses": [
+      "NMI 102"
+    ]
+  },
+  "NMI 111": {
+    "text": "Admission to the NMI program with MAT 150, ENG 101, BIO 137, CHE 140/CHE 145 and PHY 171 or consent of instructor",
+    "courses": [
+      "BIO 137",
+      "CHE 140",
+      "CHE 145",
+      "ENG 101",
+      "MAT 150",
+      "PHY 171"
+    ]
+  },
+  "NMI 200": {
+    "text": "Admission to the NMI program and successful completion of NMI 110",
+    "courses": [
+      "NMI 110"
+    ]
+  },
+  "NMI 203": {
+    "text": "NMI 111 with a grade of C or greater or consent of instructor",
+    "courses": [
+      "NMI 111"
+    ]
+  },
+  "NMI 204": {
+    "text": "Admission to the NMI program and successful completion of NMI 109",
+    "courses": [
+      "NMI 109"
+    ]
+  },
+  "NMI 210": {
+    "text": "Admission to the NMI program and successful completion of NMI 200",
+    "courses": [
+      "NMI 200"
+    ]
+  },
+  "NMI 216": {
+    "text": "Admission to the NMMI program and successful completion of NMI 204",
+    "courses": [
+      "NMI 204"
+    ]
+  },
+  "NPN 100": {
+    "text": "Admission to Practical Nursing program AND CPR for Health Care Providers certification to be maintained throughout enrollment in the program and [(NAA 100 or equivalent) within the past three years OR active status on the Medicaid Nurse Aide Registry]",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "NPN 101": {
+    "text": "Admission to Practical Nursing program AND CPR for Health Care Providers certification to be maintained throughout enrollment in the program AND [(NAA 100 or equivalent) within the past three years OR active status on the Medicaid Nurse Aide Registry]",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "NPN 105": {
+    "text": "Admission to Practical Nursing program AND CPR for Health Care Providers certification to be maintained throughout enrollment in the program AND [(NAA 100 or equivalent) within the past three years OR active status on the Medicaid Nurse Aide Registry]",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "NPN 106": {
+    "text": "Admission to Practical Nursing program AND proof of active status on Kentucky Medicaid Nurse Aide Registry or its equivalent AND (BIO 135 or BIO 137) and ENG 101 and (AHS 115 or CLA 131) with a grade of \"C\" or better in each course",
+    "courses": [
+      "AHS 115",
+      "BIO 135",
+      "BIO 137",
+      "CLA 131",
+      "ENG 101"
+    ]
+  },
+  "NPN 107": {
+    "text": "Admission to the Practical Nursing program AND proof of active status on Kentucky Medicaid Nurse Aide Registry or its equivalent AND (BIO 135 or BIO 137) and ENG 101 and (AHS 115 or CLA 131) with a grade of \"C\" or better in each course",
+    "courses": [
+      "AHS 115",
+      "BIO 135",
+      "BIO 137",
+      "CLA 131",
+      "ENG 101"
+    ]
+  },
+  "NPN 112": {
+    "text": "Admission to Practical Nursing program AND CPR for Health Care Providers certification to be maintained throughout enrollment in the program AND [(NAA 100 or equivalent) within the past three years OR active status on the Medicaid Nurse Aide Registry]",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "NPN 114": {
+    "text": "Admission to Practical Nursing program AND CPR for Health Care Providers certification to be maintained throughout enrollment in the program AND [(NAA 100 or equivalent) within the past three years OR active status on the Medicaid Nurse Aide Registry]",
+    "courses": [
+      "NAA 100"
+    ]
+  },
+  "NPN 116": {
+    "text": "(BIO 135 or BIO 139) and NPN 100 and NPN 105 and NPN 114 with grade of \"C\" or better or Consent of PN Coordinator",
+    "courses": [
+      "BIO 135",
+      "BIO 139",
+      "NPN 100",
+      "NPN 105",
+      "NPN 114"
+    ]
+  },
+  "NPN 125": {
+    "text": "Pathway 1: NPN 100 and NPN 105 and NPN 114 and (BIO 135 or BIO 139) with a grade of \"C\" or better in each course or Consent of PN coordinator",
+    "courses": [
+      "BIO 135",
+      "BIO 139",
+      "NPN 100",
+      "NPN 105",
+      "NPN 114"
+    ]
+  },
+  "NPN 135": {
+    "text": "Pathway 1: NPN 100 and NPN 105 and NPN 114 and (BIO 135 or BIO 139) with grade of \"C\" or better in each course or Consent of PN Coordinator; Pathway 2: NPN 101 and NPN 112 and (BIO 135 or BIO 139) and (AHS 120 or AHS 115 or CLA 131 or OST 103) with grade of \"C\" or better in each course",
+    "courses": [
+      "AHS 115",
+      "AHS 120",
+      "BIO 135",
+      "BIO 139",
+      "CLA 131",
+      "NPN 100",
+      "NPN 101",
+      "NPN 105",
+      "NPN 112",
+      "NPN 114",
+      "OST 103"
+    ]
+  },
+  "NPN 200": {
+    "text": "NPN 125 and NPN 116 and NPN 135 and NPN 201 with a grade of \"C\" or better in each course or consent of PN Coordinator",
+    "courses": [
+      "NPN 116",
+      "NPN 125",
+      "NPN 135",
+      "NPN 201"
+    ]
+  },
+  "NPN 201": {
+    "text": "Pathway 1: NPN 100 and NPN 105 and NPN 114 and (BIO 135 or BIO 139) with a grade of \"C\" or better in each course or consent of PN Coordinator",
+    "courses": [
+      "BIO 135",
+      "BIO 139",
+      "NPN 100",
+      "NPN 105",
+      "NPN 114"
+    ]
+  },
+  "NPN 202": {
+    "text": "NPN 101 and NPN 112 and (BIO 135 or BIO 139) and (AHS 115 or AHS 120 or CLA 131 or OST 103) with a grade of \"C\" or better in each course",
+    "courses": [
+      "AHS 115",
+      "AHS 120",
+      "BIO 135",
+      "BIO 139",
+      "CLA 131",
+      "NPN 101",
+      "NPN 112",
+      "OST 103"
+    ]
+  },
+  "NPN 203": {
+    "text": "(BIO 135 or BIO 139) and NPN 106 and NPN 107 with a grade of \"C\" or better in each course",
+    "courses": [
+      "BIO 135",
+      "BIO 139",
+      "NPN 106",
+      "NPN 107"
+    ]
+  },
+  "NPN 204": {
+    "text": "(BIO 135 or BIO 139) and NPN 106 and NPN 107 and NPN 125 and NPN 203 with a grade of \"C\" or better in each course",
+    "courses": [
+      "BIO 135",
+      "BIO 139",
+      "NPN 106",
+      "NPN 107",
+      "NPN 125",
+      "NPN 203"
+    ]
+  },
+  "NPN 205": {
+    "text": "NPN 200 with a grade of \"C\" or better",
+    "courses": [
+      "NPN 200"
+    ]
+  },
+  "NPN 206": {
+    "text": "NPN 202 with a grade of \"C\" or better",
+    "courses": [
+      "NPN 202"
+    ]
+  },
+  "NPN 210": {
+    "text": "Pathway 1: NPN 205 with a grade of \"C\" or better; Pathway 2: NPN 201 and NPN 206 with a grade of \"C\" or better in each course",
+    "courses": [
+      "NPN 201",
+      "NPN 205",
+      "NPN 206"
+    ]
+  },
+  "NPN 215": {
+    "text": "Pathway 1: NPN 125 and NPN 116 and NPN 135 and NPN 201 with grade of \"C\" or better in each course; Pathway 2: NPN 125 and NPN 135 and NPN 202 with grade of \"C\" or better in each course",
+    "courses": [
+      "NPN 116",
+      "NPN 125",
+      "NPN 135",
+      "NPN 201",
+      "NPN 202"
+    ]
+  },
+  "NPN 225": {
+    "text": "NPN 203 and NPN 204 and NPN 201 with a grade of \"C\" or better in each course",
+    "courses": [
+      "NPN 201",
+      "NPN 203",
+      "NPN 204"
+    ]
+  },
+  "NRS 101": {
+    "text": "Admission to the Nursing Program; Proof of active status on Kentucky Medicaid Nurse Aide Registry or its equivalent; BIO 137 and Quantitative Reasoning Course at AA/AS Level with a grade of \"C\" or better; PSY 110",
+    "courses": [
+      "BIO 137",
+      "PSY 110"
+    ]
+  },
+  "NRS 102": {
+    "text": "NRS 101 with letter grade of \"C\" or better",
+    "courses": [
+      "NRS 101"
+    ]
+  },
+  "NRS 200": {
+    "text": "Admission to nursing program; BIO 137, BIO 139, and Quantitative Reasoning Course at AA/AS Level with a grade of \"C\" or better; ENG 101, PSY 110",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "ENG 101",
+      "PSY 110"
+    ]
+  },
+  "NRS 203": {
+    "text": "NRS 102 with a grade of \"C\" or better",
+    "courses": [
+      "NRS 102"
+    ]
+  },
+  "NRS 204": {
+    "text": "NRS 203 and BIO 225 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 225",
+      "NRS 203"
+    ]
+  },
+  "NSG 101": {
+    "text": "Admission to the Associate Degree Nursing program, (BIO 137 and Quantitative Reasoning Course at AA/AS level) with a grade of \"C\" or better, PSY 110, and 75 hour nursing assistant course or its equivalent",
+    "courses": [
+      "BIO 137",
+      "PSY 110"
+    ]
+  },
+  "NSG 106": {
+    "text": "Admission to the Associate Degree Nursing program, BIO 137 (within ten years) and Quantitative Reasoning Course at AA/AS level] with a grade of \"C\" or better; PSY 110, 75 hour nursing assistant course or its equivalent",
+    "courses": [
+      "BIO 137",
+      "PSY 110"
+    ]
+  },
+  "NSG 109": {
+    "text": "Admission to the Associate Degree Nursing program, BIO 137 and Quantitative Reasoning Course at AA/AS level with a grade of \"C\" or better, PSY 110, documentation of completing Level 10 Military Medic certification",
+    "courses": [
+      "BIO 137",
+      "PSY 110"
+    ]
+  },
+  "NSG 194": {
+    "text": "BIO 139 with a grade of \"C\" or better; unrestricted National Registry or Kentucky Paramedic License; and Program Admission OR Consent of Instructor",
+    "courses": [
+      "BIO 139"
+    ]
+  },
+  "NSG 195": {
+    "text": "Admission to the Associate Degree nursing Program and (BIO 137, BIO 139, and Quantitative Reasoning Course at AA/AS Level) with a grade of \"C\" or better, PSY 110, and ENG 101",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "ENG 101",
+      "PSY 110"
+    ]
+  },
+  "NSG 196": {
+    "text": "Licensed practical nurse with the board of nursing, BIO 137, BIO 139, Quantitative Reasoning at an AA/AS level or higher (all of these must be a \"C\" or better and within the last 10 years), PSY 110, ENG 101",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "ENG 101",
+      "PSY 110"
+    ]
+  },
+  "NSG 199": {
+    "text": "Admission to the Associate Degree nursing Program and BIO 137, BIO 139, and Quantitative Reasoning Course at AA/AS Level with a grade of \"C\" or better, PSY 110, ENG 101, and a passing score on a national normed PN to RN mobility examination",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "ENG 101",
+      "PSY 110"
+    ]
+  },
+  "NSG 206": {
+    "text": "NSG 106 with a grade of \"C\" or better",
+    "courses": [
+      "NSG 106"
+    ]
+  },
+  "NSG 209": {
+    "text": "NSG 109 and BIO 139 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 139",
+      "NSG 109"
+    ]
+  },
+  "NSG 211": {
+    "text": "(NSG 219 and NSG 212) with a grade of \"C\" or higher, and ENG 101",
+    "courses": [
+      "ENG 101",
+      "NSG 212",
+      "NSG 219"
+    ]
+  },
+  "NSG 212": {
+    "text": "NSG 101 and BIO 139 with a grade of \"C\" or higher",
+    "courses": [
+      "BIO 139",
+      "NSG 101"
+    ]
+  },
+  "NSG 213": {
+    "text": "NSG 229 and NSG 211 and BIO 225 with a grade of \"C\"or better",
+    "courses": [
+      "BIO 225",
+      "NSG 211",
+      "NSG 229"
+    ]
+  },
+  "NSG 217": {
+    "text": "Admission to the Associate Degree Nursing Program and (BIO 137, BIO 139, and quantitative Reasoning course at AA/AS level with a grade of \"C\" or better in each course), PSY 110, ENG 101 and documentation of completing the military LPN program",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "ENG 101",
+      "PSY 110"
+    ]
+  },
+  "NSG 219": {
+    "text": "NSG 101 and BIO 139 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 139",
+      "NSG 101"
+    ]
+  },
+  "NSG 229": {
+    "text": "NSG 219 and NSG 212 with a grade of \"C\" or higher and ENG 101",
+    "courses": [
+      "ENG 101",
+      "NSG 212",
+      "NSG 219"
+    ]
+  },
+  "NSG 236": {
+    "text": "NSG 206 OR NSG 196 with a grade of \"C\" or better",
+    "courses": [
+      "NSG 196",
+      "NSG 206"
+    ]
+  },
+  "NSG 239": {
+    "text": "NSG 229 and NSG 211 and BIO 225 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 225",
+      "NSG 211",
+      "NSG 229"
+    ]
+  },
+  "NSG 246": {
+    "text": "NSG 236 with a grade of \"C\" or better",
+    "courses": [
+      "NSG 236"
+    ]
+  },
+  "NSG 299": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "ORP 101": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Technician program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 102": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Technician program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 103": {
+    "text": "ORP 100, ORP 101, and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100",
+      "ORP 101"
+    ]
+  },
+  "ORP 104": {
+    "text": "ORP 100, ORP 103, and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100",
+      "ORP 103"
+    ]
+  },
+  "ORP 105": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 106": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 107": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 108": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 195": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 200": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 201": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 202": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 203": {
+    "text": "ORP 100 and admission to the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100"
+    ]
+  },
+  "ORP 295": {
+    "text": "ORP 100, ORP 195, and in good standing in the Orthotics and Prosthetics Program",
+    "courses": [
+      "ORP 100",
+      "ORP 195"
+    ]
+  },
+  "OST 110": {
+    "text": "OST 101 or Consent of Instructor",
+    "courses": [
+      "OST 101"
+    ]
+  },
+  "OST 150": {
+    "text": "ENG 101 or Permission of Instructor and OST 110",
+    "courses": [
+      "ENG 101",
+      "OST 110"
+    ]
+  },
+  "OST 160": {
+    "text": "OST 105",
+    "courses": [
+      "OST 105"
+    ]
+  },
+  "OST 210": {
+    "text": "OST 110",
+    "courses": [
+      "OST 110"
+    ]
+  },
+  "OST 215": {
+    "text": "OST 110",
+    "courses": [
+      "OST 110"
+    ]
+  },
+  "OST 220": {
+    "text": "OST 210, OST 215, and OST 240, or consent of instructor",
+    "courses": [
+      "OST 210",
+      "OST 215",
+      "OST 240"
+    ]
+  },
+  "OST 221": {
+    "text": "OST 110",
+    "courses": [
+      "OST 110"
+    ]
+  },
+  "OST 225": {
+    "text": "(OST 105 and OST 110) or Consent of Instructor",
+    "courses": [
+      "OST 105",
+      "OST 110"
+    ]
+  },
+  "OST 235": {
+    "text": "ENG 101 or OST 108",
+    "courses": [
+      "ENG 101",
+      "OST 108"
+    ]
+  },
+  "OST 240": {
+    "text": "OST 105 or CIT 105",
+    "courses": [
+      "CIT 105",
+      "OST 105"
+    ]
+  },
+  "OST 250": {
+    "text": "OST 225 or Consent of Instructor",
+    "courses": [
+      "OST 225"
+    ]
+  },
+  "OST 255": {
+    "text": "OST 105 or OST 225 or Consent of Instructor",
+    "courses": [
+      "OST 105",
+      "OST 225"
+    ]
+  },
+  "OST 272": {
+    "text": "OST 105",
+    "courses": [
+      "OST 105"
+    ]
+  },
+  "OST 295": {
+    "text": "OST 210, OST 215, and OST 240, or consent of instructor",
+    "courses": [
+      "OST 210",
+      "OST 215",
+      "OST 240"
+    ]
+  },
+  "OTA 101": {
+    "text": "Completion of ENG 101 with a \"C\" or better and consent of instructor",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "OTA 113": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 115": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 116": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 125": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 126": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 136": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 146": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 206": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 216": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 225": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 226": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 236": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 246": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 256": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "OTA 267": {
+    "text": "Admission to the Occupational Therapy Assistant Program or permission of instructor",
+    "courses": []
+  },
+  "OTA 277": {
+    "text": "Admission to the Occupational Therapy Assistant Program or permission of instructor",
+    "courses": []
+  },
+  "OTA 286": {
+    "text": "Admission to OTA program and permission of instructor",
+    "courses": []
+  },
+  "PGL 111": {
+    "text": "ENG 101, demonstration of Digital Literacy, and placement scores for reading or completion of transitional reading courses or instructor consent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PGL 112": {
+    "text": "ENG 101, a computer/digital literary course (CIT or other qualifying course) and placement scores for college level reading or completion of Transitional reading courses or instructor consent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PGL 113": {
+    "text": "ENG 101, demonstration of Digital Literacy, and placement scores for reading or completion of transitional reading courses or instructor consent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PGL 211": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 212": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 213": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 214": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 221": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 223": {
+    "text": "PGL 213",
+    "courses": [
+      "PGL 213"
+    ]
+  },
+  "PGL 224": {
+    "text": "PGL 214",
+    "courses": [
+      "PGL 214"
+    ]
+  },
+  "PGL 231": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 233": {
+    "text": "PGL 111 and PGL 112",
+    "courses": [
+      "PGL 111",
+      "PGL 112"
+    ]
+  },
+  "PGL 235": {
+    "text": "Consent of Program Coordinator",
+    "courses": []
+  },
+  "PGL 250": {
+    "text": "Current license as a registered nurse",
+    "courses": []
+  },
+  "PGY 206U": {
+    "text": "One semester of college biology",
+    "courses": []
+  },
+  "PHA 110": {
+    "text": "Instructor Consent",
+    "courses": []
+  },
+  "PHA 146": {
+    "text": "Math ACT 16 or equivalent and instructor consent",
+    "courses": []
+  },
+  "PHA 150": {
+    "text": "PHA 110, PHA 146, PHA 136",
+    "courses": [
+      "PHA 110",
+      "PHA 136",
+      "PHA 146"
+    ]
+  },
+  "PHA 200": {
+    "text": "PHA 110, PHA 146, PHA 136",
+    "courses": [
+      "PHA 110",
+      "PHA 136",
+      "PHA 146"
+    ]
+  },
+  "PHA 205": {
+    "text": "PHA 110, PHA 136, PHA 146",
+    "courses": [
+      "PHA 110",
+      "PHA 136",
+      "PHA 146"
+    ]
+  },
+  "PHA 236": {
+    "text": "PHA 110, PHA 146, PHA 136",
+    "courses": [
+      "PHA 110",
+      "PHA 136",
+      "PHA 146"
+    ]
+  },
+  "PHA 240": {
+    "text": "PHA 110, PHA 146, PHA 136",
+    "courses": [
+      "PHA 110",
+      "PHA 136",
+      "PHA 146"
+    ]
+  },
+  "PHA 251": {
+    "text": "PHA 110, PHA 136, PHA 146, PHA 150 or Instructor Consent",
+    "courses": [
+      "PHA 110",
+      "PHA 136",
+      "PHA 146",
+      "PHA 150"
+    ]
+  },
+  "PHB 152": {
+    "text": "PHB 151, PHB 170 or MAI 120",
+    "courses": [
+      "MAI 120",
+      "PHB 151",
+      "PHB 170"
+    ]
+  },
+  "PHB 153": {
+    "text": "PHB 151 Phlebotomy for the Healthcare Worker",
+    "courses": [
+      "PHB 151"
+    ]
+  },
+  "PHB 155": {
+    "text": "PHB 151, PHB 100 or PHB 170, with a grade of \"C\" or greater if taken as a pre-requisite",
+    "courses": [
+      "PHB 100",
+      "PHB 151",
+      "PHB 170"
+    ]
+  },
+  "PHB 170": {
+    "text": "Permission of the MLT Program Director/MLT Clinical Coordinator",
+    "courses": []
+  },
+  "PHI 160": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHI 170": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHI 250": {
+    "text": "Math placement scores at or above benchmark OR KCTCS math placement exam recommendation OR Successful completion of transitional math coursework OR Concurrent enrollment in PHI250-S",
+    "courses": []
+  },
+  "PHI 260": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHI 270": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHX 150": {
+    "text": "MAT 116 or MAT 126",
+    "courses": [
+      "MAT 116",
+      "MAT 126"
+    ]
+  },
+  "PHY 151": {
+    "text": "KCTCS placement in College Algebra or completion of Intermediate Algebra",
+    "courses": []
+  },
+  "PHY 152": {
+    "text": "KCTCS placement in College Algebra or completion of Intermediate Algebra",
+    "courses": []
+  },
+  "PHY 160": {
+    "text": "GLY 160",
+    "courses": [
+      "GLY 160"
+    ]
+  },
+  "PHY 161": {
+    "text": "PHY 151",
+    "courses": [
+      "PHY 151"
+    ]
+  },
+  "PHY 162": {
+    "text": "PHY 152",
+    "courses": [
+      "PHY 152"
+    ]
+  },
+  "PHY 171": {
+    "text": "(MAT 85 or (MAT 116 or greater) or Equivalent math placement score) or consent of instructor",
+    "courses": [
+      "MAT 116",
+      "MAT 85"
+    ]
+  },
+  "PHY 172": {
+    "text": "KCTCS placement in College Algebra or completion of Intermediate Algebra",
+    "courses": []
+  },
+  "PHY 201": {
+    "text": "(MAT 150 or higher) or MA109 or an ACT math score of 25 or higher",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "PHY 202": {
+    "text": "PHY 201 or equivalent",
+    "courses": [
+      "PHY 201"
+    ]
+  },
+  "PHY 203": {
+    "text": "PHY 201 or equivalent",
+    "courses": [
+      "PHY 201"
+    ]
+  },
+  "PHY 204": {
+    "text": "PHY 203 or equivalent",
+    "courses": [
+      "PHY 203"
+    ]
+  },
+  "PHY 231": {
+    "text": "MAT 185 or MA 114 or equivalent",
+    "courses": [
+      "MA 114",
+      "MAT 185"
+    ]
+  },
+  "PHY 232": {
+    "text": "PHY 231",
+    "courses": [
+      "PHY 231"
+    ]
+  },
+  "PHY 241": {
+    "text": "PHY 231",
+    "courses": [
+      "PHY 231"
+    ]
+  },
+  "PHY 242": {
+    "text": "PHY 232",
+    "courses": [
+      "PHY 232"
+    ]
+  },
+  "PLB 115": {
+    "text": "PLB 105",
+    "courses": [
+      "PLB 105"
+    ]
+  },
+  "PLB 160": {
+    "text": "PLB 150 or equivalent",
+    "courses": [
+      "PLB 150"
+    ]
+  },
+  "PLB 250": {
+    "text": "PLB 150",
+    "courses": [
+      "PLB 150"
+    ]
+  },
+  "PLB 251": {
+    "text": "PLB 150",
+    "courses": [
+      "PLB 150"
+    ]
+  },
+  "PLB 260": {
+    "text": "PLB 150 or equivalent",
+    "courses": [
+      "PLB 150"
+    ]
+  },
+  "PLB 261": {
+    "text": "PLB 150 or equivalent",
+    "courses": [
+      "PLB 150"
+    ]
+  },
+  "PLB 262": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "PLB 269": {
+    "text": "PLB 150 or equivalent",
+    "courses": [
+      "PLB 150"
+    ]
+  },
+  "PLB 298": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "PLB 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "PLW 125": {
+    "text": "PLW 100",
+    "courses": [
+      "PLW 100"
+    ]
+  },
+  "PLW 130": {
+    "text": "Reading, English, and Mathematics assessment exam scores above the KCTCS transitional placement level or successful completion of the prescribed transitional course(s)",
+    "courses": []
+  },
+  "PLW 135": {
+    "text": "PLW 130",
+    "courses": [
+      "PLW 130"
+    ]
+  },
+  "PLW 140": {
+    "text": "PLW 135",
+    "courses": [
+      "PLW 135"
+    ]
+  },
+  "PLW 145": {
+    "text": "PLW 140",
+    "courses": [
+      "PLW 140"
+    ]
+  },
+  "PLW 200": {
+    "text": "PLW 100, PLW 125, and PLW 150",
+    "courses": [
+      "PLW 100",
+      "PLW 125",
+      "PLW 150"
+    ]
+  },
+  "PLW 225": {
+    "text": "PLW 100, PLW 125, and PLW 150",
+    "courses": [
+      "PLW 100",
+      "PLW 125",
+      "PLW 150"
+    ]
+  },
+  "PLW 250": {
+    "text": "PLW 100, PLW 125, and PLW 150",
+    "courses": [
+      "PLW 100",
+      "PLW 125",
+      "PLW 150"
+    ]
+  },
+  "PLW 295": {
+    "text": "PLW 150 AND one of the following: PLW 200, OR PLW 225, OR PLW 250, OR Consent of the APC and/or Instructor",
+    "courses": [
+      "PLW 150",
+      "PLW 200",
+      "PLW 225",
+      "PLW 250"
+    ]
+  },
+  "PSM 112": {
+    "text": "Audition",
+    "courses": []
+  },
+  "PSM 113": {
+    "text": "MUS 174 or Consent of Instructor",
+    "courses": [
+      "MUS 174"
+    ]
+  },
+  "PSM 117": {
+    "text": "PSM 107 or Consent of Instructor",
+    "courses": [
+      "PSM 107"
+    ]
+  },
+  "PSM 118": {
+    "text": "MUS 174 or Consent of Instructor",
+    "courses": [
+      "MUS 174"
+    ]
+  },
+  "PSM 121": {
+    "text": "PSM 101 or Consent of Instructor",
+    "courses": [
+      "PSM 101"
+    ]
+  },
+  "PSM 125": {
+    "text": "PSM 105 or Consent of Instructor",
+    "courses": [
+      "PSM 105"
+    ]
+  },
+  "PSM 217": {
+    "text": "PSM 117 or Consent of Instructor",
+    "courses": [
+      "PSM 117"
+    ]
+  },
+  "PSM 227": {
+    "text": "PSM 217 or Consent of Instructor",
+    "courses": [
+      "PSM 217"
+    ]
+  },
+  "PSM 231": {
+    "text": "PSM 121 or Consent of Instructor",
+    "courses": [
+      "PSM 121"
+    ]
+  },
+  "PSM 235": {
+    "text": "PSM 125 or Consent of Instructor",
+    "courses": [
+      "PSM 125"
+    ]
+  },
+  "PSM 241": {
+    "text": "PSM 231",
+    "courses": [
+      "PSM 231"
+    ]
+  },
+  "PSM 245": {
+    "text": "PSM 235 or Consent of Instructor",
+    "courses": [
+      "PSM 235"
+    ]
+  },
+  "PSM 250": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "PSY 110": {
+    "text": "Current placement scores for college level reading established by KCTCS or completion of, or concurrent enrollment in, transitional reading course(s)",
+    "courses": []
+  },
+  "PSY 180": {
+    "text": "ACT, COMPASS, or ASSET scores for college level reading OR completion of Transitional reading course(s)",
+    "courses": []
+  },
+  "PSY 188": {
+    "text": "PSY 110 and consent of instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "PSY 189": {
+    "text": "PSY 213 and consent of instructor; if PSY 215 is changed to PSY 213 Research Methods",
+    "courses": [
+      "PSY 213",
+      "PSY 215"
+    ]
+  },
+  "PSY 212": {
+    "text": "ACT, COMPASS, or ASSET score for college level mathematics or completion of Transitional math course(s); PSY 110",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "PSY 213": {
+    "text": "PSY 110",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "PSY 223": {
+    "text": "PSY 100 or PSY 110",
+    "courses": [
+      "PSY 100",
+      "PSY 110"
+    ]
+  },
+  "PSY 230": {
+    "text": "PSY 110 or SOC 101, or consent of instructor",
+    "courses": [
+      "PSY 110",
+      "SOC 101"
+    ]
+  },
+  "PSY 297": {
+    "text": "PSY 110 or consent of instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "PSY 298": {
+    "text": "PSY 110 or Consent of Instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "PSY 299": {
+    "text": "PSY 110 or consent of instructor",
+    "courses": [
+      "PSY 110"
+    ]
+  },
+  "PTA 101": {
+    "text": "Admission to the PTA Program and completion of BIO 137 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "PTA 120": {
+    "text": "Admission to the Physical Therapist Assistant Program; Completion of BIO 137 & BIO 139 with a C or better",
+    "courses": [
+      "BIO 137",
+      "BIO 139"
+    ]
+  },
+  "PTA 121": {
+    "text": "Admission to the Physical Therapist Assistant Program; Completion of BIO 137 & BIO 139 with a C or better",
+    "courses": [
+      "BIO 137",
+      "BIO 139"
+    ]
+  },
+  "PTA 125": {
+    "text": "Admission to the PTA Program and completion of BIO 137 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 137"
+    ]
+  },
+  "PTA 150": {
+    "text": "Pathway 1: Admission to the PTA Program and completion of BIO 137, BIO 139, PTA 101 & PTA 125 with a grade of C or better OR Pathway 2: Admission to the PTA Program and completion of BIO 137 & BIO 139 with a grade of C or better",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "PTA 101",
+      "PTA 125"
+    ]
+  },
+  "PTA 1501": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of BIO 137, BIO 139, PTA 101 and PTA 125 with a grade of C or better] OR [Pathway 2: Admission to the PTA Program; Completion of BIO 137 & BIO 139 with a C or better]",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "PTA 101",
+      "PTA 125"
+    ]
+  },
+  "PTA 1502": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of BIO 137, BIO 139, PTA 101 & PTA 125 with a grade of C or better] OR [Pathway 2: Admission to the PTA Program and completion of BIO 137 & BIO 139 with a C or better]",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "PTA 101",
+      "PTA 125"
+    ]
+  },
+  "PTA 160": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of BIO 137, BIO 139, PTA 101 and PTA 125 with a grade of \"C\" or better] OR [Pathway 2: Admission to the PTA Program and completion of BIO 137, BIO 139 with a grade of \"C\" or better]",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "PTA 101",
+      "PTA 125"
+    ]
+  },
+  "PTA 170": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of BIO 137, BIO 139, PTA 101 & PTA 125 with a C or better] OR [Pathway 2: Admission to the PTA Program and completion of BIO 137 & BIO 139 with a C or better]",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "PTA 101",
+      "PTA 125"
+    ]
+  },
+  "PTA 200": {
+    "text": "Admission to the PTA Program and completion of: PTA 150 and 160 with a grade of \"C\" or better; PTA 170 with a grade of \"P\"; all general education courses required for completion of the Physical Therapist Assistant program with a grade of \"C\" or better",
+    "courses": [
+      "PTA 150",
+      "PTA 170"
+    ]
+  },
+  "PTA 202": {
+    "text": "Admission to the PTA Program; Completion of PTA 1501, PTA 1502, PTA 120, PTA 121, PTA 170 with a C or better",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 170"
+    ]
+  },
+  "PTA 203": {
+    "text": "Admission to the PTA Program; Completion of PTA 1501, PTA 1502, PTA 120, PTA 121, PTA 170 with a C or better",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 170"
+    ]
+  },
+  "PTA 220": {
+    "text": "Admission to the PTA Program and completion of: PTA 150 and 160 with a grade of \"C\" or better; PTA 170 with a grade of \"P\"; all general education courses required for completion of the Physical Therapist Assistant program with a grade of \"C\" or better",
+    "courses": [
+      "PTA 150",
+      "PTA 170"
+    ]
+  },
+  "PTA 222": {
+    "text": "Admission to the PTA Program; Completion of PTA 1501, PTA 1502, PTA 160, PTA 120, and PTA 121 with a \"C\" or better",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 160"
+    ]
+  },
+  "PTA 223": {
+    "text": "Admission to the PTA Program; Completion of PTA 1501, PTA 1502, PTA 160, PTA 120, and PTA 121 with a \"C\" or better",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 160"
+    ]
+  },
+  "PTA 233": {
+    "text": "Admission to the PTA Program; Completion of PTA 1501, PTA 1502, PTA 160, PTA 120, and PTA 121 with a \"C\" or better",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 160"
+    ]
+  },
+  "PTA 234": {
+    "text": "Admission to the PTA Program; Completion of PTA 1501, PTA 1502, PTA 160, PTA 120, and PTA 121 with a \"C\" or better",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 160"
+    ]
+  },
+  "PTA 240": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of: PTA 150 and 160 with a \"C\" or better; PTA 170 with a grade of \"P\"; all general education courses required for completion of the Physical Therapist Assistant program with a grade of \"C\" or better] OR [Pathway 2: Admission to the PTA Program and completion of: PTA 120, PTA 121, PTA 160, PTA 1501, and PTA 1502 with a grade of \"C\" or better; PTA 170 with a grade of \"P\"]",
+    "courses": [
+      "PTA 120",
+      "PTA 121",
+      "PTA 150",
+      "PTA 1501",
+      "PTA 1502",
+      "PTA 160",
+      "PTA 170"
+    ]
+  },
+  "PTA 250": {
+    "text": "Admission to the PTA Program and completion of: PTA 200 and 220 with a grade of C or better and PTA 240 with a grade of P",
+    "courses": [
+      "PTA 200",
+      "PTA 240"
+    ]
+  },
+  "PTA 253": {
+    "text": "Admission to the PTA Program and completion of PTA 222, PTA 223, PTA 234, PTA 233, PTA 202, and PTA 203 with a \"C\" or better",
+    "courses": [
+      "PTA 202",
+      "PTA 203",
+      "PTA 222",
+      "PTA 223",
+      "PTA 233",
+      "PTA 234"
+    ]
+  },
+  "PTA 255": {
+    "text": "PTA 222, PTA 223, PTA 234, PTA 233, PTA 202, and PTA 203 with a \"C\" or better",
+    "courses": [
+      "PTA 202",
+      "PTA 203",
+      "PTA 222",
+      "PTA 223",
+      "PTA 233",
+      "PTA 234"
+    ]
+  },
+  "PTA 256": {
+    "text": "PTA 222, PTA 223, PTA 234, PTA 233, PTA 202, and PTA 203 with a \"C\" or better",
+    "courses": [
+      "PTA 202",
+      "PTA 203",
+      "PTA 222",
+      "PTA 223",
+      "PTA 233",
+      "PTA 234"
+    ]
+  },
+  "PTA 260": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of: PTA 200 and 220 with a grade of \"C\" or better and PTA 240 with a grade of \"P\"] OR [Pathway 2: PTA 202, PTA 203, PTA 222, PTA 223, PTA 234, and PTA 233 with a grade of \"C\" or better",
+    "courses": [
+      "PTA 200",
+      "PTA 202",
+      "PTA 203",
+      "PTA 222",
+      "PTA 223",
+      "PTA 233",
+      "PTA 234",
+      "PTA 240"
+    ]
+  },
+  "PTA 280": {
+    "text": "[Pathway 1: Admission to the PTA Program and completion of: PTA 200 and 220 with a grade of \"C\" or better and PTA 240 with a grade of \"P\"] OR [Pathway 2: PTA 202, PTA 203, PTA 222, PTA 223, PTA 232, and PTA 233 with a grade of \"C\" or better; Completion of PTA 240 with a grade of \"P\"]",
+    "courses": [
+      "PTA 200",
+      "PTA 202",
+      "PTA 203",
+      "PTA 222",
+      "PTA 223",
+      "PTA 232",
+      "PTA 233",
+      "PTA 240"
+    ]
+  },
+  "QMS 210": {
+    "text": "QMS 101 or Consent of Instructor and MA 109 or MT 150",
+    "courses": [
+      "MA 109",
+      "MT 150",
+      "QMS 101"
+    ]
+  },
+  "QMS 212": {
+    "text": "QMS 101 or consent of instructor",
+    "courses": [
+      "QMS 101"
+    ]
+  },
+  "QMS 220": {
+    "text": "QMS 101 or Consent of Instructor",
+    "courses": [
+      "QMS 101"
+    ]
+  },
+  "QMS 240": {
+    "text": "MA 109 or MT 150",
+    "courses": [
+      "MA 109",
+      "MT 150"
+    ]
+  },
+  "RAE 151": {
+    "text": "RAE 150 or consent of instructor Lecture: 4 credits (60 contact hours)",
+    "courses": [
+      "RAE 150"
+    ]
+  },
+  "RCP 110": {
+    "text": "Completion of ([MAT 110 or MAT 146 or MAT 150], BIO 137, and ENG 101) with a grade of \"C\" or better",
+    "courses": [
+      "BIO 137",
+      "ENG 101",
+      "MAT 110",
+      "MAT 146",
+      "MAT 150"
+    ]
+  },
+  "RCP 120": {
+    "text": "Completion of ([MAT 110 or MAT 146 or MAT 150], BIO 137, and ENG 101) with a grade of \"C\" or better",
+    "courses": [
+      "BIO 137",
+      "ENG 101",
+      "MAT 110",
+      "MAT 146",
+      "MAT 150"
+    ]
+  },
+  "RCP 121": {
+    "text": "RCP 122 with a grade of C or better; Valid Health Care Provider CPR card",
+    "courses": [
+      "RCP 122"
+    ]
+  },
+  "RCP 122": {
+    "text": ": [(MAT 110 or MAT 146 or MAT 150) BIO 137 and BIO 139) with a grade of C or better] or consent of instructor",
+    "courses": [
+      "BIO 137",
+      "BIO 139",
+      "MAT 110",
+      "MAT 146",
+      "MAT 150"
+    ]
+  },
+  "RCP 125": {
+    "text": "[RCP 110 and BIO 137 and (MAT 110 or MAT 146 or MAT 150 or equivalent)] with a grade of \"C\" or better",
+    "courses": [
+      "BIO 137",
+      "MAT 110",
+      "MAT 146",
+      "MAT 150",
+      "RCP 110"
+    ]
+  },
+  "RCP 135": {
+    "text": "Admission to the Respiratory Care Program",
+    "courses": []
+  },
+  "RCP 140": {
+    "text": "[(RCP 110 and RCP 122 and RCP 130) with a grade of C or better] or consent of instructor",
+    "courses": [
+      "RCP 110",
+      "RCP 122",
+      "RCP 130"
+    ]
+  },
+  "RCP 150": {
+    "text": "RCP 120 with a grade of \"C\" or better; Valid Health Care Provider CPR card",
+    "courses": [
+      "RCP 120"
+    ]
+  },
+  "RCP 175": {
+    "text": "RCP 150 with a grade of \"C\" or better",
+    "courses": [
+      "RCP 150"
+    ]
+  },
+  "RCP 176": {
+    "text": "RCP 110 and RCP 122 and RCP 135 with a grade of C or better or consent of instructor",
+    "courses": [
+      "RCP 110",
+      "RCP 122",
+      "RCP 135"
+    ]
+  },
+  "RCP 180": {
+    "text": "RCP 120 and RCP 150 with a grade of \"C\" or better",
+    "courses": [
+      "RCP 120",
+      "RCP 150"
+    ]
+  },
+  "RCP 185": {
+    "text": "[(RCP 140 and RCP 176) with a grade of C or better] or consent of instructor",
+    "courses": [
+      "RCP 140",
+      "RCP 176"
+    ]
+  },
+  "RCP 190": {
+    "text": "RCP 180 with a \"C\" or better",
+    "courses": [
+      "RCP 180"
+    ]
+  },
+  "RCP 195": {
+    "text": "[(RCP 185 and RCP 201) with a grade of C or better] or consent of instructor",
+    "courses": [
+      "RCP 185",
+      "RCP 201"
+    ]
+  },
+  "RCP 200": {
+    "text": "RCP 175 with a grade of \"C\" or better",
+    "courses": [
+      "RCP 175"
+    ]
+  },
+  "RCP 201": {
+    "text": "[(RCP 140 and RCP 176) with a grade of C or better] or Consent of Instructor",
+    "courses": [
+      "RCP 140",
+      "RCP 176"
+    ]
+  },
+  "RCP 204": {
+    "text": "RCP 135 and BIO 139 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 139",
+      "RCP 135"
+    ]
+  },
+  "RCP 206": {
+    "text": "RCP 135 and BIO 139 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 139",
+      "RCP 135"
+    ]
+  },
+  "RCP 210": {
+    "text": "[RCP 110 or (RCP 201 and RCP 185)] with a grade of \"C\" or better, or consent of instructor",
+    "courses": [
+      "RCP 110",
+      "RCP 185",
+      "RCP 201"
+    ]
+  },
+  "RCP 212": {
+    "text": "(RCP 185 and RCP 201) with a grade of C or better] or Consent of Instructor",
+    "courses": [
+      "RCP 185",
+      "RCP 201"
+    ]
+  },
+  "RCP 214": {
+    "text": "BIO 139 with a grade of \"C\" or better",
+    "courses": [
+      "BIO 139"
+    ]
+  },
+  "RCP 225": {
+    "text": "RCP 200 with a grade of \"C\" or better",
+    "courses": [
+      "RCP 200"
+    ]
+  },
+  "RCP 226": {
+    "text": "[(RCP 176 and RCP 185) with a grade of C or better] or Consent of Instructor",
+    "courses": [
+      "RCP 176",
+      "RCP 185"
+    ]
+  },
+  "RCP 228": {
+    "text": "[RCP 110 or (RCP 195 and RCP 210 and RCP 212 and RCP 226)] with a grade of \"C\" or better or consent of instructor",
+    "courses": [
+      "RCP 110",
+      "RCP 195",
+      "RCP 210",
+      "RCP 212",
+      "RCP 226"
+    ]
+  },
+  "RCP 240": {
+    "text": "[RCP 195 and RCP 210 and RCP 212,and RCP 226) with a grade of C or better] or consent of instructor",
+    "courses": [
+      "RCP 195",
+      "RCP 210",
+      "RCP 212",
+      "RCP 226"
+    ]
+  },
+  "RCP 250": {
+    "text": "RCP 225 with a grade of \"C\" or better",
+    "courses": [
+      "RCP 225"
+    ]
+  },
+  "RCP 251": {
+    "text": "[(RCP 195 and RCP 210 and RCP 212 and RCP 226) with a grade of C or better] or Consent of Instructor",
+    "courses": [
+      "RCP 195",
+      "RCP 210",
+      "RCP 212",
+      "RCP 226"
+    ]
+  },
+  "RCP 260": {
+    "text": "[(RCP 200 and RCP210 and RCP 212 and RCP 225) with a grade of C or better] or Consent of Instructor",
+    "courses": [
+      "RCP 200",
+      "RCP 212",
+      "RCP 225"
+    ]
+  },
+  "RDG 100": {
+    "text": "KCTCS Placement Policy",
+    "courses": []
+  },
+  "RDG 185": {
+    "text": "KCTCS Placement Policy",
+    "courses": []
+  },
+  "RDG 20": {
+    "text": "As determined by KCTCS Placement Policy",
+    "courses": []
+  },
+  "RDG 30": {
+    "text": "As determined by KCTCS Placement Policy, or successful completion of RDG 20",
+    "courses": [
+      "RDG 20"
+    ]
+  },
+  "RDG 41": {
+    "text": "Compass score 81-83",
+    "courses": []
+  },
+  "REA 200": {
+    "text": "REA 100",
+    "courses": [
+      "REA 100"
+    ]
+  },
+  "REA 201": {
+    "text": "REA 100",
+    "courses": [
+      "REA 100"
+    ]
+  },
+  "REA 212": {
+    "text": "REA 202",
+    "courses": [
+      "REA 202"
+    ]
+  },
+  "SCI 110": {
+    "text": "College Readiness as indicated by CPE in reading and writing",
+    "courses": []
+  },
+  "SCI 295": {
+    "text": "Mathematics, Reading, and English assessment placement scores above developmental levels or completion of requisite developmental courses; completion of 3 credit hours of general education science area in which the research project will be carried out with grade of B or higher; and Consent of Instructor",
+    "courses": []
+  },
+  "SMT 160": {
+    "text": "SMT 110, or Instructor Consent",
+    "courses": [
+      "SMT 110"
+    ]
+  },
+  "SMT 210": {
+    "text": "SMT 110",
+    "courses": [
+      "SMT 110"
+    ]
+  },
+  "SMT 230": {
+    "text": "SMT 110",
+    "courses": [
+      "SMT 110"
+    ]
+  },
+  "SMT 250": {
+    "text": "SMT 130 or Instructor Consent",
+    "courses": [
+      "SMT 130"
+    ]
+  },
+  "SMT 270": {
+    "text": "SMT 230, or Instructor Consent",
+    "courses": [
+      "SMT 230"
+    ]
+  },
+  "SOC 151": {
+    "text": "SOC 101 or PSY 110 or Consent of Instructor",
+    "courses": [
+      "PSY 110",
+      "SOC 101"
+    ]
+  },
+  "SOC 152": {
+    "text": "SOC 101 or SOC 151, or Consent of Instructor",
+    "courses": [
+      "SOC 101",
+      "SOC 151"
+    ]
+  },
+  "SOC 220": {
+    "text": "Three hours of sociology or Consent of Instructor",
+    "courses": []
+  },
+  "SOC 230": {
+    "text": "SOC 101",
+    "courses": [
+      "SOC 101"
+    ]
+  },
+  "SOC 235": {
+    "text": "Three hours of sociology or Consent of Instructor",
+    "courses": []
+  },
+  "SOC 249": {
+    "text": "SOC 101 or permission of instructor",
+    "courses": [
+      "SOC 101"
+    ]
+  },
+  "SOC 250": {
+    "text": "SOC 101",
+    "courses": [
+      "SOC 101"
+    ]
+  },
+  "SOC 260": {
+    "text": "SOC 101 or Consent of Instructor",
+    "courses": [
+      "SOC 101"
+    ]
+  },
+  "SPA 102": {
+    "text": "SPA 101, or consent of the department and placement test",
+    "courses": [
+      "SPA 101"
+    ]
+  },
+  "SPA 103U": {
+    "text": "Placement test or permission of instructor",
+    "courses": []
+  },
+  "SPA 151U": {
+    "text": "Prior college or high school Spanish or other experience with the Spanish language roughly equivalent to one semester of college study",
+    "courses": []
+  },
+  "SPA 201": {
+    "text": "SPA 102, or consent of department and placement test",
+    "courses": [
+      "SPA 102"
+    ]
+  },
+  "SPA 202": {
+    "text": "SPA 201 or consent of department and placement test",
+    "courses": [
+      "SPA 201"
+    ]
+  },
+  "SPA 203U": {
+    "text": "Placement test or permission of instructor",
+    "courses": []
+  },
+  "SPA 205U": {
+    "text": "Placement test, oral interview or permission of instructor",
+    "courses": []
+  },
+  "SPA 208U": {
+    "text": "Placement test or permission of instructor",
+    "courses": []
+  },
+  "SPA 215U": {
+    "text": "SPA 205 with \"B\" grade or higher, placement test, oral interview or permission of instructor",
+    "courses": [
+      "SPA 205"
+    ]
+  },
+  "STA 111": {
+    "text": "MAT 65",
+    "courses": [
+      "MAT 65"
+    ]
+  },
+  "STA 151": {
+    "text": "College Readiness in Mathematics",
+    "courses": []
+  },
+  "STA 210": {
+    "text": "MAT 126 or MAT 141 or MAT 146 or MAT 150 or equivalent",
+    "courses": [
+      "MAT 126",
+      "MAT 141",
+      "MAT 146",
+      "MAT 150"
+    ]
+  },
+  "STA 220": {
+    "text": "MAT 150 or equivalent, or MAT 146 or MAT 141 or equivalent with a grade of C or higher",
+    "courses": [
+      "MAT 141",
+      "MAT 146",
+      "MAT 150"
+    ]
+  },
+  "STA 221": {
+    "text": "STA 220",
+    "courses": [
+      "STA 220"
+    ]
+  },
+  "STA 251": {
+    "text": "MAT 151 or STA 151 or MAT 161",
+    "courses": [
+      "MAT 151",
+      "MAT 161",
+      "STA 151"
+    ]
+  },
+  "STA 296U": {
+    "text": "MA 113, MA 123, MA 137, or equivalent",
+    "courses": [
+      "MA 113",
+      "MA 123",
+      "MA 137"
+    ]
+  },
+  "SUR 100": {
+    "text": "Minimum \"C\" grade in [BIO 135 or (BIO 137 and BIO 139)] and (AHS 115 or CLA 131 or MIT 103) and (BIO 225 or BIO 226 or BIO 227 or BIO 118)",
+    "courses": [
+      "AHS 115",
+      "BIO 118",
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "BIO 225",
+      "BIO 226",
+      "BIO 227",
+      "CLA 131",
+      "MIT 103"
+    ]
+  },
+  "SUR 102": {
+    "text": "Minimum \"C\" grade in [BIO 135 or (BIO 137 and BIO 139)] and (AHS 115 or CLA 131 or MIT 103) and (BIO 118 or BIO 225 or BIO 226 or BIO 227)",
+    "courses": [
+      "AHS 115",
+      "BIO 118",
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "BIO 225",
+      "BIO 226",
+      "BIO 227",
+      "CLA 131",
+      "MIT 103"
+    ]
+  },
+  "SUR 110": {
+    "text": "Admission to Surgical Technology program or consent of Program Coordinator and SUR 109 and AHS 115",
+    "courses": [
+      "AHS 115",
+      "SUR 109"
+    ]
+  },
+  "SUR 117": {
+    "text": "Admission into the Surgical Technology Program and minimum \"C\" grade in [BIO 135 or (BIO 137 and BIO 139)] and (AHS 115 or CLA 131 or MIT 103)",
+    "courses": [
+      "AHS 115",
+      "BIO 135",
+      "BIO 137",
+      "BIO 139",
+      "CLA 131",
+      "MIT 103"
+    ]
+  },
+  "SUR 125": {
+    "text": "Minimum \"C\" grade in SUR 102",
+    "courses": [
+      "SUR 102"
+    ]
+  },
+  "SUR 201": {
+    "text": "Minimum grade of \"C\" in [SUR 100 or (SUR 109 and 110)] and SUR 125 and SUR 130",
+    "courses": [
+      "SUR 100",
+      "SUR 109",
+      "SUR 125",
+      "SUR 130"
+    ]
+  },
+  "SUR 2012": {
+    "text": "SUR 2011",
+    "courses": [
+      "SUR 2011"
+    ]
+  },
+  "SUR 202": {
+    "text": "Minimum \"C\" grade in [SUR 200 or SUR 109 and SUR 110] and SUR 125",
+    "courses": [
+      "SUR 109",
+      "SUR 110",
+      "SUR 125",
+      "SUR 200"
+    ]
+  },
+  "SUR 275": {
+    "text": "Minimum grade of \"C\" in SUR 202 and SUR 201",
+    "courses": [
+      "SUR 201",
+      "SUR 202"
+    ]
+  },
+  "SUR 280": {
+    "text": "Surgical Technologist or CNOR",
+    "courses": []
+  },
+  "SUR 282": {
+    "text": "Program admission and student must be a certified Surgical Technologist or an RN with operating room experience",
+    "courses": []
+  },
+  "SUR 284": {
+    "text": "Program admission",
+    "courses": []
+  },
+  "SUR 286": {
+    "text": "SUR 280, SUR 288, and SUR 295",
+    "courses": [
+      "SUR 280",
+      "SUR 288",
+      "SUR 295"
+    ]
+  },
+  "SUR 288": {
+    "text": "Program admission",
+    "courses": []
+  },
+  "SUR 294": {
+    "text": "SUR 280, SUR 288, and SUR 295",
+    "courses": [
+      "SUR 280",
+      "SUR 288",
+      "SUR 295"
+    ]
+  },
+  "SUR 295": {
+    "text": "Program admission",
+    "courses": []
+  },
+  "SUR 296": {
+    "text": "SUR 280, SUR 284 and SUR 295",
+    "courses": [
+      "SUR 280",
+      "SUR 284",
+      "SUR 295"
+    ]
+  },
+  "SUR 297": {
+    "text": "SUR 280, SUR 282, SUR 286, SUR 288, SUR 294, and SUR 295",
+    "courses": [
+      "SUR 280",
+      "SUR 282",
+      "SUR 286",
+      "SUR 288",
+      "SUR 294",
+      "SUR 295"
+    ]
+  },
+  "SUS 101": {
+    "text": "Current KCTCS placement scores for College level reading and writing",
+    "courses": []
+  },
+  "SUS 102": {
+    "text": "Current KCTCS placement scores for College level reading and writing",
+    "courses": []
+  },
+  "SUS 201": {
+    "text": "Current KCTCS placement scores for College level reading and writing",
+    "courses": []
+  },
+  "SUS 202": {
+    "text": "SUS 101 Intro to Sustainability & SUS 201 Sustainable Societies",
+    "courses": [
+      "SUS 101",
+      "SUS 201"
+    ]
+  },
+  "SWK 255": {
+    "text": "PSY 100 or PY 110 or consent of instructor",
+    "courses": [
+      "PSY 100",
+      "PY 110"
+    ]
+  },
+  "SWK 260": {
+    "text": "PSY 100 or PY 110 or permission from instructor",
+    "courses": [
+      "PSY 100",
+      "PY 110"
+    ]
+  },
+  "TA 195": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "TEC 200": {
+    "text": "Placement in college level writing or Consent of Instructor",
+    "courses": []
+  },
+  "TES 100": {
+    "text": "ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "TES 101": {
+    "text": "TES 100, ANT 160, COM 254",
+    "courses": [
+      "ANT 160",
+      "COM 254",
+      "TES 100"
+    ]
+  },
+  "TES 102": {
+    "text": "ANT 160, COM 254, TES 100",
+    "courses": [
+      "ANT 160",
+      "COM 254",
+      "TES 100"
+    ]
+  },
+  "TES 103": {
+    "text": "ANT 160, COM 254, TES 100",
+    "courses": [
+      "ANT 160",
+      "COM 254",
+      "TES 100"
+    ]
+  },
+  "THA 127": {
+    "text": "THA 126",
+    "courses": [
+      "THA 126"
+    ]
+  },
+  "THA 196": {
+    "text": "Acceptance by audition or selection by director/college staff",
+    "courses": []
+  },
+  "THA 226": {
+    "text": "THA 126 or Consent of Instructor",
+    "courses": [
+      "THA 126"
+    ]
+  },
+  "THA 227": {
+    "text": "THA 226 or Consent of Instructor",
+    "courses": [
+      "THA 226"
+    ]
+  },
+  "TNT 210": {
+    "text": "TNT 110, TNT 120",
+    "courses": [
+      "TNT 110",
+      "TNT 120"
+    ]
+  },
+  "TNT 220": {
+    "text": "TNT 110, TNT 120, TNT 210",
+    "courses": [
+      "TNT 110",
+      "TNT 120",
+      "TNT 210"
+    ]
+  },
+  "TNT 250": {
+    "text": "TNT 110, TNT 120, TNT 210, TNT 220",
+    "courses": [
+      "TNT 110",
+      "TNT 120",
+      "TNT 210",
+      "TNT 220"
+    ]
+  },
+  "TRU 100": {
+    "text": "CDL Permit",
+    "courses": []
+  },
+  "UCS 100": {
+    "text": "ELT 224",
+    "courses": [
+      "ELT 224"
+    ]
+  },
+  "UCS 101": {
+    "text": "ELT 224",
+    "courses": [
+      "ELT 224"
+    ]
+  },
+  "UST 170": {
+    "text": "UST 107 or Consent of Instructor",
+    "courses": [
+      "UST 107"
+    ]
+  },
+  "UST 200": {
+    "text": "College Ready in all areas",
+    "courses": []
+  },
+  "UST 210": {
+    "text": "UST 100 and UST 105 or Consent of Instructor",
+    "courses": [
+      "UST 100",
+      "UST 105"
+    ]
+  },
+  "UST 211": {
+    "text": "UST 210 or Consent of Instructor",
+    "courses": [
+      "UST 210"
+    ]
+  },
+  "UST 220": {
+    "text": "UST 107 or Consent of Instructor",
+    "courses": [
+      "UST 107"
+    ]
+  },
+  "UST 221": {
+    "text": "UST 107 or Consent of Instructor",
+    "courses": [
+      "UST 107"
+    ]
+  },
+  "UST 295": {
+    "text": "UST 107 or Consent of Instructor",
+    "courses": [
+      "UST 107"
+    ]
+  },
+  "UST 299": {
+    "text": "UST 107 or Consent of Instructor",
+    "courses": [
+      "UST 107"
+    ]
+  },
+  "VCA 106": {
+    "text": "VCC 150 and VCA 173",
+    "courses": [
+      "VCA 173",
+      "VCC 150"
+    ]
+  },
+  "VCA 108": {
+    "text": "VCC 125",
+    "courses": [
+      "VCC 125"
+    ]
+  },
+  "VCA 131": {
+    "text": "VCA 120 and VCC 125",
+    "courses": [
+      "VCA 120",
+      "VCC 125"
+    ]
+  },
+  "VCA 164": {
+    "text": "VCA 163 or VCA 120 with a grade of \"C\" or better",
+    "courses": [
+      "VCA 120",
+      "VCA 163"
+    ]
+  },
+  "VCA 171": {
+    "text": "VCA 170 with a grade of C or better or Consent of Instructor",
+    "courses": [
+      "VCA 170"
+    ]
+  },
+  "VCA 173": {
+    "text": "VCC 150 or VCC 125",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCA 174": {
+    "text": "VCC 125 or VCC 150 and VCA 173",
+    "courses": [
+      "VCA 173",
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCA 263": {
+    "text": "VCA 163 and VCA 164 and VCC 166 with a grade of \"C\" or better",
+    "courses": [
+      "VCA 163",
+      "VCA 164",
+      "VCC 166"
+    ]
+  },
+  "VCA 264": {
+    "text": "VCA 163 and VCA 164 and VCC 166 with a grade of \"C\" or better",
+    "courses": [
+      "VCA 163",
+      "VCA 164",
+      "VCC 166"
+    ]
+  },
+  "VCA 273": {
+    "text": "VCA 106 and VCA 173 and VCA 174 and VCC 166 with a grade of \"C\" or better",
+    "courses": [
+      "VCA 106",
+      "VCA 173",
+      "VCA 174",
+      "VCC 166"
+    ]
+  },
+  "VCA 274": {
+    "text": "VCA 106 and VCA 173 and VCA 174 and VCC 166 with a grade of \"C\" or better",
+    "courses": [
+      "VCA 106",
+      "VCA 173",
+      "VCA 174",
+      "VCC 166"
+    ]
+  },
+  "VCA 280": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "VCA 290": {
+    "text": "VCA 273 and VCA 274 or VCA 263 and VCA 264 or VCM 230 and CIT 140 or Consent of Instructor",
+    "courses": [
+      "CIT 140",
+      "VCA 263",
+      "VCA 264",
+      "VCA 273",
+      "VCA 274",
+      "VCM 230"
+    ]
+  },
+  "VCA 299": {
+    "text": "[(VCA 290 and VCA 264) or VCA 274 or VCM 230] with a grade of \"C\" or greater or consent of Instructor",
+    "courses": [
+      "VCA 264",
+      "VCA 274",
+      "VCA 290",
+      "VCM 230"
+    ]
+  },
+  "VCC 106": {
+    "text": "VCC 125",
+    "courses": [
+      "VCC 125"
+    ]
+  },
+  "VCC 110": {
+    "text": "VCC 125",
+    "courses": [
+      "VCC 125"
+    ]
+  },
+  "VCC 135": {
+    "text": "VCA 120 and VCC 125",
+    "courses": [
+      "VCA 120",
+      "VCC 125"
+    ]
+  },
+  "VCC 166": {
+    "text": "VCC 125 or VCC 150",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCC 200": {
+    "text": "VCC 125 or VCC 150",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCC 214": {
+    "text": "VCC 110 and VCC 125",
+    "courses": [
+      "VCC 110",
+      "VCC 125"
+    ]
+  },
+  "VCC 216": {
+    "text": "VCC 110 and VCC 125",
+    "courses": [
+      "VCC 110",
+      "VCC 125"
+    ]
+  },
+  "VCC 218": {
+    "text": "VCC 110 and VCC 125",
+    "courses": [
+      "VCC 110",
+      "VCC 125"
+    ]
+  },
+  "VCC 220": {
+    "text": "VCC 125 or VCC 150",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCC 235": {
+    "text": "VCC 110 & VCC 125",
+    "courses": [
+      "VCC 110",
+      "VCC 125"
+    ]
+  },
+  "VCC 245": {
+    "text": "VCC 235",
+    "courses": [
+      "VCC 235"
+    ]
+  },
+  "VCC 255": {
+    "text": "VCC 125",
+    "courses": [
+      "VCC 125"
+    ]
+  },
+  "VCC 260": {
+    "text": "VCC 110 and VCC 125",
+    "courses": [
+      "VCC 110",
+      "VCC 125"
+    ]
+  },
+  "VCC 265": {
+    "text": "VCC 235",
+    "courses": [
+      "VCC 235"
+    ]
+  },
+  "VCC 266": {
+    "text": "VCC 166",
+    "courses": [
+      "VCC 166"
+    ]
+  },
+  "VCC 275": {
+    "text": "VCC 125 and VCC 110",
+    "courses": [
+      "VCC 110",
+      "VCC 125"
+    ]
+  },
+  "VCC 285": {
+    "text": "VCC 275",
+    "courses": [
+      "VCC 275"
+    ]
+  },
+  "VCC 297": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "VCC 298": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "VCM 115": {
+    "text": "VCC 125 or (VCC 150 and VCA 173)",
+    "courses": [
+      "VCA 173",
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCM 130": {
+    "text": "VCC 125 or VCC 150",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCM 140": {
+    "text": "VCC 125 or VCC 150 or Digital Literacy",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCM 210": {
+    "text": "VCM 115",
+    "courses": [
+      "VCM 115"
+    ]
+  },
+  "VCM 215": {
+    "text": "VCC 125 or VCC 150 or Digital Literacy",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCM 220": {
+    "text": "VCC 125 or VCC 150",
+    "courses": [
+      "VCC 125",
+      "VCC 150"
+    ]
+  },
+  "VCM 225": {
+    "text": "VCM 210",
+    "courses": [
+      "VCM 210"
+    ]
+  },
+  "VCM 230": {
+    "text": "VCM 220",
+    "courses": [
+      "VCM 220"
+    ]
+  },
+  "VCM 240": {
+    "text": "VCM 140",
+    "courses": [
+      "VCM 140"
+    ]
+  },
+  "VCP 255": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "VET 101": {
+    "text": "VET 100",
+    "courses": [
+      "VET 100"
+    ]
+  },
+  "VET 120": {
+    "text": "VET 122, VET 123, VET 160, VET 165",
+    "courses": [
+      "VET 122",
+      "VET 123",
+      "VET 160",
+      "VET 165"
+    ]
+  },
+  "VET 122": {
+    "text": "VET 100, VET 101, and VET 116",
+    "courses": [
+      "VET 100",
+      "VET 101",
+      "VET 116"
+    ]
+  },
+  "VET 123": {
+    "text": "VET 100, VET 101, and VET 116",
+    "courses": [
+      "VET 100",
+      "VET 101",
+      "VET 116"
+    ]
+  },
+  "VET 160": {
+    "text": "VET 100, VET 101, VET 116",
+    "courses": [
+      "VET 100",
+      "VET 101",
+      "VET 116"
+    ]
+  },
+  "VET 165": {
+    "text": "VET 100, VET 101, and VET 116",
+    "courses": [
+      "VET 100",
+      "VET 101",
+      "VET 116"
+    ]
+  },
+  "VET 190": {
+    "text": "VET 122, VET 123",
+    "courses": [
+      "VET 122",
+      "VET 123"
+    ]
+  },
+  "VET 195": {
+    "text": "VET 122, 123, 160, and 165",
+    "courses": [
+      "VET 122"
+    ]
+  },
+  "VET 222": {
+    "text": "VET 122 and 123",
+    "courses": [
+      "VET 122"
+    ]
+  },
+  "VET 250": {
+    "text": "VET 120",
+    "courses": [
+      "VET 120"
+    ]
+  },
+  "VET 260": {
+    "text": "VET 195",
+    "courses": [
+      "VET 195"
+    ]
+  },
+  "VET 265": {
+    "text": "VET 165",
+    "courses": [
+      "VET 165"
+    ]
+  },
+  "VET 270": {
+    "text": "VET 260, 222, and 265",
+    "courses": [
+      "VET 260"
+    ]
+  },
+  "VET 275": {
+    "text": "VET 260, VET 222, and VET 265",
+    "courses": [
+      "VET 222",
+      "VET 260",
+      "VET 265"
+    ]
+  },
+  "VET 290": {
+    "text": "VET 260, VET 265, and VET 222",
+    "courses": [
+      "VET 222",
+      "VET 260",
+      "VET 265"
+    ]
+  },
+  "WLD 123": {
+    "text": "WLD 120 and 121 or Consent of Instructor",
+    "courses": [
+      "WLD 120"
+    ]
+  },
+  "WLD 133": {
+    "text": "WLD 130 or Consent of Instructor",
+    "courses": [
+      "WLD 130"
+    ]
+  },
+  "WLD 143": {
+    "text": "WLD 140 or Consent of Instructor",
+    "courses": [
+      "WLD 140"
+    ]
+  },
+  "WLD 145": {
+    "text": "WLD 140 or Consent of Instructor",
+    "courses": [
+      "WLD 140"
+    ]
+  },
+  "WLD 147": {
+    "text": "WLD 140 or Consent of Instructor",
+    "courses": [
+      "WLD 140"
+    ]
+  },
+  "WLD 161": {
+    "text": "WLD 140 or Consent of Instructor",
+    "courses": [
+      "WLD 140"
+    ]
+  },
+  "WLD 198": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "WLD 225": {
+    "text": "WLD 120 and 121 or Consent of Instructor",
+    "courses": [
+      "WLD 120"
+    ]
+  },
+  "WLD 227": {
+    "text": "WLD 225 or Consent of Instructor",
+    "courses": [
+      "WLD 225"
+    ]
+  },
+  "WLD 229": {
+    "text": "WLD 225 or Consent of Instructor",
+    "courses": [
+      "WLD 225"
+    ]
+  },
+  "WLD 235": {
+    "text": "WLD 133 or Consent of Instructor",
+    "courses": [
+      "WLD 133"
+    ]
+  },
+  "WLD 237": {
+    "text": "WLD 133 or Consent of Instructor",
+    "courses": [
+      "WLD 133"
+    ]
+  },
+  "WLD 239": {
+    "text": "WLD 130 & WLD 131 or Permission of Instructor",
+    "courses": [
+      "WLD 130",
+      "WLD 131"
+    ]
+  },
+  "WLD 247": {
+    "text": "WLD 143 or Consent of Instructor",
+    "courses": [
+      "WLD 143"
+    ]
+  },
+  "WLD 251": {
+    "text": "WLD 140/WLD 141, or consent of instructor",
+    "courses": [
+      "WLD 140",
+      "WLD 141"
+    ]
+  },
+  "WLD 299": {
+    "text": "Consent of Instructor",
+    "courses": []
+  }
+}

--- a/data/me/prereqs.json
+++ b/data/me/prereqs.json
@@ -1,0 +1,6105 @@
+{
+  "ACC 112": {
+    "text": "ACC 111",
+    "courses": [
+      "ACC 111"
+    ]
+  },
+  "ACC 122": {
+    "text": "ACC 120 with a grade of C or higher",
+    "courses": [
+      "ACC 120"
+    ]
+  },
+  "ACC 150": {
+    "text": "ACC 111",
+    "courses": [
+      "ACC 111"
+    ]
+  },
+  "ACC 201": {
+    "text": "ACC 112",
+    "courses": [
+      "ACC 112"
+    ]
+  },
+  "ACC 202": {
+    "text": "ACC 201",
+    "courses": [
+      "ACC 201"
+    ]
+  },
+  "ACC 204": {
+    "text": "ACC 112 (can be taken concurrently)",
+    "courses": [
+      "ACC 112"
+    ]
+  },
+  "ACC 240": {
+    "text": "ACC 122 with a grade of C or higher",
+    "courses": [
+      "ACC 122"
+    ]
+  },
+  "ACC 244": {
+    "text": "ACC 120",
+    "courses": [
+      "ACC 120"
+    ]
+  },
+  "ACC 248": {
+    "text": "ACC 120",
+    "courses": [
+      "ACC 120"
+    ]
+  },
+  "ACC 290": {
+    "text": "ACC 112, BUS 110, a cumulative GPA of 3.0, at least 30 credits earned in the program of study, and permission of the department chair or designee",
+    "courses": [
+      "ACC 112",
+      "BUS 110"
+    ]
+  },
+  "ACCT 105": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "ACCT 155": {
+    "text": "ACCT 105, MATH 040 or appropriate placement",
+    "courses": [
+      "ACCT 105",
+      "MATH 040"
+    ]
+  },
+  "ACCT 205": {
+    "text": "ACCT 105, MATH 040 or appropriate placement",
+    "courses": [
+      "ACCT 105",
+      "MATH 040"
+    ]
+  },
+  "ACM 102": {
+    "text": "ACM and VTA majors only",
+    "courses": []
+  },
+  "ACM 103": {
+    "text": "ACM and VTA majors only",
+    "courses": []
+  },
+  "ACM 106": {
+    "text": "ACM and VTA majors only",
+    "courses": []
+  },
+  "ACM 107": {
+    "text": "ACM and VTA majors only",
+    "courses": []
+  },
+  "ACM 110": {
+    "text": "ACM majors only",
+    "courses": []
+  },
+  "ACM 120": {
+    "text": "ACM and VTA majors only",
+    "courses": []
+  },
+  "ACM 121": {
+    "text": "ACM and VTA majors only",
+    "courses": []
+  },
+  "ACM 130": {
+    "text": "ACM 120/121. ACM and VTA majors only",
+    "courses": [
+      "ACM 120"
+    ]
+  },
+  "ACM 131": {
+    "text": "ACM 120/121. ACM and VTA majors only",
+    "courses": [
+      "ACM 120"
+    ]
+  },
+  "ACM 205": {
+    "text": "ACM 102/103 and ACM 120/121. ACM Majors only",
+    "courses": [
+      "ACM 102",
+      "ACM 120"
+    ]
+  },
+  "ACM 210": {
+    "text": "ACM 102/103 and ACM 120/121. ACM majors only",
+    "courses": [
+      "ACM 102",
+      "ACM 120"
+    ]
+  },
+  "ACM 250": {
+    "text": "ACM 102/103, ACM 106/107, ACM 110, ACM 120/121, ACM 130/131, MAT 118, and SPE 101. ACM majors only",
+    "courses": [
+      "ACM 102",
+      "ACM 106",
+      "ACM 110",
+      "ACM 120",
+      "ACM 130",
+      "MAT 118",
+      "SPE 101"
+    ]
+  },
+  "AEDD 100": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "AEDD 105": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "AEDD 107": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "AEDD 140": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "AEDD 160": {
+    "text": "AEDD 105",
+    "courses": [
+      "AEDD 105"
+    ]
+  },
+  "AEDD 170": {
+    "text": "AEDD 100 or AEDD 105 or AEDD 110 or MACH 115 or MACH 101, MACH 102 and MACH103",
+    "courses": [
+      "AEDD 100",
+      "AEDD 105",
+      "AEDD 110",
+      "MACH 101",
+      "MACH 102",
+      "MACH 103",
+      "MACH 115"
+    ]
+  },
+  "AEDD 185": {
+    "text": "AEDD 105",
+    "courses": [
+      "AEDD 105"
+    ]
+  },
+  "AEDD 190": {
+    "text": "AEDD 140",
+    "courses": [
+      "AEDD 140"
+    ]
+  },
+  "AEDD 205": {
+    "text": "AEDD 100 or AEDD 105",
+    "courses": [
+      "AEDD 100",
+      "AEDD 105"
+    ]
+  },
+  "AEDD 209": {
+    "text": "AEDD 100, AEDD 109, ENGL 100 or",
+    "courses": [
+      "AEDD 100",
+      "AEDD 109",
+      "ENGL 100"
+    ]
+  },
+  "AEDD 210": {
+    "text": "AEDD 160",
+    "courses": [
+      "AEDD 160"
+    ]
+  },
+  "AEDD 216": {
+    "text": "AEDD 100 or AEDD 105 or CONS 115 and AEDD 115 or AEDD 165 or CONS 130",
+    "courses": [
+      "AEDD 100",
+      "AEDD 105",
+      "AEDD 115",
+      "AEDD 165",
+      "CONS 115",
+      "CONS 130"
+    ]
+  },
+  "AEDD 220": {
+    "text": "AEDD 105, AEDD 165",
+    "courses": [
+      "AEDD 105",
+      "AEDD 165"
+    ]
+  },
+  "AEDD 240": {
+    "text": "AEDD 165",
+    "courses": [
+      "AEDD 165"
+    ]
+  },
+  "AEDD 250": {
+    "text": "AEDD 100 or AEDD 105 or MACH 115 or MACH 101, MACH 102 and MACH 103",
+    "courses": [
+      "AEDD 100",
+      "AEDD 105",
+      "MACH 101",
+      "MACH 102",
+      "MACH 103",
+      "MACH 115"
+    ]
+  },
+  "AEDD 255": {
+    "text": "MATH 112 or higher",
+    "courses": [
+      "MATH 112"
+    ]
+  },
+  "AEDD 260": {
+    "text": "AEDD 160",
+    "courses": [
+      "AEDD 160"
+    ]
+  },
+  "AEDD 265": {
+    "text": "AEDD 115 or AEDD 165",
+    "courses": [
+      "AEDD 115",
+      "AEDD 165"
+    ]
+  },
+  "AEDD 290": {
+    "text": "AEDD 160",
+    "courses": [
+      "AEDD 160"
+    ]
+  },
+  "ANT 200": {
+    "text": "any course work that must be completed before the student is eligible to register for a course",
+    "courses": []
+  },
+  "ANTH 105": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ARAB 102": {
+    "text": "ARAB 101 or instructor approval",
+    "courses": [
+      "ARAB 101"
+    ]
+  },
+  "ARAB 105": {
+    "text": "ARAB 101",
+    "courses": [
+      "ARAB 101"
+    ]
+  },
+  "ARC 102": {
+    "text": "ACE 101 and ACE 111 with a grade of C or higher",
+    "courses": [
+      "ACE 101",
+      "ACE 111"
+    ]
+  },
+  "ARC 107": {
+    "text": "ARC 106 or ENG 101",
+    "courses": [
+      "ARC 106",
+      "ENG 101"
+    ]
+  },
+  "ARC 120": {
+    "text": "PHY 121/122 or PHY 142/143",
+    "courses": [
+      "PHY 121",
+      "PHY 142"
+    ]
+  },
+  "ARC 154": {
+    "text": "ACE 111 with a grade of C of higher",
+    "courses": [
+      "ACE 111"
+    ]
+  },
+  "ARC 201": {
+    "text": "ACE 102, ACE 109 and CAD 201 with a grade of C or higher",
+    "courses": [
+      "ACE 102",
+      "ACE 109",
+      "CAD 201"
+    ]
+  },
+  "ARC 202": {
+    "text": "ARC 106",
+    "courses": [
+      "ARC 106"
+    ]
+  },
+  "ARC 204": {
+    "text": "ARC 106 or ARC 107",
+    "courses": [
+      "ARC 106",
+      "ARC 107"
+    ]
+  },
+  "ARC 207": {
+    "text": "ARC 202",
+    "courses": [
+      "ARC 202"
+    ]
+  },
+  "ARC 269": {
+    "text": "ACE 101 and ACE 111 with a grade of C or higher",
+    "courses": [
+      "ACE 101",
+      "ACE 111"
+    ]
+  },
+  "ARC 297": {
+    "text": "Senior standing for semester IV, department chair permission",
+    "courses": []
+  },
+  "ART 110": {
+    "text": "Meet prerequisites for or have completed ENG 101 or Department Chair approval",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ART 130": {
+    "text": "ART 101 (ARTS 170) ART 232 (ARTS 232) Commercial Photography 3 Credits In this course students learn to create professional quality images for the advertising, commercial and industrial markets",
+    "courses": [
+      "ART 101",
+      "ART 232",
+      "ARTS 170",
+      "ARTS 232"
+    ]
+  },
+  "ART 291": {
+    "text": "ASL 101 (ASLA 101) 2025 26 COLLEGE CATALOG EASTERN MAINE COMMUNITY COLLEGE PAGE 148 ATA 100 (AUTO 100) Automotive Safety and Light Vehicle Repair 4 Credits This introductory prerequisite course will introduce students to workplace safety in the automotive shop",
+    "courses": [
+      "ASL 101",
+      "ASLA 101",
+      "ATA 100",
+      "AUTO 100",
+      "PAGE 148"
+    ]
+  },
+  "ARTA 195": {
+    "text": "ARTS 130 or CNMS 115",
+    "courses": [
+      "ARTS 130",
+      "CNMS 115"
+    ]
+  },
+  "ARTH 125": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ARTH 130": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ARTH 145": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ARTH 155": {
+    "text": "ARTH 145",
+    "courses": [
+      "ARTH 145"
+    ]
+  },
+  "ARTH 192": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ARTH 235": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ARTH 236": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ARTH 295": {
+    "text": "ARTH 145, ARTS 130, ARTS 140, ARTS210",
+    "courses": [
+      "ARTH 145",
+      "ARTS 130",
+      "ARTS 140",
+      "ARTS 210"
+    ]
+  },
+  "ARTS 150": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "ARTS 210": {
+    "text": "ARTS 110",
+    "courses": [
+      "ARTS 110"
+    ]
+  },
+  "ARTS 220": {
+    "text": "ARTS 170",
+    "courses": [
+      "ARTS 170"
+    ]
+  },
+  "ARTS 230": {
+    "text": "ARTS 140",
+    "courses": [
+      "ARTS 140"
+    ]
+  },
+  "ARTS 250": {
+    "text": "ARTS 150",
+    "courses": [
+      "ARTS 150"
+    ]
+  },
+  "ARTS 255": {
+    "text": "ARTS 155",
+    "courses": [
+      "ARTS 155"
+    ]
+  },
+  "ARTS 260": {
+    "text": "ARTS 160",
+    "courses": [
+      "ARTS 160"
+    ]
+  },
+  "ARTS 270": {
+    "text": "ARTS 120",
+    "courses": [
+      "ARTS 120"
+    ]
+  },
+  "ARTS 290": {
+    "text": "Department Chair Permission",
+    "courses": []
+  },
+  "ASL 101": {
+    "text": "Fluency in English strongly recommended",
+    "courses": []
+  },
+  "ASL 102": {
+    "text": "ASL 101 or equivalent",
+    "courses": [
+      "ASL 101"
+    ]
+  },
+  "ASTR 100": {
+    "text": "Automotive program acceptance",
+    "courses": []
+  },
+  "AUT 110": {
+    "text": "AUT 100",
+    "courses": [
+      "AUT 100"
+    ]
+  },
+  "AUT 120": {
+    "text": "AUT 100",
+    "courses": [
+      "AUT 100"
+    ]
+  },
+  "AUT 150": {
+    "text": "AUT or FOA majors only",
+    "courses": []
+  },
+  "AUT 152": {
+    "text": "AUT Core, ENG 101 or ENG 105 and MAT 104",
+    "courses": [
+      "ENG 101",
+      "ENG 105",
+      "MAT 104"
+    ]
+  },
+  "AUT 159": {
+    "text": "AUT Core",
+    "courses": []
+  },
+  "AUT 180": {
+    "text": "Department chair approval and a minimum 2",
+    "courses": []
+  },
+  "AUT 181": {
+    "text": "Department chair approval and a minimum 2",
+    "courses": []
+  },
+  "AUT 182": {
+    "text": "Department chair approval and a minimum 2",
+    "courses": []
+  },
+  "AUT 184": {
+    "text": "AUT 100",
+    "courses": [
+      "AUT 100"
+    ]
+  },
+  "AUT 200": {
+    "text": "AUT Core",
+    "courses": []
+  },
+  "AUT 241": {
+    "text": "AUT 152",
+    "courses": [
+      "AUT 152"
+    ]
+  },
+  "AUT 244": {
+    "text": "AUT 244",
+    "courses": []
+  },
+  "AUT 271": {
+    "text": "AUT 159",
+    "courses": [
+      "AUT 159"
+    ]
+  },
+  "AUT 278": {
+    "text": "AUT Core and successful completion of AUT 152",
+    "courses": [
+      "AUT 152"
+    ]
+  },
+  "AUT 293": {
+    "text": "AUT Core, ENG 101 or 105 and MAT 104",
+    "courses": [
+      "ENG 101",
+      "MAT 104"
+    ]
+  },
+  "AUTO 111": {
+    "text": "AUTO 105, AUTO 155",
+    "courses": [
+      "AUTO 105",
+      "AUTO 155"
+    ]
+  },
+  "AUTO 112": {
+    "text": "AUTO 105",
+    "courses": [
+      "AUTO 105"
+    ]
+  },
+  "AUTO 116": {
+    "text": "AUTO 102, AUTO 155",
+    "courses": [
+      "AUTO 102",
+      "AUTO 155"
+    ]
+  },
+  "AUTO 117": {
+    "text": "AUTO 102, AUTO 116*, AUTO 155",
+    "courses": [
+      "AUTO 102",
+      "AUTO 116",
+      "AUTO 155"
+    ]
+  },
+  "AUTO 125": {
+    "text": "Automotive program acceptance",
+    "courses": []
+  },
+  "AUTO 155": {
+    "text": "AUTO program acceptance",
+    "courses": []
+  },
+  "AUTO 160": {
+    "text": "Automotive program acceptance",
+    "courses": []
+  },
+  "AUTO 170": {
+    "text": "AUTO 205",
+    "courses": [
+      "AUTO 205"
+    ]
+  },
+  "AUTO 174": {
+    "text": "AUTO 112, AUTO 117, AUTO 205",
+    "courses": [
+      "AUTO 112",
+      "AUTO 117",
+      "AUTO 205"
+    ]
+  },
+  "AUTO 175": {
+    "text": "AUTO 112, AUTO 117, AUTO 205",
+    "courses": [
+      "AUTO 112",
+      "AUTO 117",
+      "AUTO 205"
+    ]
+  },
+  "AUTO 176": {
+    "text": "AUTO 112, AUTO 117, AUTO 205",
+    "courses": [
+      "AUTO 112",
+      "AUTO 117",
+      "AUTO 205"
+    ]
+  },
+  "AUTO 205": {
+    "text": "AUTO 155",
+    "courses": [
+      "AUTO 155"
+    ]
+  },
+  "AUTO 210": {
+    "text": "AUTO 205",
+    "courses": [
+      "AUTO 205"
+    ]
+  },
+  "AUTO 215": {
+    "text": "AUTO 102",
+    "courses": [
+      "AUTO 102"
+    ]
+  },
+  "AUTO 260": {
+    "text": "AUTO 205",
+    "courses": [
+      "AUTO 205"
+    ]
+  },
+  "AUTO 265": {
+    "text": "AUTO 205",
+    "courses": [
+      "AUTO 205"
+    ]
+  },
+  "AUTO 270": {
+    "text": "AUTO 205",
+    "courses": [
+      "AUTO 205"
+    ]
+  },
+  "AUTO 285": {
+    "text": "AUTO 105",
+    "courses": [
+      "AUTO 105"
+    ]
+  },
+  "BCA 116": {
+    "text": "BCA 115 (COMP 115) 2025 26 COLLEGE CATALOG EASTERN MAINE COMMUNITY COLLEGE PAGE 152 BCA 205 (COMP 205) Integrated Software Applications 3 Credits Information Processing Capstone Course: Uses integrated software applications letters, memos, reports, presentation, and information development activities",
+    "courses": [
+      "BCA 115",
+      "BCA 205",
+      "COMP 115",
+      "COMP 205",
+      "PAGE 152"
+    ]
+  },
+  "BCA 152": {
+    "text": "BCA 120",
+    "courses": [
+      "BCA 120"
+    ]
+  },
+  "BCA 241": {
+    "text": "ACC 120, ACC 122, MAT 101, BUS 100, BUS 118, COM 100, BCA 120 or BCA 241, and ENG 101 or 105",
+    "courses": [
+      "ACC 120",
+      "ACC 122",
+      "BCA 120",
+      "BUS 100",
+      "BUS 118",
+      "COM 100",
+      "ENG 101",
+      "MAT 101"
+    ]
+  },
+  "BCT 143": {
+    "text": "BCT 142 or department chair approval",
+    "courses": [
+      "BCT 142"
+    ]
+  },
+  "BCT 145": {
+    "text": "BCT 144 or department chair approval",
+    "courses": [
+      "BCT 144"
+    ]
+  },
+  "BCT 152": {
+    "text": "BCT 145 or department chair approval",
+    "courses": [
+      "BCT 145"
+    ]
+  },
+  "BCT 154": {
+    "text": "Participation in BCT Jobsite Track program and department chair approval",
+    "courses": []
+  },
+  "BCT 185": {
+    "text": "department chair approval and a minimum 2",
+    "courses": []
+  },
+  "BCT 197": {
+    "text": "BCT 145",
+    "courses": [
+      "BCT 145"
+    ]
+  },
+  "BCT 200": {
+    "text": "146 In this course students will learn about the major finish components of a residential home",
+    "courses": []
+  },
+  "BCT 205": {
+    "text": "department chair approval and a minimum 2",
+    "courses": []
+  },
+  "BCT 251": {
+    "text": "BCT 144 or department chair approval",
+    "courses": [
+      "BCT 144"
+    ]
+  },
+  "BCT 285": {
+    "text": "department chair approval and a minimum 2",
+    "courses": []
+  },
+  "BCT 297": {
+    "text": "BCT 205 or department chair approval",
+    "courses": [
+      "BCT 205"
+    ]
+  },
+  "BCT 298": {
+    "text": "BCT 145",
+    "courses": [
+      "BCT 145"
+    ]
+  },
+  "BHHS 100": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BHHS 104": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BHHS 145": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BHHS 205": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BHHS 210": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BHHS 220": {
+    "text": "BHHS 100, BHHS 104, BHHS 145",
+    "courses": [
+      "BHHS 100",
+      "BHHS 104",
+      "BHHS 145"
+    ]
+  },
+  "BHHS 225": {
+    "text": "BHHS 100, BHHS 205, BHHS 210",
+    "courses": [
+      "BHHS 100",
+      "BHHS 205",
+      "BHHS 210"
+    ]
+  },
+  "BHHS 230": {
+    "text": "BHHS 100",
+    "courses": [
+      "BHHS 100"
+    ]
+  },
+  "BHHS 260": {
+    "text": "BHHS 100",
+    "courses": [
+      "BHHS 100"
+    ]
+  },
+  "BHHS 265": {
+    "text": "BHHS 205, BHHS 210",
+    "courses": [
+      "BHHS 205",
+      "BHHS 210"
+    ]
+  },
+  "BHHS 270": {
+    "text": "BHHS 205, BHHS 210",
+    "courses": [
+      "BHHS 205",
+      "BHHS 210"
+    ]
+  },
+  "BHHS 275": {
+    "text": "BHHS 225, BHHS 230, BHHS 260",
+    "courses": [
+      "BHHS 225",
+      "BHHS 230",
+      "BHHS 260"
+    ]
+  },
+  "BIO 105": {
+    "text": "Students must meet the prerequisites for both ENG 101 and MAT 115 or permission from the instructor",
+    "courses": [
+      "ENG 101",
+      "MAT 115"
+    ]
+  },
+  "BIO 116": {
+    "text": "BIO 106/107",
+    "courses": [
+      "BIO 106"
+    ]
+  },
+  "BIO 117": {
+    "text": "BIO 106/107",
+    "courses": [
+      "BIO 106"
+    ]
+  },
+  "BIO 118": {
+    "text": "BIO 101/102 or BIO 115/116 or BIO131/132 with a grade C or higher",
+    "courses": [
+      "BIO 101",
+      "BIO 115",
+      "BIO 131"
+    ]
+  },
+  "BIO 126": {
+    "text": "None, but strongly recommend a grade of C or higher in high school or college level biology with lab within the last 5 years",
+    "courses": []
+  },
+  "BIO 127": {
+    "text": "None, but strongly recommend a grade of C or higher in high school or college level biology with lab within the last 5 years",
+    "courses": []
+  },
+  "BIO 131": {
+    "text": "Must meet the prerequisites for both ENG 101 or ENG 105 and MAT 115",
+    "courses": [
+      "ENG 101",
+      "ENG 105",
+      "MAT 115"
+    ]
+  },
+  "BIO 132": {
+    "text": "Must meet the prerequisites for both ENG 101 or ENG 105 and MAT 115",
+    "courses": [
+      "ENG 101",
+      "ENG 105",
+      "MAT 115"
+    ]
+  },
+  "BIO 133": {
+    "text": "BIO 131/132 with a C or better",
+    "courses": [
+      "BIO 131"
+    ]
+  },
+  "BIO 134": {
+    "text": "BIO 124/125",
+    "courses": [
+      "BIO 124"
+    ]
+  },
+  "BIO 135": {
+    "text": "BIO 124/125",
+    "courses": [
+      "BIO 124"
+    ]
+  },
+  "BIO 136": {
+    "text": "Grade of C or higher in BIO 126/127",
+    "courses": [
+      "BIO 126"
+    ]
+  },
+  "BIO 137": {
+    "text": "Grade of C or higher in BIO 126/127",
+    "courses": [
+      "BIO 126"
+    ]
+  },
+  "BIO 211": {
+    "text": "A grade of C or better in one of the following Life Sciences course sequences: BIO 115 /116 and BIO 117/118 OR BIO 131/132 and BIO 133/134",
+    "courses": [
+      "BIO 115",
+      "BIO 117",
+      "BIO 131",
+      "BIO 133"
+    ]
+  },
+  "BIO 222": {
+    "text": "BIO 101/102 or BIO 115/116 or BIO 131/132 with a grade of C or higher",
+    "courses": [
+      "BIO 101",
+      "BIO 115",
+      "BIO 131"
+    ]
+  },
+  "BIO 223": {
+    "text": "BIO 101/102 or BIO 115/116 or BIO 105 or BIO 131/132 with a C or better",
+    "courses": [
+      "BIO 101",
+      "BIO 105",
+      "BIO 115",
+      "BIO 131"
+    ]
+  },
+  "BIO 230": {
+    "text": "BIO 136/137 (can be taken concurrently) or BIO 134/135 (can be taken concurrently)",
+    "courses": [
+      "BIO 134",
+      "BIO 136"
+    ]
+  },
+  "BIO 231": {
+    "text": "BIO 136/137 (can be taken concurrently) or BIO 134/135 (can be taken concurrently)",
+    "courses": [
+      "BIO 134",
+      "BIO 136"
+    ]
+  },
+  "BIO 241": {
+    "text": "BIO 131/132, BIO 133/134 and CHY 121/122, CHY 123/124 with a grade of C or better",
+    "courses": [
+      "BIO 131",
+      "BIO 133",
+      "CHY 121",
+      "CHY 123"
+    ]
+  },
+  "BIO 242": {
+    "text": "BIO 131/132, BIO 133/134 and CHY 121/122, CHY 123/124 with a grade of C or better",
+    "courses": [
+      "BIO 131",
+      "BIO 133",
+      "CHY 121",
+      "CHY 123"
+    ]
+  },
+  "BIO 250": {
+    "text": "BIO 136/137 or BIO 134/135",
+    "courses": [
+      "BIO 134",
+      "BIO 136"
+    ]
+  },
+  "BIOL 100": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BIOL 108": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "BIOL 110": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "BIOL 122": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "BIOL 124": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "BIOL 127": {
+    "text": "BIOL 122",
+    "courses": [
+      "BIOL 122"
+    ]
+  },
+  "BIOL 128": {
+    "text": "BIOL 124",
+    "courses": [
+      "BIOL 124"
+    ]
+  },
+  "BIOL 132": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "BIOL 138": {
+    "text": "BIOL 132",
+    "courses": [
+      "BIOL 132"
+    ]
+  },
+  "BIOL 190": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "BIOL 209": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "BIOL 212": {
+    "text": "BIOL 128",
+    "courses": [
+      "BIOL 128"
+    ]
+  },
+  "BIOL 235": {
+    "text": "BIOL 138",
+    "courses": [
+      "BIOL 138"
+    ]
+  },
+  "BIOL 250": {
+    "text": "BIOL 100 or BIOL 124 or BIOL 132",
+    "courses": [
+      "BIOL 100",
+      "BIOL 124",
+      "BIOL 132"
+    ]
+  },
+  "BIOL 255": {
+    "text": "BIOL 100 or BIOL 124",
+    "courses": [
+      "BIOL 100",
+      "BIOL 124"
+    ]
+  },
+  "BIOL 275": {
+    "text": "BIOL 110, BIOL 124, BIOL 250",
+    "courses": [
+      "BIOL 110",
+      "BIOL 124",
+      "BIOL 250"
+    ]
+  },
+  "BIOM 112": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "BIOM 170": {
+    "text": "BIOL 100 or BIOL 124",
+    "courses": [
+      "BIOL 100",
+      "BIOL 124"
+    ]
+  },
+  "BIOM 180": {
+    "text": "BIOL 100 or BIOL 124",
+    "courses": [
+      "BIOL 100",
+      "BIOL 124"
+    ]
+  },
+  "BIOM 255": {
+    "text": "BIOL 100 or BIOL 124",
+    "courses": [
+      "BIOL 100",
+      "BIOL 124"
+    ]
+  },
+  "BIOM 265": {
+    "text": "BIOL 100",
+    "courses": [
+      "BIOL 100"
+    ]
+  },
+  "BMT 207": {
+    "text": "BCA 115 (COMP 115), BMT 121 (MEDO 121), BMT 206 (MEDO 206), and BMT 233 (MEDO 233) or instructor permission",
+    "courses": [
+      "BCA 115",
+      "BMT 121",
+      "BMT 206",
+      "BMT 233",
+      "COMP 115",
+      "MEDO 121",
+      "MEDO 206",
+      "MEDO 233"
+    ]
+  },
+  "BMT 221": {
+    "text": "BCA 115 (COMP 115), BMT 113 (MEDO 113), BMT 114 (MEDO 114)",
+    "courses": [
+      "BCA 115",
+      "BMT 113",
+      "BMT 114",
+      "COMP 115",
+      "MEDO 113",
+      "MEDO 114"
+    ]
+  },
+  "BMT 222": {
+    "text": "BMT 221 BMT 232 (MEDO 232) ICD 10 CM Diagnostic Coding 3 Credits Develops a comprehensive understanding of diagnostic coding using ICD 10 CM",
+    "courses": [
+      "BMT 221",
+      "BMT 232",
+      "MEDO 232"
+    ]
+  },
+  "BMT 235": {
+    "text": "BMT 232 (MEDO 232), BMT 234 (MEDO 234), and BMT 233 (MEDO 233)",
+    "courses": [
+      "BMT 232",
+      "BMT 233",
+      "BMT 234",
+      "MEDO 232",
+      "MEDO 233",
+      "MEDO 234"
+    ]
+  },
+  "BMT 236": {
+    "text": "BMT 232 (MEDO 232), BMT 233 (MEDO 233), and BMT 234 (MEDO 234)",
+    "courses": [
+      "BMT 232",
+      "BMT 233",
+      "BMT 234",
+      "MEDO 232",
+      "MEDO 233",
+      "MEDO 234"
+    ]
+  },
+  "BMT 252": {
+    "text": "BMT 113 (MEDO 113) and BIO 100 (BIOL 100) level or higher 2025 26 COLLEGE CATALOG EASTERN MAINE COMMUNITY COLLEGE PAGE 156 BMT 261 (MEDO 261) Health Unit Coordinator 3 Credits Prepares the student to perform the duties of a basic health care secretary",
+    "courses": [
+      "BIO 100",
+      "BIOL 100",
+      "BMT 113",
+      "BMT 261",
+      "MEDO 113",
+      "MEDO 261",
+      "PAGE 156"
+    ]
+  },
+  "BMT 281": {
+    "text": "Instructor permission only BUA 101 (BUSN 101) Introduction to Business 3 Credits This course examines the role of business in American society; the interrelated activities through which business provides the goods and services essential to contemporary society; and the interrelationships between business and government, labor, and society at large",
+    "courses": [
+      "BUA 101",
+      "BUSN 101"
+    ]
+  },
+  "BUA 254": {
+    "text": "GPA 3",
+    "courses": []
+  },
+  "BUS 155": {
+    "text": "ENG 101 or 105",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "BUS 210": {
+    "text": "BUS 110",
+    "courses": [
+      "BUS 110"
+    ]
+  },
+  "BUS 230": {
+    "text": "BUS 110",
+    "courses": [
+      "BUS 110"
+    ]
+  },
+  "BUS 244": {
+    "text": "BUS 110",
+    "courses": [
+      "BUS 110"
+    ]
+  },
+  "BUS 250": {
+    "text": "BUS 110",
+    "courses": [
+      "BUS 110"
+    ]
+  },
+  "BUS 260": {
+    "text": "ACC 111 and BUS 110",
+    "courses": [
+      "ACC 111",
+      "BUS 110"
+    ]
+  },
+  "BUS 280": {
+    "text": "Accounting, Business or Finance major with at least 45 credits in program",
+    "courses": []
+  },
+  "BUS 286": {
+    "text": "BUS 215",
+    "courses": [
+      "BUS 215"
+    ]
+  },
+  "BUS 293": {
+    "text": "BUS 110, BUS 115 and, a cumulative GPA of 3.0, at least 30 credits earned in the program of study, and permission of the department chair of designee",
+    "courses": [
+      "BUS 110",
+      "BUS 115"
+    ]
+  },
+  "BUS 297": {
+    "text": "Department Chair approval",
+    "courses": []
+  },
+  "BUSN 100": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "BUSN 115": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "BUSN 130": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "BUSN 151": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "BUSN 195": {
+    "text": "BUSN 100",
+    "courses": [
+      "BUSN 100"
+    ]
+  },
+  "BUSN 200": {
+    "text": "BUSN 100; ECON 120 or ECON 125",
+    "courses": [
+      "BUSN 100",
+      "ECON 120",
+      "ECON 125"
+    ]
+  },
+  "BUSN 260": {
+    "text": "BUSN 100",
+    "courses": [
+      "BUSN 100"
+    ]
+  },
+  "CAD 112": {
+    "text": "None Core fulfilled: None",
+    "courses": []
+  },
+  "CAD 204": {
+    "text": "CAD 107",
+    "courses": [
+      "CAD 107"
+    ]
+  },
+  "CAD 210": {
+    "text": "CAD 102 or permission of the Department Chair",
+    "courses": [
+      "CAD 102"
+    ]
+  },
+  "CAD 214": {
+    "text": "CAD 115",
+    "courses": [
+      "CAD 115"
+    ]
+  },
+  "CAD 220": {
+    "text": "CAD 210 or MUL 125 or WEB 133",
+    "courses": [
+      "CAD 210",
+      "MUL 125",
+      "WEB 133"
+    ]
+  },
+  "CAD 275": {
+    "text": "CAD 204",
+    "courses": [
+      "CAD 204"
+    ]
+  },
+  "CAD 290": {
+    "text": "CAD 210, a cumulative GPA of 3.0, with at least 30 credits earned in the program of study and permission of the Department Chair",
+    "courses": [
+      "CAD 210"
+    ]
+  },
+  "CARD 100": {
+    "text": "ENGL 100 or ENGL 101, BIOL 132",
+    "courses": [
+      "BIOL 132",
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CARD 105": {
+    "text": "Program Acceptance",
+    "courses": []
+  },
+  "CARD 115": {
+    "text": "CARD program acceptance, BIOL 138",
+    "courses": [
+      "BIOL 138"
+    ]
+  },
+  "CARD 120": {
+    "text": "CARD program acceptance",
+    "courses": []
+  },
+  "CARD 125": {
+    "text": "BIOL 138",
+    "courses": [
+      "BIOL 138"
+    ]
+  },
+  "CARD 140": {
+    "text": "CARD 120",
+    "courses": [
+      "CARD 120"
+    ]
+  },
+  "CARD 150": {
+    "text": "CARD 100, CARD 105, CARD 120",
+    "courses": [
+      "CARD 100",
+      "CARD 105",
+      "CARD 120"
+    ]
+  },
+  "CARD 155": {
+    "text": "CARD 100, CARD 105, CARD 120",
+    "courses": [
+      "CARD 100",
+      "CARD 105",
+      "CARD 120"
+    ]
+  },
+  "CARD 160": {
+    "text": "CARD 100, CARD 105, CARD 120, BIOL138",
+    "courses": [
+      "BIOL 138",
+      "CARD 100",
+      "CARD 105",
+      "CARD 120"
+    ]
+  },
+  "CARD 170": {
+    "text": "CARD 115, CARD 125, CARD 160",
+    "courses": [
+      "CARD 115",
+      "CARD 125",
+      "CARD 160"
+    ]
+  },
+  "CARD 190": {
+    "text": "CARD 100, CARD 105, CARD 120, BIOL138",
+    "courses": [
+      "BIOL 138",
+      "CARD 100",
+      "CARD 105",
+      "CARD 120"
+    ]
+  },
+  "CARD 200": {
+    "text": "CARD 150, CARD 155",
+    "courses": [
+      "CARD 150",
+      "CARD 155"
+    ]
+  },
+  "CARD 210": {
+    "text": "CARD 160",
+    "courses": [
+      "CARD 160"
+    ]
+  },
+  "CARD 220": {
+    "text": "CARD 165, CARD 170",
+    "courses": [
+      "CARD 165",
+      "CARD 170"
+    ]
+  },
+  "CARD 225": {
+    "text": "CARD 175",
+    "courses": [
+      "CARD 175"
+    ]
+  },
+  "CARD 275": {
+    "text": "CARD 225",
+    "courses": [
+      "CARD 225"
+    ]
+  },
+  "CHEM 100": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "CHEM 125": {
+    "text": "CHEM 120",
+    "courses": [
+      "CHEM 120"
+    ]
+  },
+  "CHEM 131": {
+    "text": "MATH 190",
+    "courses": [
+      "MATH 190"
+    ]
+  },
+  "CHM 116": {
+    "text": "CHM 106/107",
+    "courses": [
+      "CHM 106"
+    ]
+  },
+  "CHM 117": {
+    "text": "CHM 106/107",
+    "courses": [
+      "CHM 106"
+    ]
+  },
+  "CHY 101": {
+    "text": "High School Algebra I",
+    "courses": []
+  },
+  "CHY 121": {
+    "text": "Readiness for or completion of MAT 122",
+    "courses": [
+      "MAT 122"
+    ]
+  },
+  "CHY 123": {
+    "text": "CHY 121 with C or higher",
+    "courses": [
+      "CHY 121"
+    ]
+  },
+  "CHY 124": {
+    "text": "C or better in CHY 121 and 122",
+    "courses": [
+      "CHY 121"
+    ]
+  },
+  "CHY 221": {
+    "text": "C or better in CHY 123/124",
+    "courses": [
+      "CHY 123"
+    ]
+  },
+  "CHY 222": {
+    "text": "C or better in CHY 123/124",
+    "courses": [
+      "CHY 123"
+    ]
+  },
+  "CHY 252": {
+    "text": "C or better in CHY 221/ 222",
+    "courses": [
+      "CHY 221"
+    ]
+  },
+  "CIS 226": {
+    "text": "CIS 178 and NET 110",
+    "courses": [
+      "CIS 178",
+      "NET 110"
+    ]
+  },
+  "CIS 228": {
+    "text": "CIS 178 or CIS 220",
+    "courses": [
+      "CIS 178",
+      "CIS 220"
+    ]
+  },
+  "CIS 230": {
+    "text": "CIS 118",
+    "courses": [
+      "CIS 118"
+    ]
+  },
+  "CIS 235": {
+    "text": "NET 110",
+    "courses": [
+      "NET 110"
+    ]
+  },
+  "CIS 254": {
+    "text": "CIS 152 and MAT 127",
+    "courses": [
+      "CIS 152",
+      "MAT 127"
+    ]
+  },
+  "CIS 256": {
+    "text": "CIS 170, MAT 222, and PSY 101",
+    "courses": [
+      "CIS 170",
+      "MAT 222",
+      "PSY 101"
+    ]
+  },
+  "CIS 264": {
+    "text": "CIS 131 or CIS 170 or CIS 174",
+    "courses": [
+      "CIS 131",
+      "CIS 170",
+      "CIS 174"
+    ]
+  },
+  "CIS 272": {
+    "text": "CIS 174 and MAT 222",
+    "courses": [
+      "CIS 174",
+      "MAT 222"
+    ]
+  },
+  "CIS 275": {
+    "text": "CIS 272",
+    "courses": [
+      "CIS 272"
+    ]
+  },
+  "CIS 284": {
+    "text": "CIS 170 and CIS 256",
+    "courses": [
+      "CIS 170",
+      "CIS 256"
+    ]
+  },
+  "CIS 295": {
+    "text": "CIS 230, NET 110, a cumulative GPA of 3.0, with at least 30 credits earned in the",
+    "courses": [
+      "CIS 230",
+      "NET 110"
+    ]
+  },
+  "CIS 298": {
+    "text": "CIS 264, CIS 272, and earned 45 credits",
+    "courses": [
+      "CIS 264",
+      "CIS 272"
+    ]
+  },
+  "CJS 205": {
+    "text": "CJS 101",
+    "courses": [
+      "CJS 101"
+    ]
+  },
+  "CJS 210": {
+    "text": "CJS 101",
+    "courses": [
+      "CJS 101"
+    ]
+  },
+  "CJS 280": {
+    "text": "CJS 101 or CJS 160. Must be a CRJ major, and Department Chair approval",
+    "courses": [
+      "CJS 101",
+      "CJS 160"
+    ]
+  },
+  "CJS 290": {
+    "text": "Criminal Justice majors with at least 30 credits and a GPA of 3.0 in the CRJ program, and permission of the Department Chair or his/her designee",
+    "courses": []
+  },
+  "CJUS 105": {
+    "text": "CJUS program acceptance",
+    "courses": []
+  },
+  "CJUS 107": {
+    "text": "CJUS 106",
+    "courses": [
+      "CJUS 106"
+    ]
+  },
+  "CJUS 108": {
+    "text": "CJUS 106",
+    "courses": [
+      "CJUS 106"
+    ]
+  },
+  "CJUS 109": {
+    "text": "CJUS 105",
+    "courses": [
+      "CJUS 105"
+    ]
+  },
+  "CJUS 140": {
+    "text": "CJUS 105, CJUS 115",
+    "courses": [
+      "CJUS 105",
+      "CJUS 115"
+    ]
+  },
+  "CJUS 200": {
+    "text": "CJUS 105, CJUS 130",
+    "courses": [
+      "CJUS 105",
+      "CJUS 130"
+    ]
+  },
+  "CJUS 215": {
+    "text": "CJUS 105, CJUS 130",
+    "courses": [
+      "CJUS 105",
+      "CJUS 130"
+    ]
+  },
+  "CJUS 220": {
+    "text": "CJUS 105, ENGL 100 or ENGL 101",
+    "courses": [
+      "CJUS 105",
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CJUS 230": {
+    "text": "CJUS 105, CJUS 125 (C or better), CJUS department approval",
+    "courses": [
+      "CJUS 105",
+      "CJUS 125"
+    ]
+  },
+  "CJUS 235": {
+    "text": "CJUS 105, CJUS 125 (C or better)",
+    "courses": [
+      "CJUS 105",
+      "CJUS 125"
+    ]
+  },
+  "CJUS 240": {
+    "text": "CJUS 245, CJUS 255",
+    "courses": [
+      "CJUS 245",
+      "CJUS 255"
+    ]
+  },
+  "CJUS 245": {
+    "text": "CJUS 105, CJUS 130, CJUS 215",
+    "courses": [
+      "CJUS 105",
+      "CJUS 130",
+      "CJUS 215"
+    ]
+  },
+  "CJUS 250": {
+    "text": "CJUS 105, 3.2 GPA, and CJUS department approval",
+    "courses": [
+      "CJUS 105"
+    ]
+  },
+  "CJUS 255": {
+    "text": "CJUS 105",
+    "courses": [
+      "CJUS 105"
+    ]
+  },
+  "CMIT 100": {
+    "text": "CMIT 100, CMIT 105",
+    "courses": [
+      "CMIT 105"
+    ]
+  },
+  "CMIT 135": {
+    "text": "CMIT 100, CMIT 105",
+    "courses": [
+      "CMIT 100",
+      "CMIT 105"
+    ]
+  },
+  "CMIT 140": {
+    "text": "CMIT 100, CMIT 105",
+    "courses": [
+      "CMIT 100",
+      "CMIT 105"
+    ]
+  },
+  "CMIT 215": {
+    "text": "CMIT 100, CMIT 105",
+    "courses": [
+      "CMIT 100",
+      "CMIT 105"
+    ]
+  },
+  "CMIT 220": {
+    "text": "CMIT 100, CMIT 105",
+    "courses": [
+      "CMIT 100",
+      "CMIT 105"
+    ]
+  },
+  "CMIT 225": {
+    "text": "CMIT 100, CMIT 105",
+    "courses": [
+      "CMIT 100",
+      "CMIT 105"
+    ]
+  },
+  "CMIT 240": {
+    "text": "CMIT 140, CMIT 220",
+    "courses": [
+      "CMIT 140",
+      "CMIT 220"
+    ]
+  },
+  "CMIT 250": {
+    "text": "CMIT 215, CMIT 220",
+    "courses": [
+      "CMIT 215",
+      "CMIT 220"
+    ]
+  },
+  "CMIT 270": {
+    "text": "CMIT 215",
+    "courses": [
+      "CMIT 215"
+    ]
+  },
+  "CNL 240": {
+    "text": "A grade of C or higher in CNL 120",
+    "courses": [
+      "CNL 120"
+    ]
+  },
+  "CNL 260": {
+    "text": "Grade of C or higher in CNL 120 and 240",
+    "courses": [
+      "CNL 120"
+    ]
+  },
+  "CNMS 111": {
+    "text": "CNMS program acceptance",
+    "courses": []
+  },
+  "CNMS 120": {
+    "text": "CNMS 111, CNMS 115 or ARTS 130",
+    "courses": [
+      "ARTS 130",
+      "CNMS 111",
+      "CNMS 115"
+    ]
+  },
+  "CNMS 125": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CNMS 135": {
+    "text": "CNMS 111, CNMS 115 or ARTS 130",
+    "courses": [
+      "ARTS 130",
+      "CNMS 111",
+      "CNMS 115"
+    ]
+  },
+  "CNMS 140": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CNMS 145": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CNMS 147": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CNMS 150": {
+    "text": "CNMS 111",
+    "courses": [
+      "CNMS 111"
+    ]
+  },
+  "CNMS 155": {
+    "text": "CNMS program acceptance",
+    "courses": []
+  },
+  "CNMS 160": {
+    "text": "CNMS program acceptance",
+    "courses": []
+  },
+  "CNMS 165": {
+    "text": "CNMS, CMIT, or CSCI program acceptance",
+    "courses": []
+  },
+  "CNMS 180": {
+    "text": "CNMS 111, CNMS 115 or ARTS 130",
+    "courses": [
+      "ARTS 130",
+      "CNMS 111",
+      "CNMS 115"
+    ]
+  },
+  "CNMS 195": {
+    "text": "ARTS 130 or CNMS 115",
+    "courses": [
+      "ARTS 130",
+      "CNMS 115"
+    ]
+  },
+  "CNMS 200": {
+    "text": "CNMS 140, CNMS 160",
+    "courses": [
+      "CNMS 140",
+      "CNMS 160"
+    ]
+  },
+  "CNMS 205": {
+    "text": "CNMS 120",
+    "courses": [
+      "CNMS 120"
+    ]
+  },
+  "CNMS 210": {
+    "text": "CNMS 160, CNMS 125 or CNMS 140",
+    "courses": [
+      "CNMS 125",
+      "CNMS 140",
+      "CNMS 160"
+    ]
+  },
+  "CNMS 211": {
+    "text": "CNMS 210",
+    "courses": [
+      "CNMS 210"
+    ]
+  },
+  "CNMS 215": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CNMS 225": {
+    "text": "CNMS 111",
+    "courses": [
+      "CNMS 111"
+    ]
+  },
+  "CNMS 230": {
+    "text": "CNMS 160",
+    "courses": [
+      "CNMS 160"
+    ]
+  },
+  "CNMS 235": {
+    "text": "CNMS 111, CNMS 115 or ARTS 130",
+    "courses": [
+      "ARTS 130",
+      "CNMS 111",
+      "CNMS 115"
+    ]
+  },
+  "CNMS 240": {
+    "text": "CNMS 160",
+    "courses": [
+      "CNMS 160"
+    ]
+  },
+  "CNMS 250": {
+    "text": "CNMS 105",
+    "courses": [
+      "CNMS 105"
+    ]
+  },
+  "CNMS 251": {
+    "text": "CNMS 105",
+    "courses": [
+      "CNMS 105"
+    ]
+  },
+  "CNMS 255": {
+    "text": "CNMS 111 or CNMS 120",
+    "courses": [
+      "CNMS 111",
+      "CNMS 120"
+    ]
+  },
+  "CNMS 260": {
+    "text": "CNMS 165 or CSCI 110",
+    "courses": [
+      "CNMS 165",
+      "CSCI 110"
+    ]
+  },
+  "CNMS 265": {
+    "text": "CNMS 165",
+    "courses": [
+      "CNMS 165"
+    ]
+  },
+  "CNMS 266": {
+    "text": "CNMS 160",
+    "courses": [
+      "CNMS 160"
+    ]
+  },
+  "CNMS 270": {
+    "text": "CNMS 200 OR CNMS 230",
+    "courses": [
+      "CNMS 200",
+      "CNMS 230"
+    ]
+  },
+  "CNMS 271": {
+    "text": "CNMS 111, CNMS 115 or ARTS 130",
+    "courses": [
+      "ARTS 130",
+      "CNMS 111",
+      "CNMS 115"
+    ]
+  },
+  "CNMS 275": {
+    "text": "CNMS 165",
+    "courses": [
+      "CNMS 165"
+    ]
+  },
+  "CNMS 280": {
+    "text": "CNMS 111 or CNMS 120, CNMS 115 or",
+    "courses": [
+      "CNMS 111",
+      "CNMS 115",
+      "CNMS 120"
+    ]
+  },
+  "CNMS 290": {
+    "text": "CNMS 120 or CNMS 240",
+    "courses": [
+      "CNMS 120",
+      "CNMS 240"
+    ]
+  },
+  "CNMS 294": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CNMS 295": {
+    "text": "CNMS department approval",
+    "courses": []
+  },
+  "CNMS 296": {
+    "text": "CNMS department approval",
+    "courses": []
+  },
+  "CNMS 297": {
+    "text": "CNMS department approval",
+    "courses": []
+  },
+  "CNMS 298": {
+    "text": "CNMS 111, CNMS 115, CNMS 145",
+    "courses": [
+      "CNMS 111",
+      "CNMS 115",
+      "CNMS 145"
+    ]
+  },
+  "COL 299": {
+    "text": "Admission to the Criminal Justice Program or instructor permission",
+    "courses": []
+  },
+  "COM 103": {
+    "text": "ENG 101 or 105",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "COM 110": {
+    "text": "ENG 101 or 105",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "COM 201": {
+    "text": "ENG 101 or 105 and COM 102",
+    "courses": [
+      "COM 102",
+      "ENG 101"
+    ]
+  },
+  "COM 203": {
+    "text": "ENG 101 or 105 and COM 100",
+    "courses": [
+      "COM 100",
+      "ENG 101"
+    ]
+  },
+  "COM 205": {
+    "text": "ENG 101 or 105 and COM 102",
+    "courses": [
+      "COM 102",
+      "ENG 101"
+    ]
+  },
+  "COM 207": {
+    "text": "CAD 201 Building Information Modeling I with a grade of C or higher",
+    "courses": [
+      "CAD 201"
+    ]
+  },
+  "COMM 105": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "COMM 201": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "CONS 111": {
+    "text": "Construction Technology program acceptance",
+    "courses": []
+  },
+  "CONS 135": {
+    "text": "CONS 105, CONS 115, CONS 125",
+    "courses": [
+      "CONS 105",
+      "CONS 115",
+      "CONS 125"
+    ]
+  },
+  "CONS 150": {
+    "text": "CONS 105, CONS 115, CONS 125",
+    "courses": [
+      "CONS 105",
+      "CONS 115",
+      "CONS 125"
+    ]
+  },
+  "CONS 155": {
+    "text": "CONS 101, CONS 110, MATH 130 or higher",
+    "courses": [
+      "CONS 101",
+      "CONS 110",
+      "MATH 130"
+    ]
+  },
+  "CONS 156": {
+    "text": "CONS 101, CONS 110, MATH 130 or higher",
+    "courses": [
+      "CONS 101",
+      "CONS 110",
+      "MATH 130"
+    ]
+  },
+  "CONS 200": {
+    "text": "CONS 105, CONS 115, CONS 125",
+    "courses": [
+      "CONS 105",
+      "CONS 115",
+      "CONS 125"
+    ]
+  },
+  "CONS 201": {
+    "text": "CONS 110, CONS 155, CONS 156",
+    "courses": [
+      "CONS 110",
+      "CONS 155",
+      "CONS 156"
+    ]
+  },
+  "CONS 202": {
+    "text": "CONS 110, CONS 155, CONS 156",
+    "courses": [
+      "CONS 110",
+      "CONS 155",
+      "CONS 156"
+    ]
+  },
+  "CONS 210": {
+    "text": "CONS 105, CONS 115, CONS 125",
+    "courses": [
+      "CONS 105",
+      "CONS 115",
+      "CONS 125"
+    ]
+  },
+  "CONS 220": {
+    "text": "CONS 105, CONS 115, CONS 125",
+    "courses": [
+      "CONS 105",
+      "CONS 115",
+      "CONS 125"
+    ]
+  },
+  "CONS 230": {
+    "text": "CONS 105, CONS 115, CONS 125",
+    "courses": [
+      "CONS 105",
+      "CONS 115",
+      "CONS 125"
+    ]
+  },
+  "CONS 245": {
+    "text": "CONS 105 or department approval",
+    "courses": [
+      "CONS 105"
+    ]
+  },
+  "CONS 257": {
+    "text": "CONS 110, CONS 147",
+    "courses": [
+      "CONS 110",
+      "CONS 147"
+    ]
+  },
+  "CPT 147": {
+    "text": "CPT 147",
+    "courses": []
+  },
+  "CPT 156": {
+    "text": "CPT 201 and instructor permission",
+    "courses": [
+      "CPT 201"
+    ]
+  },
+  "CPT 239": {
+    "text": "CPT 147 and 235, two or more years of IT work experience and instructor permission",
+    "courses": [
+      "CPT 147"
+    ]
+  },
+  "CPT 240": {
+    "text": "CPT 130 or instructor permission",
+    "courses": [
+      "CPT 130"
+    ]
+  },
+  "CPT 253": {
+    "text": "CPT 252 or instructor permission",
+    "courses": [
+      "CPT 252"
+    ]
+  },
+  "CPT 254": {
+    "text": "Any coding class (python, C, C++, or R), and MAT 150 Pre Calculus",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "CPT 256": {
+    "text": "Completion of any coding class or instructor permission",
+    "courses": []
+  },
+  "CPT 257": {
+    "text": "CPT 256",
+    "courses": [
+      "CPT 256"
+    ]
+  },
+  "CPT 261": {
+    "text": "CPT 147 or instructor permission",
+    "courses": [
+      "CPT 147"
+    ]
+  },
+  "CPT 266": {
+    "text": "CPT 235",
+    "courses": [
+      "CPT 235"
+    ]
+  },
+  "CPT 271": {
+    "text": "CPT 235",
+    "courses": [
+      "CPT 235"
+    ]
+  },
+  "CPT 273": {
+    "text": "CPT 235, 266, and 271",
+    "courses": [
+      "CPT 235"
+    ]
+  },
+  "CPT 286": {
+    "text": "CPT 261",
+    "courses": [
+      "CPT 261"
+    ]
+  },
+  "CPT 288": {
+    "text": "CPT 235 and 2nd year standing",
+    "courses": [
+      "CPT 235"
+    ]
+  },
+  "CPT 289": {
+    "text": "CPT 266, at least one networking elective, instructor permission",
+    "courses": [
+      "CPT 266"
+    ]
+  },
+  "CPT 297": {
+    "text": "instructor permission",
+    "courses": []
+  },
+  "CRJ 209": {
+    "text": "A grade of C or higher in CRJ 101 and 122",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 220": {
+    "text": "A grade of C or better in CRJ 101 and access to a 12 megapixel or higher digital camera",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 231": {
+    "text": "A grade of C or higher in CRJ 101",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 240": {
+    "text": "CRJ 101",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 247": {
+    "text": "CRJ 101",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 252": {
+    "text": "Enrollment by faculty nomination only",
+    "courses": []
+  },
+  "CRJ 257": {
+    "text": "A grade of C or higher in CRJ 101",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 280": {
+    "text": "Must be degree seeking (enrolled) in the Advanced Certificate in Police Operations",
+    "courses": []
+  },
+  "CRJ 291": {
+    "text": "An earned associate degree or higher with a cumulative GPA of 2",
+    "courses": []
+  },
+  "CRJ 292": {
+    "text": "An earned associate degree or higher with a cumulative GPA of 2",
+    "courses": []
+  },
+  "CRJ 294": {
+    "text": "An earned associate degree or higher with a cumulative GPA of 2",
+    "courses": []
+  },
+  "CRJ 295": {
+    "text": "CRJ 290",
+    "courses": [
+      "CRJ 290"
+    ]
+  },
+  "CRJ 296": {
+    "text": "instructor permission",
+    "courses": []
+  },
+  "CSCI 160": {
+    "text": "CSCI 110",
+    "courses": [
+      "CSCI 110"
+    ]
+  },
+  "CSCI 220": {
+    "text": "CSCI 110",
+    "courses": [
+      "CSCI 110"
+    ]
+  },
+  "CSCI 230": {
+    "text": "CSCI 160",
+    "courses": [
+      "CSCI 160"
+    ]
+  },
+  "CSCI 250": {
+    "text": "CSCI 110",
+    "courses": [
+      "CSCI 110"
+    ]
+  },
+  "CSCI 260": {
+    "text": "CSCI 160",
+    "courses": [
+      "CSCI 160"
+    ]
+  },
+  "CSCI 265": {
+    "text": "CSCI 110",
+    "courses": [
+      "CSCI 110"
+    ]
+  },
+  "CSCI 275": {
+    "text": "CSCI 110",
+    "courses": [
+      "CSCI 110"
+    ]
+  },
+  "CSCI 290": {
+    "text": "CSCI 160",
+    "courses": [
+      "CSCI 160"
+    ]
+  },
+  "CSCI 296": {
+    "text": "CSCI 250, CSCI 290",
+    "courses": [
+      "CSCI 250",
+      "CSCI 290"
+    ]
+  },
+  "CSCI 298": {
+    "text": "CSCI 290",
+    "courses": [
+      "CSCI 290"
+    ]
+  },
+  "CTE 214": {
+    "text": "CUL 112 (CULA 112), CUL 126 (CULA 126), CUL 127 (CULA 127), and CUL 131 (CULA 131); Corequisite: CUL 129 (CULA 129) CUL 129 (CULA 129) Culinary Arts II 5",
+    "courses": [
+      "CUL 112",
+      "CUL 126",
+      "CUL 127",
+      "CUL 129",
+      "CUL 131",
+      "CULA 112",
+      "CULA 126",
+      "CULA 127",
+      "CULA 129",
+      "CULA 131"
+    ]
+  },
+  "CUA 105": {
+    "text": "CUA 105",
+    "courses": []
+  },
+  "CUA 110": {
+    "text": "CUA 100",
+    "courses": [
+      "CUA 100"
+    ]
+  },
+  "CUA 115": {
+    "text": "CUA 110",
+    "courses": [
+      "CUA 110"
+    ]
+  },
+  "CUA 152": {
+    "text": "CUA 150",
+    "courses": [
+      "CUA 150"
+    ]
+  },
+  "CUA 154": {
+    "text": "CUA 115",
+    "courses": [
+      "CUA 115"
+    ]
+  },
+  "CUA 156": {
+    "text": "CUA 154",
+    "courses": [
+      "CUA 154"
+    ]
+  },
+  "CUA 210": {
+    "text": "CUA 152",
+    "courses": [
+      "CUA 152"
+    ]
+  },
+  "CUA 212": {
+    "text": "CUA 152",
+    "courses": [
+      "CUA 152"
+    ]
+  },
+  "CUA 214": {
+    "text": "CUA 210",
+    "courses": [
+      "CUA 210"
+    ]
+  },
+  "CUA 250": {
+    "text": "CUA 150 and 210",
+    "courses": [
+      "CUA 150"
+    ]
+  },
+  "CUA 252": {
+    "text": "CUA 154 and 214",
+    "courses": [
+      "CUA 154"
+    ]
+  },
+  "CUA 254": {
+    "text": "CUA 156",
+    "courses": [
+      "CUA 156"
+    ]
+  },
+  "CUA 256": {
+    "text": "CUA 152",
+    "courses": [
+      "CUA 152"
+    ]
+  },
+  "CUA 297": {
+    "text": "CUA 152 and 160",
+    "courses": [
+      "CUA 152"
+    ]
+  },
+  "CUA 299": {
+    "text": "Minimum GPA of 2",
+    "courses": []
+  },
+  "CULA 200": {
+    "text": "CULA 102, CULA 103, CULA 110, CULA120, CULA 130, CULA 140, department approval",
+    "courses": [
+      "CULA 102",
+      "CULA 103",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140"
+    ]
+  },
+  "CULA 241": {
+    "text": "CULA 102, CULA 103, CULA 110, CULA120, CULA 130, CULA 140",
+    "courses": [
+      "CULA 102",
+      "CULA 103",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140"
+    ]
+  },
+  "CULA 250": {
+    "text": "CULA 102, CULA 103, CULA 110, CULA120, CULA 130, CULA 140 (or HSMP 101), MATH 040 or appropriate placement",
+    "courses": [
+      "CULA 102",
+      "CULA 103",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140",
+      "HSMP 101",
+      "MATH 040"
+    ]
+  },
+  "CULA 260": {
+    "text": "CULA 102, CULA 103, CULA 110, CULA120, CULA 130, CULA 140",
+    "courses": [
+      "CULA 102",
+      "CULA 103",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140"
+    ]
+  },
+  "CULA 261": {
+    "text": "CULA 102, CULA 103, CULA 110, CULA120, CULA 130, CULA 140",
+    "courses": [
+      "CULA 102",
+      "CULA 103",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140"
+    ]
+  },
+  "CULA 262": {
+    "text": "CULA 102, CULA 110, CULA 120, CULA130 and CULA 140",
+    "courses": [
+      "CULA 102",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140"
+    ]
+  },
+  "CULA 263": {
+    "text": "CULA 102, CULA 110, CULA 120, CULA130 and CULA 140",
+    "courses": [
+      "CULA 102",
+      "CULA 110",
+      "CULA 120",
+      "CULA 130",
+      "CULA 140"
+    ]
+  },
+  "CULA 264": {
+    "text": "ENGL 100 or ENGL 101, CULA program acceptance",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "DTG 234": {
+    "text": "DTG 233 (DRFT 233)",
+    "courses": [
+      "DRFT 233",
+      "DTG 233"
+    ]
+  },
+  "ECE 100": {
+    "text": "ECE 100 and department chair approval",
+    "courses": []
+  },
+  "ECE 105": {
+    "text": "ECE 100",
+    "courses": [
+      "ECE 100"
+    ]
+  },
+  "ECE 107": {
+    "text": "ECE 110 (ECED 110) or permission ECE 110 (ECED 110) Child and Adolescent Development 3 Credits Studies stages of development from prenatal periods through adolescence",
+    "courses": [
+      "ECE 110",
+      "ECED 110"
+    ]
+  },
+  "ECE 113": {
+    "text": "ECE 100 and PSY 114; Corequisite: ECE 297",
+    "courses": [
+      "ECE 100",
+      "ECE 297",
+      "PSY 114"
+    ]
+  },
+  "ECE 203": {
+    "text": "Completion of a Level 100 math course and ECE 100 or EDU 101 or a current early childhood education teacher",
+    "courses": [
+      "ECE 100",
+      "EDU 101"
+    ]
+  },
+  "ECE 204": {
+    "text": "ECE 100 or EDU 101 or a current early childhood education teacher",
+    "courses": [
+      "ECE 100",
+      "EDU 101"
+    ]
+  },
+  "ECE 205": {
+    "text": "ECE 100 and PSY 114",
+    "courses": [
+      "ECE 100",
+      "PSY 114"
+    ]
+  },
+  "ECE 207": {
+    "text": "ECE 110 (ECED 110) or permission",
+    "courses": [
+      "ECE 110",
+      "ECED 110"
+    ]
+  },
+  "ECE 209": {
+    "text": "ECE 203 Must have a grade of C or better to pass this course",
+    "courses": [
+      "ECE 203"
+    ]
+  },
+  "ECE 210": {
+    "text": "ECE 216 (ECED 216) or permission ECE 216 (ECED 216) Survey of Exceptionalities 3 Credits Studies individuals with exceptionalities, birth to age 21",
+    "courses": [
+      "ECE 216",
+      "ECED 216"
+    ]
+  },
+  "ECE 229": {
+    "text": "ECE 117 (ECED 117) or instructor permission ECO 103 (ECON 103) Personal Finance 3 Credits Provides a survey of consumer and personal finance",
+    "courses": [
+      "ECE 117",
+      "ECED 117",
+      "ECO 103",
+      "ECON 103"
+    ]
+  },
+  "ECE 250": {
+    "text": "Criminal background check",
+    "courses": []
+  },
+  "ECE 299": {
+    "text": "ECE 100 or EDU 101 or a current early childhood education teacher",
+    "courses": [
+      "ECE 100",
+      "EDU 101"
+    ]
+  },
+  "ECED 100": {
+    "text": "ENGL 080 or ENGL 101, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ECED 110": {
+    "text": "ENGL 080 or ENGL 101, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ECED 150": {
+    "text": "ECED 100 or EDUC 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110",
+      "EDUC 100"
+    ]
+  },
+  "ECED 160": {
+    "text": "ECED 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110"
+    ]
+  },
+  "ECED 200": {
+    "text": "ECED 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110"
+    ]
+  },
+  "ECED 210": {
+    "text": "ECED 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110"
+    ]
+  },
+  "ECED 220": {
+    "text": "ECED 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110"
+    ]
+  },
+  "ECED 250": {
+    "text": "ECED 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110"
+    ]
+  },
+  "ECED 260": {
+    "text": "ECED 100, ECED 110",
+    "courses": [
+      "ECED 100",
+      "ECED 110"
+    ]
+  },
+  "ECED 275": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "ECO 113": {
+    "text": "MAT 111, BUS101, CPT115 with a grade of “C” or better",
+    "courses": [
+      "BUS 101",
+      "CPT 115",
+      "MAT 111"
+    ]
+  },
+  "EDB 106": {
+    "text": "ECE 110 (ECED 110) or permission EDB 114 (EDUC 114) Exploring Education 3 Credits Introduces students to the field of education in the United States",
+    "courses": [
+      "ECE 110",
+      "ECED 110",
+      "EDB 114",
+      "EDUC 114"
+    ]
+  },
+  "EDB 206": {
+    "text": "ECE 117 (ECED 117) Must have a grade of C or better to pass this course",
+    "courses": [
+      "ECE 117",
+      "ECED 117"
+    ]
+  },
+  "EDB 208": {
+    "text": "ECE 110 (ECED 110) or permission",
+    "courses": [
+      "ECE 110",
+      "ECED 110"
+    ]
+  },
+  "EDB 210": {
+    "text": "ECE 216 (ECED 216) or instructor permission",
+    "courses": [
+      "ECE 216",
+      "ECED 216"
+    ]
+  },
+  "EDB 215": {
+    "text": "EDB 206",
+    "courses": [
+      "EDB 206"
+    ]
+  },
+  "EDB 219": {
+    "text": "ECE 110 (ECED 110) or permission EDB 221 (EDUC 221) Educational Psychology 3 Credits Studies human development, learning cognition and teaching",
+    "courses": [
+      "ECE 110",
+      "ECED 110",
+      "EDB 221",
+      "EDUC 221"
+    ]
+  },
+  "EDB 232": {
+    "text": "ECE 117 (ECED 117); Corequisite: EDB 204 (EDUC 204)",
+    "courses": [
+      "ECE 117",
+      "ECED 117",
+      "EDB 204",
+      "EDUC 204"
+    ]
+  },
+  "EDSE 235": {
+    "text": "ELC 101 (ELEC 101) and ELC 111 (ELEC 111) with a grade of C or higher or instructor permission",
+    "courses": [
+      "ELC 101",
+      "ELC 111",
+      "ELEC 101",
+      "ELEC 111"
+    ]
+  },
+  "EDU 150": {
+    "text": "Students must earn a C of higher in EDU 101 or department chair approval",
+    "courses": [
+      "EDU 101"
+    ]
+  },
+  "EDU 206": {
+    "text": "EDU 102",
+    "courses": [
+      "EDU 102"
+    ]
+  },
+  "EDU 210": {
+    "text": "EDU 102",
+    "courses": [
+      "EDU 102"
+    ]
+  },
+  "EDU 215": {
+    "text": "EDU 102",
+    "courses": [
+      "EDU 102"
+    ]
+  },
+  "EDU 222": {
+    "text": "EDU 102",
+    "courses": [
+      "EDU 102"
+    ]
+  },
+  "EDU 230": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "EDU 282": {
+    "text": "ECE 100 or EDU 101 or a current early childhood education teacher",
+    "courses": [
+      "ECE 100",
+      "EDU 101"
+    ]
+  },
+  "EDU 290": {
+    "text": "EDU 101, and a G.P.A. of 3.0 in program courses, with at least 30 credits earned in the program of study, and permission of the Department Chair or designee",
+    "courses": [
+      "EDU 101"
+    ]
+  },
+  "EDUC 105": {
+    "text": "ENGL 080 or ENGL 101, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "EDUC 110": {
+    "text": "EDUC 100, ENGL 100 or ENGL 101; or",
+    "courses": [
+      "EDUC 100",
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "EDUC 205": {
+    "text": "Advanced Certificate in Education",
+    "courses": []
+  },
+  "EDUC 210": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "EDUC 220": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "EDUC 230": {
+    "text": "EDUC 100, EDUC 105, or Advanced",
+    "courses": [
+      "EDUC 100",
+      "EDUC 105"
+    ]
+  },
+  "EDUC 245": {
+    "text": "Educator Apprenticeship Program",
+    "courses": []
+  },
+  "EDUC 250": {
+    "text": "15 credits earned in the Advanced",
+    "courses": []
+  },
+  "ELC 101": {
+    "text": "ELTC majors only or have approval from instructor",
+    "courses": []
+  },
+  "ELC 120": {
+    "text": "ELC 101",
+    "courses": [
+      "ELC 101"
+    ]
+  },
+  "ELC 150": {
+    "text": "ELTC majors only or have approval from instructor",
+    "courses": []
+  },
+  "ELC 160": {
+    "text": "ELC 101",
+    "courses": [
+      "ELC 101"
+    ]
+  },
+  "ELC 180": {
+    "text": "ELTC majors only or have approval from instructor",
+    "courses": []
+  },
+  "ELC 190": {
+    "text": "ELTC majors only or have approval from instructor",
+    "courses": []
+  },
+  "ELC 201": {
+    "text": "ELC 101",
+    "courses": [
+      "ELC 101"
+    ]
+  },
+  "ELC 220": {
+    "text": "ELC 120",
+    "courses": [
+      "ELC 120"
+    ]
+  },
+  "ELC 250": {
+    "text": "ELC 201",
+    "courses": [
+      "ELC 201"
+    ]
+  },
+  "ELC 260": {
+    "text": "ELTC majors only or have approval from instructor",
+    "courses": []
+  },
+  "ELEC 100": {
+    "text": "HVAC program acceptance",
+    "courses": []
+  },
+  "ELEC 110": {
+    "text": "ELEC or ENGR program acceptance",
+    "courses": []
+  },
+  "ELEC 115": {
+    "text": "ELEC 105 w/grade of C or better",
+    "courses": [
+      "ELEC 105"
+    ]
+  },
+  "ELEC 120": {
+    "text": "ELEC program acceptance",
+    "courses": []
+  },
+  "ELEC 130": {
+    "text": "ELEC or CSCI program acceptance",
+    "courses": []
+  },
+  "ELEC 140": {
+    "text": "ELEC 101, ELEC 110 w/grade of C or better, MATH 140, MATH 146",
+    "courses": [
+      "ELEC 101",
+      "ELEC 110",
+      "MATH 140",
+      "MATH 146"
+    ]
+  },
+  "ELEC 150": {
+    "text": "ELEC 115 w/grade of C or better",
+    "courses": [
+      "ELEC 115"
+    ]
+  },
+  "ELEC 160": {
+    "text": "ELEC 105 w/grade of C or better",
+    "courses": [
+      "ELEC 105"
+    ]
+  },
+  "ELEC 170": {
+    "text": "ELEC 140 w/grade of C or better",
+    "courses": [
+      "ELEC 140"
+    ]
+  },
+  "ELEC 175": {
+    "text": "ELEC program acceptance",
+    "courses": []
+  },
+  "ELEC 205": {
+    "text": "ELEC 115 w/grade of C or better",
+    "courses": [
+      "ELEC 115"
+    ]
+  },
+  "ELEC 210": {
+    "text": "ELEC 115 w/grade of C or better",
+    "courses": [
+      "ELEC 115"
+    ]
+  },
+  "ELEC 215": {
+    "text": "ELEC 140",
+    "courses": [
+      "ELEC 140"
+    ]
+  },
+  "ELEC 235": {
+    "text": "ELEC 230",
+    "courses": [
+      "ELEC 230"
+    ]
+  },
+  "ELEC 240": {
+    "text": "ELEC or ENGR program acceptance",
+    "courses": []
+  },
+  "ELEC 250": {
+    "text": "ELEC 215 and ELEC 170 or ELEC 150 and ELEC 220",
+    "courses": [
+      "ELEC 150",
+      "ELEC 170",
+      "ELEC 215",
+      "ELEC 220"
+    ]
+  },
+  "ELEC 260": {
+    "text": "ELEC 215",
+    "courses": [
+      "ELEC 215"
+    ]
+  },
+  "ELEC 265": {
+    "text": "ELEC 110",
+    "courses": [
+      "ELEC 110"
+    ]
+  },
+  "ELEC 280": {
+    "text": "ELEC 150",
+    "courses": [
+      "ELEC 150"
+    ]
+  },
+  "ELT 115": {
+    "text": "ELT 101 and MAT 104 or 122",
+    "courses": [
+      "ELT 101",
+      "MAT 104"
+    ]
+  },
+  "ELT 201": {
+    "text": "ELT 153",
+    "courses": [
+      "ELT 153"
+    ]
+  },
+  "ELT 221": {
+    "text": "ELT 115, 123, and 153",
+    "courses": [
+      "ELT 115"
+    ]
+  },
+  "ELT 222": {
+    "text": "ELT 221",
+    "courses": [
+      "ELT 221"
+    ]
+  },
+  "ELT 231": {
+    "text": "ELT 115 and 145",
+    "courses": [
+      "ELT 115"
+    ]
+  },
+  "ELT 232": {
+    "text": "ELT 231 and 245",
+    "courses": [
+      "ELT 231"
+    ]
+  },
+  "ELT 245": {
+    "text": "ELT 115 and 145",
+    "courses": [
+      "ELT 115"
+    ]
+  },
+  "ELT 246": {
+    "text": "ELT 245",
+    "courses": [
+      "ELT 245"
+    ]
+  },
+  "ELT 275": {
+    "text": "ELT 221 and 271",
+    "courses": [
+      "ELT 221"
+    ]
+  },
+  "EMS 100": {
+    "text": "Reading Comprehension exam EMS/EMSA 116 Advanced Emergencies 1 3 Credits Introduces students to the role of the Advanced Life Support (ALS) provider, including their responsibilities, scope of practice, and professional expectations",
+    "courses": [
+      "EMSA 116"
+    ]
+  },
+  "EMS 124": {
+    "text": "Successful completion of all EMCC and EMS Program Entrance Testing and Maine EMS Licensed First Responder",
+    "courses": []
+  },
+  "EMS 270": {
+    "text": "Current licensure as a NREMTP",
+    "courses": []
+  },
+  "EMS 271": {
+    "text": "EMS 270 and EMS 280",
+    "courses": [
+      "EMS 270",
+      "EMS 280"
+    ]
+  },
+  "EMS 281": {
+    "text": "EMS 271 ENG 100 (ENGL 100) Strategies for Basic Academic and Pre professional Writing 3 Credits Develops basic academic writing skills emphasizing logical structure and clarity through the paragraph and essay forms",
+    "courses": [
+      "EMS 271",
+      "ENG 100",
+      "ENGL 100"
+    ]
+  },
+  "EMSP 115": {
+    "text": "EMSP program acceptance, BIOL 132",
+    "courses": [
+      "BIOL 132"
+    ]
+  },
+  "EMSP 120": {
+    "text": "EMSP program acceptance, BIOL 132",
+    "courses": [
+      "BIOL 132"
+    ]
+  },
+  "EMSP 150": {
+    "text": "EMSP program acceptance, BIOL 132",
+    "courses": [
+      "BIOL 132"
+    ]
+  },
+  "EMSP 165": {
+    "text": "EMSP 115, EMSP 120, EMSP 150",
+    "courses": [
+      "EMSP 115",
+      "EMSP 120",
+      "EMSP 150"
+    ]
+  },
+  "EMSP 170": {
+    "text": "BIOL 138, EMSP 115, EMSP 120",
+    "courses": [
+      "BIOL 138",
+      "EMSP 115",
+      "EMSP 120"
+    ]
+  },
+  "EMSP 175": {
+    "text": "BIOL 138, EMSP 115, EMSP 120",
+    "courses": [
+      "BIOL 138",
+      "EMSP 115",
+      "EMSP 120"
+    ]
+  },
+  "EMSP 200": {
+    "text": "EMSP 165, EMSP 170, EMSP 175",
+    "courses": [
+      "EMSP 165",
+      "EMSP 170",
+      "EMSP 175"
+    ]
+  },
+  "EMSP 201": {
+    "text": "EMSP 165, EMSP 170, EMSP 175",
+    "courses": [
+      "EMSP 165",
+      "EMSP 170",
+      "EMSP 175"
+    ]
+  },
+  "EMSP 205": {
+    "text": "EMSP 200, EMSP 201",
+    "courses": [
+      "EMSP 200",
+      "EMSP 201"
+    ]
+  },
+  "EMSP 235": {
+    "text": "EMSP 200, EMSP 201",
+    "courses": [
+      "EMSP 200",
+      "EMSP 201"
+    ]
+  },
+  "EMSP 250": {
+    "text": "EMSP 200, EMSP 201",
+    "courses": [
+      "EMSP 200",
+      "EMSP 201"
+    ]
+  },
+  "EMSP 280": {
+    "text": "EMSP 205, EMSP 235, EMSP 250",
+    "courses": [
+      "EMSP 205",
+      "EMSP 235",
+      "EMSP 250"
+    ]
+  },
+  "EMSP 285": {
+    "text": "EMSP 205, EMSP 235, EMSP 250",
+    "courses": [
+      "EMSP 205",
+      "EMSP 235",
+      "EMSP 250"
+    ]
+  },
+  "EMST 125": {
+    "text": "EMT Information Session",
+    "courses": []
+  },
+  "EMST 200": {
+    "text": "Maine EMS Emergency Medical",
+    "courses": []
+  },
+  "EMST 201": {
+    "text": "EMST 200",
+    "courses": [
+      "EMST 200"
+    ]
+  },
+  "ENG 090": {
+    "text": "See page 33 for placement and prerequisite chart",
+    "courses": []
+  },
+  "ENG 095": {
+    "text": "Directed self-placement",
+    "courses": []
+  },
+  "ENG 101": {
+    "text": "Directed self-placement or grade of C or higher in ENG 095",
+    "courses": [
+      "ENG 095"
+    ]
+  },
+  "ENG 105": {
+    "text": "See page 33 for placement & prerequisite chart or completion of ENG 090",
+    "courses": [
+      "ENG 090"
+    ]
+  },
+  "ENG 112": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 113": {
+    "text": "ENG 101 ready",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 120": {
+    "text": "Directed self-placement",
+    "courses": []
+  },
+  "ENG 121": {
+    "text": "ENG 101 ready",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 123": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 125": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 131": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 201": {
+    "text": "ENG 101 or permission of Instructor or Department Chair",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 211": {
+    "text": "ENG 101 ready",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 215": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 220": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 221": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ENG 222": {
+    "text": "ENG 101 (ENGL 101) with grade of C or higher or instructor permission PAGE 177 2025 26 COLLEGE CATALOG EASTERN MAINE COMMUNITY COLLEGE",
+    "courses": [
+      "ENG 101",
+      "ENGL 101",
+      "PAGE 177"
+    ]
+  },
+  "ENG 223": {
+    "text": "ENG 101 with grade of C or higher or instructor permission ENG 224 (ENGL 223) The Graphic Novel 3 Credits Studies the graphic novel as literature, briefly investigating the history and evolution of sequential art, developing a vocabulary for evaluating and discussing the graphic novel as a narrative form, and closely analyzing representative works of personal and political memoir, social satire, and commercial escape",
+    "courses": [
+      "ENG 101",
+      "ENG 224",
+      "ENGL 223"
+    ]
+  },
+  "ENG 235": {
+    "text": "ENG 112 (ENGL 115) with grade of C or higher or instructor permission (3 lec)",
+    "courses": [
+      "ENG 112",
+      "ENGL 115"
+    ]
+  },
+  "ENG 241": {
+    "text": "ENG 101 (ENGL 101) with grade of C or higher or instructor permission ENG 245 (ENGL 246) Mythology 3 Credits Analyzes early and modern works of literature pertaining to mythology and legend across cultural boundaries",
+    "courses": [
+      "ENG 101",
+      "ENG 245",
+      "ENGL 101",
+      "ENGL 246"
+    ]
+  },
+  "ENG 291": {
+    "text": "ENG 112 (ENGL 115) with grade of C or higher or instructor permission",
+    "courses": [
+      "ENG 112",
+      "ENGL 115"
+    ]
+  },
+  "ENG 292": {
+    "text": "ENG 100 (ENGL 100) or ENG 101 (ENGL 101) with grade of C or higher EPT 116 (ELEC 116) DC Circuits 3 Credits Explores the fundamentals of DC Electricity",
+    "courses": [
+      "ELEC 116",
+      "ENG 100",
+      "ENG 101",
+      "ENGL 100",
+      "ENGL 101",
+      "EPT 116"
+    ]
+  },
+  "ENGL 040": {
+    "text": "Appropriate placement",
+    "courses": []
+  },
+  "ENGL 080": {
+    "text": "ENGL 040 or appropriate placement",
+    "courses": [
+      "ENGL 040"
+    ]
+  },
+  "ENGL 100": {
+    "text": "ENGL 080 or appropriate placement",
+    "courses": [
+      "ENGL 080"
+    ]
+  },
+  "ENGL 101": {
+    "text": "Appropriate placement",
+    "courses": []
+  },
+  "ENGL 110": {
+    "text": "ENGL 080 or ENGL 101, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 115": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 200": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 220": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 225": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 230": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 235": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 240": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 245": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 250": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 255": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 256": {
+    "text": "ENGL 115",
+    "courses": [
+      "ENGL 115"
+    ]
+  },
+  "ENGL 270": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 280": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGL 285": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "ENGR 100": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "ENGR 172": {
+    "text": "ENGR program acceptance, MATH 225",
+    "courses": [
+      "MATH 225"
+    ]
+  },
+  "ENGR 200": {
+    "text": "ENGR 100, PHYS 200, MATH 260",
+    "courses": [
+      "ENGR 100",
+      "MATH 260",
+      "PHYS 200"
+    ]
+  },
+  "ENGR 217": {
+    "text": "ENGR 216",
+    "courses": [
+      "ENGR 216"
+    ]
+  },
+  "ENGR 230": {
+    "text": "MATH 270, PHYS 200",
+    "courses": [
+      "MATH 270",
+      "PHYS 200"
+    ]
+  },
+  "ENGR 250": {
+    "text": "ENGR 200 and MATH 270",
+    "courses": [
+      "ENGR 200",
+      "MATH 270"
+    ]
+  },
+  "ENVR 110": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "EPA 608": {
+    "text": "PMT 113 or instructor’s permission",
+    "courses": [
+      "PMT 113"
+    ]
+  },
+  "ESL 074": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "ESL 102": {
+    "text": "ENG 201 or 220 or instructor permission",
+    "courses": [
+      "ENG 201"
+    ]
+  },
+  "ESL 103": {
+    "text": "FOA 100 and 152",
+    "courses": [
+      "FOA 100"
+    ]
+  },
+  "FIGS 100": {
+    "text": "Pathway Program Acceptance",
+    "courses": []
+  },
+  "FIGS 102": {
+    "text": "Health Science Pathway Program",
+    "courses": []
+  },
+  "FIGS 110": {
+    "text": "ACSS 100 or FIGS 100",
+    "courses": [
+      "ACSS 100",
+      "FIGS 100"
+    ]
+  },
+  "FIR 107": {
+    "text": "Must have a valid driver license and be at least 18 years of age",
+    "courses": []
+  },
+  "FIR 108": {
+    "text": "Fire Science Program Acceptance FIR 131 (FIRE 131) Fire Behavior and Combustion 3 Credits Explores the fundamental processes of combustion and the methods by which fires start, spread, and are controlled",
+    "courses": [
+      "FIR 131",
+      "FIRE 131"
+    ]
+  },
+  "FIR 165": {
+    "text": "FIR 129 (FIRE 129)",
+    "courses": [
+      "FIR 129",
+      "FIRE 129"
+    ]
+  },
+  "FIR 210": {
+    "text": "30 credits toward major FIR 215 (FIRE 215) Fire Service Leadership 3 Credits This course is designed to develop a foundation of leadership, supervision and communication skills for the fire officer",
+    "courses": [
+      "FIR 215",
+      "FIRE 215"
+    ]
+  },
+  "FIR 221": {
+    "text": "FIR 110 (FIRE 110), FIR 115 (FIRE 115) FIR 229 (FIRE 229) Internship for Fire Science 3 3 Credits Students will have successfully completed all requirements of FIR 179 (FIRE 179)   Internship 2 and expand on skills and knowledge covered in that course",
+    "courses": [
+      "FIR 110",
+      "FIR 115",
+      "FIR 179",
+      "FIR 229",
+      "FIRE 110",
+      "FIRE 115",
+      "FIRE 179",
+      "FIRE 229"
+    ]
+  },
+  "FIR 230": {
+    "text": "FIR 155 (FIRE 155) FIR 250 (FIRE 250) Fire Ground Operations 3 Credits This course offers basic tactics and strategies to the firefighter",
+    "courses": [
+      "FIR 155",
+      "FIR 250",
+      "FIRE 155",
+      "FIRE 250"
+    ]
+  },
+  "FIR 262": {
+    "text": "FIR 261",
+    "courses": [
+      "FIR 261"
+    ]
+  },
+  "FIR 291": {
+    "text": "WEL 269 (WELD 269) FIT 233 (PFIT 233) Practical Pipefitting I 1",
+    "courses": [
+      "FIT 233",
+      "PFIT 233",
+      "WEL 269",
+      "WELD 269"
+    ]
+  },
+  "FOA 211": {
+    "text": "FOA 151 or instructor permission",
+    "courses": [
+      "FOA 151"
+    ]
+  },
+  "FOA 232": {
+    "text": "FOA 130",
+    "courses": [
+      "FOA 130"
+    ]
+  },
+  "FOA 270": {
+    "text": "FOA 232",
+    "courses": [
+      "FOA 232"
+    ]
+  },
+  "FOA 271": {
+    "text": "FRE 101 or two years of high school French",
+    "courses": [
+      "FRE 101"
+    ]
+  },
+  "FRE 102": {
+    "text": "FOA 190",
+    "courses": [
+      "FOA 190"
+    ]
+  },
+  "FSW 280": {
+    "text": "FSW majors only and 54 completed credit hours in the major",
+    "courses": []
+  },
+  "FYES 100": {
+    "text": "FREN 101 or instructor approval",
+    "courses": [
+      "FREN 101"
+    ]
+  },
+  "GISS 250": {
+    "text": "GISS 150",
+    "courses": [
+      "GISS 150"
+    ]
+  },
+  "GRC 201": {
+    "text": "GRC 102, 103, 106, and 176 or instructor approval",
+    "courses": [
+      "GRC 102"
+    ]
+  },
+  "GRC 204": {
+    "text": "GRC 106",
+    "courses": [
+      "GRC 106"
+    ]
+  },
+  "GRC 205": {
+    "text": "GRC 119",
+    "courses": [
+      "GRC 119"
+    ]
+  },
+  "GRC 249": {
+    "text": "GRC 102, 103, 106, 107, 176",
+    "courses": [
+      "GRC 102"
+    ]
+  },
+  "GRC 250": {
+    "text": "GRC 103",
+    "courses": [
+      "GRC 103"
+    ]
+  },
+  "GRC 252": {
+    "text": "GRC 153",
+    "courses": [
+      "GRC 153"
+    ]
+  },
+  "GRC 254": {
+    "text": "GRC 102, 103, 106, 107 and 176",
+    "courses": [
+      "GRC 102"
+    ]
+  },
+  "GRC 276": {
+    "text": "GRC 176",
+    "courses": [
+      "GRC 176"
+    ]
+  },
+  "GRC 297": {
+    "text": "GRC 102, 103, 106, 107, 119, 176 and instructor approval prior to registration",
+    "courses": [
+      "GRC 102"
+    ]
+  },
+  "GRC 298": {
+    "text": "GRC 102, 103, 106, 107, 119, 176",
+    "courses": [
+      "GRC 102"
+    ]
+  },
+  "GRMN 200": {
+    "text": "GRMN 100",
+    "courses": [
+      "GRMN 100"
+    ]
+  },
+  "HEOP 100": {
+    "text": "HEOP program acceptance",
+    "courses": []
+  },
+  "HEOP 145": {
+    "text": "HEOP 100",
+    "courses": [
+      "HEOP 100"
+    ]
+  },
+  "HEOP 160": {
+    "text": "HEOP 100, HEOP 115, HEOP 130",
+    "courses": [
+      "HEOP 100",
+      "HEOP 115",
+      "HEOP 130"
+    ]
+  },
+  "HEOP 175": {
+    "text": "HEOP 130, HEOP 145, HEOP 160",
+    "courses": [
+      "HEOP 130",
+      "HEOP 145",
+      "HEOP 160"
+    ]
+  },
+  "HIS 125": {
+    "text": "Grade of C or higher in ENG 095, or appropriate reading placement",
+    "courses": [
+      "ENG 095"
+    ]
+  },
+  "HIS 296": {
+    "text": "One history course or instructor permission",
+    "courses": []
+  },
+  "HIST 120": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 125": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 130": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 136": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 139": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 140": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 145": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 155": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 165": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 170": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 175": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 201": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 202": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 203": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 208": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HIST 225": {
+    "text": "ENGL 080 or ENGL 101, or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "HLTH 100": {
+    "text": "ENGL 080 or or appropriate placement",
+    "courses": [
+      "ENGL 080"
+    ]
+  },
+  "HLTH 105": {
+    "text": "BIOL 138",
+    "courses": [
+      "BIOL 138"
+    ]
+  },
+  "HLTH 125": {
+    "text": "HLTH program acceptance",
+    "courses": []
+  },
+  "HLTH 155": {
+    "text": "BIOL 105 or BIOL 132",
+    "courses": [
+      "BIOL 105",
+      "BIOL 132"
+    ]
+  },
+  "HLTH 200": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "HLTH 205": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "HLTH 210": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "HLTH 215": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "HORT 120": {
+    "text": "HORT 110",
+    "courses": [
+      "HORT 110"
+    ]
+  },
+  "HORT 150": {
+    "text": "HORT 110",
+    "courses": [
+      "HORT 110"
+    ]
+  },
+  "HORT 175": {
+    "text": "HORT 130, HORT 140, and HORT 110 or HORT 200",
+    "courses": [
+      "HORT 110",
+      "HORT 130",
+      "HORT 140",
+      "HORT 200"
+    ]
+  },
+  "HORT 200": {
+    "text": "HORT 110 or department approval",
+    "courses": [
+      "HORT 110"
+    ]
+  },
+  "HORT 210": {
+    "text": "MATH 112 or higher",
+    "courses": [
+      "MATH 112"
+    ]
+  },
+  "HORT 220": {
+    "text": "HORT 110, HORT 130",
+    "courses": [
+      "HORT 110",
+      "HORT 130"
+    ]
+  },
+  "HORT 230": {
+    "text": "HORT 110, HORT 200, HORT 210",
+    "courses": [
+      "HORT 110",
+      "HORT 200",
+      "HORT 210"
+    ]
+  },
+  "HORT 280": {
+    "text": "HORT 175, HORT 180",
+    "courses": [
+      "HORT 175",
+      "HORT 180"
+    ]
+  },
+  "HSPM 106": {
+    "text": "HORT 130, HORT 200",
+    "courses": [
+      "HORT 130",
+      "HORT 200"
+    ]
+  },
+  "HSPM 175": {
+    "text": "HSPM program acceptance",
+    "courses": []
+  },
+  "HSPM 230": {
+    "text": "HSPM 102",
+    "courses": [
+      "HSPM 102"
+    ]
+  },
+  "HSPM 255": {
+    "text": "ACCT 105",
+    "courses": [
+      "ACCT 105"
+    ]
+  },
+  "HSPM 270": {
+    "text": "ENGL 100 or ENGL 101, HSPM program acceptance",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "HSPM 275": {
+    "text": "HSPM 102",
+    "courses": [
+      "HSPM 102"
+    ]
+  },
+  "HUM 110": {
+    "text": "Grade of C or higher in ENG 095, or appropriate reading placement",
+    "courses": [
+      "ENG 095"
+    ]
+  },
+  "HUM 201": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUM 296": {
+    "text": "The student must have completed (12) credit hours in a catalog program, be in good academic standing, be recommended by his or her advisor, and meet with the course instructor",
+    "courses": []
+  },
+  "HUS 151": {
+    "text": "Completion of HUS 112 and PSY 101, with a grade of C or better",
+    "courses": [
+      "HUS 112",
+      "PSY 101"
+    ]
+  },
+  "HUS 155": {
+    "text": "Successful completion of HUS 112",
+    "courses": [
+      "HUS 112"
+    ]
+  },
+  "HUS 204": {
+    "text": "HUS 202 with grade of C or higher",
+    "courses": [
+      "HUS 202"
+    ]
+  },
+  "HUS 230": {
+    "text": "HUS 151 with a C or higher",
+    "courses": [
+      "HUS 151"
+    ]
+  },
+  "HUS 235": {
+    "text": "Students should have successfully completed 30 credits of the HUS degree requirements and permission from Department Chair",
+    "courses": []
+  },
+  "HUS 251": {
+    "text": "HUS 241",
+    "courses": [
+      "HUS 241"
+    ]
+  },
+  "HUS 296": {
+    "text": "Meet the ENG 105 prerequisites",
+    "courses": [
+      "ENG 105"
+    ]
+  },
+  "HVAC 115": {
+    "text": "HVAC program acceptance",
+    "courses": []
+  },
+  "HVAC 120": {
+    "text": "HVAC program acceptance",
+    "courses": []
+  },
+  "HVAC 220": {
+    "text": "HVAC program acceptance",
+    "courses": []
+  },
+  "HVT 152": {
+    "text": "HVT 105 and HVT 111",
+    "courses": [
+      "HVT 105",
+      "HVT 111"
+    ]
+  },
+  "HVT 180": {
+    "text": "HVT 105 and 111",
+    "courses": [
+      "HVT 105"
+    ]
+  },
+  "HVT 252": {
+    "text": "HVT 120",
+    "courses": [
+      "HVT 120"
+    ]
+  },
+  "HVT 255": {
+    "text": "HVT 180",
+    "courses": [
+      "HVT 180"
+    ]
+  },
+  "HVT 297": {
+    "text": "HVT 180, completion of the OSHA 10 hour card, and department chair approval",
+    "courses": [
+      "HVT 180"
+    ]
+  },
+  "ICEX 160": {
+    "text": "ELEC 100, HVAC 115",
+    "courses": [
+      "ELEC 100",
+      "HVAC 115"
+    ]
+  },
+  "IDST 120": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "IDST 140": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "IDST 150": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "IDST 160": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "IDST 170": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "INS 101": {
+    "text": "Successful completion of ENG 101 or 105 with a C or better",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "INS 211": {
+    "text": "Successful completion of ENG 101 or ENG 105 with a C or better",
+    "courses": [
+      "ENG 101",
+      "ENG 105"
+    ]
+  },
+  "INS 250": {
+    "text": "Successful completion of ENG 101 or ENG 105 with a C or better",
+    "courses": [
+      "ENG 101",
+      "ENG 105"
+    ]
+  },
+  "INSC 160": {
+    "text": "CMIT 100, CMIT 105, MATH 040 or appropriate placement",
+    "courses": [
+      "CMIT 100",
+      "CMIT 105",
+      "MATH 040"
+    ]
+  },
+  "INSC 170": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "INSC 260": {
+    "text": "CMIT 105, INSC 160",
+    "courses": [
+      "CMIT 105",
+      "INSC 160"
+    ]
+  },
+  "INSC 270": {
+    "text": "INSC 160",
+    "courses": [
+      "INSC 160"
+    ]
+  },
+  "INSC 275": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "INSC 280": {
+    "text": "24 credits earned",
+    "courses": []
+  },
+  "INT 102": {
+    "text": "ARC 101 and ARC 111 with a grade of C or higher",
+    "courses": [
+      "ARC 101",
+      "ARC 111"
+    ]
+  },
+  "INT 201": {
+    "text": "Successful Completion of ENG 101 or ENG 105 with a C or better",
+    "courses": [
+      "ENG 101",
+      "ENG 105"
+    ]
+  },
+  "INT 202": {
+    "text": "INT 201 and CAD 202 with a grade of C or higher",
+    "courses": [
+      "CAD 202",
+      "INT 201"
+    ]
+  },
+  "INT 215": {
+    "text": "ARC 101 and ARC 111 with a grade of C or higher",
+    "courses": [
+      "ARC 101",
+      "ARC 111"
+    ]
+  },
+  "INT 216": {
+    "text": "INT 201 and CAD 202 with a grade or C or higher",
+    "courses": [
+      "CAD 202",
+      "INT 201"
+    ]
+  },
+  "JUS 204": {
+    "text": "CRJ 101 or PSY 101 or instructor permission",
+    "courses": [
+      "CRJ 101",
+      "PSY 101"
+    ]
+  },
+  "LDR 210": {
+    "text": "LDR 101",
+    "courses": [
+      "LDR 101"
+    ]
+  },
+  "LDR 220": {
+    "text": "LDR 101 Corequisite(s): LDR 210",
+    "courses": [
+      "LDR 101",
+      "LDR 210"
+    ]
+  },
+  "LEG 202": {
+    "text": "LEG 101 and CJS 120",
+    "courses": [
+      "CJS 120",
+      "LEG 101"
+    ]
+  },
+  "LEG 203": {
+    "text": "LEG 101, LEG 102, and LEG 103",
+    "courses": [
+      "LEG 101",
+      "LEG 102",
+      "LEG 103"
+    ]
+  },
+  "LEG 280": {
+    "text": "CJS 125, Legal Studies major with at least 45 earned credits",
+    "courses": [
+      "CJS 125"
+    ]
+  },
+  "LEG 290": {
+    "text": "Legal Studies majors with at least 30 credits and a GPA of 3.0 in the Legal",
+    "courses": []
+  },
+  "MACH 101": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MACH 102": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MACH 103": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MACH 105": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MACH 106": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MACH 115": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MACH 151": {
+    "text": "MACH 115, or MACH 101 and MACH103",
+    "courses": [
+      "MACH 101",
+      "MACH 103",
+      "MACH 115"
+    ]
+  },
+  "MACH 152": {
+    "text": "MACH 115, or MACH 101, MACH 102 and MACH 103",
+    "courses": [
+      "MACH 101",
+      "MACH 102",
+      "MACH 103",
+      "MACH 115"
+    ]
+  },
+  "MACH 153": {
+    "text": "MACH 115, or MACH 101, MACH 102 and MACH 103",
+    "courses": [
+      "MACH 101",
+      "MACH 102",
+      "MACH 103",
+      "MACH 115"
+    ]
+  },
+  "MACH 155": {
+    "text": "MACH 105, MACH 106, AEDD 105",
+    "courses": [
+      "AEDD 105",
+      "MACH 105",
+      "MACH 106"
+    ]
+  },
+  "MACH 156": {
+    "text": "MACH 105, MACH 106, AEDD 105",
+    "courses": [
+      "AEDD 105",
+      "MACH 105",
+      "MACH 106"
+    ]
+  },
+  "MACH 165": {
+    "text": "MACH 115 or MACH 101, MACH 102",
+    "courses": [
+      "MACH 101",
+      "MACH 102",
+      "MACH 115"
+    ]
+  },
+  "MACH 205": {
+    "text": "MACH 155, MACH 156",
+    "courses": [
+      "MACH 155",
+      "MACH 156"
+    ]
+  },
+  "MACH 206": {
+    "text": "MACH 155, MACH 156",
+    "courses": [
+      "MACH 155",
+      "MACH 156"
+    ]
+  },
+  "MACH 215": {
+    "text": "MACH 165",
+    "courses": [
+      "MACH 165"
+    ]
+  },
+  "MACH 255": {
+    "text": "MACH 205, MACH 206",
+    "courses": [
+      "MACH 205",
+      "MACH 206"
+    ]
+  },
+  "MACH 256": {
+    "text": "MACH 205, MACH 206",
+    "courses": [
+      "MACH 205",
+      "MACH 206"
+    ]
+  },
+  "MACH 265": {
+    "text": "MACH 215",
+    "courses": [
+      "MACH 215"
+    ]
+  },
+  "MACH 275": {
+    "text": "MACH 105, MACH 106",
+    "courses": [
+      "MACH 105",
+      "MACH 106"
+    ]
+  },
+  "MAS 102": {
+    "text": "MAS 102, BMT 113 (MEDO 113), and BIO 127 (BIOL 215 ) MAS 201 (MDA201) Principles of Pharmacology 3 Credits Introduces the basic concepts of pharmacology",
+    "courses": [
+      "BIO 127",
+      "BIOL 215",
+      "BMT 113",
+      "MAS 201",
+      "MDA 201",
+      "MEDO 113"
+    ]
+  },
+  "MAT 101": {
+    "text": "Refer to Placement Chart on Page 45",
+    "courses": []
+  },
+  "MAT 103": {
+    "text": "students must be matriculated in the Early Childhood Education or Education program",
+    "courses": []
+  },
+  "MAT 109": {
+    "text": "Refer to Placement Chart on Page 45",
+    "courses": []
+  },
+  "MAT 116": {
+    "text": "Appropriate math placement",
+    "courses": []
+  },
+  "MAT 118": {
+    "text": "Appropriate math placement",
+    "courses": []
+  },
+  "MAT 120": {
+    "text": "MAT 104 with a C or higher",
+    "courses": [
+      "MAT 104"
+    ]
+  },
+  "MAT 123": {
+    "text": "MAT 116 (MATH 140) and MAT 120 (MATH 160) with grade of C or higher or MAT 123 (MAT 145) with grade of C or higher, or equivalent PAGE 189 2025 26 COLLEGE CATALOG EASTERN MAINE COMMUNITY COLLEGE MAT 163 (MATH 155) Introduction to Statistics 3 Credits Studies methods of collecting, organizing, summarizing, and presenting data, providing students the opportunity to develop skills using statistical techniques",
+    "courses": [
+      "MAT 116",
+      "MAT 120",
+      "MAT 145",
+      "MAT 163",
+      "MATH 140",
+      "MATH 155",
+      "MATH 160",
+      "PAGE 189"
+    ]
+  },
+  "MAT 124": {
+    "text": "Appropriate math placement",
+    "courses": []
+  },
+  "MAT 126": {
+    "text": "Appropriate math placement",
+    "courses": []
+  },
+  "MAT 127": {
+    "text": "Appropriate math placement",
+    "courses": []
+  },
+  "MAT 150": {
+    "text": "MAT 122",
+    "courses": [
+      "MAT 122"
+    ]
+  },
+  "MAT 163": {
+    "text": "MAT 150",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "MAT 164": {
+    "text": "MAT 163 with a grade C or higher",
+    "courses": [
+      "MAT 163"
+    ]
+  },
+  "MAT 222": {
+    "text": "Grade of C or higher in MAT 127 or appropriate math placement",
+    "courses": [
+      "MAT 127"
+    ]
+  },
+  "MAT 225": {
+    "text": "MAT 150 or instructor approval",
+    "courses": [
+      "MAT 150"
+    ]
+  },
+  "MAT 227": {
+    "text": "Grade of C or higher in MAT 127",
+    "courses": [
+      "MAT 127"
+    ]
+  },
+  "MAT 230": {
+    "text": "MAT 227 (MATH 280) with grade of C or higher",
+    "courses": [
+      "MAT 227",
+      "MATH 280"
+    ]
+  },
+  "MAT 235": {
+    "text": "MAT 226 (MATH 270) with grade of C or higher MATL 110 (MATH 132) Technical Mathematics I with Lab 3 Credits Focuses on mathematics topics relevant to a variety of trades and technical disciplines",
+    "courses": [
+      "MAT 226",
+      "MATH 132",
+      "MATH 270",
+      "MATL 110"
+    ]
+  },
+  "MAT 236": {
+    "text": "MAT 163 or instructor approval",
+    "courses": [
+      "MAT 163"
+    ]
+  },
+  "MAT 251": {
+    "text": "Grade of C or higher in MAT 227",
+    "courses": [
+      "MAT 227"
+    ]
+  },
+  "MAT 265": {
+    "text": "MAT 164",
+    "courses": [
+      "MAT 164"
+    ]
+  },
+  "MAT 291": {
+    "text": "MAT 165 with a C or higher department chair approval",
+    "courses": [
+      "MAT 165"
+    ]
+  },
+  "MAT 293": {
+    "text": "MAT 265 with grade C or higher or department chair approval",
+    "courses": [
+      "MAT 265"
+    ]
+  },
+  "MAT 296": {
+    "text": "TBD by department",
+    "courses": []
+  },
+  "MATH 111": {
+    "text": "Appropriate placement",
+    "courses": []
+  },
+  "MATH 112": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 115": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 116": {
+    "text": "MATH 115",
+    "courses": [
+      "MATH 115"
+    ]
+  },
+  "MATH 120": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "MATH 125": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 130": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 140": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 142": {
+    "text": "Appropriate placement",
+    "courses": []
+  },
+  "MATH 145": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 146": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 155": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "MATH 160": {
+    "text": "MATH 140 or MATH 142",
+    "courses": [
+      "MATH 140",
+      "MATH 142"
+    ]
+  },
+  "MATH 190": {
+    "text": "MATH 140 or MATH 142, MATH 146 or MATH 160",
+    "courses": [
+      "MATH 140",
+      "MATH 142",
+      "MATH 146",
+      "MATH 160"
+    ]
+  },
+  "MATH 220": {
+    "text": "MATH 140",
+    "courses": [
+      "MATH 140"
+    ]
+  },
+  "MATH 225": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement, MATH 140 or MATH 142",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 140",
+      "MATH 142"
+    ]
+  },
+  "MATH 260": {
+    "text": "MATH 190",
+    "courses": [
+      "MATH 190"
+    ]
+  },
+  "MATH 270": {
+    "text": "MATH 260",
+    "courses": [
+      "MATH 260"
+    ]
+  },
+  "MATH 275": {
+    "text": "MATH 270",
+    "courses": [
+      "MATH 270"
+    ]
+  },
+  "MATH 280": {
+    "text": "MATH 270",
+    "courses": [
+      "MATH 270"
+    ]
+  },
+  "MCO 116": {
+    "text": "MET 111 and BIO 105 or BIO 117/118",
+    "courses": [
+      "BIO 105",
+      "BIO 117",
+      "MET 111"
+    ]
+  },
+  "MCO 125": {
+    "text": "MCO 125",
+    "courses": []
+  },
+  "MCO 150": {
+    "text": "MET 111",
+    "courses": [
+      "MET 111"
+    ]
+  },
+  "MCO 215": {
+    "text": "MCO 111",
+    "courses": [
+      "MCO 111"
+    ]
+  },
+  "MCO 299": {
+    "text": "C or higher in MCO 121, 125 and MET 111",
+    "courses": [
+      "MCO 121",
+      "MET 111"
+    ]
+  },
+  "MDAS 100": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "MDAS 105": {
+    "text": "MDAS 110",
+    "courses": [
+      "MDAS 110"
+    ]
+  },
+  "MDAS 110": {
+    "text": "MDAS program acceptance, ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "MDAS 111": {
+    "text": "MDASC program acceptance",
+    "courses": []
+  },
+  "MDAS 125": {
+    "text": "MDAS 110",
+    "courses": [
+      "MDAS 110"
+    ]
+  },
+  "MDAS 150": {
+    "text": "MDAS program acceptance, MDAS100, BIOL 132",
+    "courses": [
+      "BIOL 132",
+      "MDAS 100"
+    ]
+  },
+  "MDAS 160": {
+    "text": "BIOL 132",
+    "courses": [
+      "BIOL 132"
+    ]
+  },
+  "MDAS 205": {
+    "text": "MDAS 105, MDAS 150",
+    "courses": [
+      "MDAS 105",
+      "MDAS 150"
+    ]
+  },
+  "MDAS 210": {
+    "text": "MDAS 125, MDAS 150, MDAS 160",
+    "courses": [
+      "MDAS 125",
+      "MDAS 150",
+      "MDAS 160"
+    ]
+  },
+  "MDAS 260": {
+    "text": "MDAS 105, MDAS 160",
+    "courses": [
+      "MDAS 105",
+      "MDAS 160"
+    ]
+  },
+  "MDAS 275": {
+    "text": "All MDAS Courses and department approval",
+    "courses": []
+  },
+  "MEF 201": {
+    "text": "MEF 101",
+    "courses": [
+      "MEF 101"
+    ]
+  },
+  "MEF 202": {
+    "text": "MEF 201",
+    "courses": [
+      "MEF 201"
+    ]
+  },
+  "MUL 125": {
+    "text": "ART 126 and MUL 110",
+    "courses": [
+      "ART 126",
+      "MUL 110"
+    ]
+  },
+  "MUL 126": {
+    "text": "ART 126",
+    "courses": [
+      "ART 126"
+    ]
+  },
+  "MUL 130": {
+    "text": "ART 120",
+    "courses": [
+      "ART 120"
+    ]
+  },
+  "MUL 200": {
+    "text": "MUL 110",
+    "courses": [
+      "MUL 110"
+    ]
+  },
+  "MUL 202": {
+    "text": "MUL 110 and MUL 225",
+    "courses": [
+      "MUL 110",
+      "MUL 225"
+    ]
+  },
+  "MUL 210": {
+    "text": "MUL 110",
+    "courses": [
+      "MUL 110"
+    ]
+  },
+  "MUL 220": {
+    "text": "MUL 110",
+    "courses": [
+      "MUL 110"
+    ]
+  },
+  "MUL 230": {
+    "text": "MUL 110",
+    "courses": [
+      "MUL 110"
+    ]
+  },
+  "MUL 265": {
+    "text": "MUL 110",
+    "courses": [
+      "MUL 110"
+    ]
+  },
+  "MUL 290": {
+    "text": "MUL 125 or MUL 225, a cumulative GPA of 3.0, with at least 30 credits earned in the program of study and permission of the Department Chair",
+    "courses": [
+      "MUL 125",
+      "MUL 225"
+    ]
+  },
+  "MUS 111": {
+    "text": "Admission to the Nursing Program; Corequisites: BIO 115/116; ENG 101 or 105",
+    "courses": [
+      "BIO 115",
+      "ENG 101"
+    ]
+  },
+  "MUSI 107": {
+    "text": "MUSI 106",
+    "courses": [
+      "MUSI 106"
+    ]
+  },
+  "MUSI 120": {
+    "text": "ENGL 080 or appropriate placement",
+    "courses": [
+      "ENGL 080"
+    ]
+  },
+  "MUSI 123": {
+    "text": "BUA 111 (BUSN 111) with grade of C or higher Description Prerequisite(s) Explanation of Course Description Codes: The distributions contained in this Catalog are based on a \"typical\" 15 week semester",
+    "courses": [
+      "BUA 111",
+      "BUSN 111"
+    ]
+  },
+  "MUSI 151": {
+    "text": "MUSI 101 or permission of the instructor",
+    "courses": [
+      "MUSI 101"
+    ]
+  },
+  "MUSI 152": {
+    "text": "MUSI 102 or permission of the instructor",
+    "courses": [
+      "MUSI 102"
+    ]
+  },
+  "MUSI 153": {
+    "text": "MUSI 103 or permission of the instructor",
+    "courses": [
+      "MUSI 103"
+    ]
+  },
+  "MUSI 154": {
+    "text": "MUSI 104 or permission of the instructor",
+    "courses": [
+      "MUSI 104"
+    ]
+  },
+  "MUSI 203": {
+    "text": "ENGL 100 or ENGL 101, PSYC 100",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "MUSI 210": {
+    "text": "MUSI 102 or MUSI 103 or MUSI 104 or",
+    "courses": [
+      "MUSI 102",
+      "MUSI 103",
+      "MUSI 104"
+    ]
+  },
+  "MUSI 250": {
+    "text": "Bachelor's degree in Music or Music",
+    "courses": []
+  },
+  "MUSI 251": {
+    "text": "Bachelor's degree in Music or Music",
+    "courses": []
+  },
+  "NET 120": {
+    "text": "NET 110",
+    "courses": [
+      "NET 110"
+    ]
+  },
+  "NET 221": {
+    "text": "CIS 178 and NET 110",
+    "courses": [
+      "CIS 178",
+      "NET 110"
+    ]
+  },
+  "NUR 112": {
+    "text": "NUR 112, www",
+    "courses": []
+  },
+  "NUR 115": {
+    "text": "Admis­sion to the Nursing Program",
+    "courses": []
+  },
+  "NUR 201": {
+    "text": "NUR 110",
+    "courses": [
+      "NUR 110"
+    ]
+  },
+  "NUR 205": {
+    "text": "NUR 201",
+    "courses": [
+      "NUR 201"
+    ]
+  },
+  "NUR 210": {
+    "text": "NUR 201",
+    "courses": [
+      "NUR 201"
+    ]
+  },
+  "NUR 212": {
+    "text": "All Level I (1st year) courses",
+    "courses": []
+  },
+  "NURS 111": {
+    "text": "NURS 100, BIOL 132, ENGL 100 or",
+    "courses": [
+      "BIOL 132",
+      "ENGL 100",
+      "NURS 100"
+    ]
+  },
+  "NURS 125": {
+    "text": "NURS program acceptance, MATH 112 or higher",
+    "courses": [
+      "MATH 112"
+    ]
+  },
+  "NURS 175": {
+    "text": "NURS 125 or NURS 111(LPN",
+    "courses": [
+      "NURS 111",
+      "NURS 125"
+    ]
+  },
+  "NURS 195": {
+    "text": "NURS 175, PSYC 220, department approval",
+    "courses": [
+      "NURS 175",
+      "PSYC 220"
+    ]
+  },
+  "NURS 225": {
+    "text": "NURS 175, PSYC 220",
+    "courses": [
+      "NURS 175",
+      "PSYC 220"
+    ]
+  },
+  "NURS 275": {
+    "text": "NURS 225, BIOL 250",
+    "courses": [
+      "BIOL 250",
+      "NURS 225"
+    ]
+  },
+  "NUTR 100": {
+    "text": "NUTR program acceptance",
+    "courses": []
+  },
+  "NUTR 110": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "NUTR 140": {
+    "text": "ENGL 080 or ENGL 101 and MATH 040 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "MATH 040"
+    ]
+  },
+  "NUTR 150": {
+    "text": "NUTR program acceptance",
+    "courses": []
+  },
+  "NUTR 191": {
+    "text": "NUTR 190",
+    "courses": [
+      "NUTR 190"
+    ]
+  },
+  "NUTR 210": {
+    "text": "NUTR 110",
+    "courses": [
+      "NUTR 110"
+    ]
+  },
+  "NUTR 221": {
+    "text": "NUTR 110",
+    "courses": [
+      "NUTR 110"
+    ]
+  },
+  "NUTR 250": {
+    "text": "ENGL 100 or ENGL 101, NUTR 100",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "NUTR 100"
+    ]
+  },
+  "NUTR 275": {
+    "text": "NUTR 210",
+    "courses": [
+      "NUTR 210"
+    ]
+  },
+  "OCEA 105": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "OHS 111": {
+    "text": "NUR 212, BIO 211/212, and PSY 111",
+    "courses": [
+      "BIO 211",
+      "NUR 212",
+      "PSY 111"
+    ]
+  },
+  "OSHA 130": {
+    "text": "MATH 040 or appropriate placement",
+    "courses": [
+      "MATH 040"
+    ]
+  },
+  "PHF 150": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PHF 155": {
+    "text": "BIO 105 or BIO 115/116",
+    "courses": [
+      "BIO 105",
+      "BIO 115"
+    ]
+  },
+  "PHF 197": {
+    "text": "PHF 155",
+    "courses": [
+      "PHF 155"
+    ]
+  },
+  "PHF 204": {
+    "text": "BIO 121",
+    "courses": [
+      "BIO 121"
+    ]
+  },
+  "PHF 207": {
+    "text": "PHF 155 and BIO 105 or BIO 115/116",
+    "courses": [
+      "BIO 105",
+      "BIO 115",
+      "PHF 155"
+    ]
+  },
+  "PHF 208": {
+    "text": "PHF 155",
+    "courses": [
+      "PHF 155"
+    ]
+  },
+  "PHF 299": {
+    "text": "PHF 122, 197 and 204 all with grades C or higher",
+    "courses": [
+      "PHF 122"
+    ]
+  },
+  "PHI 101": {
+    "text": "SAT® ERW score of 420 or higher or Reading Accuplacer® score of 68 or higher and Writeplacer Accuplacer® score of 5 or higher or completion of ENG 090 or ESL 101 with a C or higher",
+    "courses": [
+      "ENG 090",
+      "ESL 101"
+    ]
+  },
+  "PHI 102": {
+    "text": "ENG 101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHI 151": {
+    "text": "Successful Completion of ENG 090 or ESL 101 with a C or better or ENG 101 or 105",
+    "courses": [
+      "ENG 090",
+      "ENG 101",
+      "ESL 101"
+    ]
+  },
+  "PHI 153": {
+    "text": "Successful completion of ESL 090 or ESL 101 with a C or better or ENG 101 or 105",
+    "courses": [
+      "ENG 101",
+      "ESL 090",
+      "ESL 101"
+    ]
+  },
+  "PHI 291": {
+    "text": "MAT 110 (MATH 130) or MAT 116 (MATH 140) with grade of C or higher or instructor permission",
+    "courses": [
+      "MAT 110",
+      "MAT 116",
+      "MATH 130",
+      "MATH 140"
+    ]
+  },
+  "PHIL 100": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "PHIL 105": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "PHIL 155": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "PHT 125": {
+    "text": "PHT 103",
+    "courses": [
+      "PHT 103"
+    ]
+  },
+  "PHT 207": {
+    "text": "PHT 125 or HVT 180",
+    "courses": [
+      "HVT 180",
+      "PHT 125"
+    ]
+  },
+  "PHT 209": {
+    "text": "PHT 125 or HVT 180",
+    "courses": [
+      "HVT 180",
+      "PHT 125"
+    ]
+  },
+  "PHT 257": {
+    "text": "PHT 207",
+    "courses": [
+      "PHT 207"
+    ]
+  },
+  "PHT 259": {
+    "text": "PHT 209",
+    "courses": [
+      "PHT 209"
+    ]
+  },
+  "PHT 297": {
+    "text": "Department chair approval, PHT 207, 209 and successful completion of OSHA 10 hour card",
+    "courses": [
+      "PHT 207"
+    ]
+  },
+  "PHY 118": {
+    "text": "MAT 114 (MATH 135) or MAT 120 (MATH 160) with a grade of C or higher or by instructor permission; Corequisite: PHY 122 (PHYS 152)",
+    "courses": [
+      "MAT 114",
+      "MAT 120",
+      "MATH 135",
+      "MATH 160",
+      "PHY 122",
+      "PHYS 152"
+    ]
+  },
+  "PHY 151": {
+    "text": "MAT 126",
+    "courses": [
+      "MAT 126"
+    ]
+  },
+  "PHY 153": {
+    "text": "PHY 151",
+    "courses": [
+      "PHY 151"
+    ]
+  },
+  "PHY 251": {
+    "text": "MAT 163 with a C or higher",
+    "courses": [
+      "MAT 163"
+    ]
+  },
+  "PHY 253": {
+    "text": "PHY 251/252 with C or higher",
+    "courses": [
+      "PHY 251"
+    ]
+  },
+  "PHY 254": {
+    "text": "BIO 105 or BIO 115/116",
+    "courses": [
+      "BIO 105",
+      "BIO 115"
+    ]
+  },
+  "PHY 296": {
+    "text": "Instructor review",
+    "courses": []
+  },
+  "PHYS 110": {
+    "text": "PHYS 150",
+    "courses": [
+      "PHYS 150"
+    ]
+  },
+  "PHYS 200": {
+    "text": "MATH 190",
+    "courses": [
+      "MATH 190"
+    ]
+  },
+  "PHYS 250": {
+    "text": "PHYS 200, MATH 260",
+    "courses": [
+      "MATH 260",
+      "PHYS 200"
+    ]
+  },
+  "PMT 103": {
+    "text": "PMT 111 or faculty approval",
+    "courses": [
+      "PMT 111"
+    ]
+  },
+  "PMT 111": {
+    "text": "None Corequisite(s) None",
+    "courses": []
+  },
+  "PMT 122": {
+    "text": "PMT 112 or faculty approval",
+    "courses": [
+      "PMT 112"
+    ]
+  },
+  "PMT 124": {
+    "text": "PMT 118 or faculty approval",
+    "courses": [
+      "PMT 118"
+    ]
+  },
+  "PMT 125": {
+    "text": "PMT 119 or instructor permission",
+    "courses": [
+      "PMT 119"
+    ]
+  },
+  "PMT 209": {
+    "text": "PMT 103 or faculty approval",
+    "courses": [
+      "PMT 103"
+    ]
+  },
+  "PMT 211": {
+    "text": "PMT 121 or faculty approval",
+    "courses": [
+      "PMT 121"
+    ]
+  },
+  "PMT 212": {
+    "text": "PMT 124",
+    "courses": [
+      "PMT 124"
+    ]
+  },
+  "PMT 214": {
+    "text": "PMT 125 or faculty approval",
+    "courses": [
+      "PMT 125"
+    ]
+  },
+  "PMT 217": {
+    "text": "PMT 211, 212 or faculty approval",
+    "courses": [
+      "PMT 211"
+    ]
+  },
+  "PMT 221": {
+    "text": "PMT 214",
+    "courses": [
+      "PMT 214"
+    ]
+  },
+  "PMT 228": {
+    "text": "PMT 118 and 119",
+    "courses": [
+      "PMT 118"
+    ]
+  },
+  "PMT 230": {
+    "text": "PMT 209 or 210 or faculty approval",
+    "courses": [
+      "PMT 209"
+    ]
+  },
+  "POLS 100": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "POLS 105": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "POLS 110": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "POLS 115": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "POLS 120": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "POLS 180": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "POLS 205": {
+    "text": "POLS 100 or POLS 105 or POLS 110",
+    "courses": [
+      "POLS 100",
+      "POLS 105",
+      "POLS 110"
+    ]
+  },
+  "POLS 212": {
+    "text": "POLS 100 or POLS 105 or POLS 110",
+    "courses": [
+      "POLS 100",
+      "POLS 105",
+      "POLS 110"
+    ]
+  },
+  "POLS 250": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "POS 290": {
+    "text": "Liberal Studies majors with at least 30 credits earned in the Liberal Studies program, and a GPA of 3.0, and permission of the department chair or his/her designee",
+    "courses": []
+  },
+  "PRS 199": {
+    "text": "Significant occupational training and experience",
+    "courses": []
+  },
+  "PSM 101": {
+    "text": "PSM 105",
+    "courses": [
+      "PSM 105"
+    ]
+  },
+  "PSM 205": {
+    "text": "PSM 100",
+    "courses": [
+      "PSM 100"
+    ]
+  },
+  "PSY 200": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 202": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 210": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 212": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 214": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 220": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 226": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 228": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 230": {
+    "text": "PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 239": {
+    "text": "PSY 101 (PSYC 100)",
+    "courses": [
+      "PSY 101",
+      "PSYC 100"
+    ]
+  },
+  "PSY 241": {
+    "text": "PSY 101 (PSYC 100)",
+    "courses": [
+      "PSY 101",
+      "PSYC 100"
+    ]
+  },
+  "PSY 254": {
+    "text": "RAH 103 (HVAC 103) RAH 113 (HVAC 113) Refrigeration Components and Physical Principles 2",
+    "courses": [
+      "HVAC 103",
+      "HVAC 113",
+      "RAH 103",
+      "RAH 113"
+    ]
+  },
+  "PSY 260": {
+    "text": "Grade of C or higher in PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 290": {
+    "text": "HUS 101 and PSY 101, and a G.P.A. of 3.0 in program courses, with at least 30 credits earned in the program of study, and permission of the Department Chair or designee",
+    "courses": [
+      "HUS 101",
+      "PSY 101"
+    ]
+  },
+  "PSYC 200": {
+    "text": "ENGL 100 or ENGL 101, PSYC 100",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 203": {
+    "text": "ENGL 100 or ENGL 101, PSYC 100",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 215": {
+    "text": "ENGL 100 or ENGL 101, PSYC 100",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 220": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement, PSYC 100",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 225": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement, PSYC 100",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 230": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement, PSYC 100",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 235": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement, PSYC 100",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "PSYC 240": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement, PSYC 100",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "RADG 100": {
+    "text": "RADG program acceptance",
+    "courses": []
+  },
+  "RADG 105": {
+    "text": "RADG program acceptance",
+    "courses": []
+  },
+  "RADG 115": {
+    "text": "RADG program acceptance",
+    "courses": []
+  },
+  "RADG 130": {
+    "text": "RADG program acceptance",
+    "courses": []
+  },
+  "RADG 155": {
+    "text": "RADG 105, RADG 130",
+    "courses": [
+      "RADG 105",
+      "RADG 130"
+    ]
+  },
+  "RADG 160": {
+    "text": "RADG 175, RADG 190",
+    "courses": [
+      "RADG 175",
+      "RADG 190"
+    ]
+  },
+  "RADG 190": {
+    "text": "RADG 160",
+    "courses": [
+      "RADG 160"
+    ]
+  },
+  "RADG 205": {
+    "text": "RADG 155",
+    "courses": [
+      "RADG 155"
+    ]
+  },
+  "RADG 215": {
+    "text": "RADG 115",
+    "courses": [
+      "RADG 115"
+    ]
+  },
+  "RADG 230": {
+    "text": "RADG 215",
+    "courses": [
+      "RADG 215"
+    ]
+  },
+  "RADG 235": {
+    "text": "RADG 160",
+    "courses": [
+      "RADG 160"
+    ]
+  },
+  "RADG 245": {
+    "text": "BIOL 138",
+    "courses": [
+      "BIOL 138"
+    ]
+  },
+  "RADG 255": {
+    "text": "RADG 235",
+    "courses": [
+      "RADG 235"
+    ]
+  },
+  "RADG 260": {
+    "text": "RADG 230",
+    "courses": [
+      "RADG 230"
+    ]
+  },
+  "RADG 275": {
+    "text": "RADG 175, RADG 230",
+    "courses": [
+      "RADG 175",
+      "RADG 230"
+    ]
+  },
+  "REL 101": {
+    "text": "ENG 101 or 105 ready",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "RESP 100": {
+    "text": "RESP program acceptance",
+    "courses": []
+  },
+  "RESP 101": {
+    "text": "RESP program acceptance",
+    "courses": []
+  },
+  "RESP 105": {
+    "text": "BIOL 138, RESP 100, RESP 101, RESP120",
+    "courses": [
+      "BIOL 138",
+      "RESP 100",
+      "RESP 101",
+      "RESP 120"
+    ]
+  },
+  "RESP 110": {
+    "text": "BIOL 138, RESP 100, RESP 101, RESP120",
+    "courses": [
+      "BIOL 138",
+      "RESP 100",
+      "RESP 101",
+      "RESP 120"
+    ]
+  },
+  "RESP 120": {
+    "text": "RESP Program Acceptance",
+    "courses": []
+  },
+  "RESP 125": {
+    "text": "RESP 100, RESP 101, RESP 120",
+    "courses": [
+      "RESP 100",
+      "RESP 101",
+      "RESP 120"
+    ]
+  },
+  "RESP 170": {
+    "text": "RESP 100, RESP 101, RESP 120",
+    "courses": [
+      "RESP 100",
+      "RESP 101",
+      "RESP 120"
+    ]
+  },
+  "RESP 172": {
+    "text": "RESP 170, RESP 175",
+    "courses": [
+      "RESP 170",
+      "RESP 175"
+    ]
+  },
+  "RESP 210": {
+    "text": "RESP 170, RESP 175",
+    "courses": [
+      "RESP 170",
+      "RESP 175"
+    ]
+  },
+  "RESP 220": {
+    "text": "RESP 170, RESP 172, RESP 175",
+    "courses": [
+      "RESP 170",
+      "RESP 172",
+      "RESP 175"
+    ]
+  },
+  "RESP 225": {
+    "text": "RESP 170, RESP 175",
+    "courses": [
+      "RESP 170",
+      "RESP 175"
+    ]
+  },
+  "SOC 113": {
+    "text": "SOC 101 (SOCI 100) SOC 214 (SOCI 210) Contemporary Social Problems 3 Credits An overview of contemporary social problems focusing on literature of local and global social problems with an effort made to address possible solutions",
+    "courses": [
+      "SOC 101",
+      "SOC 214",
+      "SOCI 100",
+      "SOCI 210"
+    ]
+  },
+  "SOCI 125": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "SOCI 160": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "SOCI 190": {
+    "text": "SOCI 100",
+    "courses": [
+      "SOCI 100"
+    ]
+  },
+  "SOCI 201": {
+    "text": "ENGL 100 or ENGL 101",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101"
+    ]
+  },
+  "SOCI 205": {
+    "text": "ENGL 100 or ENGL 101, PSYC 100 or",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "SOCI 210": {
+    "text": "SPAN 101 or instructor approval",
+    "courses": [
+      "SPAN 101"
+    ]
+  },
+  "SPA 102": {
+    "text": "SPA 101 or two years of high school Spanish",
+    "courses": [
+      "SPA 101"
+    ]
+  },
+  "SPTM 105": {
+    "text": "ENGL 080 or ENGL 101 or appropriate placement",
+    "courses": [
+      "ENGL 080",
+      "ENGL 101"
+    ]
+  },
+  "SPTM 200": {
+    "text": "SPTM 155",
+    "courses": [
+      "SPTM 155"
+    ]
+  },
+  "SPTM 205": {
+    "text": "SPTM 155",
+    "courses": [
+      "SPTM 155"
+    ]
+  },
+  "SSC 200": {
+    "text": "ENG 101 or 105",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "SSC 296": {
+    "text": "The student must have completed (12) credit hours in a catalog program, be in good academic standing, be recommended by their advisor, and meet with the course instructor",
+    "courses": []
+  },
+  "SSC 298": {
+    "text": "SSC 200",
+    "courses": [
+      "SSC 200"
+    ]
+  },
+  "SWO 111": {
+    "text": "HUS 101",
+    "courses": [
+      "HUS 101"
+    ]
+  },
+  "SWO 201": {
+    "text": "PSY 228 and PSY 232",
+    "courses": [
+      "PSY 228",
+      "PSY 232"
+    ]
+  },
+  "SWRK 201": {
+    "text": "ENGL 100 or ENGL 101, PSYC 100",
+    "courses": [
+      "ENGL 100",
+      "ENGL 101",
+      "PSYC 100"
+    ]
+  },
+  "SWRK 215": {
+    "text": "ENGL 100 and one of the following:",
+    "courses": [
+      "ENGL 100"
+    ]
+  },
+  "TTO 124": {
+    "text": "Admission to the Welding Program or instructor permission",
+    "courses": []
+  },
+  "VET 120": {
+    "text": "Grade of C or better in MAT 118, BIO 124/125, and VET 101. This course is only available to students in the Veterinary Technology program",
+    "courses": [
+      "BIO 124",
+      "MAT 118",
+      "VET 101"
+    ]
+  },
+  "VET 125": {
+    "text": "Grade of C or better in MAT 118, BIO 124/125, and VET 101, as well as permission from Department Chair or designee. This course is only available to students in the Veterinary",
+    "courses": [
+      "BIO 124",
+      "MAT 118",
+      "VET 101"
+    ]
+  },
+  "VET 126": {
+    "text": "Grade of C or better in MAT 118, BIO 124/125, and VET 101, as well as permission from Department Chair or designee. This course is only available to students in the Veterinary",
+    "courses": [
+      "BIO 124",
+      "MAT 118",
+      "VET 101"
+    ]
+  },
+  "WEB 133": {
+    "text": "WEB 131",
+    "courses": [
+      "WEB 131"
+    ]
+  },
+  "WEB 215": {
+    "text": "CIS 133",
+    "courses": [
+      "CIS 133"
+    ]
+  },
+  "WEL 161": {
+    "text": "Admission to the Welding Program or instructor permission",
+    "courses": []
+  }
+}

--- a/data/ms/prereqs.json
+++ b/data/ms/prereqs.json
@@ -1,0 +1,1342 @@
+{
+  "ACC 2223": {
+    "text": "ACC 2213 . (3,3,0)",
+    "courses": [
+      "ACC 2213"
+    ]
+  },
+  "ART 1323": {
+    "text": "ART 1313 or permission of instructor. (3,0,6)",
+    "courses": [
+      "ART 1313"
+    ]
+  },
+  "ART 2513": {
+    "text": "ART 1313 & ART 1433 or permission of instructor. (3,0,6)",
+    "courses": [
+      "ART 1313",
+      "ART 1433"
+    ]
+  },
+  "ART 2523": {
+    "text": "ART 2513 or permission of instructor. (3,0,6)",
+    "courses": [
+      "ART 2513"
+    ]
+  },
+  "ART 2623": {
+    "text": "ART 2613 or permission of the instructor. (3,0,6)",
+    "courses": [
+      "ART 2613"
+    ]
+  },
+  "BAD 2323": {
+    "text": "MAT 1313 or MAT 1314 . (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314"
+    ]
+  },
+  "BAD 2743": {
+    "text": "BAD 2713 or Real Estate Sales or Broker License. (3,3,0)",
+    "courses": [
+      "BAD 2713"
+    ]
+  },
+  "BIO 1144": {
+    "text": "BIO 1134 (4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 1314": {
+    "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 .(4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 1613": {
+    "text": "BIO 1134 , BIO 2514 and BIO 2524 recommended. (3,3,0)",
+    "courses": [
+      "BIO 1134",
+      "BIO 2514",
+      "BIO 2524"
+    ]
+  },
+  "BIO 1721": {
+    "text": "BIO 1711 (By invitation only.) (1,0,2)",
+    "courses": [
+      "BIO 1711"
+    ]
+  },
+  "BIO 2214": {
+    "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 .(4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 2231": {
+    "text": "BIO 1134 or higher. Co-requisite: BIO 2233 (1,0,1)",
+    "courses": [
+      "BIO 1134",
+      "BIO 2233"
+    ]
+  },
+  "BIO 2233": {
+    "text": "BIO 1134 or higher. Co-requisite: BIO 2231 . (3,3,0)",
+    "courses": [
+      "BIO 1134",
+      "BIO 2231"
+    ]
+  },
+  "BIO 2234": {
+    "text": "BIO 1134 or higher. (4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 2414": {
+    "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 . (4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 2424": {
+    "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 . (4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 2514": {
+    "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 . (4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BIO 2524": {
+    "text": "BIO 2514 . (4,3,2)",
+    "courses": [
+      "BIO 2514"
+    ]
+  },
+  "BIO 2924": {
+    "text": "BIO 1134 (4,3,2)",
+    "courses": [
+      "BIO 1134"
+    ]
+  },
+  "BOT 1233": {
+    "text": "Instructor Approved. (3,2,2)",
+    "courses": []
+  },
+  "BOT 1243": {
+    "text": "Instructor Approved (3,2,2)",
+    "courses": []
+  },
+  "BOT 1443": {
+    "text": "BOT 1433 (3,3,0)",
+    "courses": [
+      "BOT 1433"
+    ]
+  },
+  "BOT 1823": {
+    "text": "BOT 1313 (3,2,2)",
+    "courses": [
+      "BOT 1313"
+    ]
+  },
+  "BOT 1853": {
+    "text": "BOT 1823 (3,2,2)",
+    "courses": [
+      "BOT 1823"
+    ]
+  },
+  "BOT 2423": {
+    "text": "BOT 1433 or ACC 2213 . (3,2,2)",
+    "courses": [
+      "ACC 2213",
+      "BOT 1433"
+    ]
+  },
+  "BOT 2433": {
+    "text": "ACC 2213 or BOT 1433 (3,2,2)",
+    "courses": [
+      "ACC 2213",
+      "BOT 1433"
+    ]
+  },
+  "BOT 2463": {
+    "text": "BOT 1433 or ACC 2213 . (3,2,2)",
+    "courses": [
+      "ACC 2213",
+      "BOT 1433"
+    ]
+  },
+  "BOT 2473": {
+    "text": "ACC 2213 or BOT 1433 . (3,2,2)",
+    "courses": [
+      "ACC 2213",
+      "BOT 1433"
+    ]
+  },
+  "BOT 2813": {
+    "text": "BOT 1713 , BOT 1233 , or by consent of instructor. (3,3,0)",
+    "courses": [
+      "BOT 1233",
+      "BOT 1713"
+    ]
+  },
+  "CAT 2133": {
+    "text": "CAT 1113, CAT 1213. (3,1,4)",
+    "courses": [
+      "CAT 1113",
+      "CAT 1213"
+    ]
+  },
+  "CAT 2263": {
+    "text": "CAT 1213. (3,1,4)",
+    "courses": [
+      "CAT 1213"
+    ]
+  },
+  "CAT 2313": {
+    "text": "CAT 1113 , CAT 1213 , or by consent of instructor. (3,1,4)",
+    "courses": [
+      "CAT 1113",
+      "CAT 1213"
+    ]
+  },
+  "CAT 2323": {
+    "text": "CAT 2313 (3,1,4)",
+    "courses": [
+      "CAT 2313"
+    ]
+  },
+  "CAT 2333": {
+    "text": "CAT 2313 or by consent of instructor. (3,1,4)",
+    "courses": [
+      "CAT 2313"
+    ]
+  },
+  "CAT 2914": {
+    "text": "Completion of one semester of coursework in the Graphic Design Technology program (4,2,4)",
+    "courses": []
+  },
+  "CDT 2813": {
+    "text": "CDT 2913 (3,3,0)",
+    "courses": [
+      "CDT 2913"
+    ]
+  },
+  "CDT 2913": {
+    "text": "CDT 2613 . (3,0,6)",
+    "courses": [
+      "CDT 2613"
+    ]
+  },
+  "CDT 2943": {
+    "text": "CDT 2913 (3,0,6)",
+    "courses": [
+      "CDT 2913"
+    ]
+  },
+  "CHE 1214": {
+    "text": "The student must meet one or more of the following requirements: (1) completed CHE 1314 , (2) completed one year of high school chemistry and one year of algebra, (3) ACT math score of 19 or higher, (4) satisfactory score on challenge exam, (5) Corequisite: MAT 1313 or higher (4,3,2)",
+    "courses": [
+      "CHE 1314",
+      "MAT 1313"
+    ]
+  },
+  "CHE 1224": {
+    "text": "CHE 1214 . (4,3,2)",
+    "courses": [
+      "CHE 1214"
+    ]
+  },
+  "CHE 1324": {
+    "text": "CHE 1314 or CHE 1214 . (4,3,2)",
+    "courses": [
+      "CHE 1214",
+      "CHE 1314"
+    ]
+  },
+  "CHE 2425": {
+    "text": "CHE 1214 and CHE 1224 . (5,3,4)",
+    "courses": [
+      "CHE 1214",
+      "CHE 1224"
+    ]
+  },
+  "CHE 2435": {
+    "text": "CHE 2425 (5,3,4)",
+    "courses": [
+      "CHE 2425"
+    ]
+  },
+  "CON 2123": {
+    "text": "CON 1223 and CON 1213 . (3,2,2)",
+    "courses": [
+      "CON 1213",
+      "CON 1223"
+    ]
+  },
+  "CON 2233": {
+    "text": "CON 1233 . (3,2,2)",
+    "courses": [
+      "CON 1233"
+    ]
+  },
+  "COV 1732": {
+    "text": "COV 1722 . (2,1,3)",
+    "courses": [
+      "COV 1722"
+    ]
+  },
+  "CSC 1213": {
+    "text": "a) minimum ACT score of 19 on the math component, b) credit for MAT 1313 or MAT 1314 , or c) permission of the instructor. (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314"
+    ]
+  },
+  "CSC 2134": {
+    "text": "MAT 1313 or MAT 1314 and CSC 1213 , previous programming experience or permission of instructor. (4,3,2)",
+    "courses": [
+      "CSC 1213",
+      "MAT 1313",
+      "MAT 1314"
+    ]
+  },
+  "CSC 2144": {
+    "text": "CSC 2134 - Programming I with C++ . (4,3,2)",
+    "courses": [
+      "CSC 2134"
+    ]
+  },
+  "CSC 2844": {
+    "text": "CSC 2144 . (4,3,2)",
+    "courses": [
+      "CSC 2144"
+    ]
+  },
+  "CST 2123": {
+    "text": "CST 2113 . (3,2,2)",
+    "courses": [
+      "CST 2113"
+    ]
+  },
+  "CST 2223": {
+    "text": "CST 1213 . (3,2,2)",
+    "courses": [
+      "CST 1213"
+    ]
+  },
+  "CST 2913": {
+    "text": "Consent of Instructor. (3,0,6)",
+    "courses": []
+  },
+  "CUT 1513": {
+    "text": "CUT 1114 (3,1,4)",
+    "courses": [
+      "CUT 1114"
+    ]
+  },
+  "CUT 2314": {
+    "text": "CUT 1114 (4,2,4)",
+    "courses": [
+      "CUT 1114"
+    ]
+  },
+  "CUT 2424": {
+    "text": "CUT 1124 , CUT 1114 or permission of instructor. (4,2,4)",
+    "courses": [
+      "CUT 1114",
+      "CUT 1124"
+    ]
+  },
+  "DDT 1173": {
+    "text": "DDT 1163 , DDT 1313 , DDT 1323 (3,1,4)",
+    "courses": [
+      "DDT 1163",
+      "DDT 1313",
+      "DDT 1323"
+    ]
+  },
+  "DDT 1313": {
+    "text": "DDT 1163 (3,2,2)",
+    "courses": [
+      "DDT 1163"
+    ]
+  },
+  "DDT 1323": {
+    "text": "DDT 1313 (3,1,4)",
+    "courses": [
+      "DDT 1313"
+    ]
+  },
+  "DDT 1613": {
+    "text": "DDT 1313 , DDT 1323 , DDT 1513 . (3,1,4)",
+    "courses": [
+      "DDT 1313",
+      "DDT 1323",
+      "DDT 1513"
+    ]
+  },
+  "DDT 2153": {
+    "text": "DDT 1163 , DDT 1313 , DDT 1323 , DDT 1513 (3,1,4)",
+    "courses": [
+      "DDT 1163",
+      "DDT 1313",
+      "DDT 1323",
+      "DDT 1513"
+    ]
+  },
+  "DDT 2213": {
+    "text": "DDT 1163 , DDT 1313 , DDT 1323 , DDT 1513 (3,1,4)",
+    "courses": [
+      "DDT 1163",
+      "DDT 1313",
+      "DDT 1323",
+      "DDT 1513"
+    ]
+  },
+  "DDT 2373": {
+    "text": "DDT 1163 , DDT 1313 and DDT 1323 . (3,1,4)",
+    "courses": [
+      "DDT 1163",
+      "DDT 1313",
+      "DDT 1323"
+    ]
+  },
+  "DDT 2523": {
+    "text": "DDT 1313 , DDT 1323 (3,1,4)",
+    "courses": [
+      "DDT 1313",
+      "DDT 1323"
+    ]
+  },
+  "DDT 2563": {
+    "text": "DDT 1313 , DDT 1323 , DDT 1513 (3,2,2)",
+    "courses": [
+      "DDT 1313",
+      "DDT 1323",
+      "DDT 1513"
+    ]
+  },
+  "DDT 2623": {
+    "text": "DDT 1613 . (3,1,4)",
+    "courses": [
+      "DDT 1613"
+    ]
+  },
+  "DDT 2723": {
+    "text": "DDT 1313 , DDT 1323 , DDT 1513 (3,1,4)",
+    "courses": [
+      "DDT 1313",
+      "DDT 1323",
+      "DDT 1513"
+    ]
+  },
+  "DDT 2753": {
+    "text": "DDT 2373 (3,1,4)",
+    "courses": [
+      "DDT 2373"
+    ]
+  },
+  "DDT 2823": {
+    "text": "DDT 1513 , DDT 1613 (3,1,4)",
+    "courses": [
+      "DDT 1513",
+      "DDT 1613"
+    ]
+  },
+  "DDT 2913": {
+    "text": "Consent of instructor. (3,0,6)",
+    "courses": []
+  },
+  "EET 1123": {
+    "text": "EET 1114 . (3,2,2)",
+    "courses": [
+      "EET 1114"
+    ]
+  },
+  "EET 2913": {
+    "text": "Consent of instructor. (3,2,2)",
+    "courses": []
+  },
+  "EGR 2413": {
+    "text": "C or Higher in both MAT 1623 and PHY 2514 . (3,3,0)",
+    "courses": [
+      "MAT 1623",
+      "PHY 2514"
+    ]
+  },
+  "EGR 2433": {
+    "text": "EGR 2413 and credit or enrollment in MAT 2613 , Calculus III. (3,3,0)",
+    "courses": [
+      "EGR 2413",
+      "MAT 2613"
+    ]
+  },
+  "ELT 1113": {
+    "text": "ELT 1123 (3,2,2)",
+    "courses": [
+      "ELT 1123"
+    ]
+  },
+  "ELT 1123": {
+    "text": "ELT 1233 . (3,2,2)",
+    "courses": [
+      "ELT 1233"
+    ]
+  },
+  "ELT 1183": {
+    "text": "ELT 1113 (3,2,2)",
+    "courses": [
+      "ELT 1113"
+    ]
+  },
+  "ELT 1213": {
+    "text": "ELT 1143 . (3,2,2)",
+    "courses": [
+      "ELT 1143"
+    ]
+  },
+  "ELT 1253": {
+    "text": "ELT 1213 . (3,2,2)",
+    "courses": [
+      "ELT 1213"
+    ]
+  },
+  "ELT 1263": {
+    "text": "ELT 1253 . (3,2,2)",
+    "courses": [
+      "ELT 1253"
+    ]
+  },
+  "ELT 1413": {
+    "text": "ELT 1263 . (3,2,2)",
+    "courses": [
+      "ELT 1263"
+    ]
+  },
+  "ELT 2423": {
+    "text": "ELT 2113 . (3,1,4)",
+    "courses": [
+      "ELT 2113"
+    ]
+  },
+  "ELT 2613": {
+    "text": "ELT 2423 . (3,2,2)",
+    "courses": [
+      "ELT 2423"
+    ]
+  },
+  "ELT 2623": {
+    "text": "ELT 2613 - Programmable Logic Controllers and ELT 1413 - Motor Control Systems . (3,2,2)",
+    "courses": [
+      "ELT 1413",
+      "ELT 2613"
+    ]
+  },
+  "EMS 1222": {
+    "text": "Instructor approved (2,1,2)",
+    "courses": []
+  },
+  "EMS 1231": {
+    "text": "Instructor approved (1,1,0)",
+    "courses": []
+  },
+  "EMS 1262": {
+    "text": "Instructor approved (2,1,2)",
+    "courses": []
+  },
+  "EMS 1362": {
+    "text": "Instructor approved (2,1,2)",
+    "courses": []
+  },
+  "EMS 1373": {
+    "text": "Instructor approved (3,2,2)",
+    "courses": []
+  },
+  "EMS 1384": {
+    "text": "Instructor approved (4,3,2)",
+    "courses": []
+  },
+  "EMS 1533": {
+    "text": "Instructor approved (3,0,9)",
+    "courses": []
+  },
+  "EMS 1543": {
+    "text": "Instructor approved (3,2,2)",
+    "courses": []
+  },
+  "EMS 1552": {
+    "text": "Instructor approved (2,1,2)",
+    "courses": []
+  },
+  "EMS 1593": {
+    "text": "Instructor approved (3,3,0)",
+    "courses": []
+  },
+  "EMS 2764": {
+    "text": "Instructor approved (4,2,4)",
+    "courses": []
+  },
+  "EMS 2773": {
+    "text": "Instructor approved (3,2,2)",
+    "courses": []
+  },
+  "EMS 2784": {
+    "text": "Instructor approved (4,0,12)",
+    "courses": []
+  },
+  "EMS 2863": {
+    "text": "Instructor approved (3,2,2)",
+    "courses": []
+  },
+  "EMS 2873": {
+    "text": "Instructor approved (3,0,9)",
+    "courses": []
+  },
+  "EMS 2883": {
+    "text": "Instructor approved (3,1,4)",
+    "courses": []
+  },
+  "EMS 2893": {
+    "text": "Instructor approved (3,0,9)",
+    "courses": []
+  },
+  "ENG 1113": {
+    "text": "ACT English 17 or higher or Equivalent ACCUPLACER score in writing. (3,3,0)",
+    "courses": []
+  },
+  "ENG 1123": {
+    "text": "ENG 1113 (3,3,0)",
+    "courses": [
+      "ENG 1113"
+    ]
+  },
+  "ENG 2133": {
+    "text": "ENG 1123H or ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2143": {
+    "text": "ENG 2133 (3,3,0)",
+    "courses": [
+      "ENG 2133"
+    ]
+  },
+  "ENG 2223": {
+    "text": "ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1123"
+    ]
+  },
+  "ENG 2233": {
+    "text": "ENG 1123H or ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2323": {
+    "text": "ENG 1123 or ENG 1123H . (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2333": {
+    "text": "ENG 1123H or ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2333H": {
+    "text": "ENG 1123H . (3,3,0)",
+    "courses": [
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2423": {
+    "text": "ENG 1123H or ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2423H": {
+    "text": "ENG 1123 or ENG 1123H. (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2433": {
+    "text": "ENG 1123H or ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1123",
+      "ENG 1123H"
+    ]
+  },
+  "ENG 2513": {
+    "text": "ENG 1113 and ENG 1123 . (3,3,0)",
+    "courses": [
+      "ENG 1113",
+      "ENG 1123"
+    ]
+  },
+  "ENG 2613": {
+    "text": "ENG 1113 or ENG 1114 . (3,3,0)",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114"
+    ]
+  },
+  "ENT 2353": {
+    "text": "ENT 1313 (3,2,2)",
+    "courses": [
+      "ENT 1313"
+    ]
+  },
+  "EPY 2513": {
+    "text": "PSY 1513 . (3,3,0)",
+    "courses": [
+      "PSY 1513"
+    ]
+  },
+  "EPY 2533": {
+    "text": "PSY 1513 . (3,3,0)",
+    "courses": [
+      "PSY 1513"
+    ]
+  },
+  "FCS 1253": {
+    "text": "BIO 1134 , BIO 2514 , and BIO 2524 recommended. (3,3,0)",
+    "courses": [
+      "BIO 1134",
+      "BIO 2514",
+      "BIO 2524"
+    ]
+  },
+  "HIT 1114": {
+    "text": "Admission to the Health Information Technology: Billing and Coding Program",
+    "courses": []
+  },
+  "HIT 1322": {
+    "text": "HIT 1114 (2,2,0)",
+    "courses": [
+      "HIT 1114"
+    ]
+  },
+  "HIT 2615": {
+    "text": "HIT 1214 , HIT 1114 , and BIO 2524 . (5,3,4)",
+    "courses": [
+      "BIO 2524",
+      "HIT 1114",
+      "HIT 1214"
+    ]
+  },
+  "HIT 2626": {
+    "text": "HIT 2615 . (6,4,4)",
+    "courses": [
+      "HIT 2615"
+    ]
+  },
+  "HIT 2633": {
+    "text": "HIT 2615 . (3,3,0)",
+    "courses": [
+      "HIT 2615"
+    ]
+  },
+  "HIT 2713": {
+    "text": "HIT 2133 . (3,3,0)",
+    "courses": [
+      "HIT 2133"
+    ]
+  },
+  "HPR 2222": {
+    "text": "Completed American Red Cross swimmer level course or have equivalent skills. (2,0,2)",
+    "courses": []
+  },
+  "IDT 1234": {
+    "text": "IDT 1224 . (4,3,2)",
+    "courses": [
+      "IDT 1224"
+    ]
+  },
+  "IDT 2243": {
+    "text": "IDT 1224 and IDT 1234 . (3,2,2)",
+    "courses": [
+      "IDT 1224",
+      "IDT 1234"
+    ]
+  },
+  "IDT 2263": {
+    "text": "IDT 1224 and IDT 1253 . (3,3,0)",
+    "courses": [
+      "IDT 1224",
+      "IDT 1253"
+    ]
+  },
+  "IDT 2413": {
+    "text": "Approval of Instructor. (3,150 clock hours) (3,0,9)",
+    "courses": []
+  },
+  "IET 1113": {
+    "text": "IET 1214 , EET 1114 . (3,2,2)",
+    "courses": [
+      "EET 1114",
+      "IET 1214"
+    ]
+  },
+  "IET 1214": {
+    "text": "IET 1113 , EET 1114 . (4,2,4)",
+    "courses": [
+      "EET 1114",
+      "IET 1113"
+    ]
+  },
+  "IET 1313": {
+    "text": "IET 1113 , IET 1214 , EET 1114 (3,2,2)",
+    "courses": [
+      "EET 1114",
+      "IET 1113",
+      "IET 1214"
+    ]
+  },
+  "IET 2113": {
+    "text": "IET 1313 (3,2,2)",
+    "courses": [
+      "IET 1313"
+    ]
+  },
+  "IET 2413": {
+    "text": "IET 2113 (3,2,2)",
+    "courses": [
+      "IET 2113"
+    ]
+  },
+  "IST 1224": {
+    "text": "IST 1134 . (4,2,4)",
+    "courses": [
+      "IST 1134"
+    ]
+  },
+  "IST 1414": {
+    "text": "IST 1154 or IST 1433 (4,2,4)",
+    "courses": [
+      "IST 1154",
+      "IST 1433"
+    ]
+  },
+  "IST 1534": {
+    "text": "IST 1513 . (4,3,2)",
+    "courses": [
+      "IST 1513"
+    ]
+  },
+  "IST 1624": {
+    "text": "IST 1134 (4,2,4)",
+    "courses": [
+      "IST 1134"
+    ]
+  },
+  "IST 1633": {
+    "text": "IST 1134 and IST 1624 . (3,2,2)",
+    "courses": [
+      "IST 1134",
+      "IST 1624"
+    ]
+  },
+  "IST 1934": {
+    "text": "IST 1914 (4,2,4)",
+    "courses": [
+      "IST 1914"
+    ]
+  },
+  "IST 2224": {
+    "text": "IST 1224 (4,2,4)",
+    "courses": [
+      "IST 1224"
+    ]
+  },
+  "IST 2263": {
+    "text": "IST 1253 (3,1,4)",
+    "courses": [
+      "IST 1253"
+    ]
+  },
+  "IST 2283": {
+    "text": "IST 2563 (3,2,2)",
+    "courses": [
+      "IST 2563"
+    ]
+  },
+  "IST 2324": {
+    "text": "IST 1154 or IST 1433 (4,2,4)",
+    "courses": [
+      "IST 1154",
+      "IST 1433"
+    ]
+  },
+  "IST 2334": {
+    "text": "IST 1313 . (4,2,4)",
+    "courses": [
+      "IST 1313"
+    ]
+  },
+  "IST 2524": {
+    "text": "IST 1124 (4,2,4)",
+    "courses": [
+      "IST 1124"
+    ]
+  },
+  "IST 2563": {
+    "text": "IST 2293 (3,2,2)",
+    "courses": [
+      "IST 2293"
+    ]
+  },
+  "IST 2594": {
+    "text": "IST 2584 (4,2,4)",
+    "courses": [
+      "IST 2584"
+    ]
+  },
+  "IST 2653": {
+    "text": "IST 2563 (3,2,2)",
+    "courses": [
+      "IST 2563"
+    ]
+  },
+  "IST 2814": {
+    "text": "IST 1433 or IST 1154 and IST 1723 . (4,2,4)",
+    "courses": [
+      "IST 1154",
+      "IST 1433",
+      "IST 1723"
+    ]
+  },
+  "LVT 1211": {
+    "text": "C or better in LVT 1114 (1,1,0)",
+    "courses": [
+      "LVT 1114"
+    ]
+  },
+  "LVT 1223": {
+    "text": "C or better in LVT 1123 (3,1,4)",
+    "courses": [
+      "LVT 1123"
+    ]
+  },
+  "LVT 1253": {
+    "text": "C or better in LVT 1114 and LVT 1211 (3,2,2)",
+    "courses": [
+      "LVT 1114",
+      "LVT 1211"
+    ]
+  },
+  "LVT 2332": {
+    "text": "C or better in LVT 2321 (2,1,2)",
+    "courses": [
+      "LVT 2321"
+    ]
+  },
+  "LVT 2343": {
+    "text": "C or better in LVT 1114 , LVT 1211 , and LVT 1253 . (3,1,4)",
+    "courses": [
+      "LVT 1114",
+      "LVT 1211",
+      "LVT 1253"
+    ]
+  },
+  "LVT 2353": {
+    "text": "C or better in LVT 1123 , LVT 1223 , LVT 1253 , and LVT 2343 . (3,1,4)",
+    "courses": [
+      "LVT 1123",
+      "LVT 1223",
+      "LVT 1253",
+      "LVT 2343"
+    ]
+  },
+  "LVT 2363": {
+    "text": "C or better in LVT 1114 and LVT 1211 . (3,2,2)",
+    "courses": [
+      "LVT 1114",
+      "LVT 1211"
+    ]
+  },
+  "LVT 2373": {
+    "text": "C or better in LVT 1133 . (3,2,2)",
+    "courses": [
+      "LVT 1133"
+    ]
+  },
+  "LVT 2383": {
+    "text": "C or better in LVT 1133 and LVT 2373 . (3,2,2)",
+    "courses": [
+      "LVT 1133",
+      "LVT 2373"
+    ]
+  },
+  "LVT 2393": {
+    "text": "C or better in LVT 1114 and LVT 1133 . (3,1,4)",
+    "courses": [
+      "LVT 1114",
+      "LVT 1133"
+    ]
+  },
+  "MAR 1123": {
+    "text": "MAR 1113 . (3,2,2)",
+    "courses": [
+      "MAR 1113"
+    ]
+  },
+  "MAT 1313": {
+    "text": "ACT Math 19 or higher or equivalent ACCUPLACER score. (3,3,0)",
+    "courses": []
+  },
+  "MAT 1323": {
+    "text": "C or higher in two years of high school algebra or ACT Math minimum score of 21 or C or higher in MAT 1313 /1314 . (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314"
+    ]
+  },
+  "MAT 1343": {
+    "text": "C or higher in two years of high school algebra or ACT Math miniumum score of 21 or C or higher in MAT 1323 . (3,3,0)",
+    "courses": [
+      "MAT 1323"
+    ]
+  },
+  "MAT 1513": {
+    "text": "MAT 1313 /1314 . (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314"
+    ]
+  },
+  "MAT 1613": {
+    "text": "C or higher in MAT 1313 /1314 and MAT 1323 or C or higher in MAT 1343 or high school equivalents and ACT Math minimum of 25. (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314",
+      "MAT 1323",
+      "MAT 1343"
+    ]
+  },
+  "MAT 1623": {
+    "text": "C or higher in MAT 1613 (3,3,0)",
+    "courses": [
+      "MAT 1613"
+    ]
+  },
+  "MAT 1733": {
+    "text": "MAT 1313 or MAT 1314 . (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314"
+    ]
+  },
+  "MAT 2113": {
+    "text": "MAT 1623 (3,3,0)",
+    "courses": [
+      "MAT 1623"
+    ]
+  },
+  "MAT 2323": {
+    "text": "C or higher in MAT 1313 /1314 or MAT 1753 (3,3,0)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314",
+      "MAT 1753"
+    ]
+  },
+  "MAT 2613": {
+    "text": "C or higher in MAT 1623 (3,3,0)",
+    "courses": [
+      "MAT 1623"
+    ]
+  },
+  "MAT 2623": {
+    "text": "C or higher in MAT 2613 . (3,3,0)",
+    "courses": [
+      "MAT 2613"
+    ]
+  },
+  "MAT 2913": {
+    "text": "MAT 2623 or enrollment in MAT 2623 . (3,3,0)",
+    "courses": [
+      "MAT 2623"
+    ]
+  },
+  "MET 1313": {
+    "text": "MET 1113 , MET 1513 , and CPR-Health Care Provider certification",
+    "courses": [
+      "MET 1113",
+      "MET 1513"
+    ]
+  },
+  "MFL 1123": {
+    "text": "MFL 1113 or 1 year of previous language study. One laboratory hour per week. (3,3,0)",
+    "courses": [
+      "MFL 1113"
+    ]
+  },
+  "MFL 1223": {
+    "text": "MFL 1213 or 1 year of previous language study. One laboratory hour per week. (3,3,0)",
+    "courses": [
+      "MFL 1213"
+    ]
+  },
+  "MFL 1423": {
+    "text": "MFL 1413 (3,3,0)",
+    "courses": [
+      "MFL 1413"
+    ]
+  },
+  "MFL 2113": {
+    "text": "MFL 1113 and MFL 1123 or two years of high school French. One laboratory hour per week. (3,3,0)",
+    "courses": [
+      "MFL 1113",
+      "MFL 1123"
+    ]
+  },
+  "MFL 2123": {
+    "text": "MFL 2113 . One laboratory hour per week. (3,3,0)",
+    "courses": [
+      "MFL 2113"
+    ]
+  },
+  "MFL 2213": {
+    "text": "MFL 1213 and MFL 1223 or two years high school Spanish. One laboratory hour per week. (3,3,0)",
+    "courses": [
+      "MFL 1213",
+      "MFL 1223"
+    ]
+  },
+  "MFL 2223": {
+    "text": "MFL 2213 . One laboratory hour per week. (3,3,0)",
+    "courses": [
+      "MFL 2213"
+    ]
+  },
+  "MLT 1314": {
+    "text": "MLT 1212 , 2612, BIO 2514 , CHE 1214 . (4,3,2)",
+    "courses": [
+      "BIO 2514",
+      "CHE 1214",
+      "MLT 1212"
+    ]
+  },
+  "MLT 1324": {
+    "text": "MLT 1314 , MLT 1413 ; (4,2,4)",
+    "courses": [
+      "MLT 1314",
+      "MLT 1413"
+    ]
+  },
+  "MLT 1413": {
+    "text": "MLT 1212 , 2612, BIO 2514 , CHE 1214 . (3,2,2)",
+    "courses": [
+      "BIO 2514",
+      "CHE 1214",
+      "MLT 1212"
+    ]
+  },
+  "MLT 1515": {
+    "text": "MLT 1413 . (5,3,4)",
+    "courses": [
+      "MLT 1413"
+    ]
+  },
+  "MLT 2424": {
+    "text": "MLT 1314 , MLT 1413 (4,2,4)",
+    "courses": [
+      "MLT 1314",
+      "MLT 1413"
+    ]
+  },
+  "MLT 2614": {
+    "text": "MLT 1314 , MLT 1413 ; BIO 2924 . (4,2,4)",
+    "courses": [
+      "BIO 2924",
+      "MLT 1314",
+      "MLT 1413"
+    ]
+  },
+  "MLT 2711": {
+    "text": "Completion of all didactic Medical Laboratory Technology courses. (1,0,2)",
+    "courses": []
+  },
+  "MLT 2943": {
+    "text": "MLT 1113 , MLT 1212 , MLT 1413 (3,0,9)",
+    "courses": [
+      "MLT 1113",
+      "MLT 1212",
+      "MLT 1413"
+    ]
+  },
+  "MLT 2954": {
+    "text": "MLT 1324 , MLT 2424 , MLT 2614 . (4,0,12)",
+    "courses": [
+      "MLT 1324",
+      "MLT 2424",
+      "MLT 2614"
+    ]
+  },
+  "MLT 2964": {
+    "text": "MLT 1324 , MLT 2424 , MLT 2614 . (4,0,12)",
+    "courses": [
+      "MLT 1324",
+      "MLT 2424",
+      "MLT 2614"
+    ]
+  },
+  "MLT 2974": {
+    "text": "MLT 1324 , MLT 2424 , MLT 2614 . (4,0,12)",
+    "courses": [
+      "MLT 1324",
+      "MLT 2424",
+      "MLT 2614"
+    ]
+  },
+  "MMT 1123": {
+    "text": "MMT 1113 . (3,2,2)",
+    "courses": [
+      "MMT 1113"
+    ]
+  },
+  "MST 1212": {
+    "text": "MST 1412 (2,1,2)",
+    "courses": [
+      "MST 1412"
+    ]
+  },
+  "MST 1243": {
+    "text": "MST 1222 (3,2,2)",
+    "courses": [
+      "MST 1222"
+    ]
+  },
+  "MST 1263": {
+    "text": "MST 1232 (3,2,2)",
+    "courses": [
+      "MST 1232"
+    ]
+  },
+  "MST 1412": {
+    "text": "MST 1313 (2,1,2)",
+    "courses": [
+      "MST 1313"
+    ]
+  },
+  "MST 1422": {
+    "text": "MST 1412 (2,1,2)",
+    "courses": [
+      "MST 1412"
+    ]
+  },
+  "MST 2513": {
+    "text": "MST 1243 (3,2,2)",
+    "courses": [
+      "MST 1243"
+    ]
+  },
+  "MST 2523": {
+    "text": "MST 1263 (3,2,2)",
+    "courses": [
+      "MST 1263"
+    ]
+  },
+  "MST 2532": {
+    "text": "MST 1251 (2,1,2)",
+    "courses": [
+      "MST 1251"
+    ]
+  },
+  "MST 2542": {
+    "text": "MST 1263 (2,1,2)",
+    "courses": [
+      "MST 1263"
+    ]
+  },
+  "MST 2552": {
+    "text": "MST 2725 (2,1,2)",
+    "courses": [
+      "MST 2725"
+    ]
+  },
+  "MST 2725": {
+    "text": "MST 2714 (5,2,6)",
+    "courses": [
+      "MST 2714"
+    ]
+  },
+  "MUA 1721": {
+    "text": "MUA 1711 (1,1,0)",
+    "courses": [
+      "MUA 1711"
+    ]
+  },
+  "MUA 1782": {
+    "text": "MUA 1772 (2,1,0)",
+    "courses": [
+      "MUA 1772"
+    ]
+  },
+  "MUA 2711": {
+    "text": "MUA 1721 (1,1,0)",
+    "courses": [
+      "MUA 1721"
+    ]
+  },
+  "MUA 2721": {
+    "text": "MUA 2711 (1,1,0)",
+    "courses": [
+      "MUA 2711"
+    ]
+  },
+  "MUA 2772": {
+    "text": "MUA 1782 (2,1,0)",
+    "courses": [
+      "MUA 1782"
+    ]
+  },
+  "MUA 2782": {
+    "text": "MUA 2772 (2,1,0)",
+    "courses": [
+      "MUA 2772"
+    ]
+  },
+  "MUO 1221": {
+    "text": "MUO 1211 (1,1,0)",
+    "courses": [
+      "MUO 1211"
+    ]
+  },
+  "MUO 2211": {
+    "text": "MUO 1221 (1,1,0)",
+    "courses": [
+      "MUO 1221"
+    ]
+  },
+  "MUO 2221": {
+    "text": "MUO 2211 (1,1,0)",
+    "courses": [
+      "MUO 2211"
+    ]
+  },
+  "MUS 1224": {
+    "text": "MUS 1214 (4,3,2)",
+    "courses": [
+      "MUS 1214"
+    ]
+  }
+}

--- a/scripts/ky/scrape-catalog-prereqs.ts
+++ b/scripts/ky/scrape-catalog-prereqs.ts
@@ -1,0 +1,259 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes KCTCS's CourseLeaf catalog at https://catalog.kctcs.edu to
+ * extract prerequisite text for every course in the system-wide catalog.
+ * KCTCS (Kentucky Community & Technical College System) uses a single
+ * centralized catalog covering all 16 colleges with common course numbering.
+ *
+ * CourseLeaf organizes courses by subject — each subject has a page at
+ * /course-descriptions/{subject}/ containing all courses as
+ * `<div class="courseblock">` elements. Prerequisites live in a
+ * `<div class="section__content">` block labeled `<strong>Pre-requisite:</strong>`.
+ * Course cross-references use `<a class="bubblelink code">` anchors whose
+ * text contains the readable course code (e.g. "MAT 150").
+ *
+ * Flow:
+ *   1. Fetch /course-descriptions/ to discover all subject slugs.
+ *   2. For each subject page, parse all courseblocks and extract
+ *      prereq text + referenced course codes.
+ *   3. Write data/ky/prereqs.json keyed by "${PREFIX} ${NUMBER}".
+ *
+ * Usage:
+ *   npx tsx scripts/ky/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/ky/scrape-catalog-prereqs.ts --limit=5   # smoke test (5 subjects)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BASE = "https://catalog.kctcs.edu";
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 4;
+const DELAY_MS = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return "";
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function discoverSubjects(html: string): string[] {
+  const matches = html.match(/href="\/course-descriptions\/([a-z]+)\/"/g) || [];
+  const slugs = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/\/course-descriptions\/([a-z]+)\//);
+    if (mm) slugs.add(mm[1]);
+  }
+  return Array.from(slugs).sort();
+}
+
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+const BOILERPLATE_RE =
+  /^(none|not applicable|n\/a|no prerequisites?)\s*\.?\s*$/i;
+
+function parseSubjectPage(html: string): Map<string, PrereqEntry> {
+  const results = new Map<string, PrereqEntry>();
+
+  // Split on courseblock boundaries
+  const blocks = html.split(/<div class="courseblock">/);
+  blocks.shift(); // discard content before first courseblock
+
+  for (const block of blocks) {
+    // Extract course code from detail-code span
+    const codeMatch = block.match(
+      /<span[^>]*class="[^"]*detail-code[^"]*"[^>]*>\s*<strong>\s*([A-Z]{2,5})\s+(\d{1,4}[A-Z]?)\s*<\/strong>/,
+    );
+    if (!codeMatch) continue;
+    const prefix = codeMatch[1].toUpperCase();
+    const number = codeMatch[2];
+    const key = `${prefix} ${number}`;
+
+    // Look for Pre-requisite section (handles "Pre-requisite:", "Pre- or co-requisite:")
+    const prereqMatch = block.match(
+      /<strong>\s*Pre-?\s*(?:requisite|or co-requisite)\s*:?\s*<\/strong>\s*([\s\S]*?)(?:<\/div>)/i,
+    );
+    if (!prereqMatch) continue;
+
+    const rawBlock = prereqMatch[1];
+    const text = htmlToText(rawBlock);
+    if (!text || BOILERPLATE_RE.test(text)) continue;
+
+    // Extract course codes from bubblelink anchors and plain text
+    const courses = new Set<string>();
+
+    // From <a class="bubblelink code"> anchor text
+    const anchorRegex = /<a[^>]*class="[^"]*bubblelink[^"]*"[^>]*>([^<]+)<\/a>/g;
+    let m: RegExpExecArray | null;
+    while ((m = anchorRegex.exec(rawBlock)) !== null) {
+      const anchorText = m[1].trim();
+      const codeInAnchor = anchorText.match(/^([A-Z]{2,5})\s+(\d{1,4}[A-Z]?)$/);
+      if (codeInAnchor) {
+        const code = `${codeInAnchor[1]} ${codeInAnchor[2]}`;
+        if (code !== key) courses.add(code);
+      }
+    }
+
+    // Also scan plain text for course codes the anchors might miss
+    const codeRegex = /\b([A-Z]{2,5})\s+(\d{1,4}[A-Z]?)\b/g;
+    while ((m = codeRegex.exec(text)) !== null) {
+      const code = `${m[1]} ${m[2]}`;
+      if (code !== key && code !== "ACT 19" && code !== "ACT 22" && code !== "ACT 27" &&
+          !code.startsWith("ACT ") && !code.startsWith("SAT ") && !code.startsWith("GPA ")) {
+        courses.add(code);
+      }
+    }
+
+    results.set(key, { text, courses: Array.from(courses).sort() });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limit = parseInt(args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0", 10);
+
+  console.log("KCTCS CourseLeaf catalog prereq scraper");
+  console.log(`  Base: ${BASE}`);
+
+  // --- Phase 1: discover subject slugs ---
+  console.log("\n[1/2] Discovering subject slugs...");
+  const indexHtml = await retryFetch(`${BASE}/course-descriptions/`, "subject-index");
+  let subjects = discoverSubjects(indexHtml);
+  console.log(`  Found ${subjects.length} subjects`);
+
+  if (limit > 0) {
+    subjects = subjects.slice(0, limit);
+    console.log(`  Limited to first ${limit} for smoke test`);
+  }
+
+  // --- Phase 2: fetch each subject page, parse courseblocks ---
+  console.log("\n[2/2] Fetching subject pages + parsing prereqs...");
+  const prereqs: Record<string, PrereqEntry> = {};
+  let totalCourses = 0;
+  let withPrereqs = 0;
+
+  await pmap(subjects, CONCURRENCY, async (subject, idx) => {
+    const url = `${BASE}/course-descriptions/${subject}/`;
+    const html = await retryFetch(url, `subject(${subject})`);
+    if (!html) return;
+
+    const parsed = parseSubjectPage(html);
+    for (const [key, entry] of parsed) {
+      if (!prereqs[key]) {
+        prereqs[key] = entry;
+        withPrereqs++;
+      }
+    }
+    totalCourses += (html.match(/<div class="courseblock">/g) || []).length;
+
+    if ((idx + 1) % 20 === 0) {
+      console.log(`  ${idx + 1}/${subjects.length} subjects (${withPrereqs} prereqs so far)`);
+    }
+  });
+  console.log(`  Processed ${subjects.length} subjects, ~${totalCourses} total courses`);
+  console.log(`  Extracted prereqs for ${withPrereqs} courses`);
+
+  // Sort keys alphabetically
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(prereqs).sort()) {
+    sorted[key] = prereqs[key];
+  }
+
+  // --- Write ---
+  const outDir = path.join(process.cwd(), "data", "ky");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/me/scrape-catalog-prereqs.ts
+++ b/scripts/me/scrape-catalog-prereqs.ts
@@ -1,0 +1,393 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Extracts prerequisite text from Maine Community College System (MCCS)
+ * catalogs. All 7 MCCS colleges publish catalogs exclusively as PDFs —
+ * there are no Acalog or CourseLeaf instances.
+ *
+ * Strategy: download each college's PDF catalog, run `pdftotext` (flow
+ * mode) to get plain text, then parse course entries and extract
+ * Prerequisite lines.
+ *
+ * Two main formats:
+ *   SMCC/YCCC (own-line): "Prerequisite(s): ACCT-105, MATH-040"
+ *   CMCC/EMCC/NMCC/KVCC (inline): "...description text. Prerequisite: ACC 120"
+ *
+ * Course codes vary by college:
+ *   SMCC uses hyphens (ACCT-105), others use spaces (ACC 120/ACC120)
+ *
+ * Output: data/me/prereqs.json keyed by "${PREFIX} ${NUMBER}" with
+ * normalized codes (hyphens → spaces).
+ *
+ * Usage:
+ *   npx tsx scripts/me/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/me/scrape-catalog-prereqs.ts --college=smcc
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+
+interface CollegeCatalog {
+  name: string;
+  url: string;
+  format: "own-line" | "inline";
+}
+
+const CATALOGS: Record<string, CollegeCatalog> = {
+  smcc: {
+    name: "Southern Maine CC",
+    url: "https://www.smccme.edu/wp-content/uploads/2025/10/SMCC-Catalog-2025-2026.pdf",
+    format: "own-line",
+  },
+  yccc: {
+    name: "York County CC",
+    url: "https://yccc.b-cdn.net/app/uploads/2025/12/YCCC-CourseCatalog_2025-26_12192025.pdf",
+    format: "own-line",
+  },
+  cmcc: {
+    name: "Central Maine CC",
+    url: "https://www.cmcc.edu/wp-content/uploads/2023/05/FINAL-2026-2027-Academic-Catalog_041026-1.pdf",
+    format: "inline",
+  },
+  emcc: {
+    name: "Eastern Maine CC",
+    url: "https://www.emcc.edu/wp-content/uploads/2026/01/2025-26-Catalog-20260106-Addendum-compressed.pdf",
+    format: "inline",
+  },
+  kvcc: {
+    name: "Kennebec Valley CC",
+    url: "https://www.kvcc.me.edu/wp-content/uploads/2026/02/KVCC-2025-2026-CourseCatalog-v6.pdf",
+    format: "inline",
+  },
+  nmcc: {
+    name: "Northern Maine CC",
+    url: "https://www.nmcc.edu/wp-content/uploads/CURRENT2024-2026-Course-Catalog-.pdf",
+    format: "inline",
+  },
+};
+
+// WCCC omitted — research found only ~5 prereq mentions with non-standard format
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+// ---------------------------------------------------------------------------
+// PDF download + text extraction
+// ---------------------------------------------------------------------------
+
+async function downloadPdf(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} downloading ${url}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  fs.writeFileSync(dest, buf);
+}
+
+function pdfToText(pdfPath: string): string {
+  const txtPath = pdfPath.replace(/\.pdf$/, ".txt");
+  execSync(`pdftotext "${pdfPath}" "${txtPath}"`, { timeout: 60000 });
+  return fs.readFileSync(txtPath, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Course code normalization
+// ---------------------------------------------------------------------------
+
+function normalizeCode(raw: string): string {
+  // "ACCT-105" → "ACCT 105", "ACC120" → "ACC 120", "ACC 120" → "ACC 120"
+  return raw
+    .replace(/-/g, " ")
+    .replace(/([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)/, "$1 $2")
+    .trim();
+}
+
+function extractCourseRefs(text: string): string[] {
+  const codes = new Set<string>();
+  // Match "PREFIX-NNN", "PREFIX NNN", "PREFIXNNN"
+  const re = /\b([A-Z]{2,5})[-\s]?(\d{3,4}[A-Z]?)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (
+      !code.startsWith("GPA ") &&
+      !code.startsWith("SAT ")
+    ) {
+      codes.add(code);
+    }
+  }
+  return Array.from(codes).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Own-line format parser (SMCC, YCCC)
+//
+// Course entries look like:
+//   SUBJ NNN Title (or SUBJ NNN – Title)
+//   N cr. (or N credits/N contact hours)
+//   ...description...
+//   Prerequisite(s): ...
+//   Corequisite(s): ... (optional)
+// ---------------------------------------------------------------------------
+
+function parseOwnLineFormat(text: string): Map<string, PrereqEntry> {
+  const results = new Map<string, PrereqEntry>();
+  const lines = text.split("\n");
+
+  // Find the course descriptions section
+  let startIdx = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^COURSE DESCRIPTIONS$/i.test(lines[i].trim())) {
+      startIdx = i + 1;
+      break;
+    }
+  }
+
+  // Course header: "ACCT 105 Financial Accounting" or "ACC 111 – Accounting I"
+  const headerRe = /^([A-Z]{2,5})\s+(\d{3}[A-Z]?)\s+[–\-]?\s*[A-Z]/;
+  // Prereq line
+  const prereqRe = /^Prerequisite\(s\):\s*(.*)/i;
+
+  let currentCode: string | null = null;
+  let prereqText = "";
+  let collectingPrereq = false;
+
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    // Page number lines (just a number alone)
+    if (/^\d{1,3}$/.test(line)) continue;
+
+    const headerMatch = line.match(headerRe);
+    if (headerMatch) {
+      // Save any collected prereq for the previous course
+      if (currentCode && prereqText) {
+        const cleaned = cleanPrereqText(prereqText, currentCode);
+        if (cleaned) results.set(currentCode, cleaned);
+      }
+      currentCode = `${headerMatch[1]} ${headerMatch[2]}`;
+      prereqText = "";
+      collectingPrereq = false;
+      continue;
+    }
+
+    const prereqMatch = line.match(prereqRe);
+    if (prereqMatch && currentCode) {
+      prereqText = prereqMatch[1];
+      collectingPrereq = true;
+      continue;
+    }
+
+    // If we're collecting a multiline prereq, check if the next line continues it
+    if (collectingPrereq && currentCode) {
+      if (/^(Corequisite|Core fulfilled|$)/i.test(line) || headerRe.test(line)) {
+        collectingPrereq = false;
+      } else if (/^[a-z]/.test(line) || /^(placement|permission|and |or )/i.test(line)) {
+        prereqText += " " + line;
+      } else {
+        collectingPrereq = false;
+      }
+    }
+  }
+
+  // Don't forget the last course
+  if (currentCode && prereqText) {
+    const cleaned = cleanPrereqText(prereqText, currentCode);
+    if (cleaned) results.set(currentCode, cleaned);
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Inline format parser (CMCC, EMCC, NMCC, KVCC)
+//
+// Prereqs appear inline in description paragraphs:
+//   "...description text. Prerequisite: ACC 120 with a grade of C or higher."
+// ---------------------------------------------------------------------------
+
+function parseInlineFormat(text: string): Map<string, PrereqEntry> {
+  const results = new Map<string, PrereqEntry>();
+  const lines = text.split("\n");
+
+  // Course header with credits pattern:
+  // "ACC 120 Principles of Financial\nAccounting\n3 Credits (3 Lecture 0 Lab 0 Shop)"
+  // or "ACC 122 Managerial Accounting\n3 Credits"
+  const headerRe = /^([A-Z]{2,5})\s+(\d{3}[A-Z]?)\s+[A-Z]/;
+  const creditsRe = /^\d+\s+Credits?\b/i;
+
+  let currentCode: string | null = null;
+  let blockLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    const headerMatch = line.match(headerRe);
+    if (headerMatch) {
+      // Process the previous block
+      if (currentCode && blockLines.length > 0) {
+        const block = blockLines.join(" ");
+        const entry = extractInlinePrereq(block, currentCode);
+        if (entry) results.set(currentCode, entry);
+      }
+      currentCode = `${headerMatch[1]} ${headerMatch[2]}`;
+      blockLines = [line];
+      continue;
+    }
+
+    if (currentCode) {
+      blockLines.push(line);
+    }
+  }
+
+  // Last block
+  if (currentCode && blockLines.length > 0) {
+    const block = blockLines.join(" ");
+    const entry = extractInlinePrereq(block, currentCode);
+    if (entry) results.set(currentCode, entry);
+  }
+
+  return results;
+}
+
+function extractInlinePrereq(block: string, courseCode: string): PrereqEntry | null {
+  // Match "Prerequisite:" or "Prerequisites:" followed by the prereq text
+  const m = block.match(
+    /Prerequisite(?:s|\(s\))?\s*:\s*(.*?)(?:\.|$)/i,
+  );
+  if (!m) return null;
+
+  let text = m[1].trim();
+  if (!text) return null;
+
+  // Clean and check for boilerplate
+  text = text.replace(/\s+/g, " ").trim();
+  if (/^(none|n\/a|not applicable)\s*$/i.test(text)) return null;
+
+  const refs = extractCourseRefs(text).filter(
+    (c) => c !== courseCode,
+  );
+
+  return { text: normalizeCode(text), courses: refs };
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function cleanPrereqText(raw: string, courseCode: string): PrereqEntry | null {
+  let text = raw.replace(/\s+/g, " ").trim();
+  // Remove trailing period
+  text = text.replace(/[.;,]\s*$/, "").trim();
+
+  if (!text) return null;
+  if (/^(none|n\/a|not applicable|department permission)\s*$/i.test(text)) return null;
+
+  // Normalize codes (ACCT-105 → ACCT 105)
+  text = text.replace(/([A-Z]{2,5})-(\d{3,4}[A-Z]?)/g, "$1 $2");
+
+  const refs = extractCourseRefs(text).filter(
+    (c) => c !== courseCode,
+  );
+
+  return { text, courses: refs };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeFilter = args.find((a) => a.startsWith("--college="))?.split("=")[1];
+
+  console.log("Maine MCCS catalog prereq scraper (PDF-based)");
+
+  const tmpDir = "/tmp/me-catalogs";
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  const slugs = collegeFilter ? [collegeFilter] : Object.keys(CATALOGS);
+
+  const outDir = path.join(process.cwd(), "data", "me");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+
+  let merged: Record<string, PrereqEntry> = {};
+  if (fs.existsSync(outPath) && !collegeFilter) {
+    // Don't load existing when doing full run — start fresh
+  } else if (fs.existsSync(outPath) && collegeFilter) {
+    merged = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    console.log(`  Loaded ${Object.keys(merged).length} existing prereqs`);
+  }
+
+  for (const slug of slugs) {
+    const config = CATALOGS[slug];
+    if (!config) {
+      console.error(`Unknown college: ${slug}`);
+      continue;
+    }
+
+    console.log(`\n--- ${config.name} (${slug}) ---`);
+    const pdfPath = path.join(tmpDir, `${slug}-catalog.pdf`);
+
+    try {
+      // Download if not already cached
+      if (!fs.existsSync(pdfPath)) {
+        console.log(`  Downloading: ${config.url}`);
+        await downloadPdf(config.url, pdfPath);
+        console.log(`  Downloaded: ${(fs.statSync(pdfPath).size / 1024 / 1024).toFixed(1)} MB`);
+      } else {
+        console.log(`  Using cached PDF: ${pdfPath}`);
+      }
+
+      // Extract text
+      console.log("  Extracting text with pdftotext...");
+      const text = pdfToText(pdfPath);
+      console.log(`  Extracted ${text.split("\n").length} lines`);
+
+      // Parse
+      let prereqs: Map<string, PrereqEntry>;
+      if (config.format === "own-line") {
+        prereqs = parseOwnLineFormat(text);
+      } else {
+        prereqs = parseInlineFormat(text);
+      }
+
+      let added = 0;
+      for (const [key, entry] of prereqs) {
+        if (!merged[key]) {
+          merged[key] = entry;
+          added++;
+        }
+      }
+      console.log(`  ${prereqs.size} courses with prereqs (+${added} new)`);
+    } catch (e) {
+      console.error(`  ⚠ ${slug} failed: ${e}`);
+    }
+  }
+
+  // Sort and write
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(merged).sort()) {
+    sorted[key] = merged[key];
+  }
+
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ms/scrape-catalog-prereqs.ts
+++ b/scripts/ms/scrape-catalog-prereqs.ts
@@ -1,0 +1,409 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes Acalog catalogs from 6 Mississippi community colleges to extract
+ * prerequisite text. Unlike CT/TN (single catalog), MS has per-college
+ * Acalog instances with varying prereq label formats:
+ *
+ *   - MGCCC:     `Prerequisite:` inline in description paragraph
+ *   - Hinds:     `(Prerequisites:` parenthesized, inline
+ *   - East MS:   `<strong>Prerequisites:</strong>` separated by `<br><br>`
+ *   - JCJC:      `<strong>Prerequisite(s):</strong>` separated
+ *   - Meridian:  `Prerequisite: None` separated (filter "None")
+ *   - Northwest: `<strong>Prerequisite(s):</strong>` separated
+ *
+ * All colleges use Mississippi's common course numbering (4-letter prefix +
+ * 4-digit number, e.g. ENG 1113). The scraper deduplicates by course code
+ * across colleges — first college to provide a prereq wins.
+ *
+ * Flow:
+ *   1. For each college, auto-discover catoid + navoid.
+ *   2. Paginate the course list, collect coids.
+ *   3. Fetch each detail page, extract prereqs.
+ *   4. Merge into a single data/ms/prereqs.json.
+ *
+ * Usage:
+ *   npx tsx scripts/ms/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/ms/scrape-catalog-prereqs.ts --limit=20
+ *   npx tsx scripts/ms/scrape-catalog-prereqs.ts --college=mgccc
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { discoverAcalogCatoid } from "../lib/discover-catalog.js";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 60;
+const MAX_PAGES = 25;
+
+interface CollegeConfig {
+  name: string;
+  base: string;
+  catoid: number;  // fallback — auto-discovered
+  navoid: number;
+}
+
+const COLLEGES: Record<string, CollegeConfig> = {
+  mgccc: {
+    name: "Mississippi Gulf Coast CC",
+    base: "https://catalog.mgccc.edu",
+    catoid: 32,
+    navoid: 3170,
+  },
+  hinds: {
+    name: "Hinds CC",
+    base: "https://catalog.hindscc.edu",
+    catoid: 22,
+    navoid: 1047,
+  },
+  eastms: {
+    name: "East Mississippi CC",
+    base: "https://catalog.eastms.edu",
+    catoid: 6,
+    navoid: 583,
+  },
+  jcjc: {
+    name: "Jones County Junior College",
+    base: "https://catalog.jcjc.edu",
+    catoid: 9,
+    navoid: 653,
+  },
+  meridian: {
+    name: "Meridian CC",
+    base: "https://catalog.meridiancc.edu",
+    catoid: 6,
+    navoid: 140,
+  },
+  northwest: {
+    name: "Northwest Mississippi CC",
+    base: "https://catalog.northwestms.edu",
+    catoid: 8,
+    navoid: 395,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+interface CourseDetail {
+  coid: string;
+  prefix: string;
+  number: string;
+  html: string;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return "";
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Acalog endpoints
+// ---------------------------------------------------------------------------
+
+function listUrl(base: string, catoid: number, navoid: number, cpage: number): string {
+  return (
+    `${base}/content.php?catoid=${catoid}` +
+    `&catoid=${catoid}` +
+    `&navoid=${navoid}` +
+    `&filter%5Bitem_type%5D=3` +
+    `&filter%5Bonly_active%5D=1` +
+    `&filter%5B3%5D=1` +
+    `&filter%5Bcpage%5D=${cpage}`
+  );
+}
+
+function detailUrl(base: string, catoid: number, coid: string): string {
+  return `${base}/preview_course_nopop.php?catoid=${catoid}&coid=${coid}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function extractCoids(html: string): string[] {
+  const matches = html.match(/preview_course_nopop\.php\?catoid=\d+&(?:amp;)?coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+function extractCourseCode(html: string): { prefix: string; number: string } | null {
+  // Try <h1> first, then <title>
+  const m = html.match(/<h1[^>]*>\s*([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*-/) ||
+            html.match(/<title>\s*([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*-/);
+  if (!m) return null;
+  return { prefix: m[1].toUpperCase(), number: m[2] };
+}
+
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&ldquo;/g, "“")
+    .replace(/&rdquo;/g, "”")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+/**
+ * Extract prereq text from an Acalog detail page. Handles multiple MS
+ * college formats:
+ *   1. `<strong>Prerequisite(s):</strong> text<br>`
+ *   2. `Prerequisite: text<br>` (inline, no strong)
+ *   3. `(Prerequisites: text)` (parenthesized, inline)
+ */
+function extractPrereqBlock(html: string): string | null {
+  // Pattern 1: (Prerequisites: ...) parenthesized inline (Hinds format).
+  // Match up to the first `)` after stripping the opening `(Prerequisite:`.
+  let m = html.match(
+    /\(Pre-?requisite(?:s|\(s\))?\s*:\s*([\s\S]{1,2000}?)\)\s/i,
+  );
+  if (m) return m[1];
+
+  // Pattern 2: <strong>Prerequisite(s):</strong> ... up to <br> or </p> or next <strong>
+  m = html.match(
+    /(?:<strong>\s*)?Pre-?requisite(?:s|\(s\))?\s*:\s*(?:<\/strong>)?\s*([\s\S]*?)(?:<br\s*\/?>\s*(?:<br|$)|<\/p>|<strong>(?!<\/strong>))/i,
+  );
+  if (m) return m[1];
+
+  return null;
+}
+
+function extractAnchorCoids(htmlBlock: string): string[] {
+  const matches = htmlBlock.match(/coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+const BOILERPLATE_RE =
+  /^(none|not applicable|n\/a|no prerequisites?)\s*\.?\s*$/i;
+
+// ---------------------------------------------------------------------------
+// Per-college scrape
+// ---------------------------------------------------------------------------
+
+async function scrapeCollege(
+  slug: string,
+  config: CollegeConfig,
+  limit: number,
+): Promise<Map<string, PrereqEntry>> {
+  console.log(`\n--- ${config.name} (${slug}) ---`);
+  console.log(`  Base: ${config.base}`);
+
+  let catoid = config.catoid;
+  try {
+    const discovered = await discoverAcalogCatoid(config.base, config.catoid);
+    if (discovered > 0) catoid = discovered;
+  } catch {
+    // fall through to fallback
+  }
+  console.log(`  catoid=${catoid} navoid=${config.navoid}`);
+
+  // Paginate course list
+  const allCoids = new Set<string>();
+  for (let cpage = 1; cpage <= MAX_PAGES; cpage++) {
+    const html = await retryFetch(
+      listUrl(config.base, catoid, config.navoid, cpage),
+      `${slug}/list(cpage=${cpage})`,
+    );
+    const coids = extractCoids(html);
+    if (coids.length === 0) break;
+    for (const c of coids) allCoids.add(c);
+    await sleep(100);
+  }
+  let coidList = Array.from(allCoids);
+  console.log(`  ${coidList.length} total coids`);
+
+  if (limit > 0) {
+    coidList = coidList.slice(0, limit);
+    console.log(`  Limited to ${limit} for smoke test`);
+  }
+
+  // Fetch detail pages + build coid index
+  const details: CourseDetail[] = [];
+  const codeByCoid = new Map<string, string>();
+  await pmap(coidList, CONCURRENCY, async (coid) => {
+    const html = await retryFetch(
+      detailUrl(config.base, catoid, coid),
+      `${slug}/detail(${coid})`,
+    );
+    if (!html) return;
+    const code = extractCourseCode(html);
+    if (!code) return;
+    details.push({ coid, prefix: code.prefix, number: code.number, html });
+    codeByCoid.set(coid, `${code.prefix} ${code.number}`);
+  });
+  console.log(`  Fetched ${details.length} course pages`);
+
+  // Parse prereqs
+  const prereqs = new Map<string, PrereqEntry>();
+  let resolvedAnchors = 0;
+  for (const d of details) {
+    const block = extractPrereqBlock(d.html);
+    if (!block) continue;
+
+    const text = htmlToText(block);
+    if (!text || BOILERPLATE_RE.test(text)) continue;
+
+    const courses = new Set<string>();
+    const codeRegex = /\b([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\b/g;
+    let m: RegExpExecArray | null;
+    while ((m = codeRegex.exec(text)) !== null) {
+      const code = `${m[1]} ${m[2]}`;
+      if (code !== `${d.prefix} ${d.number}`) courses.add(code);
+    }
+
+    for (const anchorCoid of extractAnchorCoids(block)) {
+      const resolved = codeByCoid.get(anchorCoid);
+      if (resolved && resolved !== `${d.prefix} ${d.number}`) {
+        courses.add(resolved);
+        resolvedAnchors++;
+      }
+    }
+
+    const key = `${d.prefix} ${d.number}`;
+    if (!prereqs.has(key)) {
+      prereqs.set(key, { text, courses: Array.from(courses).sort() });
+    }
+  }
+  console.log(`  ${prereqs.size} courses with prereqs (${resolvedAnchors} anchor refs resolved)`);
+  return prereqs;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limit = parseInt(args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0", 10);
+  const collegeFilter = args.find((a) => a.startsWith("--college="))?.split("=")[1];
+
+  console.log("Mississippi multi-college Acalog prereq scraper");
+
+  const slugs = collegeFilter
+    ? [collegeFilter]
+    : Object.keys(COLLEGES);
+
+  // Load existing prereqs to merge with
+  const outDir = path.join(process.cwd(), "data", "ms");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  let merged: Record<string, PrereqEntry> = {};
+  if (fs.existsSync(outPath)) {
+    merged = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    console.log(`  Loaded ${Object.keys(merged).length} existing prereqs`);
+  }
+
+  for (const slug of slugs) {
+    const config = COLLEGES[slug];
+    if (!config) {
+      console.error(`Unknown college: ${slug}`);
+      continue;
+    }
+    try {
+      const collegePrereqs = await scrapeCollege(slug, config, limit);
+      let added = 0;
+      for (const [key, entry] of collegePrereqs) {
+        if (!merged[key]) {
+          merged[key] = entry;
+          added++;
+        }
+      }
+      console.log(`  +${added} new (${collegePrereqs.size - added} already known)`);
+    } catch (e) {
+      console.error(`  ⚠ ${slug} failed: ${e}`);
+      console.error(`  Continuing with remaining colleges...`);
+    }
+  }
+
+  // Sort and write
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(merged).sort()) {
+    sorted[key] = merged[key];
+  }
+
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for site users

Students in Kentucky, Maine, and Mississippi now see prerequisite chains when planning courses. Previously these three states had zero (or near-zero) prereqs because their course scrapers don't embed prerequisite data — sections come from class-search APIs that simply don't return it. This PR adds dedicated catalog scrapers that go to the authoritative source for each state.

**KY** — 1,612 prereqs (69% of the 2,327-course KCTCS catalog). Scraped from `catalog.kctcs.edu`, a centralized CourseLeaf catalog covering all 16 Kentucky community colleges.

**ME** — 948 prereqs across 6 of 7 Maine community colleges. Scraped from downloadable PDF catalogs (MCCS has no web-based catalog platform). SMCC contributes the most (494), followed by CMCC (251) and YCCC (139).

**MS** — 216 prereqs from Mississippi Gulf Coast CC (MGCCC). The remaining 5 Acalog-hosted MS colleges were temporarily blocked by AWS WAF during the scrape — re-running the scraper will pick them up once the block expires.

## Three new scraper templates

| State | Template | Source | Script |
|-------|----------|--------|--------|
| KY | CourseLeaf | `catalog.kctcs.edu/course-descriptions/{subject}/` | `scripts/ky/scrape-catalog-prereqs.ts` |
| ME | PDF + pdftotext | 6 college catalog PDFs | `scripts/me/scrape-catalog-prereqs.ts` |
| MS | Multi-college Acalog | 6 per-college `catalog.{domain}` sites | `scripts/ms/scrape-catalog-prereqs.ts` |

## Test plan

- [x] KY smoke test (5 subjects → 49 prereqs) + full run (209 subjects → 1,612)
- [x] ME SMCC test (494 prereqs) + full run across 6 colleges (948)
- [x] MS MGCCC test (100 courses → 55 prereqs) + full run (216 from MGCCC)
- [x] Course reference resolution verified (KY bubblelink anchors, ME code regex, MS coid→code index)
- [ ] Re-run MS scraper once remaining 5 WAF blocks expire

🤖 Generated with [Claude Code](https://claude.com/claude-code)