### PR TITLE
feat(ms): Playwright WAF bypass — MS prereqs 216 → 1,848

### DIFF
--- a/data/ms/prereqs.json
+++ b/data/ms/prereqs.json
@@ -1,14 +1,442 @@
 {
+  "ABT 2336": {
+    "text": "ABT 1323",
+    "courses": [
+      "ABT 1323"
+    ]
+  },
+  "ABT 2921": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ABT 2922": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ABT 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ABT 2924": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ABT 2925": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ABT 2926": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ACC 2213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "ACC 2223": {
     "text": "ACC 2213 . (3,3,0)",
     "courses": [
       "ACC 2213"
     ]
   },
+  "ACT 1133": {
+    "text": "High School Diploma or equivalent",
+    "courses": []
+  },
+  "ACT 1313": {
+    "text": "High School Diploma or equivalent",
+    "courses": []
+  },
+  "ACT 1713": {
+    "text": "High School Diploma or equivalent",
+    "courses": []
+  },
+  "ACT 2324": {
+    "text": "must complete freshman courses and have CORE and Type I EPA certification",
+    "courses": []
+  },
+  "ACT 2413": {
+    "text": "must complete freshman courses and have CORE and Type I EPA certification",
+    "courses": []
+  },
+  "ACT 2424": {
+    "text": "ACT 2414",
+    "courses": [
+      "ACT 2414"
+    ]
+  },
+  "ACT 2425": {
+    "text": "must complete freshman courses and have CORE and Type I EPA certification",
+    "courses": []
+  },
+  "ACT 2433": {
+    "text": "must complete freshman courses and have CORE and Type IEPA certification",
+    "courses": []
+  },
+  "ACT 2513": {
+    "text": "must complete freshman courses",
+    "courses": []
+  },
+  "ACT 2624": {
+    "text": "must complete freshman courses and have CORE and Type IEPA certification",
+    "courses": []
+  },
+  "ACT 2913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ACT 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AFR 1211": {
+    "text": "Minimum 2.0 cumulative GPA",
+    "courses": []
+  },
+  "AFR 2111": {
+    "text": "Minimum 2.0 cumulative GPA",
+    "courses": []
+  },
+  "AFR 2211": {
+    "text": "Minimum 2.0 cumulative GPA",
+    "courses": []
+  },
+  "AGR 2314": {
+    "text": "MAT 1134 or higher",
+    "courses": [
+      "MAT 1134"
+    ]
+  },
+  "AGT 1163": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 1254": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "AGT 1333": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 1354": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 1913": {
+    "text": "AGT 1214 & Instructor Approval",
+    "courses": [
+      "AGT 1214"
+    ]
+  },
+  "AGT 2154": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2164": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2174": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2413": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2434": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2463": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2474": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2483": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2513": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2523": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2533": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2553": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2573": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2583": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "AGT 2663": {
+    "text": "AGT 1214",
+    "courses": [
+      "AGT 1214"
+    ]
+  },
+  "AGT 2713": {
+    "text": "AGT 1214",
+    "courses": [
+      "AGT 1214"
+    ]
+  },
+  "AGT 2723": {
+    "text": "AGT 2713",
+    "courses": [
+      "AGT 2713"
+    ]
+  },
+  "AHT 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "AMR 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "AMR 1123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "AMR 2113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "AMR 2123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "AMT 1223": {
+    "text": "Electrical/Electronics Systems ( AMT 1213 )",
+    "courses": [
+      "AMT 1213"
+    ]
+  },
+  "AMT 1323": {
+    "text": "Basic Power Trains (AMT 1313 ) and Basic Hydraulics (AMT 1613)",
+    "courses": [
+      "AMT 1313",
+      "AMT 1613"
+    ]
+  },
+  "AMT 1424": {
+    "text": "Basic Engines (AMT 1413 )",
+    "courses": [
+      "AMT 1413"
+    ]
+  },
+  "AMT 2623": {
+    "text": "Basic Hydraulic Systems (AMT 1615 ) and Basic Power Trains (AMT 1313 )",
+    "courses": [
+      "AMT 1313",
+      "AMT 1615"
+    ]
+  },
+  "AMT 2926": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "AMT 2936": {
+    "text": "Consent of instructor",
+    "courses": []
+  },
+  "ANR 2213": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "ANT 1123": {
+    "text": "AVM 1113",
+    "courses": [
+      "AVM 1113"
+    ]
+  },
+  "ANT 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ANT 2133": {
+    "text": "ANT 1123",
+    "courses": [
+      "ANT 1123"
+    ]
+  },
+  "ANT 2153": {
+    "text": "ANT 2133",
+    "courses": [
+      "ANT 2133"
+    ]
+  },
+  "ANT 2343": {
+    "text": "ANT 2323",
+    "courses": [
+      "ANT 2323"
+    ]
+  },
+  "ANT 2553": {
+    "text": "ANT 2513",
+    "courses": [
+      "ANT 2513"
+    ]
+  },
+  "ANT 2623": {
+    "text": "ANT 2613) Orientation and familiarization with full-scale aircraft simulation software and hardware systems; intermediate flight skills training to include aircraft preflight and systems check, recovery from unusual altitudes, and flight dynamics of heavily-loaded, high-performance aircraft; practical application in external flight training of basic and advanced UAS aircraft. (2 hr lecture, 2 hr lab)",
+    "courses": [
+      "ANT 2613"
+    ]
+  },
+  "ANT 2633": {
+    "text": "ANT 2623",
+    "courses": [
+      "ANT 2623"
+    ]
+  },
+  "ANT 2643": {
+    "text": "ANT 2633) Introduction of autonomous systems theory including UAS autopilot operation, setup, tuning and troubleshooting; practical application of UAS mission planning and aircraft flight testing including launch/recovery, flight following, situational awareness, Crew Resource Management, risk awareness and emergency procedures. (2 hr lecture, 2 hr lab)",
+    "courses": [
+      "ANT 2633"
+    ]
+  },
+  "ANT 2713": {
+    "text": "ANT 2613",
+    "courses": [
+      "ANT 2613"
+    ]
+  },
+  "ANT 2723": {
+    "text": "ANT 2613) Emphasis on rotary airframe construction and repair techniques, aircraft tuning, and weight/balance considerations; installation of data link, sensors, and autopilot systems. (2 hr lecture, 2 hr lab)",
+    "courses": [
+      "ANT 2613"
+    ]
+  },
+  "ANT 2813": {
+    "text": "ANT 2643",
+    "courses": [
+      "ANT 2643"
+    ]
+  },
+  "ANT 2823": {
+    "text": "ANT 2813",
+    "courses": [
+      "ANT 2813"
+    ]
+  },
+  "ANT 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "APT 1213": {
+    "text": "APT 1162",
+    "courses": [
+      "APT 1162"
+    ]
+  },
+  "APT 2114": {
+    "text": "APT 1213 , APT 1233",
+    "courses": [
+      "APT 1213",
+      "APT 1233"
+    ]
+  },
+  "APT 2123": {
+    "text": "All powerplant courses",
+    "courses": []
+  },
+  "APT 2212": {
+    "text": "APT 2143",
+    "courses": [
+      "APT 2143"
+    ]
+  },
+  "ART 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ART 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "ART 1323": {
     "text": "ART 1313 or permission of instructor. (3,0,6)",
     "courses": [
       "ART 1313"
+    ]
+  },
+  "ART 1393": {
+    "text": "ART 1383",
+    "courses": [
+      "ART 1383"
+    ]
+  },
+  "ART 1433": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ART 1443": {
+    "text": "ART 1433",
+    "courses": [
+      "ART 1433"
+    ]
+  },
+  "ART 1453": {
+    "text": "ART 1433",
+    "courses": [
+      "ART 1433"
+    ]
+  },
+  "ART 1811": {
+    "text": "Permission of the instructor",
+    "courses": []
+  },
+  "ART 1821": {
+    "text": "ART 1811 and permission of the instructor",
+    "courses": [
+      "ART 1811"
+    ]
+  },
+  "ART 2353": {
+    "text": "ART 1323",
+    "courses": [
+      "ART 1323"
+    ]
+  },
+  "ART 2433": {
+    "text": "ART 1433 , ART 1443 , ART 1513",
+    "courses": [
+      "ART 1433",
+      "ART 1443",
+      "ART 1513"
+    ]
+  },
+  "ART 2463": {
+    "text": "ART 1433 , ART 1443 ,ART 1513 , ART 2433",
+    "courses": [
+      "ART 1433",
+      "ART 1443",
+      "ART 1513",
+      "ART 2433"
     ]
   },
   "ART 2513": {
@@ -24,11 +452,167 @@
       "ART 2513"
     ]
   },
+  "ART 2613": {
+    "text": "ART 1313 , ART 1323 , ART 1433 , and ART 1443 or permission of the instructor",
+    "courses": [
+      "ART 1313",
+      "ART 1323",
+      "ART 1433",
+      "ART 1443"
+    ]
+  },
   "ART 2623": {
     "text": "ART 2613 or permission of the instructor. (3,0,6)",
     "courses": [
       "ART 2613"
     ]
+  },
+  "ART 2713": {
+    "text": "ENG 0124 or higher; REA 1213",
+    "courses": [
+      "ENG 0124",
+      "REA 1213"
+    ]
+  },
+  "ART 2723": {
+    "text": "ENG 0124 or higher; REA 1213",
+    "courses": [
+      "ENG 0124",
+      "REA 1213"
+    ]
+  },
+  "ART 2913": {
+    "text": "Six hours of courses in the area selected for special studio and recommendation by the art faculty",
+    "courses": []
+  },
+  "ATT 1124": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ATT 1134": {
+    "text": "ATT 1124",
+    "courses": [
+      "ATT 1124"
+    ]
+  },
+  "ATT 1214": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ATT 1424": {
+    "text": "Basic Electrical/Electronic Systems (ATV 1124/ATT 1124 ) Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "ATT 1124",
+      "ATV 1124"
+    ]
+  },
+  "ATT 1714": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ATT 1811": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ATT 2324": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ATT 2325": {
+    "text": "ATT 1124",
+    "courses": [
+      "ATT 1124"
+    ]
+  },
+  "ATT 2334": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ATT 2434": {
+    "text": "ATT 1424",
+    "courses": [
+      "ATT 1424"
+    ]
+  },
+  "ATT 2444": {
+    "text": "ATT 2434",
+    "courses": [
+      "ATT 2434"
+    ]
+  },
+  "ATT 2445": {
+    "text": "ATT 2434",
+    "courses": [
+      "ATT 2434"
+    ]
+  },
+  "ATT 2614": {
+    "text": "ATT 1124",
+    "courses": [
+      "ATT 1124"
+    ]
+  },
+  "ATT 2911": {
+    "text": "Instructor Approval and completion of one semester of classes in Automotive Technology",
+    "courses": []
+  },
+  "ATT 2912": {
+    "text": "Instructor Approval and completion of one semester of classes in Automotive Technology",
+    "courses": []
+  },
+  "ATT 2913": {
+    "text": "Instructor Approval and completion of one semester of classes in Automotive Technology",
+    "courses": []
+  },
+  "ATT 2921": {
+    "text": "Instructor Approval and completion of one semester of Automotive Technology classes",
+    "courses": []
+  },
+  "ATT 2922": {
+    "text": "Instructor Approval and completion of one semester of classes in Automotive Technology",
+    "courses": []
+  },
+  "ATT 2923": {
+    "text": "Instructor Approval and completion of one semester of Automotive Technology classes",
+    "courses": []
+  },
+  "ATT 2924": {
+    "text": "Instructor Approval and completion of one semester of Automotive Technology classes",
+    "courses": []
+  },
+  "ATT 2925": {
+    "text": "Instructor Approval and completion of one semester Automotive Technology classes",
+    "courses": []
+  },
+  "ATT 2926": {
+    "text": "Instructor Approval and completion of one semester of Automotive Technology classes",
+    "courses": []
+  },
+  "ATT 2934": {
+    "text": "Three semesters of coursework in ATT and instructor approval",
+    "courses": []
+  },
+  "AVM 1223": {
+    "text": "AVM 1213",
+    "courses": [
+      "AVM 1213"
+    ]
+  },
+  "AVM 2213": {
+    "text": "AVM 1223",
+    "courses": [
+      "AVM 1223"
+    ]
+  },
+  "AVM 2313": {
+    "text": "AVM 1223",
+    "courses": [
+      "AVM 1223"
+    ]
+  },
+  "BAD 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "BAD 2323": {
     "text": "MAT 1313 or MAT 1314 . (3,3,0)",
@@ -37,10 +621,259 @@
       "MAT 1314"
     ]
   },
+  "BAD 2413": {
+    "text": "REA 1213 ; ENG 0124 or higher; MAT 1133 /MAT 1134 or higher",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BAD 2533": {
+    "text": "Keyboarding or typewriting skills",
+    "courses": []
+  },
   "BAD 2743": {
     "text": "BAD 2713 or Real Estate Sales or Broker License. (3,3,0)",
     "courses": [
       "BAD 2713"
+    ]
+  },
+  "BAV 1218": {
+    "text": "BAV 1118",
+    "courses": [
+      "BAV 1118"
+    ]
+  },
+  "BAV 1318": {
+    "text": "BAV 1118, BAV 1218) Fundamental practices in sanitation, sterilization, prevention and control of contamination, and execution of decontamination in the workplace, hygiene and good grooming, hair analysis, and the application of a chemical hair relaxer and style. Practices are performed independently with supervision. (2 hr lecture, 18 hr clinical lab)",
+    "courses": [
+      "BAV 1118",
+      "BAV 1218"
+    ]
+  },
+  "BAV 1418": {
+    "text": "BAV 1118, BAV 1218, BAV 1318) Intermediate practices including theory of colors, classifications of hair color, color preparation and applications, and treatment of damaged hair. Practices are performed independently with supervision. (3 hr lecture, 15 hr clinical lab)",
+    "courses": [
+      "BAV 1118",
+      "BAV 1218",
+      "BAV 1318"
+    ]
+  },
+  "BAV 1518": {
+    "text": "BAV 1118, BAV 1218, BAV 1318, BAV 1418) Additional study of the structure and function of the skin, common skin disorders, and scalp and hair disorders. Practices include providing facial massages, rendering plain facials, shaving, mustache and beard trimming, and barbering services previously introduced. (6 hr lecture, 6 hr clinical lab)",
+    "courses": [
+      "BAV 1118",
+      "BAV 1218",
+      "BAV 1318",
+      "BAV 1418"
+    ]
+  },
+  "BAV 1618": {
+    "text": "BAV 1118, BAV 1218, BAV 1318, BAV 1418, BAV 1518) Advance practices in business management and business law applicable to barber/styling shop management in preparation for the MS State Board of Barber Examiners licensing exam. (6 hr lecture, 6 hr clinical lab)",
+    "courses": [
+      "BAV 1118",
+      "BAV 1218",
+      "BAV 1318",
+      "BAV 1418",
+      "BAV 1518"
+    ]
+  },
+  "BAV 1621": {
+    "text": "BAV 1418 , BAV 1518 , BAV 1618",
+    "courses": [
+      "BAV 1418",
+      "BAV 1518",
+      "BAV 1618"
+    ]
+  },
+  "BAV 2217": {
+    "text": "BAV 1118 , BAV 1218 , BAV 1318 , BAV 1418 , BAV 1518 , BAV 1618 , Instructor Approval, and a current, valid barber license) Successful completion of this course will enable the student to apply the training and instruction he or she received at the community/junior college program with the company of his or her choice. The student will perform/observe independently with minimal supervision from a company trainer. (2 hr lecture, 15 hr clinical)",
+    "courses": [
+      "BAV 1118",
+      "BAV 1218",
+      "BAV 1318",
+      "BAV 1418",
+      "BAV 1518",
+      "BAV 1618"
+    ]
+  },
+  "BAV 2227": {
+    "text": "BAV 2217 , Instructor Approval, and a current and valid Barber license",
+    "courses": [
+      "BAV 2217"
+    ]
+  },
+  "BAV 2237": {
+    "text": "BAV 2217 , BAV 2227 , Instructor Approval, and a current and valid barber license",
+    "courses": [
+      "BAV 2217",
+      "BAV 2227"
+    ]
+  },
+  "BAV 2247": {
+    "text": "BAV 2217 , BAV 2227 , BAV 2237 , Instructor Approval, and a current and valid barber license",
+    "courses": [
+      "BAV 2217",
+      "BAV 2227",
+      "BAV 2237"
+    ]
+  },
+  "BBT 1425": {
+    "text": "BBT 1115",
+    "courses": [
+      "BBT 1115"
+    ]
+  },
+  "BBT 1525": {
+    "text": "BBT 1115",
+    "courses": [
+      "BBT 1115"
+    ]
+  },
+  "BBT 1623": {
+    "text": "BBT 1115",
+    "courses": [
+      "BBT 1115"
+    ]
+  },
+  "BBT 1723": {
+    "text": "BBT 1115",
+    "courses": [
+      "BBT 1115"
+    ]
+  },
+  "BBT 1823": {
+    "text": "BBT 1115",
+    "courses": [
+      "BBT 1115"
+    ]
+  },
+  "BBT 2112": {
+    "text": "BBT 1115",
+    "courses": [
+      "BBT 1115"
+    ]
+  },
+  "BCT 1813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BCT 1823": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BCT 2813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BCT 2823": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BFT 2413": {
+    "text": "BOT 1433",
+    "courses": [
+      "BOT 1433"
+    ]
+  },
+  "BFT 2914": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "BIO 1111": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "BIO 1113": {
+    "text": "ENG 0124",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "BIO 1114": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "BIO 1121": {
+    "text": "BIO 1111 / BIO 1113 or BIO 1131 / BIO 1133",
+    "courses": [
+      "BIO 1111",
+      "BIO 1113",
+      "BIO 1131",
+      "BIO 1133"
+    ]
+  },
+  "BIO 1123": {
+    "text": "BIO 1111 / BIO 1113 or BIO 1131 / BIO 1133",
+    "courses": [
+      "BIO 1111",
+      "BIO 1113",
+      "BIO 1131",
+      "BIO 1133"
+    ]
+  },
+  "BIO 1124": {
+    "text": "BIO 1111 /BIO 1113 or BIO 1131 /BIO 1133 or BIO 1114 ) A combined lecture and laboratory course for non-science majors that emphasizes the survey of the diversity of life, ecology, evolution, and an overview of organ systems. Labs associated with this course contain experiments and exercises that reinforce the principles introduced in lecture classes. (4 hr lecture and lab)",
+    "courses": [
+      "BIO 1111",
+      "BIO 1113",
+      "BIO 1114",
+      "BIO 1131",
+      "BIO 1133"
+    ]
+  },
+  "BIO 1131": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1133": {
+    "text": "MAT 1133 or higher; ENG 1114 or higher; REA 1213",
+    "courses": [
+      "ENG 1114",
+      "MAT 1133",
+      "REA 1213"
+    ]
+  },
+  "BIO 1134": {
+    "text": "MAT 1133 /MAT 1134 or higher; ENG 1113 /ENG 1114 or higher; REA 1213 ) A combined lecture and laboratory course for science majors that covers the major themes of biology, the scientific method, chemistry relevant to biological systems, cell processes including photosynthesis and cellular respiration, cell division, genetics, and molecular genetics. (4 hr lecture and lab)",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1141": {
+    "text": "BIO 1131 /BIO 1133 ; MAT 1133 or MAT 1134 or higher; REA 1213 ) (Corequisites: BIO 1143 ) A laboratory course for science majors that contains experiments and exercises that reinforce the principles introduced in BIO 1143 General Biology II, Lecture. (2 hr lab)",
+    "courses": [
+      "BIO 1131",
+      "BIO 1133",
+      "BIO 1143",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1143": {
+    "text": "BIO 1131 /BIO 1133 ; MAT 1133 or MAT 1134 or higher; REA 1213 ) (Corequisites: BIO 1141 ) A lecture course for science majors that reinforces concepts introduced in BIO 1133 General Biology I, Lecture, while emphasizing the diversity of life. Topics covered include evolution, classification, ecology, detailed consideration of each group of organisms and viruses, study of animals and plants including their basic anatomy and physiology. (3 hr lecture)",
+    "courses": [
+      "BIO 1131",
+      "BIO 1133",
+      "BIO 1141",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
     ]
   },
   "BIO 1144": {
@@ -49,11 +882,99 @@
       "BIO 1134"
     ]
   },
+  "BIO 1211": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1213": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1214": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1311": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 1313": {
+    "text": "MAT 1133 ; REA 1213 ; ENG 1114 or higher",
+    "courses": [
+      "ENG 1114",
+      "MAT 1133",
+      "REA 1213"
+    ]
+  },
   "BIO 1314": {
     "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 .(4,3,2)",
     "courses": [
       "BIO 1134"
     ]
+  },
+  "BIO 1511": {
+    "text": "None Corequisite: BIO 1513 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1513"
+    ]
+  },
+  "BIO 1513": {
+    "text": "None Corequisite: BIO 1511 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1511"
+    ]
+  },
+  "BIO 1514": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BIO 1521": {
+    "text": "None Corequisite: BIO 1523 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1523"
+    ]
+  },
+  "BIO 1523": {
+    "text": "None Corequisite: BIO 1521 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1521"
+    ]
+  },
+  "BIO 1524": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BIO 1531": {
+    "text": "None Corequisite: BIO 1533 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1533"
+    ]
+  },
+  "BIO 1533": {
+    "text": "None Corequisite: BIO 1531 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1531"
+    ]
+  },
+  "BIO 1534": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "BIO 1613": {
     "text": "BIO 1134 , BIO 2514 and BIO 2524 recommended. (3,3,0)",
@@ -63,11 +984,23 @@
       "BIO 2524"
     ]
   },
+  "BIO 1711": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "BIO 1721": {
     "text": "BIO 1711 (By invitation only.) (1,0,2)",
     "courses": [
       "BIO 1711"
     ]
+  },
+  "BIO 2211": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BIO 2213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "BIO 2214": {
     "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 .(4,3,2)",
@@ -95,10 +1028,42 @@
       "BIO 1134"
     ]
   },
+  "BIO 2314": {
+    "text": "BIO 1313 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1313"
+    ]
+  },
+  "BIO 2411": {
+    "text": "None Corequisite: BIO 2413 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2413"
+    ]
+  },
+  "BIO 2413": {
+    "text": "None Corequisite: BIO 2411 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2411"
+    ]
+  },
   "BIO 2414": {
     "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 . (4,3,2)",
     "courses": [
       "BIO 1134"
+    ]
+  },
+  "BIO 2421": {
+    "text": "None Corequisite: BIO 2423 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2423"
+    ]
+  },
+  "BIO 2423": {
+    "text": "BIO 1133 or BIO 2413 Corequisite: BIO 2421 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 1133",
+      "BIO 2413",
+      "BIO 2421"
     ]
   },
   "BIO 2424": {
@@ -107,10 +1072,72 @@
       "BIO 1134"
     ]
   },
+  "BIO 2431": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 2433": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 2434": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 2511": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 2513": {
+    "text": "High school biology recommended. MAT 1133 ; ENG 1114 or higher; REA 1213",
+    "courses": [
+      "ENG 1114",
+      "MAT 1133",
+      "REA 1213"
+    ]
+  },
   "BIO 2514": {
     "text": "Completion of one of the following: a) minimum ACT composite of 21 on the science component, b) completion of three high school science courses (biology or chemistry) with no grade lower than a “C”, or c) credit for BIO 1134 . (4,3,2)",
     "courses": [
       "BIO 1134"
+    ]
+  },
+  "BIO 2521": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213 ; BIO 2513 /BIO 2511 ) (Corequisites: BIO 2523 ) A laboratory course that contains experiments and exercises that reinforce the principles introduced in BIO 2523 - Anatomy and Physiology II, Lecture . (2 hr lab)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2523",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 2523": {
+    "text": "MAT 1133 ; REA 1213 ; ENG 1114 or higher; BIO 2511 /BIO 2513 ) (Corequisites: BIO 2521 ) A lecture course that includes detailed studies of the anatomy and physiology of the human special senses, endocrine, cardiovascular, lymphatic, respiratory, digestive, and urinary systems, as well as reproduction and development. (3 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "ENG 1114",
+      "MAT 1133",
+      "REA 1213"
     ]
   },
   "BIO 2524": {
@@ -119,11 +1146,65 @@
       "BIO 2514"
     ]
   },
+  "BIO 2611": {
+    "text": "None Corequisite: BIO 2613 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2613"
+    ]
+  },
+  "BIO 2613": {
+    "text": "None Corequisite: BIO 2611 Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2611"
+    ]
+  },
+  "BIO 2614": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BIO 2921": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "BIO 2923": {
+    "text": "4 hours of any BIO courses; ENG 1114 ; REA 1213 ; MAT 1133",
+    "courses": [
+      "ENG 1114",
+      "MAT 1133",
+      "REA 1213"
+    ]
+  },
   "BIO 2924": {
     "text": "BIO 1134 (4,3,2)",
     "courses": [
       "BIO 1134"
     ]
+  },
+  "BOA 2613": {
+    "text": "A grade of C or better in ENG 1113 - English Composition I or permission of instructor",
+    "courses": [
+      "ENG 1113"
+    ]
+  },
+  "BOT 1113": {
+    "text": "Prior to enrollment in this course, students will be required to key straight-copy material at a minimum of 35 GWPM on a five-minute timed writing, with a maximum of one error per minute or successfully complete BOT 1013",
+    "courses": [
+      "BOT 1013"
+    ]
+  },
+  "BOT 1123": {
+    "text": "BOT 1113 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 1113"
+    ]
+  },
+  "BOT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "BOT 1233": {
     "text": "Instructor Approved. (3,2,2)",
@@ -133,11 +1214,47 @@
     "text": "Instructor Approved (3,2,2)",
     "courses": []
   },
+  "BOT 1273": {
+    "text": "Instructor Approval This course will introduce an operating system and word processing, spreadsheet, database management, and presentation software applications using the Microsoft® Office® suite. (3 hr lecture)",
+    "courses": []
+  },
+  "BOT 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BOT 1433": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "BOT 1443": {
     "text": "BOT 1433 (3,3,0)",
     "courses": [
       "BOT 1433"
     ]
+  },
+  "BOT 1493": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BOT 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BOT 1623": {
+    "text": "BOT 1613",
+    "courses": [
+      "BOT 1613"
+    ]
+  },
+  "BOT 1643": {
+    "text": "A grade of C or better in BOT 1613 - Medical Terminology I",
+    "courses": [
+      "BOT 1613"
+    ]
+  },
+  "BOT 1763": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "BOT 1823": {
     "text": "BOT 1313 (3,2,2)",
@@ -149,6 +1266,31 @@
     "text": "BOT 1823 (3,2,2)",
     "courses": [
       "BOT 1823"
+    ]
+  },
+  "BOT 2133": {
+    "text": "BOT 1143 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 1143"
+    ]
+  },
+  "BOT 2183": {
+    "text": "Instructor approved Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "BOT 2233": {
+    "text": "Instructor Approved Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "BOT 2333": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BOT 2413": {
+    "text": "BOT 1433 or ACC 2213 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "ACC 2213",
+      "BOT 1433"
     ]
   },
   "BOT 2423": {
@@ -179,12 +1321,135 @@
       "BOT 1433"
     ]
   },
+  "BOT 2523": {
+    "text": "BOT 1113 , BOT 1613 and BOT 1623 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 1113",
+      "BOT 1613",
+      "BOT 1623"
+    ]
+  },
+  "BOT 2613": {
+    "text": "Instructor Approved Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "BOT 2643": {
+    "text": "BOT 1613 , BOT 1623 or Instructor Approval",
+    "courses": [
+      "BOT 1613",
+      "BOT 1623"
+    ]
+  },
+  "BOT 2653": {
+    "text": "BOT 1613 , BOT 1623 or Instructor Approval",
+    "courses": [
+      "BOT 1613",
+      "BOT 1623"
+    ]
+  },
+  "BOT 2663": {
+    "text": "BOT 2643 and BOT 2653 with grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 2643",
+      "BOT 2653"
+    ]
+  },
+  "BOT 2673": {
+    "text": "BOT 2643 and BOT 2653 with grades of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 2643",
+      "BOT 2653"
+    ]
+  },
+  "BOT 2723": {
+    "text": "BOT 1243",
+    "courses": [
+      "BOT 1243"
+    ]
+  },
+  "BOT 2743": {
+    "text": "Instructor Approval This course will provide coverage and integration of medical office skills and issues using knowledge of medical terminology. Problem solving will be emphasized. (3 hr lecture)",
+    "courses": []
+  },
+  "BOT 2753": {
+    "text": "BOT 2743 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 2743"
+    ]
+  },
+  "BOT 2763": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "BOT 2813": {
     "text": "BOT 1713 , BOT 1233 , or by consent of instructor. (3,3,0)",
     "courses": [
       "BOT 1233",
       "BOT 1713"
     ]
+  },
+  "BOT 2823": {
+    "text": "BOT 1143 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 1143"
+    ]
+  },
+  "BOT 2833": {
+    "text": "BOT 1143 , BOT 2813 , BOT 2323 , and BOT 1813 with a grade of “C” or above unless approved by the Dean, Instructor, or Advisor",
+    "courses": [
+      "BOT 1143",
+      "BOT 1813",
+      "BOT 2323",
+      "BOT 2813"
+    ]
+  },
+  "BOT 2913": {
+    "text": "Successful completion of at least 30 semester hours in the program and Instructor Approval",
+    "courses": []
+  },
+  "BOT 2923": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BOT 2933": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "BPT 2324": {
+    "text": "HRT 1213 Sanitation and Safety",
+    "courses": [
+      "HRT 1213"
+    ]
+  },
+  "CAT 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CAT 1123": {
+    "text": "CAT 1113 , CAT 1213",
+    "courses": [
+      "CAT 1113",
+      "CAT 1213"
+    ]
+  },
+  "CAT 1143": {
+    "text": "CAT 1213 , CAT 1113",
+    "courses": [
+      "CAT 1113",
+      "CAT 1213"
+    ]
+  },
+  "CAT 1153": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CAT 1163": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CAT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "CAT 2133": {
     "text": "CAT 1113, CAT 1213. (3,1,4)",
@@ -196,6 +1461,13 @@
   "CAT 2263": {
     "text": "CAT 1213. (3,1,4)",
     "courses": [
+      "CAT 1213"
+    ]
+  },
+  "CAT 2312": {
+    "text": "Graphic Design and Production I (CAT 1113 ), Fundamentals of Graphic Computers (CAT 1213 ), or by consent of instructor Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "CAT 1113",
       "CAT 1213"
     ]
   },
@@ -218,8 +1490,165 @@
       "CAT 2313"
     ]
   },
+  "CAT 2334": {
+    "text": "CAT 2313 , CAT 2323 , and minimum assessment scores: Reading- ACT®, 17 or ACCUPLACER, 76 or Next-Generation ACCUPLACER, 246; English- ACT®, 17 or ACCUPLACER, 88 or Next-Generation ACCUPLACER, 245-300, Instructor Approval",
+    "courses": [
+      "CAT 2313",
+      "CAT 2323"
+    ]
+  },
+  "CAT 2413": {
+    "text": "CAT 1213 , CAT 1113 , and minimum assessment scores: Reading- ACT®, 17 or ACCUPLACER, 76 or Next-Generation ACCUPLACER, 246; English- ACT®, 17 or ACCUPLACER, 88 or Next-Generation ACCUPLACER, 245-300. A study of various illustration and rendering techniques. The student will learn professional methods of illustration and visual production for mass distribution using electronic, mechanical, and traditional art techniques. (1 hr lecture, 4 hr lab)",
+    "courses": [
+      "CAT 1113",
+      "CAT 1213"
+    ]
+  },
+  "CAT 2824": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CAT 2834": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CAT 2913": {
+    "text": "Completion of one semester of coursework in the Graphic Design Technology program and Instructor Approval",
+    "courses": []
+  },
   "CAT 2914": {
     "text": "Completion of one semester of coursework in the Graphic Design Technology program (4,2,4)",
+    "courses": []
+  },
+  "CAT 2921": {
+    "text": "Consent of instructor and the completion of two semesters of coursework in the Graphic Design Technology program",
+    "courses": []
+  },
+  "CAT 2923": {
+    "text": "Instructor Approval and the completion of two semesters of coursework in the Graphic Design Technology program",
+    "courses": []
+  },
+  "CAT 2933": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CCT 1116": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CCT 1123": {
+    "text": "CCT 1116",
+    "courses": [
+      "CCT 1116"
+    ]
+  },
+  "CCT 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CCT 1163": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CCT 1236": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CCT 1245": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CCT 1314": {
+    "text": "NONE Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "CCT 2313": {
+    "text": "CCT 1315",
+    "courses": [
+      "CCT 1315"
+    ]
+  },
+  "CCT 2913": {
+    "text": "Sophomore standing in Carpentry",
+    "courses": []
+  },
+  "CCT 2922": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CCT 2926": {
+    "text": "Sophomore standing in Carpentry",
+    "courses": []
+  },
+  "CCT 2933": {
+    "text": "NONE Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "CDT 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1214": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1224": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1343": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1344": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CDT 1713": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 2111": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 2121": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 2233": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 2413": {
+    "text": "CDT 1214 , CDT 1224",
+    "courses": [
+      "CDT 1214",
+      "CDT 1224"
+    ]
+  },
+  "CDT 2513": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CDT 2613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 2714": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
     "courses": []
   },
   "CDT 2813": {
@@ -234,10 +1663,62 @@
       "CDT 2613"
     ]
   },
+  "CDT 2914": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CDT 2924": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CDT 2934": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
   "CDT 2943": {
     "text": "CDT 2913 (3,0,6)",
     "courses": [
       "CDT 2913"
+    ]
+  },
+  "CDT 2944": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CHE 1111": {
+    "text": "ACT math sub-score of 18 or completion of MAT 1233 with a “C” or higher Corequisite: CHE 1113 Prerequisite/Corequisite: None",
+    "courses": [
+      "CHE 1113",
+      "MAT 1233"
+    ]
+  },
+  "CHE 1113": {
+    "text": "ACT math sub-score of 18 or completion of MAT 1233 with a “C” or higher Corequisite: CHE 1111 Prerequisite/Corequisite: None",
+    "courses": [
+      "CHE 1111",
+      "MAT 1233"
+    ]
+  },
+  "CHE 1114": {
+    "text": "ACT math sub-score of 18 or higher or completion of MAT 1233 with a “C” or higher Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MAT 1233"
+    ]
+  },
+  "CHE 1211": {
+    "text": "None Corequisite: CHE 1213 Prerequisite/Corequisite: MAT 1313 or higher",
+    "courses": [
+      "CHE 1213",
+      "MAT 1313"
+    ]
+  },
+  "CHE 1213": {
+    "text": "MAT 1313 /MAT 1314 - College Algebra or higher or CHE 1314 - Principles of Chemistry I , students that have not taken any Chemistry but completed College Algebra should consider taking CHE 1314 Principles of Chemistry first. (Corequisites: CHE 1211",
+    "courses": [
+      "CHE 1211",
+      "CHE 1314",
+      "MAT 1313",
+      "MAT 1314"
     ]
   },
   "CHE 1214": {
@@ -247,10 +1728,49 @@
       "MAT 1313"
     ]
   },
+  "CHE 1221": {
+    "text": "CHE 1211 , CHE 1213",
+    "courses": [
+      "CHE 1211",
+      "CHE 1213"
+    ]
+  },
+  "CHE 1223": {
+    "text": "CHE 1211 , CHE 1213",
+    "courses": [
+      "CHE 1211",
+      "CHE 1213"
+    ]
+  },
   "CHE 1224": {
     "text": "CHE 1214 . (4,3,2)",
     "courses": [
       "CHE 1214"
+    ]
+  },
+  "CHE 1313": {
+    "text": "MAT 1133 or MAT 1134 or higher; ENG 0124 or higher; REA 1213",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "CHE 1314": {
+    "text": "MAT 1133 or MAT 1134 or higher; ENG 0124 or higher; REA 1213",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "CHE 1323": {
+    "text": "successful completion of CHE 1313 /CHE 1311 with grades of “C” or better",
+    "courses": [
+      "CHE 1311",
+      "CHE 1313"
     ]
   },
   "CHE 1324": {
@@ -260,6 +1780,60 @@
       "CHE 1314"
     ]
   },
+  "CHE 1411": {
+    "text": "CHE 1213 or CHE 1313 and lab",
+    "courses": [
+      "CHE 1213",
+      "CHE 1313"
+    ]
+  },
+  "CHE 1413": {
+    "text": "CHE 1213 or CHE 1313",
+    "courses": [
+      "CHE 1213",
+      "CHE 1313"
+    ]
+  },
+  "CHE 1414": {
+    "text": "CHE 1213 or CHE 1313 or CHE 1214 or CHE 1314",
+    "courses": [
+      "CHE 1213",
+      "CHE 1214",
+      "CHE 1313",
+      "CHE 1314"
+    ]
+  },
+  "CHE 1711": {
+    "text": "CHE 1211 and CHE 1213 or CHE 1214 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "CHE 1211",
+      "CHE 1213",
+      "CHE 1214"
+    ]
+  },
+  "CHE 2421": {
+    "text": "CHE 1213 and CHE 1223 Corequisite: CHE 2423 Prerequisite/Corequisite: None",
+    "courses": [
+      "CHE 1213",
+      "CHE 1223",
+      "CHE 2423"
+    ]
+  },
+  "CHE 2423": {
+    "text": "CHE 1221 & CHE 1223",
+    "courses": [
+      "CHE 1221",
+      "CHE 1223"
+    ]
+  },
+  "CHE 2424": {
+    "text": "CHE 1221 /CHE 1223 or CHE 1224",
+    "courses": [
+      "CHE 1221",
+      "CHE 1223",
+      "CHE 1224"
+    ]
+  },
   "CHE 2425": {
     "text": "CHE 1214 and CHE 1224 . (5,3,4)",
     "courses": [
@@ -267,11 +1841,199 @@
       "CHE 1224"
     ]
   },
+  "CHE 2431": {
+    "text": "CHE 2421 , CHE 2423",
+    "courses": [
+      "CHE 2421",
+      "CHE 2423"
+    ]
+  },
+  "CHE 2433": {
+    "text": "CHE 2421 , CHE 2423",
+    "courses": [
+      "CHE 2421",
+      "CHE 2423"
+    ]
+  },
+  "CHE 2434": {
+    "text": "CHE 2421 /CHE 2423 or CHE 2424",
+    "courses": [
+      "CHE 2421",
+      "CHE 2423",
+      "CHE 2424"
+    ]
+  },
   "CHE 2435": {
     "text": "CHE 2425 (5,3,4)",
     "courses": [
       "CHE 2425"
     ]
+  },
+  "CHE 2711": {
+    "text": "CHE 1211 and CHE 1213 or CHE 1214 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "CHE 1211",
+      "CHE 1213",
+      "CHE 1214"
+    ]
+  },
+  "CHE 2721": {
+    "text": "CHE 1211 andCHE 1213 or CHE 1214 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "CHE 1211",
+      "CHE 1213",
+      "CHE 1214"
+    ]
+  },
+  "CIT 1113": {
+    "text": "CIT 1413",
+    "courses": [
+      "CIT 1413"
+    ]
+  },
+  "CIT 2123": {
+    "text": "CIT 1413 , CIT 1113 , and CIT 2433",
+    "courses": [
+      "CIT 1113",
+      "CIT 1413",
+      "CIT 2433"
+    ]
+  },
+  "CIT 2433": {
+    "text": "CIT 1413",
+    "courses": [
+      "CIT 1413"
+    ]
+  },
+  "CIT 2443": {
+    "text": "CIT 1413 , CIT 1113 , and CIT 2433 , or by permission of the instructor",
+    "courses": [
+      "CIT 1113",
+      "CIT 1413",
+      "CIT 2433"
+    ]
+  },
+  "CIT 2911": {
+    "text": "Minimum of 12 hours, CIT related courses",
+    "courses": []
+  },
+  "CIT 2913": {
+    "text": "Minimum of 12 hours, CIT related courses",
+    "courses": []
+  },
+  "COE 1021": {
+    "text": "COE 1011 or COE 1012 or COE 1013",
+    "courses": [
+      "COE 1011",
+      "COE 1012",
+      "COE 1013"
+    ]
+  },
+  "COE 1022": {
+    "text": "COE 1011 or COE 1012 or COE 1013",
+    "courses": [
+      "COE 1011",
+      "COE 1012",
+      "COE 1013"
+    ]
+  },
+  "COE 1023": {
+    "text": "COE 1011 or COE 1012 or COE 1013",
+    "courses": [
+      "COE 1011",
+      "COE 1012",
+      "COE 1013"
+    ]
+  },
+  "COE 1031": {
+    "text": "COE 1021 or COE 1022 or COE 1023",
+    "courses": [
+      "COE 1021",
+      "COE 1022",
+      "COE 1023"
+    ]
+  },
+  "COE 1032": {
+    "text": "COE 1021 or COE 1022 or COE 1023",
+    "courses": [
+      "COE 1021",
+      "COE 1022",
+      "COE 1023"
+    ]
+  },
+  "COE 1033": {
+    "text": "COE 1021 or COE 1022 or COE 1023",
+    "courses": [
+      "COE 1021",
+      "COE 1022",
+      "COE 1023"
+    ]
+  },
+  "COE 1041": {
+    "text": "COE 1031 or COE 1032 or COE 1033",
+    "courses": [
+      "COE 1031",
+      "COE 1032",
+      "COE 1033"
+    ]
+  },
+  "COE 1042": {
+    "text": "COE 1031 or COE 1032 or COE 1033",
+    "courses": [
+      "COE 1031",
+      "COE 1032",
+      "COE 1033"
+    ]
+  },
+  "COE 1043": {
+    "text": "COE 1031 or COE 1032 or COE 1033",
+    "courses": [
+      "COE 1031",
+      "COE 1032",
+      "COE 1033"
+    ]
+  },
+  "COM 1433": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COM 1443": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COM 1463": {
+    "text": "ENG 1114 or higher; REA 1213",
+    "courses": [
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "COM 1511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COM 1521": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COM 2463": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COM 2483": {
+    "text": "ENG 1114 or higher; REA 1213",
+    "courses": [
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "COM 2511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COM 2521": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "CON 2123": {
     "text": "CON 1223 and CON 1213 . (3,2,2)",
@@ -286,17 +2048,241 @@
       "CON 1233"
     ]
   },
+  "COV 1122": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1245": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1255": {
+    "text": "COV 1245",
+    "courses": [
+      "COV 1245"
+    ]
+  },
+  "COV 1263": {
+    "text": "COV 1255",
+    "courses": [
+      "COV 1255"
+    ]
+  },
+  "COV 1426": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1436": {
+    "text": "COV 1426",
+    "courses": [
+      "COV 1426"
+    ]
+  },
+  "COV 1443": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1522": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1532": {
+    "text": "COV 1522",
+    "courses": [
+      "COV 1522"
+    ]
+  },
+  "COV 1542": {
+    "text": "COV 1532",
+    "courses": [
+      "COV 1532"
+    ]
+  },
+  "COV 1622": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1632": {
+    "text": "COV 1622",
+    "courses": [
+      "COV 1622"
+    ]
+  },
+  "COV 1642": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 1722": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "COV 1732": {
     "text": "COV 1722 . (2,1,3)",
     "courses": [
       "COV 1722"
     ]
   },
+  "COV 2816": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2825": {
+    "text": "COV 2815",
+    "courses": [
+      "COV 2815"
+    ]
+  },
+  "COV 2826": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2835": {
+    "text": "COV 2815 , COV 2825",
+    "courses": [
+      "COV 2815",
+      "COV 2825"
+    ]
+  },
+  "COV 2836": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2845": {
+    "text": "COV 2815 , COV 2825 , COV 2835",
+    "courses": [
+      "COV 2815",
+      "COV 2825",
+      "COV 2835"
+    ]
+  },
+  "COV 2846": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2855": {
+    "text": "COV 2815 , COV 2825 , COV 2835 , COV 2845 , and Instructor Approval",
+    "courses": [
+      "COV 2815",
+      "COV 2825",
+      "COV 2835",
+      "COV 2845"
+    ]
+  },
+  "COV 2866": {
+    "text": "COV 2815 , COV 2825 , COV 2835 , COV 2845 , COV 2855 , and Instructor Approval) Instruction will be given in classroom management techniques; cosmetology laws, rules, and regulations; and practical application of cosmetology instruction. (2 lecture, 12 clinical)",
+    "courses": [
+      "COV 2815",
+      "COV 2825",
+      "COV 2835",
+      "COV 2845",
+      "COV 2855"
+    ]
+  },
+  "COV 2877": {
+    "text": "COV 2815 , COV 2825 , COV 2835 , COV 2845 , COV 2855 , COV 2866 , and Instructor Approval) Instruction will be given in classroom management techniques, cosmetology laws, rules, and regulations; and practical application of cosmetology instruction. (21 hr clinical)",
+    "courses": [
+      "COV 2815",
+      "COV 2825",
+      "COV 2835",
+      "COV 2845",
+      "COV 2855",
+      "COV 2866"
+    ]
+  },
+  "COV 2887": {
+    "text": "COV 2815 , COV 2825 , COV 2835 , COV 2845 , COV 2855 , COV 2866 , COV 2877 , and Instructor Approval) Instruction will be given in classroom management techniques; cosmetology laws, rules, and regulations; and practical application of cosmetology instruction. (21 hr clinical)",
+    "courses": [
+      "COV 2815",
+      "COV 2825",
+      "COV 2835",
+      "COV 2845",
+      "COV 2855",
+      "COV 2866",
+      "COV 2877"
+    ]
+  },
+  "COV 2951": {
+    "text": "Instructor Approval Corequisite: none Prerequisite/Corequisite: none",
+    "courses": []
+  },
+  "COV 2952": {
+    "text": "Instructor approval Corequisite: none Prerequisite/Corequisite: none",
+    "courses": []
+  },
+  "COV 2953": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2954": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2955": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "COV 2956": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CRJ 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CRJ 1323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CRJ 1353": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CRJ 1363": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CRJ 1383": {
+    "text": "REA 0123 or REA 1213",
+    "courses": [
+      "REA 0123",
+      "REA 1213"
+    ]
+  },
+  "CRJ 2513": {
+    "text": "CRJ 2333",
+    "courses": [
+      "CRJ 2333"
+    ]
+  },
+  "CSC 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CSC 1123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CSC 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "CSC 1213": {
     "text": "a) minimum ACT score of 19 on the math component, b) credit for MAT 1313 or MAT 1314 , or c) permission of the instructor. (3,3,0)",
     "courses": [
       "MAT 1313",
       "MAT 1314"
+    ]
+  },
+  "CSC 1613": {
+    "text": "CSC 2134 or previous programming experience or permission of the instructor",
+    "courses": [
+      "CSC 2134"
+    ]
+  },
+  "CSC 1614": {
+    "text": "MAT 1233 - Intermediate Algebra",
+    "courses": [
+      "MAT 1233"
     ]
   },
   "CSC 2134": {
@@ -313,14 +2299,47 @@
       "CSC 2134"
     ]
   },
+  "CSC 2623": {
+    "text": "CSC 1613 or previous programming experience or permission of the instructor",
+    "courses": [
+      "CSC 1613"
+    ]
+  },
+  "CSC 2624": {
+    "text": "A grade of “C” or better in CSC 1614",
+    "courses": [
+      "CSC 1614"
+    ]
+  },
+  "CSC 2833": {
+    "text": "CSC 2144 , CSC 2623 , and MAT 1613",
+    "courses": [
+      "CSC 2144",
+      "CSC 2623",
+      "MAT 1613"
+    ]
+  },
   "CSC 2844": {
     "text": "CSC 2144 . (4,3,2)",
     "courses": [
       "CSC 2144"
     ]
   },
+  "CST 2113": {
+    "text": "CST 1114 , CST 1123",
+    "courses": [
+      "CST 1114",
+      "CST 1123"
+    ]
+  },
   "CST 2123": {
     "text": "CST 2113 . (3,2,2)",
+    "courses": [
+      "CST 2113"
+    ]
+  },
+  "CST 2134": {
+    "text": "CST 2113",
     "courses": [
       "CST 2113"
     ]
@@ -331,14 +2350,116 @@
       "CST 1213"
     ]
   },
+  "CST 2911": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CST 2912": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
   "CST 2913": {
     "text": "Consent of Instructor. (3,0,6)",
+    "courses": []
+  },
+  "CST 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CST 2924": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CST 2925": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CST 2926": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CTE 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CTE 1332": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CTV 2123": {
+    "text": "CTV 1123",
+    "courses": [
+      "CTV 1123"
+    ]
+  },
+  "CTV 2134": {
+    "text": "CTV 1134",
+    "courses": [
+      "CTV 1134"
+    ]
+  },
+  "CUT 1114": {
+    "text": "HRT 1213 & Instructor Approval",
+    "courses": [
+      "HRT 1213"
+    ]
+  },
+  "CUT 1124": {
+    "text": "HRT 1213 Sanitation and Safety",
+    "courses": [
+      "HRT 1213"
+    ]
+  },
+  "CUT 1134": {
+    "text": "CUT 1114 /HRT 1114 & CUT 1124",
+    "courses": [
+      "CUT 1114",
+      "CUT 1124",
+      "HRT 1114"
+    ]
+  },
+  "CUT 1153": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CUT 1511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
     "courses": []
   },
   "CUT 1513": {
     "text": "CUT 1114 (3,1,4)",
     "courses": [
       "CUT 1114"
+    ]
+  },
+  "CUT 1514": {
+    "text": "CUT 1114 /HRT 1114, CUT 1124",
+    "courses": [
+      "CUT 1114",
+      "CUT 1124",
+      "HRT 1114"
+    ]
+  },
+  "CUT 1521": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CUT 1531": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CUT 1541": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CUT 2223": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "CUT 2243": {
+    "text": "HRT 1213 Sanitation and Safety",
+    "courses": [
+      "HRT 1213"
     ]
   },
   "CUT 2314": {
@@ -354,6 +2475,208 @@
       "CUT 1124"
     ]
   },
+  "CUT 2921": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CUT 2922": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CUT 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CUT 2924": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CUT 2925": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "CUT 2926": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAN 1223": {
+    "text": "DAN 1212",
+    "courses": [
+      "DAN 1212"
+    ]
+  },
+  "DAN 1322": {
+    "text": "DAN 1312 or HPR 1112",
+    "courses": [
+      "DAN 1312",
+      "HPR 1112"
+    ]
+  },
+  "DAN 1422": {
+    "text": "DAN 1412 or Instructor Approval",
+    "courses": [
+      "DAN 1412"
+    ]
+  },
+  "DAN 1553": {
+    "text": "DAN 1542",
+    "courses": [
+      "DAN 1542"
+    ]
+  },
+  "DAN 1572": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DAN 1582": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DAN 1712": {
+    "text": "By audition only",
+    "courses": []
+  },
+  "DAN 2253": {
+    "text": "DAN 2243",
+    "courses": [
+      "DAN 2243"
+    ]
+  },
+  "DAN 2572": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DAN 2582": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DAT 1111": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1214": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1323": {
+    "text": "DAT 1313",
+    "courses": [
+      "DAT 1313"
+    ]
+  },
+  "DAT 1415": {
+    "text": "CPR-C Certification",
+    "courses": []
+  },
+  "DAT 1423": {
+    "text": "All First Semester Courses",
+    "courses": []
+  },
+  "DAT 1433": {
+    "text": "DAT 1423",
+    "courses": [
+      "DAT 1423"
+    ]
+  },
+  "DAT 1514": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1522": {
+    "text": "All First Semester Courses",
+    "courses": []
+  },
+  "DAT 1612": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1714": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1815": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1823": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DAT 1932": {
+    "text": "DAT 1111 , DAT 1214 , DAT 1313 , DAT 1415 , DAT 1513 , & SPT 1113 /SPT 2173 ) Supervised clinical experience in an authorized dental clinic with assistance of dental team members. (6 hr clinical)",
+    "courses": [
+      "DAT 1111",
+      "DAT 1214",
+      "DAT 1313",
+      "DAT 1415",
+      "DAT 1513",
+      "SPT 1113",
+      "SPT 2173"
+    ]
+  },
+  "DAT 1943": {
+    "text": "FALL ADMISSION: DAT 1111 , DAT 1214 , DAT 1313 , DAT 1415 , DAT 1513 , & SPT 1113 /SPT 2173 ; SPRING ADMISSION: DAT 1423 , DAT 1522 , & DAT 1932 ) Continuation of supervised clinical experience in an authorized dental clinic with minimal assistance from dental team members with a focus on general dentistry and specialty dentistry. (9 hr clinical)",
+    "courses": [
+      "DAT 1111",
+      "DAT 1214",
+      "DAT 1313",
+      "DAT 1415",
+      "DAT 1423",
+      "DAT 1513",
+      "DAT 1522",
+      "DAT 1932",
+      "SPT 1113",
+      "SPT 2173"
+    ]
+  },
+  "DAT 1952": {
+    "text": "FALL ADMISSION: DAT 1323 , DAT 1423 , DAT 1522 , DAT 1612 , DAT 1714 , DAT 1932 & DAT 1943 ; SPRING ADMISSION: DAT 1423 , DAT 1522 , & DAT 1932 ) Continuation of supervised clinical experience in an authorized dental clinic with minimal assistance from dental team members with a focus on general dentistry. (6 hr clinical)",
+    "courses": [
+      "DAT 1323",
+      "DAT 1423",
+      "DAT 1522",
+      "DAT 1612",
+      "DAT 1714",
+      "DAT 1932",
+      "DAT 1943"
+    ]
+  },
+  "DDT 1143": {
+    "text": "DDT 1163 , DDT 1314",
+    "courses": [
+      "DDT 1163",
+      "DDT 1314"
+    ]
+  },
+  "DDT 1153": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213 ; DDT 1163",
+    "courses": [
+      "DDT 1163",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "DDT 1163": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
   "DDT 1173": {
     "text": "DDT 1163 , DDT 1313 , DDT 1323 (3,1,4)",
     "courses": [
@@ -362,10 +2685,32 @@
       "DDT 1323"
     ]
   },
+  "DDT 1183": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "DDT 1213": {
+    "text": "REA 0133 or REA 1213",
+    "courses": [
+      "REA 0133",
+      "REA 1213"
+    ]
+  },
   "DDT 1313": {
     "text": "DDT 1163 (3,2,2)",
     "courses": [
       "DDT 1163"
+    ]
+  },
+  "DDT 1314": {
+    "text": "MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
     ]
   },
   "DDT 1323": {
@@ -374,12 +2719,36 @@
       "DDT 1313"
     ]
   },
+  "DDT 1324": {
+    "text": "DDT 1163 , DDT 1314",
+    "courses": [
+      "DDT 1163",
+      "DDT 1314"
+    ]
+  },
+  "DDT 1413": {
+    "text": "MAT 1233 or MAT 1133 , REA 0133 or REA 1213",
+    "courses": [
+      "MAT 1133",
+      "MAT 1233",
+      "REA 0133",
+      "REA 1213"
+    ]
+  },
   "DDT 1613": {
     "text": "DDT 1313 , DDT 1323 , DDT 1513 . (3,1,4)",
     "courses": [
       "DDT 1313",
       "DDT 1323",
       "DDT 1513"
+    ]
+  },
+  "DDT 1614": {
+    "text": "DDT 1163 , DDT 1314 , DDT 1324",
+    "courses": [
+      "DDT 1163",
+      "DDT 1314",
+      "DDT 1324"
     ]
   },
   "DDT 2153": {
@@ -391,6 +2760,12 @@
       "DDT 1513"
     ]
   },
+  "DDT 2183": {
+    "text": "DDT 1173",
+    "courses": [
+      "DDT 1173"
+    ]
+  },
   "DDT 2213": {
     "text": "DDT 1163 , DDT 1313 , DDT 1323 , DDT 1513 (3,1,4)",
     "courses": [
@@ -400,6 +2775,30 @@
       "DDT 1513"
     ]
   },
+  "DDT 2233": {
+    "text": "DDT 2213",
+    "courses": [
+      "DDT 2213"
+    ]
+  },
+  "DDT 2243": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "DDT 2273": {
+    "text": "DDT 1163 , DDT 1324",
+    "courses": [
+      "DDT 1163",
+      "DDT 1324"
+    ]
+  },
+  "DDT 2363": {
+    "text": "Instructor approval",
+    "courses": []
+  },
   "DDT 2373": {
     "text": "DDT 1163 , DDT 1313 and DDT 1323 . (3,1,4)",
     "courses": [
@@ -408,11 +2807,53 @@
       "DDT 1323"
     ]
   },
+  "DDT 2383": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "DDT 2423": {
+    "text": "DDT 1324",
+    "courses": [
+      "DDT 1324"
+    ]
+  },
+  "DDT 2433": {
+    "text": "DDT 1413",
+    "courses": [
+      "DDT 1413"
+    ]
+  },
+  "DDT 2443": {
+    "text": "DDT 1413 , DDT 2153",
+    "courses": [
+      "DDT 1413",
+      "DDT 2153"
+    ]
+  },
+  "DDT 2453": {
+    "text": "DDT 1413",
+    "courses": [
+      "DDT 1413"
+    ]
+  },
+  "DDT 2463": {
+    "text": "DDT 1413 , DDT 2433",
+    "courses": [
+      "DDT 1413",
+      "DDT 2433"
+    ]
+  },
   "DDT 2523": {
     "text": "DDT 1313 , DDT 1323 (3,1,4)",
     "courses": [
       "DDT 1313",
       "DDT 1323"
+    ]
+  },
+  "DDT 2533": {
+    "text": "DDT 1324",
+    "courses": [
+      "DDT 1324"
     ]
   },
   "DDT 2563": {
@@ -429,6 +2870,21 @@
       "DDT 1613"
     ]
   },
+  "DDT 2633": {
+    "text": "DDT 1324 , DDT 1614 , DDT 1213",
+    "courses": [
+      "DDT 1213",
+      "DDT 1324",
+      "DDT 1614"
+    ]
+  },
+  "DDT 2693": {
+    "text": "DDT 1324 , DDT 1413",
+    "courses": [
+      "DDT 1324",
+      "DDT 1413"
+    ]
+  },
   "DDT 2723": {
     "text": "DDT 1313 , DDT 1323 , DDT 1513 (3,1,4)",
     "courses": [
@@ -437,10 +2893,22 @@
       "DDT 1513"
     ]
   },
+  "DDT 2743": {
+    "text": "DDT 1743",
+    "courses": [
+      "DDT 1743"
+    ]
+  },
   "DDT 2753": {
     "text": "DDT 2373 (3,1,4)",
     "courses": [
       "DDT 2373"
+    ]
+  },
+  "DDT 2813": {
+    "text": "DDT 1324",
+    "courses": [
+      "DDT 1324"
     ]
   },
   "DDT 2823": {
@@ -450,8 +2918,415 @@
       "DDT 1613"
     ]
   },
+  "DDT 2911": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
   "DDT 2913": {
     "text": "Consent of instructor. (3,0,6)",
+    "courses": []
+  },
+  "DDT 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1114": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1213": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1223": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1263": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DET 1264": {
+    "text": "DET 1223",
+    "courses": [
+      "DET 1223"
+    ]
+  },
+  "DET 1363": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1364": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DET 1373": {
+    "text": "DET 1363",
+    "courses": [
+      "DET 1363"
+    ]
+  },
+  "DET 1374": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DET 1513": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DET 1514": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1613": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1614": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DET 1713": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 1813": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DET 1814": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2112": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2253": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2273": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2383": {
+    "text": "DET 1373",
+    "courses": [
+      "DET 1373"
+    ]
+  },
+  "DET 2514": {
+    "text": "DET 1514",
+    "courses": [
+      "DET 1514"
+    ]
+  },
+  "DET 2524": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2623": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DET 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "DHT 1115": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1243": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1252": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1314": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1416": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1931": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 1941": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2232": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2426": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2436": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2713": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2823": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2832": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2922": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2952": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DHT 2961": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DMS 1114": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ,and MAT 1313 ) (Pre/Corequisites: DMS 1213 , DMS 1313 , DMS 1415 , and DMS 1513 ) Students will be introduced to ultrasound equipment. Cleaning and disinfectant procedures will be shown. Types of film, paper printers, video recorders, scanning tables, ultrasound probes, and recording methods will be discussed. Legal/ethical issues and patient contact within the ultrasound department, as well as scanning orientation are included. Students will learn the sonographer’s role in patient care. (3 hr lecture, 2 hr lab)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "DMS 1213",
+      "DMS 1313",
+      "DMS 1415",
+      "DMS 1513",
+      "MAT 1313"
+    ]
+  },
+  "DMS 1323": {
+    "text": "DMS 1313",
+    "courses": [
+      "DMS 1313"
+    ]
+  },
+  "DMS 1426": {
+    "text": "DMS 1415",
+    "courses": [
+      "DMS 1415"
+    ]
+  },
+  "DMS 1435": {
+    "text": "DMS 1426",
+    "courses": [
+      "DMS 1426"
+    ]
+  },
+  "DMS 1524": {
+    "text": "DMS 1114 , DMS 1213 , DMS 1513",
+    "courses": [
+      "DMS 1114",
+      "DMS 1213",
+      "DMS 1513"
+    ]
+  },
+  "DMS 1533": {
+    "text": "DMS 1114 , DMS 1213 , DMS 1513",
+    "courses": [
+      "DMS 1114",
+      "DMS 1213",
+      "DMS 1513"
+    ]
+  },
+  "DMS 1622": {
+    "text": "DMS 1513 , DMS 1524",
+    "courses": [
+      "DMS 1513",
+      "DMS 1524"
+    ]
+  },
+  "DTV 1114": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DTV 1116": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DTV 1124": {
+    "text": "DTV 1114",
+    "courses": [
+      "DTV 1114"
+    ]
+  },
+  "DTV 1126": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DTV 1137": {
+    "text": "DTV 1114",
+    "courses": [
+      "DTV 1114"
+    ]
+  },
+  "DTV 1138": {
+    "text": "DTV 1114 and DTV 1124",
+    "courses": [
+      "DTV 1114",
+      "DTV 1124"
+    ]
+  },
+  "DTV 1148": {
+    "text": "DTV 1114 and DTV 1124",
+    "courses": [
+      "DTV 1114",
+      "DTV 1124"
+    ]
+  },
+  "DTV 1212": {
+    "text": "Valid Class A CDL",
+    "courses": []
+  },
+  "DTV 1232": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DTV 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "DTV 1323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECO 2113": {
+    "text": "ENG 0124 or higher; MAT 1134 or higher",
+    "courses": [
+      "ENG 0124",
+      "MAT 1134"
+    ]
+  },
+  "ECO 2123": {
+    "text": "ENG 0124 or higher; MAT 1134 or higher",
+    "courses": [
+      "ENG 0124",
+      "MAT 1134"
+    ]
+  },
+  "ECT 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 1123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 1223": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 1813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2333": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2423": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2433": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2623": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2633": {
+    "text": "Consent of program coordinator and prior or concurrent enrollment in ECT courses Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2713": {
+    "text": "Consent of program coordinator and prior or concurrent enrollment in ECT courses",
+    "courses": []
+  },
+  "ECT 2813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2833": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "ECT 2933": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EDU 1613": {
+    "text": "ENG 1113 or ENG 1114 and REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "EDU 2513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EDU 2613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
     "courses": []
   },
   "EET 1123": {
@@ -460,9 +3335,164 @@
       "EET 1114"
     ]
   },
+  "EET 1133": {
+    "text": "DC/AC Circuits (EET 1145 ).Motor Control Systems (EET 1344 )",
+    "courses": [
+      "EET 1145",
+      "EET 1344"
+    ]
+  },
+  "EET 1163": {
+    "text": "Electrical Power (EET 1133 )",
+    "courses": [
+      "EET 1133"
+    ]
+  },
+  "EET 1174": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1192": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1234": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1333": {
+    "text": "None Corequisite: EET 1123 Prerequisite/Corequisite: None",
+    "courses": [
+      "EET 1123"
+    ]
+  },
+  "EET 1334": {
+    "text": "DC/AC Circuits (EET 1145 )",
+    "courses": [
+      "EET 1145"
+    ]
+  },
+  "EET 1343": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1344": {
+    "text": "Prerequisite DC/AC Circuits (EET 1145 )",
+    "courses": [
+      "EET 1145"
+    ]
+  },
+  "EET 1353": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1363": {
+    "text": "EET 1214",
+    "courses": [
+      "EET 1214"
+    ]
+  },
+  "EET 1382": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 1443": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 2113": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "EET 2115": {
+    "text": "Sophomore standing in Electronics, EET 1311",
+    "courses": [
+      "EET 1311"
+    ]
+  },
+  "EET 2223": {
+    "text": "EET 2113 & Instructor Approval",
+    "courses": [
+      "EET 2113"
+    ]
+  },
+  "EET 2225": {
+    "text": "EET 2115",
+    "courses": [
+      "EET 2115"
+    ]
+  },
+  "EET 2334": {
+    "text": "EET 1334",
+    "courses": [
+      "EET 1334"
+    ]
+  },
+  "EET 2354": {
+    "text": "Motor Control Systems (EET 1344 ).Programmable Logic Controllers (EET 2363 )",
+    "courses": [
+      "EET 1344",
+      "EET 2363"
+    ]
+  },
+  "EET 2363": {
+    "text": "EET 1114 , EET 1334 , EET 1214 , EET 1123",
+    "courses": [
+      "EET 1114",
+      "EET 1123",
+      "EET 1214",
+      "EET 1334"
+    ]
+  },
+  "EET 2373": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EET 2383": {
+    "text": "EET 2363",
+    "courses": [
+      "EET 2363"
+    ]
+  },
+  "EET 2414": {
+    "text": "EET 1334",
+    "courses": [
+      "EET 1334"
+    ]
+  },
+  "EET 2423": {
+    "text": "EET 2414",
+    "courses": [
+      "EET 2414"
+    ]
+  },
+  "EET 2514": {
+    "text": "EET 1214 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "EET 1214"
+    ]
+  },
+  "EET 2812": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "EET 2913": {
     "text": "Consent of instructor. (3,2,2)",
     "courses": []
+  },
+  "EET 2923": {
+    "text": "Instructor Approval and completion of at least one semester of advanced coursework in electrical/electronics related programs",
+    "courses": []
+  },
+  "EGR 1122": {
+    "text": "EGR 1112",
+    "courses": [
+      "EGR 1112"
+    ]
   },
   "EGR 2413": {
     "text": "C or Higher in both MAT 1623 and PHY 2514 . (3,3,0)",
@@ -490,6 +3520,26 @@
       "ELT 1233"
     ]
   },
+  "ELT 1133": {
+    "text": "ELT 1193",
+    "courses": [
+      "ELT 1193"
+    ]
+  },
+  "ELT 1144": {
+    "text": "ELT 1192* Fundamentals of Electricity Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "ELT 1192"
+    ]
+  },
+  "ELT 1153": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 1163": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
   "ELT 1183": {
     "text": "ELT 1113 (3,2,2)",
     "courses": [
@@ -501,6 +3551,20 @@
     "courses": [
       "ELT 1143"
     ]
+  },
+  "ELT 1223": {
+    "text": "ELT 1213",
+    "courses": [
+      "ELT 1213"
+    ]
+  },
+  "ELT 1232": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 1243": {
+    "text": "Instructor Approval",
+    "courses": []
   },
   "ELT 1253": {
     "text": "ELT 1213 . (3,2,2)",
@@ -514,16 +3578,125 @@
       "ELT 1253"
     ]
   },
+  "ELT 1273": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 1283": {
+    "text": "ELT 1193",
+    "courses": [
+      "ELT 1193"
+    ]
+  },
+  "ELT 1324": {
+    "text": "ELT 2613 , ELT 2623 ; Instructor Approval",
+    "courses": [
+      "ELT 2613",
+      "ELT 2623"
+    ]
+  },
+  "ELT 1353": {
+    "text": "ELT 1413 , ELT 2613 , ELT 2423 , Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2423",
+      "ELT 2613"
+    ]
+  },
+  "ELT 1363": {
+    "text": "ELT 1413 , ELT 2613 , ELT 2423 , Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2423",
+      "ELT 2613"
+    ]
+  },
+  "ELT 1373": {
+    "text": "ELT 1413 , ELT 2613 , ELT 2423 , Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2423",
+      "ELT 2613"
+    ]
+  },
+  "ELT 1383": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
   "ELT 1413": {
     "text": "ELT 1263 . (3,2,2)",
     "courses": [
       "ELT 1263"
     ]
   },
+  "ELT 1434": {
+    "text": "ELT 1144 , ELT 1193 ; Instructor Approval",
+    "courses": [
+      "ELT 1144",
+      "ELT 1193"
+    ]
+  },
+  "ELT 1513": {
+    "text": "ELT 1413 , ELT 2613 , ELT 2423 , Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2423",
+      "ELT 2613"
+    ]
+  },
+  "ELT 1523": {
+    "text": "ELT 1144 , ELT 1193 ; Instructor Approval",
+    "courses": [
+      "ELT 1144",
+      "ELT 1193"
+    ]
+  },
+  "ELT 1533": {
+    "text": "ELT 1413 , ELT 2613 , ELT 2423 , Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2423",
+      "ELT 2613"
+    ]
+  },
+  "ELT 1563": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 1614": {
+    "text": "ELT 1413 , ELT 2613 , ELT 2423 , Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2423",
+      "ELT 2613"
+    ]
+  },
+  "ELT 2123": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2133": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2153": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2163": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
   "ELT 2423": {
     "text": "ELT 2113 . (3,1,4)",
     "courses": [
       "ELT 2113"
+    ]
+  },
+  "ELT 2424": {
+    "text": "Motor Control Systems (ELT 1413 )",
+    "courses": [
+      "ELT 1413"
     ]
   },
   "ELT 2613": {
@@ -539,6 +3712,123 @@
       "ELT 2613"
     ]
   },
+  "ELT 2624": {
+    "text": "Programmable Logic Controllers (ELT 2613 ) and Motor Control Systems (ELT 1413 ) or instructor approval",
+    "courses": [
+      "ELT 1413",
+      "ELT 2613"
+    ]
+  },
+  "ELT 2911": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2912": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2921": {
+    "text": "Consent of instructor and completion of at least one semester of advanced coursework in electrical/electronic related programs",
+    "courses": []
+  },
+  "ELT 2923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "ELT 2931": {
+    "text": "ELT 2913",
+    "courses": [
+      "ELT 2913"
+    ]
+  },
+  "ELT 2932": {
+    "text": "ELT 2913",
+    "courses": [
+      "ELT 2913"
+    ]
+  },
+  "ELT 2933": {
+    "text": "ELT 2913 ; Instructor Approval",
+    "courses": [
+      "ELT 2913"
+    ]
+  },
+  "ELT 2943": {
+    "text": "ELT 2923 ; Instructor Approval",
+    "courses": [
+      "ELT 2923"
+    ]
+  },
+  "EMS 1117": {
+    "text": "Current MS Driver’s License and Healthcare Provider Card issued by the American Heart Association",
+    "courses": []
+  },
+  "EMS 1118": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1122": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1142": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 1151 ) (Pre/Corequisites: EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) This course includes a comprehensive review of the knowledge base and skill set of the Emergency Medical Technician. History of EMS, well-being of the EMT, medical legal issues, communication and documentation will be expanded to the role of the paramedic. This course includes the theory related to intravenous/intraosseous access, medication administration, patient assessment, and introductory pharmacology calculations. (2 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 2742",
+      "EMS 2751"
+    ]
+  },
+  "EMS 1151": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 1142 ) (Pre/Corequisites: EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) A laboratory experience designed to give psychomotor experience to the theoretical concepts developed in the lecture. (2 hr lab)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1142",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 2742",
+      "EMS 2751"
+    ]
+  },
+  "EMS 1163": {
+    "text": "Composite ACT of 16 or higher, 18 years of age or older and selection by the interview committee",
+    "courses": []
+  },
+  "EMS 1174": {
+    "text": "Successful completion of EMS 1163 with a B or higher",
+    "courses": [
+      "EMS 1163"
+    ]
+  },
+  "EMS 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "EMS 1222": {
     "text": "Instructor approved (2,1,2)",
     "courses": []
@@ -547,9 +3837,80 @@
     "text": "Instructor approved (1,1,0)",
     "courses": []
   },
+  "EMS 1242": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 1251 ) (Pre/Corequisites: EMS 1142 , EMS 1151 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) This course integrates complex knowledge of anatomy, physiology, and pathophysiology into the assessment to develop and implement a treatment plan with the goal of ensuring a patient airway, adequate mechanical ventilation, and respiration for patients of all ages. (2 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 2742",
+      "EMS 2751"
+    ]
+  },
+  "EMS 1251": {
+    "text": "EMS 1117",
+    "courses": [
+      "EMS 1117"
+    ]
+  },
   "EMS 1262": {
     "text": "Instructor approved (2,1,2)",
     "courses": []
+  },
+  "EMS 1314": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1325": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1342": {
+    "text": "Current NREMT and State of MS EMT certifications, Current AHA BLS card and acceptance per the program admissions procedures",
+    "courses": []
+  },
+  "EMS 1343": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 1351 ) (Pre/Corequisites: EMS 1142 , EMS 1151 , EMS 1242 , EMS 1514 , EMS 2742 , EMS 2751 ) This course consists of the theory, anatomy, physiology, pathophysiology and treatments associated with the conditions of the cardiovascular system. This includes the theory of introductory, advanced, and multi-lead electrocardiogram interpretation. Changes in the lifespan will also be included. (3 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 2742",
+      "EMS 2751"
+    ]
+  },
+  "EMS 1351": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 1343 ) (Pre/Corequisites: EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1514 ,EMS 2742 , EMS 2751 ) A laboratory experience designed to give psychomotor experience to the theoretical concepts developed in the lecture. (2 hr lab)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1514",
+      "EMS 2742",
+      "EMS 2751"
+    ]
   },
   "EMS 1362": {
     "text": "Instructor approved (2,1,2)",
@@ -562,6 +3923,51 @@
   "EMS 1384": {
     "text": "Instructor approved (4,3,2)",
     "courses": []
+  },
+  "EMS 1414": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1422": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1514": {
+    "text": "EMS 1117",
+    "courses": [
+      "EMS 1117"
+    ]
+  },
+  "EMS 1524": {
+    "text": "Successful completion of EMS 1514 with a B or higher",
+    "courses": [
+      "EMS 1514"
+    ]
+  },
+  "EMS 1525": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) (Pre/Corequisites: EMS 1742 , EMS 1751 , EMS 1951 , EMS 2343 , EMS 2351 , EMS 2912 , EMS 1942 ) A continuation of EMS-1514. Using supervised rotations in a definitive care setting, the students will continue to develop assessment and treatment skills. The student will transition to field experience upon achieving competencies in the definitive care setting. (15 hr clinical)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
   },
   "EMS 1533": {
     "text": "Instructor approved (3,0,9)",
@@ -579,6 +3985,262 @@
     "text": "Instructor approved (3,3,0)",
     "courses": []
   },
+  "EMS 1614": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1713": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1742": {
+    "text": "EMS 1351 , EMS 1514 , EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 2742 , EMS 2751 ) (Corequisites: EMS 1751 ) (Pre/Corequisites: EMS 1942 , EMS 1951 , EMS 1525 , EMS 1951 , EMS 2343 , EMS 2912 ) This course consists of the theory, anatomy, physiology, pathophysiology, and treatments associated with conditions of the nervous system. This includes conditions related to structure and those associated with organic and nonorganic brain disease. Changes in the lifespan will be included. (2 hr lecture)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
+  },
+  "EMS 1751": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1514 , EMS 1351 , EMS 2742 , EMS 2751 ) (Corequisites: EMS 1742 (Pre/Corequisites: EMS 1525 EMS 1942 EMS 2343 EMS 2351 EMS 1951 EMS 2912 ) A laboratory experience designed to give psychomotor experience to the theoretical concepts developed in the lecture. (2 hr lecture)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
+  },
+  "EMS 1825": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1913": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 1942": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) (Corequisites: EMS 1951 ) (Pre/Corequisites: EMS 1525 , EMS 1742 , EMS 1751 , EMS 2343 , EMS 2351 , EMS 2912 ) This course consists of the theory, anatomy, physiology, pathophysiology, and treatments associated with conditions of the reproductive system. The course includes care of the newborn as part of the concepts in reproductive medicine. Changes in the lifespan will be included. (2 hr lecture)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
+  },
+  "EMS 1951": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) (Corequisites: EMS 1942 ) (Pre/Corequisites: EMS 1525 , EMS 1742 , EMS 1751 , EMS 2343 , EMS 2351 , EMS 2912 ) A laboratory experience designed to give psychomotor experience to the theoretical concepts developed in the lecture. (2 hr lab)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
+  },
+  "EMS 2312": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1352 , and EMS 1514",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1352",
+      "EMS 1514"
+    ]
+  },
+  "EMS 2314": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 2342": {
+    "text": "Successful completion of EMS 1142, EMS 1151, EMS 1242, EMS 1251, EMS 1343 & EMS 1352 with a B or higher",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1352"
+    ]
+  },
+  "EMS 2343": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) (Corequisites: EMS 2351 ) (Pre/Corequisites: EMS 1742 , EMS 1525 , EMS 1751 , EMS 1942 , EMS 1951 , EMS 2912 ) This course will integrate patient assessment and assessment findings with principles of epidemiology and pathophysiology across the lifespan. At the conclusion of this course, the student will be able to formulate a field impression and implement a comprehensive treatment/disposition plan for a patient with a medical complaint. (3 hr lecture)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2351",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
+  },
+  "EMS 2351": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) (Corequisites: EMS 2343 ) (Pre/Corequisites: EMS 1525 , EMS 1742 , EMS 1751 , EMS 1942 , EMS 1951 , EMS 2912 ) This course will integrate patient assessment and assessment findings with principles of epidemiology and pathophysiology across the lifespan. At the conclusion of this course, the student will be able to perform a secondary assessment in order to formulate a field impression and implement a comprehensive treatment/disposition plan for a patient with a medical complaint. (2 hr lab)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2742",
+      "EMS 2751",
+      "EMS 2912"
+    ]
+  },
+  "EMS 2414": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 2565": {
+    "text": "Successful completion of EMS 1525 with a B or higher",
+    "courses": [
+      "EMS 1525"
+    ]
+  },
+  "EMS 2566": {
+    "text": "EMS 1525 , EMS 1742 , EMS 1751 , EMS 1942 , EMS 1951 ,EMS 2343 , EMS 2351 , EMS 2912 ) (Pre/Corequisites: EMS 2942 , EMS 2952 ) Under the supervision of an approved program preceptor, the student will continue to apply the concepts developed in the didactic, laboratory, and clinical settings to the care of patients in the environment of EMS. (18 hr clinical)",
+    "courses": [
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2912",
+      "EMS 2942",
+      "EMS 2952"
+    ]
+  },
+  "EMS 2715": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 2742": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 2751 ) (Pre/Corequisites: EMS 1514 , EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 ) This course will develop the basis for the pathophysiology, identification, and treatment of traumatic emergencies including coverage of concepts related to trauma systems and shock management. These concepts will be examined in patients across the life span. (2 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 2751"
+    ]
+  },
+  "EMS 2743": {
+    "text": "Successful completion of EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 & EMS 1352 with a B or higher",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1352"
+    ]
+  },
+  "EMS 2751": {
+    "text": "EMS 1117 , BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 ) (Corequisites: EMS 2742 ) (Pre/Corequisites: EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 ) The trauma laboratory experience is designed to give psychomotor experience to the theoretical concepts developed in the lecture. (2 hr lab)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "EMS 1117",
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 2742"
+    ]
+  },
+  "EMS 2752": {
+    "text": "EMS 1142 ,EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1352 , and EMS 1514",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1352",
+      "EMS 1514"
+    ]
+  },
   "EMS 2764": {
     "text": "Instructor approved (4,2,4)",
     "courses": []
@@ -589,6 +4251,10 @@
   },
   "EMS 2784": {
     "text": "Instructor approved (4,0,12)",
+    "courses": []
+  },
+  "EMS 2855": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
     "courses": []
   },
   "EMS 2863": {
@@ -607,9 +4273,82 @@
     "text": "Instructor approved (3,0,9)",
     "courses": []
   },
+  "EMS 2912": {
+    "text": "EMS 1142 , EMS 1151 , EMS 1242 , EMS 1251 , EMS 1343 , EMS 1351 , EMS 1514 , EMS 2742 , EMS 2751 ) (Pre/Corequisites: EMS 1525 , EMS 1742 , EMS 1751 , EMS 1942 , EMS 1951 , EMS 2343 , EMS 2351 ) Knowledge of operational roles and responsibilities to ensure safe patient, public, and personnel safety. (2 hr lecture)",
+    "courses": [
+      "EMS 1142",
+      "EMS 1151",
+      "EMS 1242",
+      "EMS 1251",
+      "EMS 1343",
+      "EMS 1351",
+      "EMS 1514",
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2742",
+      "EMS 2751"
+    ]
+  },
+  "EMS 2934": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "EMS 2942": {
+    "text": "EMS 1751 , EMS 1525 , EMS 1742 , EMS 1942 , EMS 1951 , EMS 2343 , EMS 2351 , EMS 2912 ) (Corequisites: EMS 2952 ) (Pre/Corequisites: EMS 2566 ) This course serves as a capstone experience course at the end of the Paramedic Program. This course will include the following topics: special needs patient populations, EMS research, principles of public health, integration of leadership, and emerging roles in EMS. (2 hr lecture)",
+    "courses": [
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2566",
+      "EMS 2912",
+      "EMS 2952"
+    ]
+  },
+  "EMS 2952": {
+    "text": "EMS 1525 , EMS 1742 , EMS 1751 , EMS 1942 , EMS 1951 , EMS 2343 , EMS 2351 , EMS 2912 ) (Corequisites: EMS 2942 ) (Pre/Corequisites: EMS 2566 ) This course will provide the student with a final opportunity to incorporate their cognitive knowledge and psychomotor skills through cumulative practical skill evaluations and a comprehensive final examination. (4 hr lab)",
+    "courses": [
+      "EMS 1525",
+      "EMS 1742",
+      "EMS 1751",
+      "EMS 1942",
+      "EMS 1951",
+      "EMS 2343",
+      "EMS 2351",
+      "EMS 2566",
+      "EMS 2912",
+      "EMS 2942"
+    ]
+  },
+  "ENG 0123": {
+    "text": "ACT English subscore of 14 or below",
+    "courses": []
+  },
+  "ENG 0124": {
+    "text": "ACT® English subscore of 1-13, or ACCUPLACER score of 20-69, or Next-Generation ACCUPLACER score of 200-230",
+    "courses": []
+  },
+  "ENG 1033": {
+    "text": "ACT® score of 17 or above or ACCUPLACER score of 88 or above or Next-Generation ACCUPLACER score of 245-300). This course is designed specifically for Career Tech students who are pursuing the AAS degree. In this course, students will focus on appropriate writing for business and industry and will produce technical documents which may include resumes, letters, emails, memos/reports, proposals, multimedia presentations, and other related documents. (3 hr lecture)",
+    "courses": []
+  },
   "ENG 1113": {
     "text": "ACT English 17 or higher or Equivalent ACCUPLACER score in writing. (3,3,0)",
     "courses": []
+  },
+  "ENG 1114": {
+    "text": "ENG 0124 or ACT® English subscore of 14-16, or ACCUPLACER score of 70-87, or Next-Generation ACCUPLACER score of 231-244",
+    "courses": [
+      "ENG 0124"
+    ]
   },
   "ENG 1123": {
     "text": "ENG 1113 (3,3,0)",
@@ -628,6 +4367,12 @@
     "text": "ENG 2133 (3,3,0)",
     "courses": [
       "ENG 2133"
+    ]
+  },
+  "ENG 2153": {
+    "text": "ENG 1123",
+    "courses": [
+      "ENG 1123"
     ]
   },
   "ENG 2223": {
@@ -663,6 +4408,12 @@
       "ENG 1123H"
     ]
   },
+  "ENG 2413": {
+    "text": "ENG 1113",
+    "courses": [
+      "ENG 1113"
+    ]
+  },
   "ENG 2423": {
     "text": "ENG 1123H or ENG 1123 . (3,3,0)",
     "courses": [
@@ -691,11 +4442,43 @@
       "ENG 1123"
     ]
   },
+  "ENG 2523": {
+    "text": "ENG 1123",
+    "courses": [
+      "ENG 1123"
+    ]
+  },
+  "ENG 2533": {
+    "text": "ENG 1123",
+    "courses": [
+      "ENG 1123"
+    ]
+  },
   "ENG 2613": {
     "text": "ENG 1113 or ENG 1114 . (3,3,0)",
     "courses": [
       "ENG 1113",
       "ENG 1114"
+    ]
+  },
+  "ENG 2813": {
+    "text": "ENG 1113 or ENG 1114 and Instructor Approval, or ENG 1123",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "ENG 1123"
+    ]
+  },
+  "ENG 2922": {
+    "text": "ENG 1123 or Instructor Approval",
+    "courses": [
+      "ENG 1123"
+    ]
+  },
+  "ENG 2993": {
+    "text": "ENG 1123 or Instructor Approval This course will provide a study of various topics related to writing and literature, offering students an expanded perspective on content that may only receive limited exposure in a survey course. (3 hr Lecture)",
+    "courses": [
+      "ENG 1123"
     ]
   },
   "ENT 2353": {
@@ -710,10 +4493,23 @@
       "PSY 1513"
     ]
   },
+  "EPY 2523": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "EPY 2533": {
     "text": "PSY 1513 . (3,3,0)",
     "courses": [
       "PSY 1513"
+    ]
+  },
+  "FCS 1233": {
+    "text": "REA 1213 ; ENG 0124 or higher; MAT 1133 /MAT 1134 or higher",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
     ]
   },
   "FCS 1253": {
@@ -724,8 +4520,258 @@
       "BIO 2524"
     ]
   },
+  "FFT 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 1123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 1223": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 1813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 1913": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2333": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2423": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2433": {
+    "text": "Consent of program coordinator and prior or concurrent enrollment in FFT courses Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2823": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2833": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2913": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2923": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FFT 2933": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "FOT 1114": {
+    "text": "A course covering fundamentals of forest measurements",
+    "courses": []
+  },
+  "FOT 1124": {
+    "text": "Must have passed Forest Measurements I, with a grade of C or better before moving on to this course",
+    "courses": []
+  },
+  "FOT 2623": {
+    "text": "Must have passed Silviculture I with a grade of C or better before moving on to this course",
+    "courses": []
+  },
+  "FOT 2913": {
+    "text": "Minimum of 12 semester credit hours of Forestry Technology related courses or consent of instructor",
+    "courses": []
+  },
+  "FST 1123": {
+    "text": "Mortuary Anatomy I (FST 1113 )",
+    "courses": [
+      "FST 1113"
+    ]
+  },
+  "FST 1224": {
+    "text": "Embalming I (FST 1213 )",
+    "courses": [
+      "FST 1213"
+    ]
+  },
+  "FST 2812": {
+    "text": "Student must be in their final semester, have a GPA of 2. 0 or better, taking only FST 2823 Current Issues in Funeral Service Technology and one other FST course and have permission from the program director",
+    "courses": [
+      "FST 2823"
+    ]
+  },
+  "GEO 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "GEO 1123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "GEO 1213": {
+    "text": "ENG 0124 or higher; MAT 1133 /MAT 1134 or higher",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "GEO 2313": {
+    "text": "GEO 1113 or GEO 1123 required",
+    "courses": [
+      "GEO 1113",
+      "GEO 1123"
+    ]
+  },
+  "GIT 1253": {
+    "text": "GIT 2123",
+    "courses": [
+      "GIT 2123"
+    ]
+  },
+  "GIT 2123": {
+    "text": "DDT 1314",
+    "courses": [
+      "DDT 1314"
+    ]
+  },
+  "GIT 2263": {
+    "text": "GIT 2113 , GIT 2423",
+    "courses": [
+      "GIT 2113",
+      "GIT 2423"
+    ]
+  },
+  "GLY 1111": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "GLY 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "GLY 1114": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "GLY 1124": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HCA 1115": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HCA 1123": {
+    "text": "HCA 1116 , HCA 1214",
+    "courses": [
+      "HCA 1116",
+      "HCA 1214"
+    ]
+  },
+  "HCA 1125": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: HCA 1115",
+    "courses": [
+      "HCA 1115"
+    ]
+  },
+  "HCA 1133": {
+    "text": "HCA 1116 , HCA 1214",
+    "courses": [
+      "HCA 1116",
+      "HCA 1214"
+    ]
+  },
+  "HCA 1214": {
+    "text": "HCA 1115 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "HCA 1115"
+    ]
+  },
+  "HCA 1312": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HIS 1113": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 1123": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 1163": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 1173": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 1613": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 2213": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 2223": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "HIS 2813": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
   "HIT 1114": {
     "text": "Admission to the Health Information Technology: Billing and Coding Program",
+    "courses": []
+  },
+  "HIT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
     "courses": []
   },
   "HIT 1322": {
@@ -734,12 +4780,107 @@
       "HIT 1114"
     ]
   },
+  "HIT 1323": {
+    "text": "BIO 2511 /BIO 2513 or BIO 2514 , BIO 2521 /BIO 2523 or BIO 2524 ) (Pre/Corequisites: Admission to the Health Information Technology program) This course is a study of the principles of law as applied to health information systems with emphasis on health records, release of information, confidentiality, consents, and authorizations. (3 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2514",
+      "BIO 2521",
+      "BIO 2523",
+      "BIO 2524"
+    ]
+  },
+  "HIT 2123": {
+    "text": "HIT 2142",
+    "courses": [
+      "HIT 2142"
+    ]
+  },
+  "HIT 2133": {
+    "text": "HIT 2512",
+    "courses": [
+      "HIT 2512"
+    ]
+  },
+  "HIT 2142": {
+    "text": "HIT 2253 , HIT 2414 , HIT 2913 ) This course covers the aspects of electronic health records (EHR",
+    "courses": [
+      "HIT 2253",
+      "HIT 2414",
+      "HIT 2913"
+    ]
+  },
+  "HIT 2253": {
+    "text": "BIO 2511 /BIO 2513 or BIO 2514 , BIO 2521 /BIO 2523 or BIO 2524 ) (Pre/Corequisites: Admission to the Health Information Technology program) This course covers structural and functional changes caused by disease in tissues and organs, clinical manifestations, and principles of treatment with emphasis on general concepts and diseases affecting the body as a whole. In addition, common medications used to treat disease processes will be addressed. (3 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2514",
+      "BIO 2521",
+      "BIO 2523",
+      "BIO 2524"
+    ]
+  },
+  "HIT 2414": {
+    "text": "HIT 1114 , HIT 1213 , HIT 1323 , HIT 2253 , CSC 1123 ) This course provides a basic introduction on how to transform narrative descriptions of diseases and injuries into alphanumeric diagnostic ICD-10-CM codes and/or ICD-10-PCS. The course is designed to provide the student with knowledge of diagnostic and/or procedural coding applications and how they pertain to all aspects of medical care, research, data analysis, and financial implications. (3 hr lecture, 2 hr lab)",
+    "courses": [
+      "CSC 1123",
+      "HIT 1114",
+      "HIT 1213",
+      "HIT 1323",
+      "HIT 2253"
+    ]
+  },
+  "HIT 2453": {
+    "text": "HIT 1114 , HIT 1213 , HIT 1323 , HIT 2253 , CSC 1123 ) This course is a continuation of HIT 2253 - Pathopharmacology I with emphasis on conditions relating to specific body systems, manifestations, and principles of treatment. In addition, common medications used to treat disease processes will be addressed. (3 hr lecture)",
+    "courses": [
+      "CSC 1123",
+      "HIT 1114",
+      "HIT 1213",
+      "HIT 1323",
+      "HIT 2253"
+    ]
+  },
+  "HIT 2512": {
+    "text": "HIT 2414 , HIT 2453 , HIT 2914",
+    "courses": [
+      "HIT 2414",
+      "HIT 2453",
+      "HIT 2914"
+    ]
+  },
+  "HIT 2522": {
+    "text": "HIT 2133 , HIT 2543 , HIT 2823",
+    "courses": [
+      "HIT 2133",
+      "HIT 2543",
+      "HIT 2823"
+    ]
+  },
+  "HIT 2543": {
+    "text": "HIT 2512",
+    "courses": [
+      "HIT 2512"
+    ]
+  },
   "HIT 2615": {
     "text": "HIT 1214 , HIT 1114 , and BIO 2524 . (5,3,4)",
     "courses": [
       "BIO 2524",
       "HIT 1114",
       "HIT 1214"
+    ]
+  },
+  "HIT 2625": {
+    "text": "BIO 2513 /BIO 2511 , BIO 2523 /BIO 2521 , HIT 2453 and HIT 2615 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "HIT 2453",
+      "HIT 2615"
     ]
   },
   "HIT 2626": {
@@ -754,14 +4895,349 @@
       "HIT 2615"
     ]
   },
+  "HIT 2643": {
+    "text": "HIT 2133 , HIT 2543 , HIT 2823",
+    "courses": [
+      "HIT 2133",
+      "HIT 2543",
+      "HIT 2823"
+    ]
+  },
   "HIT 2713": {
     "text": "HIT 2133 . (3,3,0)",
     "courses": [
       "HIT 2133"
     ]
   },
+  "HIT 2823": {
+    "text": "HIT 2512",
+    "courses": [
+      "HIT 2512"
+    ]
+  },
+  "HIT 2914": {
+    "text": "HIT 1114 , HIT 1213 , HIT 1323 , HIT 2253 ,CSC 1123 ) This course is an overview of computer use in health-care facilities with an emphasis on applications for health information systems, including the electronic health record. This course covers aspects of electronic health records (EHR) in the health-care environment. In addition, it explores implementation of EHR in various health-care settings. (3 hr lecture, 2 hr lab)",
+    "courses": [
+      "CSC 1123",
+      "HIT 1114",
+      "HIT 1213",
+      "HIT 1323",
+      "HIT 2253"
+    ]
+  },
+  "HIT 2921": {
+    "text": "HIT 2133 , HIT 2543 , HIT 2823",
+    "courses": [
+      "HIT 2133",
+      "HIT 2543",
+      "HIT 2823"
+    ]
+  },
+  "HON 1713": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HON 1911": {
+    "text": "Admission is by invitation only",
+    "courses": []
+  },
+  "HON 1912": {
+    "text": "Admission is by invitation only",
+    "courses": []
+  },
+  "HON 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HON 1922": {
+    "text": "Admission is by invitation only",
+    "courses": []
+  },
+  "HON 2911": {
+    "text": "Admission is by invatation only",
+    "courses": []
+  },
+  "HON 2912": {
+    "text": "Admission is by invitation only",
+    "courses": []
+  },
+  "HON 2921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HON 2922": {
+    "text": "Admission is by invitation only",
+    "courses": []
+  },
+  "HPR 1111": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1121": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1132": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1142": {
+    "text": "NONE Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "HPR 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1521": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1531": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1532": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1541": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1551": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1552": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1561": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1562": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1571": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1593": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2111": {
+    "text": "Pass the skills test for Advanced Beginner Swimmer Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2121": {
+    "text": "Pass the skills test for Intermediate Swimmer Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2132": {
+    "text": "NONE Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "HPR 2142": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "HPR 2222": {
     "text": "Completed American Red Cross swimmer level course or have equivalent skills. (2,0,2)",
+    "courses": []
+  },
+  "HPR 2232": {
+    "text": "Proficient swimming skills Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2412": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2423": {
+    "text": "Practice with intercollegiate football squad",
+    "courses": []
+  },
+  "HPR 2433": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2453": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2483": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2521": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2531": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2541": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2551": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2561": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2571": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HPR 2711": {
+    "text": "HPR 2733",
+    "courses": [
+      "HPR 2733"
+    ]
+  },
+  "HPR 2723": {
+    "text": "HPR 2733 , HPR 2711",
+    "courses": [
+      "HPR 2711",
+      "HPR 2733"
+    ]
+  },
+  "HPR 2733": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1114": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1123": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1163": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1223": {
+    "text": "HRT 1213 Sanitation and Safety",
+    "courses": [
+      "HRT 1213"
+    ]
+  },
+  "HRT 1224": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1521": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1531": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1541": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1552": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 1562": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 2233": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 2613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 2623": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 2843": {
+    "text": "HRT 1833",
+    "courses": [
+      "HRT 1833"
+    ]
+  },
+  "HRT 2853": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HRT 2913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "HRT 2915": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "HUM 1113": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "IDT 1113": {
+    "text": "ACT® English subscore of 14 or higher or an ACCUPLACER English score of 70 or higher or Next-Generation ACCUPLACER English score of 231 or higher and eligible for ENG 1114 or ENG 1113 or ENG 1033",
+    "courses": [
+      "ENG 1033",
+      "ENG 1113",
+      "ENG 1114"
+    ]
+  },
+  "IDT 1224": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
     "courses": []
   },
   "IDT 1234": {
@@ -783,6 +5259,20 @@
       "IDT 1224",
       "IDT 1253"
     ]
+  },
+  "IDT 2313": {
+    "text": "IDT 2243",
+    "courses": [
+      "IDT 2243"
+    ]
+  },
+  "IDT 2343": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IDT 2353": {
+    "text": "Instructor Approval",
+    "courses": []
   },
   "IDT 2413": {
     "text": "Approval of Instructor. (3,150 clock hours) (3,0,9)",
@@ -822,10 +5312,334 @@
       "IET 2113"
     ]
   },
+  "IMM 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1143": {
+    "text": "IMM 1113",
+    "courses": [
+      "IMM 1113"
+    ]
+  },
+  "IMM 1153": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 1163": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 1214": {
+    "text": "IMM 1113",
+    "courses": [
+      "IMM 1113"
+    ]
+  },
+  "IMM 1235": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1243": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 1253": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 1273": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 1283": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 1323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1474": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1484": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1614": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1713": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1734": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 1911": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1912": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1921": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1922": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1923": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1924": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1925": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1926": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 1935": {
+    "text": "Silver Level Career Readiness Certificate",
+    "courses": []
+  },
+  "IMM 2114": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 2214": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 2224": {
+    "text": "IMM 1113 or CTE 1143",
+    "courses": [
+      "CTE 1143",
+      "IMM 1113"
+    ]
+  },
+  "IMM 2424": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 2433": {
+    "text": "IMM 1153",
+    "courses": [
+      "IMM 1153"
+    ]
+  },
+  "IMM 2444": {
+    "text": "IMM 1113 Industrial Maintenance Core & Safety Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "IMM 1113"
+    ]
+  },
+  "IMM 2513": {
+    "text": "ELT 1413 or IMM 1323 or Instructor Approval",
+    "courses": [
+      "ELT 1413",
+      "IMM 1323"
+    ]
+  },
+  "IMM 2613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMM 2714": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 2814": {
+    "text": "Instructor Approval or IMM 2513",
+    "courses": [
+      "IMM 2513"
+    ]
+  },
+  "IMM 2824": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 2833": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 2844": {
+    "text": "IMM 2814",
+    "courses": [
+      "IMM 2814"
+    ]
+  },
+  "IMM 2854": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMM 2863": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMT 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMT 1524": {
+    "text": "IMT 1513",
+    "courses": [
+      "IMT 1513"
+    ]
+  },
+  "IMT 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IMT 1614": {
+    "text": "IMT 1513",
+    "courses": [
+      "IMT 1513"
+    ]
+  },
+  "IMT 2143": {
+    "text": "Instructor Approved In this course, students will identify the company roles, team roles, and responsibilities related to the game development process and apply time and project-management skills. Students will also explore the importance of audience knowledge and target marketing in game design technology. Students will research consumer behavior, publisher relations, and functions of marketing such as: advertising, public relations, sales, and promotions. Additionally, students will research and analyze the economics of the video game industry. (3 Lecture)",
+    "courses": []
+  },
+  "IMT 2153": {
+    "text": "Instructor Approved In this course, students will explore in-depth advanced techniques for creating quality 2D animation. This course is designed to teach advanced application of 2D techniques that build upon the basics learned in IMT 1114 Introduction to Animation and Simulation. Students will create their own characters, storyboards, and final animation of a short piece utilizing digital animation software. (Suggested Software: Moho Pro, Adobe Animate",
+    "courses": [
+      "IMT 1114"
+    ]
+  },
+  "IMT 2413": {
+    "text": "Instructor Approved This capstone class is the culmination of lessons learned in previous and present courses leading to the creation of final projects for a professional digital portfolio. The student will originate and/or revise a minimum of two projects and create a “sizzle reel” video utilizing the standard process of preproduction planning, production, revision, and final publication. (1 hr lecture, 4 hr lab)",
+    "courses": []
+  },
+  "IMT 2733": {
+    "text": "Instructor Approved In this course, students will work in teams to plan and produce a comprehensive project that integrates knowledge and skills from across the curriculum. Project will be student-originated; dependent upon instructor approval. (2 hr lecture, 2 hr lab)",
+    "courses": []
+  },
+  "IMT 2743": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMT 2763": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IMT 2772": {
+    "text": "Instructor Approved This course is designed to aid students in creating a functional simulation or game with minimal aid from the instructor. Students will also instructed on the creation and presentation of a simulation and game development portfolio. (1 hr lecture, 2 hr lab)",
+    "courses": []
+  },
+  "IST 1112": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1114": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "IST 1124": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1143": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1154": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1163": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1223": {
+    "text": "Fundamentals of Data Communications (IST 1134 )",
+    "courses": [
+      "IST 1134"
+    ]
+  },
   "IST 1224": {
     "text": "IST 1134 . (4,2,4)",
     "courses": [
       "IST 1134"
+    ]
+  },
+  "IST 1244": {
+    "text": "IT Foundations (IST 1124 ) or permission of instructor",
+    "courses": [
+      "IST 1124"
+    ]
+  },
+  "IST 1254": {
+    "text": "IT Foundations (IST 1124 ) or permission of instructor",
+    "courses": [
+      "IST 1124"
+    ]
+  },
+  "IST 1283": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 1314": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1413": {
+    "text": "IST 1153 and a Programming Language",
+    "courses": [
+      "IST 1153"
     ]
   },
   "IST 1414": {
@@ -833,6 +5647,35 @@
     "courses": [
       "IST 1154",
       "IST 1433"
+    ]
+  },
+  "IST 1423": {
+    "text": "IST 1153 or permission of instructor",
+    "courses": [
+      "IST 1153"
+    ]
+  },
+  "IST 1453": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1523": {
+    "text": "IST 1514 - SQL Programming I",
+    "courses": [
+      "IST 1514"
+    ]
+  },
+  "IST 1524": {
+    "text": "IST 1514",
+    "courses": [
+      "IST 1514"
     ]
   },
   "IST 1534": {
@@ -854,10 +5697,54 @@
       "IST 1624"
     ]
   },
+  "IST 1634": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1644": {
+    "text": "IST 1623 and IST 1134 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "IST 1134",
+      "IST 1623"
+    ]
+  },
+  "IST 1714": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1724": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 1754": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 1764": {
+    "text": "IST 1724",
+    "courses": [
+      "IST 1724"
+    ]
+  },
   "IST 1934": {
     "text": "IST 1914 (4,2,4)",
     "courses": [
       "IST 1914"
+    ]
+  },
+  "IST 2213": {
+    "text": "Network Components (IST 1223 )",
+    "courses": [
+      "IST 1223"
+    ]
+  },
+  "IST 2214": {
+    "text": "IST 1144",
+    "courses": [
+      "IST 1144"
     ]
   },
   "IST 2224": {
@@ -866,16 +5753,61 @@
       "IST 1224"
     ]
   },
+  "IST 2233": {
+    "text": "IST 2224 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "IST 2224"
+    ]
+  },
+  "IST 2234": {
+    "text": "IST 1134 , IST 1224",
+    "courses": [
+      "IST 1134",
+      "IST 1224"
+    ]
+  },
+  "IST 2253": {
+    "text": "IT Foundations (IST 1124 ) and Network Administration using Microsoft Windows Server (IST 1244 )",
+    "courses": [
+      "IST 1124",
+      "IST 1244"
+    ]
+  },
+  "IST 2254": {
+    "text": "IST 1244",
+    "courses": [
+      "IST 1244"
+    ]
+  },
   "IST 2263": {
     "text": "IST 1253 (3,1,4)",
     "courses": [
       "IST 1253"
     ]
   },
+  "IST 2264": {
+    "text": "IST 1254",
+    "courses": [
+      "IST 1254"
+    ]
+  },
   "IST 2283": {
     "text": "IST 2563 (3,2,2)",
     "courses": [
       "IST 2563"
+    ]
+  },
+  "IST 2313": {
+    "text": "Concepts of Database Design (IST 1163 ) and Web Server (IST 2483 ) or by permission of instructor",
+    "courses": [
+      "IST 1163",
+      "IST 2483"
+    ]
+  },
+  "IST 2314": {
+    "text": "IST 1314",
+    "courses": [
+      "IST 1314"
     ]
   },
   "IST 2324": {
@@ -889,6 +5821,99 @@
     "text": "IST 1313 . (4,2,4)",
     "courses": [
       "IST 1313"
+    ]
+  },
+  "IST 2344": {
+    "text": "Advanced Visual Basic Programming Language (IST 2334 ) or permission of instructor",
+    "courses": [
+      "IST 2334"
+    ]
+  },
+  "IST 2354": {
+    "text": "IST 1324",
+    "courses": [
+      "IST 1324"
+    ]
+  },
+  "IST 2364": {
+    "text": "IST 1334",
+    "courses": [
+      "IST 1334"
+    ]
+  },
+  "IST 2373": {
+    "text": "Any Programming Language course or by permission of instructor",
+    "courses": []
+  },
+  "IST 2374": {
+    "text": "Successful completion of any IST programming language course or permission of instructor",
+    "courses": []
+  },
+  "IST 2383": {
+    "text": "C Programming Language (IST 2373 )",
+    "courses": [
+      "IST 2373"
+    ]
+  },
+  "IST 2384": {
+    "text": "IST 2374",
+    "courses": [
+      "IST 2374"
+    ]
+  },
+  "IST 2424": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 2433": {
+    "text": "IST 1413",
+    "courses": [
+      "IST 1413"
+    ]
+  },
+  "IST 2443": {
+    "text": "Server Side Programming I (IST 2433 )",
+    "courses": [
+      "IST 2433"
+    ]
+  },
+  "IST 2444": {
+    "text": "IST 2434",
+    "courses": [
+      "IST 2434"
+    ]
+  },
+  "IST 2453": {
+    "text": "Visual BASIC Programming (IST 1314 )",
+    "courses": [
+      "IST 1314"
+    ]
+  },
+  "IST 2454": {
+    "text": "IST 1453",
+    "courses": [
+      "IST 1453"
+    ]
+  },
+  "IST 2473": {
+    "text": "Server Side Programming I (IST 2433 ) or permission of instructor",
+    "courses": [
+      "IST 2433"
+    ]
+  },
+  "IST 2483": {
+    "text": "IT Foundations (IST 1124 )",
+    "courses": [
+      "IST 1124"
+    ]
+  },
+  "IST 2514": {
+    "text": "IST 1534",
+    "courses": [
+      "IST 1534"
     ]
   },
   "IST 2524": {
@@ -909,10 +5934,45 @@
       "IST 2584"
     ]
   },
+  "IST 2614": {
+    "text": "IST 1244) This course provides the knowledge and fundamental understanding of Windows security, how to harden current Windows operating systems, and how to defend against attacks. Topics include designing Active Directory, authentication for Windows, group security and policy, service security, remote access security, planning a public key infrastructure, securing file resources, Internet Protocol Security, and additional Windows security topics. (3 hr lecture, 2 hr lab)",
+    "courses": [
+      "IST 1244"
+    ]
+  },
+  "IST 2623": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 2624": {
+    "text": "IST 1254",
+    "courses": [
+      "IST 1254"
+    ]
+  },
+  "IST 2634": {
+    "text": "IST 1134 , IST 1224",
+    "courses": [
+      "IST 1134",
+      "IST 1224"
+    ]
+  },
   "IST 2653": {
     "text": "IST 2563 (3,2,2)",
     "courses": [
       "IST 2563"
+    ]
+  },
+  "IST 2723": {
+    "text": "Java Programming (IST 1714 )",
+    "courses": [
+      "IST 1714"
+    ]
+  },
+  "IST 2724": {
+    "text": "IST 1714",
+    "courses": [
+      "IST 1714"
     ]
   },
   "IST 2814": {
@@ -922,6 +5982,277 @@
       "IST 1433",
       "IST 1723"
     ]
+  },
+  "IST 2824": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 2834": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 2844": {
+    "text": "IST 2834",
+    "courses": [
+      "IST 2834"
+    ]
+  },
+  "IST 2854": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 2883": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "IST 2884": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "IST 2921": {
+    "text": "consent of instructor",
+    "courses": []
+  },
+  "IST 2931": {
+    "text": "consent of instructor",
+    "courses": []
+  },
+  "IST 2941": {
+    "text": "consent of instructor",
+    "courses": []
+  },
+  "IST 2954": {
+    "text": "consent of instructor",
+    "courses": []
+  },
+  "IST 2955": {
+    "text": "IST 1154 or IST 1434",
+    "courses": [
+      "IST 1154",
+      "IST 1434"
+    ]
+  },
+  "JOU 1111": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "JOU 1121": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "JOU 2111": {
+    "text": "JOU 1111 , JOU 1121 and JOU 1313 or Instructor Approval",
+    "courses": [
+      "JOU 1111",
+      "JOU 1121",
+      "JOU 1313"
+    ]
+  },
+  "JOU 2121": {
+    "text": "JOU 1111 , JOU 1121 , JOU 1313 and JOU 2111 or Instructor Approval",
+    "courses": [
+      "JOU 1111",
+      "JOU 1121",
+      "JOU 1313",
+      "JOU 2111"
+    ]
+  },
+  "LEA 1811": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LEA 1821": {
+    "text": "LEA 1811",
+    "courses": [
+      "LEA 1811"
+    ]
+  },
+  "LEA 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LEA 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LEA 2811": {
+    "text": "LEA 1811 , LEA 1821",
+    "courses": [
+      "LEA 1811",
+      "LEA 1821"
+    ]
+  },
+  "LEA 2821": {
+    "text": "LEA 1811 , LEA 1821 , LEA 2811",
+    "courses": [
+      "LEA 1811",
+      "LEA 1821",
+      "LEA 2811"
+    ]
+  },
+  "LEA 2911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LEA 2921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LET 1123": {
+    "text": "REA 1213 ; ENG 0124 or higher; MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "LET 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LET 1713": {
+    "text": "LET 1213",
+    "courses": [
+      "LET 1213"
+    ]
+  },
+  "LET 2313": {
+    "text": "LET 1123 & LET 1213",
+    "courses": [
+      "LET 1123",
+      "LET 1213"
+    ]
+  },
+  "LET 2323": {
+    "text": "LET 1123",
+    "courses": [
+      "LET 1123"
+    ]
+  },
+  "LET 2333": {
+    "text": "LET 2313",
+    "courses": [
+      "LET 2313"
+    ]
+  },
+  "LET 2373": {
+    "text": "LET 1123 & LET 1213",
+    "courses": [
+      "LET 1123",
+      "LET 1213"
+    ]
+  },
+  "LET 2383": {
+    "text": "LET 1123 & LET 1213",
+    "courses": [
+      "LET 1123",
+      "LET 1213"
+    ]
+  },
+  "LET 2463": {
+    "text": "LET 2453",
+    "courses": [
+      "LET 2453"
+    ]
+  },
+  "LET 2523": {
+    "text": "LET 1123",
+    "courses": [
+      "LET 1123"
+    ]
+  },
+  "LET 2653": {
+    "text": "LET 1123 & LET 1213",
+    "courses": [
+      "LET 1123",
+      "LET 1213"
+    ]
+  },
+  "LET 2913": {
+    "text": "All LET courses as scheduled and Instructor Approval",
+    "courses": []
+  },
+  "LET 2923": {
+    "text": "All LET courses as scheduled and Instructor Approval",
+    "courses": []
+  },
+  "LGT 2324": {
+    "text": "Instructor Approval and completion of at least one semester of advanced coursework in Logistics Technology",
+    "courses": []
+  },
+  "LGT 2814": {
+    "text": "ENG 1113 - English Composition I OR ENG 1033 - Technical English",
+    "courses": [
+      "ENG 1033",
+      "ENG 1113"
+    ]
+  },
+  "LGT 2911": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "LGT 2912": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "LGT 2913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "LLS 1151": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1211": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1312": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1321": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1351": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1352": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1413": {
+    "text": "Students enrolled in two or more of the following, REA 1213 , MAT 1133 /MAT 1134 , ENG 0124 should not take LLS-1413 until LLS 1153 has been completed) This course is designed to aid the student in study skills, promote student success in basic reading and note-taking techniques, critical thinking, time management, test-taking strategies, listening and memory enhancement. (3 hr lecture)",
+    "courses": [
+      "ENG 0124",
+      "LLS 1153",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "LLS 1423": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "LLS 1723": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "LVT 1211": {
     "text": "C or better in LVT 1114 (1,1,0)",
@@ -998,15 +6329,62 @@
       "MAR 1113"
     ]
   },
+  "MAT 0123": {
+    "text": "ACT Math sub-score of 13-15 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MAT 1033": {
+    "text": "MAT 1233 /MAT 1234 or MAT 1133 or MAT 1134 with a grade of “C” or higher or ACT® Math subscore of 19 or higher, or ACCUPLACER Math score of 76 or higher, or Next-Generation ACCUPLACER Math score of 263 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1233",
+      "MAT 1234"
+    ]
+  },
+  "MAT 1133": {
+    "text": "ACT® Math subscore of 15-16, or ACCUPLACER Math score of 46-58, or Next-Generation ACCUPLACER Math score of 237-249",
+    "courses": []
+  },
+  "MAT 1134": {
+    "text": "ACT® Math subscore of 1-14 or ACCUPLACER Math score of 1-45 or Next-Generation ACCUPLACER Math score of 200-236",
+    "courses": []
+  },
+  "MAT 1233": {
+    "text": "MAT 0123 with a grade of “D” or better or at least one unit of high school algebra with an ACT math sub-score of 16-18 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MAT 0123"
+    ]
+  },
+  "MAT 1234": {
+    "text": "MAT 1033 , grade C or better, or ACT math score of 15 or 16",
+    "courses": [
+      "MAT 1033"
+    ]
+  },
   "MAT 1313": {
     "text": "ACT Math 19 or higher or equivalent ACCUPLACER score. (3,3,0)",
     "courses": []
+  },
+  "MAT 1314": {
+    "text": "MAT 1234 with a grade of “C” or higher, or MAT 1133 or MAT 1134 with a grade of “C” or higher, or ACT® Math subscore of 17-18, or ACCUPLACER Math score of 59-75, or Next-Generation ACCUPLACER Math score of 250-262",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1234"
+    ]
   },
   "MAT 1323": {
     "text": "C or higher in two years of high school algebra or ACT Math minimum score of 21 or C or higher in MAT 1313 /1314 . (3,3,0)",
     "courses": [
       "MAT 1313",
       "MAT 1314"
+    ]
+  },
+  "MAT 1333": {
+    "text": "MAT 1313 with a grade of “C” or better or equivalent Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MAT 1313"
     ]
   },
   "MAT 1343": {
@@ -1022,6 +6400,19 @@
       "MAT 1314"
     ]
   },
+  "MAT 1523": {
+    "text": "MAT 1513 with a grade of “C” or above",
+    "courses": [
+      "MAT 1513"
+    ]
+  },
+  "MAT 1611": {
+    "text": "MAT 1323 or MAT 1343",
+    "courses": [
+      "MAT 1323",
+      "MAT 1343"
+    ]
+  },
   "MAT 1613": {
     "text": "C or higher in MAT 1313 /1314 and MAT 1323 or C or higher in MAT 1343 or high school equivalents and ACT Math minimum of 25. (3,3,0)",
     "courses": [
@@ -1031,10 +6422,23 @@
       "MAT 1343"
     ]
   },
+  "MAT 1621": {
+    "text": "MAT 1613",
+    "courses": [
+      "MAT 1613"
+    ]
+  },
   "MAT 1623": {
     "text": "C or higher in MAT 1613 (3,3,0)",
     "courses": [
       "MAT 1613"
+    ]
+  },
+  "MAT 1723": {
+    "text": "MAT 1313 or MAT 1314 with a grade of “C” or ACT® Math subscore of 22 or above",
+    "courses": [
+      "MAT 1313",
+      "MAT 1314"
     ]
   },
   "MAT 1733": {
@@ -1042,6 +6446,27 @@
     "courses": [
       "MAT 1313",
       "MAT 1314"
+    ]
+  },
+  "MAT 1743": {
+    "text": "MAT 1723 with a grade of “C” or above",
+    "courses": [
+      "MAT 1723"
+    ]
+  },
+  "MAT 1753": {
+    "text": "MAT 1233 with a grade of “C” or higher, or ACT® Math Subscore of 19 or higher, or ACCUPLACER score of 76 or higher, or Next-Generation ACCUPLACER Math score of 263 or higher",
+    "courses": [
+      "MAT 1233"
+    ]
+  },
+  "MAT 1754": {
+    "text": "MAT 1133 /MAT 1134 with a grade of “C” or higher, or MAT 1233 /MAT 1234 with a grade of “C” or higher, or ACT® Math subscore of 17-18, or ACCUPLACER Math subscore of 59-75, or Next-Generation ACCUPLACER Math subscore of 250-262",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1233",
+      "MAT 1234"
     ]
   },
   "MAT 2113": {
@@ -1056,6 +6481,12 @@
       "MAT 1313",
       "MAT 1314",
       "MAT 1753"
+    ]
+  },
+  "MAT 2513": {
+    "text": "MAT 1513 with grade of “C” or higher",
+    "courses": [
+      "MAT 1513"
     ]
   },
   "MAT 2613": {
@@ -1076,6 +6507,98 @@
       "MAT 2623"
     ]
   },
+  "MDT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 1243": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 1413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 1423": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 1813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 1823": {
+    "text": "MDT 1813 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MDT 1813"
+    ]
+  },
+  "MDT 2113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2314": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2324": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2423": {
+    "text": "MDT 2413 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MDT 2413"
+    ]
+  },
+  "MDT 2434": {
+    "text": "MDT 2414",
+    "courses": [
+      "MDT 2414"
+    ]
+  },
+  "MDT 2513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2614": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2624": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MDT 2823": {
+    "text": "MDT 2813 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MDT 2813"
+    ]
+  },
+  "MDT 2913": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1214": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MET 1313": {
     "text": "MET 1113 , MET 1513 , and CPR-Health Care Provider certification",
     "courses": [
@@ -1083,17 +6606,77 @@
       "MET 1513"
     ]
   },
+  "MET 1323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1513": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 1931": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 2224": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 2234": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 2334": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 2613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MET 2715": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MFL 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MFL 1123": {
     "text": "MFL 1113 or 1 year of previous language study. One laboratory hour per week. (3,3,0)",
     "courses": [
       "MFL 1113"
     ]
   },
+  "MFL 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MFL 1223": {
     "text": "MFL 1213 or 1 year of previous language study. One laboratory hour per week. (3,3,0)",
     "courses": [
       "MFL 1213"
     ]
+  },
+  "MFL 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MFL 1323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "MFL 1423": {
     "text": "MFL 1413 (3,3,0)",
@@ -1127,6 +6710,43 @@
       "MFL 2213"
     ]
   },
+  "MFL 2243": {
+    "text": "MFL 1213 or permission of instructor",
+    "courses": [
+      "MFL 1213"
+    ]
+  },
+  "MFL 2253": {
+    "text": "A grade of “D” or higher in MFL 2243 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MFL 2243"
+    ]
+  },
+  "MFL 2613": {
+    "text": "MFL 1113 , MFL 1123 , MFL 1213 , MFL 1223 , MFL 2213 , or MFL 2223 ) This course is a unique language and culture-learning opportunity designed and provided by individual colleges. Location, duration, and requirements may vary by institution",
+    "courses": [
+      "MFL 1113",
+      "MFL 1123",
+      "MFL 1213",
+      "MFL 1223",
+      "MFL 2213",
+      "MFL 2223"
+    ]
+  },
+  "MLT 1112": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MLT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MLT 1313": {
+    "text": "MLT 1213 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MLT 1213"
+    ]
+  },
   "MLT 1314": {
     "text": "MLT 1212 , 2612, BIO 2514 , CHE 1214 . (4,3,2)",
     "courses": [
@@ -1156,12 +6776,26 @@
       "MLT 1413"
     ]
   },
+  "MLT 1532": {
+    "text": "Approved chemistry elective Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MLT 1543": {
+    "text": "MLT 1532 MLT Chem I Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MLT 1532"
+    ]
+  },
   "MLT 2424": {
     "text": "MLT 1314 , MLT 1413 (4,2,4)",
     "courses": [
       "MLT 1314",
       "MLT 1413"
     ]
+  },
+  "MLT 2523": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "MLT 2614": {
     "text": "MLT 1314 , MLT 1413 ; BIO 2924 . (4,2,4)",
@@ -1175,12 +6809,22 @@
     "text": "Completion of all didactic Medical Laboratory Technology courses. (1,0,2)",
     "courses": []
   },
+  "MLT 2722": {
+    "text": "Completion of all didactic MLT courses Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MLT 2943": {
     "text": "MLT 1113 , MLT 1212 , MLT 1413 (3,0,9)",
     "courses": [
       "MLT 1113",
       "MLT 1212",
       "MLT 1413"
+    ]
+  },
+  "MLT 2953": {
+    "text": "MLT 2943 MLT Clinical Practicum I Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MLT 2943"
     ]
   },
   "MLT 2954": {
@@ -1191,12 +6835,27 @@
       "MLT 2614"
     ]
   },
+  "MLT 2963": {
+    "text": "MLT 2943 and MLT 2953 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MLT 2943",
+      "MLT 2953"
+    ]
+  },
   "MLT 2964": {
     "text": "MLT 1324 , MLT 2424 , MLT 2614 . (4,0,12)",
     "courses": [
       "MLT 1324",
       "MLT 2424",
       "MLT 2614"
+    ]
+  },
+  "MLT 2973": {
+    "text": "MLT 2943 , MLT 2953 and MLT 2963 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MLT 2943",
+      "MLT 2953",
+      "MLT 2963"
     ]
   },
   "MLT 2974": {
@@ -1207,10 +6866,139 @@
       "MLT 2614"
     ]
   },
+  "MMT 1000": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MMT 1123": {
     "text": "MMT 1113 . (3,2,2)",
     "courses": [
       "MMT 1113"
+    ]
+  },
+  "MMT 1223": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 1323": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 1413": {
+    "text": "MAT 1134 or MAT 1133 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "MMT 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 1643": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 1722": {
+    "text": "Marketing Seminar I (MMT 1712 )",
+    "courses": [
+      "MMT 1712"
+    ]
+  },
+  "MMT 2113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2233": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2243": {
+    "text": "MMT 1123",
+    "courses": [
+      "MMT 1123"
+    ]
+  },
+  "MMT 2323": {
+    "text": "MMT 1113 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MMT 1113"
+    ]
+  },
+  "MMT 2343": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2423": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2513": {
+    "text": "MMT 1113 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MMT 1113"
+    ]
+  },
+  "MMT 2613": {
+    "text": "MMT 1113 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MMT 1113"
+    ]
+  },
+  "MMT 2623": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MMT 2913": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "MMT 2916": {
+    "text": "Permission of the instructor",
+    "courses": []
+  },
+  "MNT 1233": {
+    "text": "MNT 1123",
+    "courses": [
+      "MNT 1123"
+    ]
+  },
+  "MNT 2114": {
+    "text": "MNT 1213",
+    "courses": [
+      "MNT 1213"
+    ]
+  },
+  "MNT 2234": {
+    "text": "MNT 2114",
+    "courses": [
+      "MNT 2114"
+    ]
+  },
+  "MST 1115": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 1124": {
+    "text": "MST 1114",
+    "courses": [
+      "MST 1114"
     ]
   },
   "MST 1212": {
@@ -1218,6 +7006,10 @@
     "courses": [
       "MST 1412"
     ]
+  },
+  "MST 1222": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "MST 1243": {
     "text": "MST 1222 (3,2,2)",
@@ -1231,17 +7023,91 @@
       "MST 1232"
     ]
   },
+  "MST 1313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MST 1412": {
     "text": "MST 1313 (2,1,2)",
     "courses": [
       "MST 1313"
     ]
   },
+  "MST 1413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MST 1422": {
     "text": "MST 1412 (2,1,2)",
     "courses": [
       "MST 1412"
     ]
+  },
+  "MST 1423": {
+    "text": "MST 1413",
+    "courses": [
+      "MST 1413"
+    ]
+  },
+  "MST 1613": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 1624": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 191Z": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 1931": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 1941": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2134": {
+    "text": "MST 1124",
+    "courses": [
+      "MST 1124"
+    ]
+  },
+  "MST 2135": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2144": {
+    "text": "MST 2134",
+    "courses": [
+      "MST 2134"
+    ]
+  },
+  "MST 2145": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2413": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2423": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
   },
   "MST 2513": {
     "text": "MST 1243 (3,2,2)",
@@ -1273,10 +7139,282 @@
       "MST 2725"
     ]
   },
+  "MST 2715": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2724": {
+    "text": "MST 2714) A continuation of Computer Numerical Control Operations I. Includes instruction in writing and editing CNC programs, machine setup and operation, and use of CAM equipment to program and operate CNC machines. (CNC lathes, CNC mills, CNC machine centers and wire EDM). (2 hr lecture, 4 hr lab)",
+    "courses": [
+      "MST 2714"
+    ]
+  },
   "MST 2725": {
     "text": "MST 2714 (5,2,6)",
     "courses": [
       "MST 2714"
+    ]
+  },
+  "MST 2734": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2754": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2763": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2813": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MST 2913": {
+    "text": "Minimum of 12 SH in Machine Shop Technology related courses",
+    "courses": []
+  },
+  "MST 2926": {
+    "text": "Instructor Approval and the completion of at least one semester of advanced coursework in Machine Tool Technology",
+    "courses": []
+  },
+  "MUA 1121": {
+    "text": "MUA 1111 or audition",
+    "courses": [
+      "MUA 1111"
+    ]
+  },
+  "MUA 1141": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1151": {
+    "text": "MUA 1141 or audition",
+    "courses": [
+      "MUA 1141"
+    ]
+  },
+  "MUA 1172": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1173": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1182": {
+    "text": "MUA 1172 or audition",
+    "courses": [
+      "MUA 1172"
+    ]
+  },
+  "MUA 1183": {
+    "text": "MUA 1173 or audition",
+    "courses": [
+      "MUA 1173"
+    ]
+  },
+  "MUA 1211": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUA 1221": {
+    "text": "MUA 1211 or audition",
+    "courses": [
+      "MUA 1211"
+    ]
+  },
+  "MUA 1241": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1251": {
+    "text": "MUA 1241 or audition",
+    "courses": [
+      "MUA 1241"
+    ]
+  },
+  "MUA 1272": {
+    "text": "MUA 1221 or audition",
+    "courses": [
+      "MUA 1221"
+    ]
+  },
+  "MUA 1282": {
+    "text": "MUA 1272 or audition",
+    "courses": [
+      "MUA 1272"
+    ]
+  },
+  "MUA 1311": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "MUA 1321": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "MUA 1331": {
+    "text": "Piano audition",
+    "courses": []
+  },
+  "MUA 1341": {
+    "text": "MUA 1331 or audition",
+    "courses": [
+      "MUA 1331"
+    ]
+  },
+  "MUA 1362": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1363": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1372": {
+    "text": "MUA 1362 or audition",
+    "courses": [
+      "MUA 1362"
+    ]
+  },
+  "MUA 1373": {
+    "text": "MUA 1363 or audition",
+    "courses": [
+      "MUA 1363"
+    ]
+  },
+  "MUA 1421": {
+    "text": "MUA 1411 or audition",
+    "courses": [
+      "MUA 1411"
+    ]
+  },
+  "MUA 1441": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1451": {
+    "text": "MUA 1441 or audition",
+    "courses": [
+      "MUA 1441"
+    ]
+  },
+  "MUA 1472": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1473": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1482": {
+    "text": "MUA 1472 or audition",
+    "courses": [
+      "MUA 1472"
+    ]
+  },
+  "MUA 1483": {
+    "text": "MUA 1473 or audition",
+    "courses": [
+      "MUA 1473"
+    ]
+  },
+  "MUA 1511": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUA 1521": {
+    "text": "MUA 1511 or audition",
+    "courses": [
+      "MUA 1511"
+    ]
+  },
+  "MUA 1541": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1542": {
+    "text": "None Corequisite: MUS 1214 , MUS 1224 , MUS 2214 , or MUS 2224 Prerequisite/Corequisite: None",
+    "courses": [
+      "MUS 1214",
+      "MUS 1224",
+      "MUS 2214",
+      "MUS 2224"
+    ]
+  },
+  "MUA 1551": {
+    "text": "MUA 1541 or audition",
+    "courses": [
+      "MUA 1541"
+    ]
+  },
+  "MUA 1552": {
+    "text": "None Corequisite: MUS 1214 , MUS 1224 , MUS 2214 , or MUS 2224 Prerequisite/Corequisite: None",
+    "courses": [
+      "MUS 1214",
+      "MUS 1224",
+      "MUS 2214",
+      "MUS 2224"
+    ]
+  },
+  "MUA 1561": {
+    "text": "MUA 1531",
+    "courses": [
+      "MUA 1531"
+    ]
+  },
+  "MUA 1572": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1573": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1581": {
+    "text": "MUA 1571",
+    "courses": [
+      "MUA 1571"
+    ]
+  },
+  "MUA 1582": {
+    "text": "MUA 1572 or audition",
+    "courses": [
+      "MUA 1572"
+    ]
+  },
+  "MUA 1583": {
+    "text": "MUA 1573 or audition",
+    "courses": [
+      "MUA 1573"
+    ]
+  },
+  "MUA 1621": {
+    "text": "MUA 1611 or audition",
+    "courses": [
+      "MUA 1611"
+    ]
+  },
+  "MUA 1641": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1651": {
+    "text": "MUA 1641 or audition",
+    "courses": [
+      "MUA 1641"
+    ]
+  },
+  "MUA 1672": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1682": {
+    "text": "MUA 1672 or audition",
+    "courses": [
+      "MUA 1672"
     ]
   },
   "MUA 1721": {
@@ -1285,10 +7423,360 @@
       "MUA 1711"
     ]
   },
+  "MUA 1741": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1751": {
+    "text": "MUA 1741 or audition",
+    "courses": [
+      "MUA 1741"
+    ]
+  },
+  "MUA 1772": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1773": {
+    "text": "Audition",
+    "courses": []
+  },
   "MUA 1782": {
     "text": "MUA 1772 (2,1,0)",
     "courses": [
       "MUA 1772"
+    ]
+  },
+  "MUA 1783": {
+    "text": "MUA 1773 or audition",
+    "courses": [
+      "MUA 1773"
+    ]
+  },
+  "MUA 1821": {
+    "text": "MUA 1811 or audition",
+    "courses": [
+      "MUA 1811"
+    ]
+  },
+  "MUA 1841": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1851": {
+    "text": "MUA 1841 or audition",
+    "courses": [
+      "MUA 1841"
+    ]
+  },
+  "MUA 1872": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1873": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUA 1882": {
+    "text": "MUA 1872 or audition",
+    "courses": [
+      "MUA 1872"
+    ]
+  },
+  "MUA 1883": {
+    "text": "MUA 1873 or audition",
+    "courses": [
+      "MUA 1873"
+    ]
+  },
+  "MUA 2111": {
+    "text": "MUA 1121",
+    "courses": [
+      "MUA 1121"
+    ]
+  },
+  "MUA 2121": {
+    "text": "MUA 2111",
+    "courses": [
+      "MUA 2111"
+    ]
+  },
+  "MUA 2141": {
+    "text": "MUA 1151 or audition",
+    "courses": [
+      "MUA 1151"
+    ]
+  },
+  "MUA 2172": {
+    "text": "MUA 1182 or audition",
+    "courses": [
+      "MUA 1182"
+    ]
+  },
+  "MUA 2173": {
+    "text": "MUA 1183 or audition",
+    "courses": [
+      "MUA 1183"
+    ]
+  },
+  "MUA 2182": {
+    "text": "MUA 2172 or audition",
+    "courses": [
+      "MUA 2172"
+    ]
+  },
+  "MUA 2183": {
+    "text": "MUA 2173 or audition",
+    "courses": [
+      "MUA 2173"
+    ]
+  },
+  "MUA 2211": {
+    "text": "MUA 1221",
+    "courses": [
+      "MUA 1221"
+    ]
+  },
+  "MUA 2221": {
+    "text": "MUA 2211",
+    "courses": [
+      "MUA 2211"
+    ]
+  },
+  "MUA 2241": {
+    "text": "MUA 1251 or audition",
+    "courses": [
+      "MUA 1251"
+    ]
+  },
+  "MUA 2251": {
+    "text": "MUA 2241 or audition",
+    "courses": [
+      "MUA 2241"
+    ]
+  },
+  "MUA 2272": {
+    "text": "MUA 1282 or audition",
+    "courses": [
+      "MUA 1282"
+    ]
+  },
+  "MUA 2282": {
+    "text": "MUA 2272 or audition",
+    "courses": [
+      "MUA 2272"
+    ]
+  },
+  "MUA 2311": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "MUA 2321": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "MUA 2331": {
+    "text": "MUA 1341 or audition",
+    "courses": [
+      "MUA 1341"
+    ]
+  },
+  "MUA 2341": {
+    "text": "MUA 2331 or audition",
+    "courses": [
+      "MUA 2331"
+    ]
+  },
+  "MUA 2362": {
+    "text": "MUA 1372 or audition",
+    "courses": [
+      "MUA 1372"
+    ]
+  },
+  "MUA 2363": {
+    "text": "MUA 1373 or audition",
+    "courses": [
+      "MUA 1373"
+    ]
+  },
+  "MUA 2372": {
+    "text": "MUA 2362 or audition",
+    "courses": [
+      "MUA 2362"
+    ]
+  },
+  "MUA 2373": {
+    "text": "MUA 2363 or audition",
+    "courses": [
+      "MUA 2363"
+    ]
+  },
+  "MUA 2411": {
+    "text": "MUA 1421",
+    "courses": [
+      "MUA 1421"
+    ]
+  },
+  "MUA 2421": {
+    "text": "MUA 2411",
+    "courses": [
+      "MUA 2411"
+    ]
+  },
+  "MUA 2441": {
+    "text": "MUA 1451 or audition",
+    "courses": [
+      "MUA 1451"
+    ]
+  },
+  "MUA 2451": {
+    "text": "MUA 2441 or audition",
+    "courses": [
+      "MUA 2441"
+    ]
+  },
+  "MUA 2472": {
+    "text": "MUA 1482 or audition",
+    "courses": [
+      "MUA 1482"
+    ]
+  },
+  "MUA 2473": {
+    "text": "MUA 1483 or audition",
+    "courses": [
+      "MUA 1483"
+    ]
+  },
+  "MUA 2482": {
+    "text": "MUA 2472 or audition",
+    "courses": [
+      "MUA 2472"
+    ]
+  },
+  "MUA 2483": {
+    "text": "MUA 2473 or audition",
+    "courses": [
+      "MUA 2473"
+    ]
+  },
+  "MUA 2511": {
+    "text": "MUA 1521 or audition",
+    "courses": [
+      "MUA 1521"
+    ]
+  },
+  "MUA 2521": {
+    "text": "MUA 2511 or audition",
+    "courses": [
+      "MUA 2511"
+    ]
+  },
+  "MUA 2531": {
+    "text": "MUA 1561",
+    "courses": [
+      "MUA 1561"
+    ]
+  },
+  "MUA 2541": {
+    "text": "MUA 1551 or audition",
+    "courses": [
+      "MUA 1551"
+    ]
+  },
+  "MUA 2542": {
+    "text": "MUA 1552",
+    "courses": [
+      "MUA 1552"
+    ]
+  },
+  "MUA 2551": {
+    "text": "MUA 2541 or audition",
+    "courses": [
+      "MUA 2541"
+    ]
+  },
+  "MUA 2552": {
+    "text": "MUA 2542",
+    "courses": [
+      "MUA 2542"
+    ]
+  },
+  "MUA 2561": {
+    "text": "MUA 2531",
+    "courses": [
+      "MUA 2531"
+    ]
+  },
+  "MUA 2571": {
+    "text": "MUA 1581",
+    "courses": [
+      "MUA 1581"
+    ]
+  },
+  "MUA 2572": {
+    "text": "MUA 1582 or audition",
+    "courses": [
+      "MUA 1582"
+    ]
+  },
+  "MUA 2573": {
+    "text": "MUA 1583 or audition",
+    "courses": [
+      "MUA 1583"
+    ]
+  },
+  "MUA 2581": {
+    "text": "MUA 2571",
+    "courses": [
+      "MUA 2571"
+    ]
+  },
+  "MUA 2582": {
+    "text": "MUA 2572 or audition",
+    "courses": [
+      "MUA 2572"
+    ]
+  },
+  "MUA 2583": {
+    "text": "MUA 2573 or audition",
+    "courses": [
+      "MUA 2573"
+    ]
+  },
+  "MUA 2611": {
+    "text": "MUA 1621",
+    "courses": [
+      "MUA 1621"
+    ]
+  },
+  "MUA 2621": {
+    "text": "MUA 2611",
+    "courses": [
+      "MUA 2611"
+    ]
+  },
+  "MUA 2641": {
+    "text": "MUA 1651 or audition",
+    "courses": [
+      "MUA 1651"
+    ]
+  },
+  "MUA 2651": {
+    "text": "MUA 2641 or audition",
+    "courses": [
+      "MUA 2641"
+    ]
+  },
+  "MUA 2672": {
+    "text": "MUA 1682 or audition",
+    "courses": [
+      "MUA 1682"
+    ]
+  },
+  "MUA 2682": {
+    "text": "MUA 2672 or audition",
+    "courses": [
+      "MUA 2672"
     ]
   },
   "MUA 2711": {
@@ -1303,10 +7791,28 @@
       "MUA 2711"
     ]
   },
+  "MUA 2741": {
+    "text": "MUA 1751 or audition",
+    "courses": [
+      "MUA 1751"
+    ]
+  },
+  "MUA 2751": {
+    "text": "MUA 2741 or audition",
+    "courses": [
+      "MUA 2741"
+    ]
+  },
   "MUA 2772": {
     "text": "MUA 1782 (2,1,0)",
     "courses": [
       "MUA 1782"
+    ]
+  },
+  "MUA 2773": {
+    "text": "MUA 1783 or audition",
+    "courses": [
+      "MUA 1783"
     ]
   },
   "MUA 2782": {
@@ -1315,11 +7821,222 @@
       "MUA 2772"
     ]
   },
+  "MUA 2783": {
+    "text": "MUA 2773 or audition",
+    "courses": [
+      "MUA 2773"
+    ]
+  },
+  "MUA 2811": {
+    "text": "MUA 1821 or audition",
+    "courses": [
+      "MUA 1821"
+    ]
+  },
+  "MUA 2821": {
+    "text": "MUA 2811 or audition",
+    "courses": [
+      "MUA 2811"
+    ]
+  },
+  "MUA 2841": {
+    "text": "MUA 1851 or audition",
+    "courses": [
+      "MUA 1851"
+    ]
+  },
+  "MUA 2851": {
+    "text": "MUA 2841 or audition",
+    "courses": [
+      "MUA 2841"
+    ]
+  },
+  "MUA 2872": {
+    "text": "MUA 1882 or audition",
+    "courses": [
+      "MUA 1882"
+    ]
+  },
+  "MUA 2873": {
+    "text": "MUA 1883 or audition",
+    "courses": [
+      "MUA 1883"
+    ]
+  },
+  "MUA 2882": {
+    "text": "MUA 2872 or audition",
+    "courses": [
+      "MUA 2872"
+    ]
+  },
+  "MUA 2883": {
+    "text": "MUA 2873 or audition",
+    "courses": [
+      "MUA 2873"
+    ]
+  },
+  "MUO 1111": {
+    "text": "Audition or Instructor Approval",
+    "courses": []
+  },
+  "MUO 1112": {
+    "text": "Audition or Instructor Approval",
+    "courses": []
+  },
+  "MUO 1121": {
+    "text": "MUO 1111 or MUO 1112 or audition or consent of instructor",
+    "courses": [
+      "MUO 1111",
+      "MUO 1112"
+    ]
+  },
+  "MUO 1131": {
+    "text": "Instructor’s permission",
+    "courses": []
+  },
+  "MUO 1132": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 1141": {
+    "text": "Instructor’s permission",
+    "courses": []
+  },
+  "MUO 1142": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 1151": {
+    "text": "Instructor’s permission",
+    "courses": []
+  },
+  "MUO 1152": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 1161": {
+    "text": "MUO 1151",
+    "courses": [
+      "MUO 1151"
+    ]
+  },
+  "MUO 1162": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 1171": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUO 1181": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUO 1211": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 1212": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MUO 1221": {
     "text": "MUO 1211 (1,1,0)",
     "courses": [
       "MUO 1211"
     ]
+  },
+  "MUO 1222": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 1241": {
+    "text": "Enrollment by successful audition",
+    "courses": []
+  },
+  "MUO 1242": {
+    "text": "Audition Corequisite: MUO 1212 , MUO 1222 , MUO 2212 or MUO 2222 Prerequisite/Corequisite: None",
+    "courses": [
+      "MUO 1212",
+      "MUO 1222",
+      "MUO 2212",
+      "MUO 2222"
+    ]
+  },
+  "MUO 1251": {
+    "text": "MUO 1241",
+    "courses": [
+      "MUO 1241"
+    ]
+  },
+  "MUO 1252": {
+    "text": "Audition Corequisite: MUO 1212 , MUO 1222 , MUO 2212 or MUO 2222 Prerequisite/Corequisite: None",
+    "courses": [
+      "MUO 1212",
+      "MUO 1222",
+      "MUO 2212",
+      "MUO 2222"
+    ]
+  },
+  "MUO 1311": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "MUO 2111": {
+    "text": "MUO 1121 or audition or consent of instructor",
+    "courses": [
+      "MUO 1121"
+    ]
+  },
+  "MUO 2121": {
+    "text": "MUO 2111 or audition or consent of instructor",
+    "courses": [
+      "MUO 2111"
+    ]
+  },
+  "MUO 2131": {
+    "text": "Instructor’s permission",
+    "courses": []
+  },
+  "MUO 2132": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 2141": {
+    "text": "Instructor’s permission",
+    "courses": []
+  },
+  "MUO 2142": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 2151": {
+    "text": "MUO 1161",
+    "courses": [
+      "MUO 1161"
+    ]
+  },
+  "MUO 2152": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 2161": {
+    "text": "MUO 2151 Designed to explore varied levels of literature and develop the student’s knowledge of performance technique in small ensembles and auxiliary groups. (2 hr lab)",
+    "courses": [
+      "MUO 2151"
+    ]
+  },
+  "MUO 2162": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 2171": {
+    "text": "Audition",
+    "courses": []
+  },
+  "MUO 2181": {
+    "text": "Audition or instructor permission required",
+    "courses": []
   },
   "MUO 2211": {
     "text": "MUO 1221 (1,1,0)",
@@ -1327,10 +8044,80 @@
       "MUO 1221"
     ]
   },
+  "MUO 2212": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
   "MUO 2221": {
     "text": "MUO 2211 (1,1,0)",
     "courses": [
       "MUO 2211"
+    ]
+  },
+  "MUO 2222": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUO 2241": {
+    "text": "MUO 1251",
+    "courses": [
+      "MUO 1251"
+    ]
+  },
+  "MUO 2242": {
+    "text": "Audition Corequisite: MUO 1212 , MUO 1222 , MUO 2212 or MUO 2222 Prerequisite/Corequisite: None",
+    "courses": [
+      "MUO 1212",
+      "MUO 1222",
+      "MUO 2212",
+      "MUO 2222"
+    ]
+  },
+  "MUO 2251": {
+    "text": "MUO 2241",
+    "courses": [
+      "MUO 2241"
+    ]
+  },
+  "MUO 2252": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUS 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUS 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUS 1143": {
+    "text": "Minimum grade of “C” in MUS 1213",
+    "courses": [
+      "MUS 1213"
+    ]
+  },
+  "MUS 1211": {
+    "text": "Same as Music Theory I",
+    "courses": []
+  },
+  "MUS 1213": {
+    "text": "REA 0123 or REA 1213 ; successfully pass Music Theory Placement exam",
+    "courses": [
+      "REA 0123",
+      "REA 1213"
+    ]
+  },
+  "MUS 1221": {
+    "text": "Minimum grade of “C” in MUS 1211",
+    "courses": [
+      "MUS 1211"
+    ]
+  },
+  "MUS 1223": {
+    "text": "Minimum grade of “C” in MUS 1213",
+    "courses": [
+      "MUS 1213"
     ]
   },
   "MUS 1224": {
@@ -1338,5 +8125,2492 @@
     "courses": [
       "MUS 1214"
     ]
+  },
+  "MUS 1413": {
+    "text": "ENG 0124 or higher; MAT 1133 or MAT 1134 or higher; REA 1213",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "REA 1213"
+    ]
+  },
+  "MUS 1423": {
+    "text": "MUS 1133 , MUA 1511 , and department chair approval",
+    "courses": [
+      "MUA 1511",
+      "MUS 1133"
+    ]
+  },
+  "MUS 1812": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUS 1821": {
+    "text": "MUS 1811 - Music Theatre Workshop I The workshop is designed to introduce and engage students in all facets of music theatre. Open to music majors and non-music majors. (Lecture, Lab)",
+    "courses": [
+      "MUS 1811"
+    ]
+  },
+  "MUS 1822": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUS 2123": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "MUS 2211": {
+    "text": "Minimum Grade of “C” in MUS 1221",
+    "courses": [
+      "MUS 1221"
+    ]
+  },
+  "MUS 2213": {
+    "text": "Minimum grade of “C” in MUS 1223 and a grade of “Pass” on both parts of the Comprehensive Music Fundamentals Exam",
+    "courses": [
+      "MUS 1223"
+    ]
+  },
+  "MUS 2214": {
+    "text": "MUS 1224 (4,3,2)",
+    "courses": [
+      "MUS 1224"
+    ]
+  },
+  "MUS 2221": {
+    "text": "Minimum grade of “C” in MUS 2211",
+    "courses": [
+      "MUS 2211"
+    ]
+  },
+  "MUS 2223": {
+    "text": "Minimum grade of “C” in MUS 2213",
+    "courses": [
+      "MUS 2213"
+    ]
+  },
+  "MUS 2224": {
+    "text": "MUS 1224 and MUS 2214 (4,3,2)",
+    "courses": [
+      "MUS 1224",
+      "MUS 2214"
+    ]
+  },
+  "MUS 2413": {
+    "text": "MUS 1133 , MUS 1413 , MUA 1511 , and department chair approval",
+    "courses": [
+      "MUA 1511",
+      "MUS 1133",
+      "MUS 1413"
+    ]
+  },
+  "MUS 2423": {
+    "text": "MUS 2413 , MUS 1211 , MUS 1213 , MUA 1521",
+    "courses": [
+      "MUA 1521",
+      "MUS 1211",
+      "MUS 1213",
+      "MUS 2413"
+    ]
+  },
+  "MUS 2433": {
+    "text": "MUS 1213 , MUS 1211 , MUA 1521 , and department chair approval",
+    "courses": [
+      "MUA 1521",
+      "MUS 1211",
+      "MUS 1213"
+    ]
+  },
+  "MUS 2443": {
+    "text": "MUS 1413 , MUS 1433",
+    "courses": [
+      "MUS 1413",
+      "MUS 1433"
+    ]
+  },
+  "MUS 2444": {
+    "text": "MUS 2413 , with a C or better",
+    "courses": [
+      "MUS 2413"
+    ]
+  },
+  "MUS 2453": {
+    "text": "MUS 2443",
+    "courses": [
+      "MUS 2443"
+    ]
+  },
+  "MUS 2513": {
+    "text": "MAT 1134 or MAT 1133 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "MUS 2811": {
+    "text": "MUS 1821 - Music Theatre Workshop II The workshop is designed to introduce and engage students in all facets of music theatre. Open to music and non-music majors. (Lecture, Lab)",
+    "courses": [
+      "MUS 1821"
+    ]
+  },
+  "MUS 2812": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "MUS 2821": {
+    "text": "MUS 2811 - Music Theatre Workshop III The workshop is designed to introduce and engage students in all facets of music theatre. Open to music majors and non-music majors. (Lecture, Lab)",
+    "courses": [
+      "MUS 2811"
+    ]
+  },
+  "MUS 2822": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1002": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1003": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1012": {
+    "text": "None Corequisite: NUR 1110 Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 1110"
+    ]
+  },
+  "NUR 1102": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1103": {
+    "text": "NUR 1107 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 1107"
+    ]
+  },
+  "NUR 1107": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 and BIO 2523 Corequisite: None Prerequisite/Corequisite: EPY 2533 , BIO 2921 and BIO 2923",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "BIO 2921",
+      "BIO 2923",
+      "EPY 2533"
+    ]
+  },
+  "NUR 1109": {
+    "text": "Admission to the Nursing Program, BIO 2513 , BIO 2511 , MAT 1313",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "MAT 1313"
+    ]
+  },
+  "NUR 1110": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 and BIO 2523 Corequisite: NUR 1012 Prerequisite/Corequisite: EPY 2533 , BIO 2921 and BIO 2923",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "BIO 2921",
+      "BIO 2923",
+      "EPY 2533",
+      "NUR 1012"
+    ]
+  },
+  "NUR 1112": {
+    "text": "NUR 1110 or NUR 1107 /NUR 1103 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 1103",
+      "NUR 1107",
+      "NUR 1110"
+    ]
+  },
+  "NUR 1113": {
+    "text": "BIO 2514 , BIO 2524 , BIO 2924 , MAT 1313 , PSY 1513 , and FCS 1253",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "FCS 1253",
+      "MAT 1313",
+      "PSY 1513"
+    ]
+  },
+  "NUR 1115": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; ENG 1123 ; PSY 1513 ; BIO 2514 *; BIO 2524 ; BIO 2924 . (5,3,6)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113",
+      "ENG 1123",
+      "PSY 1513"
+    ]
+  },
+  "NUR 1116": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; ENG 1123 ; PSY 1513 ; BIO 2514 *; BIO 2524 ; BIO 2924 ; NUR 1115 (NUR 1115 is required of EMS-Paramedics and Respiratory Therapist-to-RN students only). (6,4,6)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113",
+      "ENG 1123",
+      "NUR 1115",
+      "PSY 1513"
+    ]
+  },
+  "NUR 1118": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; BIO 2514 ; BIO 2524 ; BIO 2924 . (8,4,12)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113"
+    ]
+  },
+  "NUR 1119": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 with a grade of “C” or above in each course, and SOC 2113 ) (Pre/Corequisites: ENG 1113 , PSY 1513 ) Within the framework of the nursing process and across the lifespan, the focus of this course is on fundamental nursing concepts related to the introduction of nursing practice and nursing as a profession. Nursing core competencies including the knowledge, skills, and attitudes to provide safe, quality care are introduced. Laboratory, simulation, and clinical experiences will include professional development and fundamental care of clients in long-term and/or acute care settings. (5 hr lecture, 4.5 hr lab, 5.25 hr clinical)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "ENG 1113",
+      "PSY 1513",
+      "SOC 2113"
+    ]
+  },
+  "NUR 1121": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; BIO 2514 ; BIO 2524 ; BIO 2924 . (1,1,0)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113"
+    ]
+  },
+  "NUR 1129": {
+    "text": "NUR 1119 or NUR 1113",
+    "courses": [
+      "NUR 1113",
+      "NUR 1119"
+    ]
+  },
+  "NUR 1131": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; BIO 2514 ; BIO 2524 ; BIO 2924 . (1,1,0)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113"
+    ]
+  },
+  "NUR 1133": {
+    "text": "NUR 1119 , NUR 1229",
+    "courses": [
+      "NUR 1119",
+      "NUR 1229"
+    ]
+  },
+  "NUR 1202": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1203": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1204": {
+    "text": "NUR 1107 and NUR 1103 Corequisite: None Prerequisite/Corequisite: ENG 1113 and PSY 1513",
+    "courses": [
+      "ENG 1113",
+      "NUR 1103",
+      "NUR 1107",
+      "PSY 1513"
+    ]
+  },
+  "NUR 1206": {
+    "text": "NUR 1204 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 1204"
+    ]
+  },
+  "NUR 1209": {
+    "text": "NUR 1109 , BIO 2523 , BIO 2521",
+    "courses": [
+      "BIO 2521",
+      "BIO 2523",
+      "NUR 1109"
+    ]
+  },
+  "NUR 1210": {
+    "text": "NUR 1110 Corequisite: None Prerequisite/Corequisite: ENG 1113 and PSY 1513",
+    "courses": [
+      "ENG 1113",
+      "NUR 1110",
+      "PSY 1513"
+    ]
+  },
+  "NUR 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 1217": {
+    "text": "NUR 1118 ; NUR 1121 ; NUR 1131 ; BIO 2524 . (7,4,9)",
+    "courses": [
+      "BIO 2524",
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131"
+    ]
+  },
+  "NUR 1223": {
+    "text": "NUR 1118 ; NUR 1121 ; NUR 1131 . (3,2,3)",
+    "courses": [
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131"
+    ]
+  },
+  "NUR 1229": {
+    "text": "NUR 1119 , ENG 1113 , PSY 1513",
+    "courses": [
+      "ENG 1113",
+      "NUR 1119",
+      "PSY 1513"
+    ]
+  },
+  "NUR 1233": {
+    "text": "Successful completion of NUR 1217 and NUR 1223 . (3,0,0,9)",
+    "courses": [
+      "NUR 1217",
+      "NUR 1223"
+    ]
+  },
+  "NUR 1322": {
+    "text": "BIO 2511, BIO 2513, BIO 2521, BIO 2523, BIO 2921, BIO 2923, ENG 1113, EPY 2533 and PSY 1513 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "BIO 2921",
+      "BIO 2923",
+      "ENG 1113",
+      "EPY 2533",
+      "PSY 1513"
+    ]
+  },
+  "NUR 2002": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2003": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2013": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2102": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2103": {
+    "text": "NUR 2107 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 2107"
+    ]
+  },
+  "NUR 2107": {
+    "text": "NUR 1204 and NUR 1206 Corequisite: None Prerequisite/Corequisite: SPT 1113 and ENG 1123",
+    "courses": [
+      "ENG 1123",
+      "NUR 1204",
+      "NUR 1206",
+      "SPT 1113"
+    ]
+  },
+  "NUR 2110": {
+    "text": "NUR 1210 or NUR 1320 Corequisite: None Prerequisite/Corequisite: SPT 1113 and ENG 1123",
+    "courses": [
+      "ENG 1123",
+      "NUR 1210",
+      "NUR 1320",
+      "SPT 1113"
+    ]
+  },
+  "NUR 2112": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2113": {
+    "text": "NUR 1129 , NUR 1113 , PSY 1513 , & PSY 2533",
+    "courses": [
+      "NUR 1113",
+      "NUR 1129",
+      "PSY 1513",
+      "PSY 2533"
+    ]
+  },
+  "NUR 2114": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 , BIO 2921 , & BIO 2923 with a grade of “C” or above in each course, ENG 1113 , ENG 1123 , PSY 2533 , PSY 1513 , SOC 2113 , SPT 1113 /SPT 2173 , Fine Arts/Humanities) Within the framework of the nursing process and across the lifespan, the focus of this course is to introduce the paramedic, respiratory therapist, and licensed practical nurse to fundamental nursing concepts related to role transition and the introduction of nursing practice and nursing as a profession. Nursing core competencies including the knowledge, skills, and attitudes to provide safe, quality care are introduced. Laboratory experiences will include fundamental care of clients and professional development. (8 week course: 6 hr lecture, 4 hr lab)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "BIO 2921",
+      "BIO 2923",
+      "ENG 1113",
+      "ENG 1123",
+      "PSY 1513",
+      "PSY 2533",
+      "SOC 2113",
+      "SPT 1113",
+      "SPT 2173"
+    ]
+  },
+  "NUR 2119": {
+    "text": "NUR 1109 , EPY 2533 , NUR 1209 or NUR 1316",
+    "courses": [
+      "EPY 2533",
+      "NUR 1109",
+      "NUR 1209",
+      "NUR 1316"
+    ]
+  },
+  "NUR 2123": {
+    "text": "Admission to ADN Nursing Program; Clock hours:45 theory",
+    "courses": []
+  },
+  "NUR 2129": {
+    "text": "NUR 1129",
+    "courses": [
+      "NUR 1129"
+    ]
+  },
+  "NUR 2133": {
+    "text": "Pre-requisites: NUR 1109 and NUR 1209",
+    "courses": [
+      "NUR 1109",
+      "NUR 1209"
+    ]
+  },
+  "NUR 2139": {
+    "text": "NUR 1229 , Fine Arts/Humanities Elective, PSY 2533 , ENG 1123",
+    "courses": [
+      "ENG 1123",
+      "NUR 1229",
+      "PSY 2533"
+    ]
+  },
+  "NUR 2201": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2204": {
+    "text": "NUR 2107 and NUR 2103 Corequisite: None Prerequisite/Corequisite: A humanities or fine arts elective",
+    "courses": [
+      "NUR 2103",
+      "NUR 2107"
+    ]
+  },
+  "NUR 2206": {
+    "text": "NUR 2204 Corequisite: NUR 2201 Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 2201",
+      "NUR 2204"
+    ]
+  },
+  "NUR 2210": {
+    "text": "NUR 2110 - Nursing III Corequisite: NUR 2201 Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 2110",
+      "NUR 2201"
+    ]
+  },
+  "NUR 2211": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2212": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2213": {
+    "text": "NUR 1213 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "NUR 1213"
+    ]
+  },
+  "NUR 2228": {
+    "text": "NUR 2114",
+    "courses": [
+      "NUR 2114"
+    ]
+  },
+  "NUR 2243": {
+    "text": "NUR 2139",
+    "courses": [
+      "NUR 2139"
+    ]
+  },
+  "NUR 2248": {
+    "text": "NUR 2228",
+    "courses": [
+      "NUR 2228"
+    ]
+  },
+  "NUR 2249": {
+    "text": "NUR 2139 , BIO 2921 , BIO 2923 with a grade of “C” or above in each course",
+    "courses": [
+      "BIO 2921",
+      "BIO 2923",
+      "NUR 2139"
+    ]
+  },
+  "NUR 2254": {
+    "text": "NUR 2248",
+    "courses": [
+      "NUR 2248"
+    ]
+  },
+  "NUR 2303": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "NUR 2313": {
+    "text": "NUR 2119",
+    "courses": [
+      "NUR 2119"
+    ]
+  },
+  "NUR 2316": {
+    "text": "NUR 2215",
+    "courses": [
+      "NUR 2215"
+    ]
+  },
+  "NUR 2318": {
+    "text": "NUR 1118 ; NUR 1121 ; NUR 1131 ; NUR 1217 ; NUR 1223 ; ENG 1123 (8,4.4,10.8)",
+    "courses": [
+      "ENG 1123",
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131",
+      "NUR 1217",
+      "NUR 1223"
+    ]
+  },
+  "NUR 2322": {
+    "text": "NUR 1118 ; NUR 1121 ; NUR 1131 ; NUR 1217 ; NUR 1223 (2,1.6,1.2)",
+    "courses": [
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131",
+      "NUR 1217",
+      "NUR 1223"
+    ]
+  },
+  "NUR 2323": {
+    "text": "NUR 1209",
+    "courses": [
+      "NUR 1209"
+    ]
+  },
+  "NUR 2332": {
+    "text": "NUR 2249 or NUR 2254",
+    "courses": [
+      "NUR 2249",
+      "NUR 2254"
+    ]
+  },
+  "NUR 2416": {
+    "text": "SPT 1113 ; NUR 1118 ; NUR 1121 ; NUR 1131 ; NUR 1217 ; NUR 1223 ; NUR 2318 ; NUR 2322 (6,4,6)",
+    "courses": [
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131",
+      "NUR 1217",
+      "NUR 1223",
+      "NUR 2318",
+      "NUR 2322",
+      "SPT 1113"
+    ]
+  },
+  "NUR 2422": {
+    "text": "SPT 1113 ; NUR 1118 ; NUR 1121 ; NUR 1131 ; NUR 1217 ; NUR 1223 ; NUR 2318 ; NUR 2322 (2,2,0)",
+    "courses": [
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131",
+      "NUR 1217",
+      "NUR 1223",
+      "NUR 2318",
+      "NUR 2322",
+      "SPT 1113"
+    ]
+  },
+  "NUR 2434": {
+    "text": "SPT 1113 ; NUR 1118 ; NUR 1121 ; NUR 1131 ; NUR 1217 ; NUR 1223 ; NUR 2318 ; NUR 2322 (4,2,6)",
+    "courses": [
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131",
+      "NUR 1217",
+      "NUR 1223",
+      "NUR 2318",
+      "NUR 2322",
+      "SPT 1113"
+    ]
+  },
+  "OTA 1113": {
+    "text": "Instructor Approved. (3,3,0)",
+    "courses": []
+  },
+  "OTA 1121": {
+    "text": "Instructor Approved. (1,1,0)",
+    "courses": []
+  },
+  "OTA 1132": {
+    "text": "Instructor Approved. (2,1,2)",
+    "courses": []
+  },
+  "OTA 1213": {
+    "text": "Instructor Approved. (3,3,0)",
+    "courses": []
+  },
+  "OTA 1223": {
+    "text": "Instructor Approved. (3,3,0)",
+    "courses": []
+  },
+  "OTA 1233": {
+    "text": "Instructor Approved. (3,3,0)",
+    "courses": []
+  },
+  "OTA 1242": {
+    "text": "Instructor Approved. (2,2,0)",
+    "courses": []
+  },
+  "OTA 1314": {
+    "text": "Instructor Approved. (4,3,2)",
+    "courses": []
+  },
+  "OTA 1413": {
+    "text": "Instructor Approved. (3,2,2)",
+    "courses": []
+  },
+  "OTA 1423": {
+    "text": "Instructor Approved. (3,2,2)",
+    "courses": []
+  },
+  "OTA 1433": {
+    "text": "Instructor Approved. (3,2,2)",
+    "courses": []
+  },
+  "OTA 1513": {
+    "text": "Instructor Approved. (3,2,2)",
+    "courses": []
+  },
+  "OTA 1913": {
+    "text": "Instructor Approved. (3,1,0,6)",
+    "courses": []
+  },
+  "OTA 2443": {
+    "text": "Instructor Approved. (3,2,2)",
+    "courses": []
+  },
+  "OTA 2714": {
+    "text": "Instructor Approved. (4,3,2)",
+    "courses": []
+  },
+  "OTA 2812": {
+    "text": "Instructor Approved. (2,2,0)",
+    "courses": []
+  },
+  "OTA 2935": {
+    "text": "Instructor Approved. (5,1,0,12)",
+    "courses": []
+  },
+  "OTA 2946": {
+    "text": "Instructor Approved. (6,0,0,18)",
+    "courses": []
+  },
+  "OTA 2956": {
+    "text": "Instructor Approved. (6,0,0,18)",
+    "courses": []
+  },
+  "OTA 2961": {
+    "text": "Instructor Approved. (1,1,0)",
+    "courses": []
+  },
+  "OTA 2971": {
+    "text": "Instructor Approved. (1,1,0)",
+    "courses": []
+  },
+  "PHI 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PHI 1133": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PHI 1153": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PHI 1163": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PHI 2113": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "PHI 2123": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "PHI 2143": {
+    "text": "ENG 1114 or higher",
+    "courses": [
+      "ENG 1114"
+    ]
+  },
+  "PHI 2613": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "PHI 2713": {
+    "text": "ENG 1114 or higher",
+    "courses": [
+      "ENG 1114"
+    ]
+  },
+  "PHI 2813": {
+    "text": "ENG 1114 or higher",
+    "courses": [
+      "ENG 1114"
+    ]
+  },
+  "PHM 1313": {
+    "text": "MAT 1234",
+    "courses": [
+      "MAT 1234"
+    ]
+  },
+  "PHY 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PHY 1114": {
+    "text": "MAT 1234 Intermediate Algebra or higher or permission of instructor",
+    "courses": [
+      "MAT 1234"
+    ]
+  },
+  "PHY 2241": {
+    "text": "None Corequisite: PHY 2243 Prerequisite/Corequisite: None",
+    "courses": [
+      "PHY 2243"
+    ]
+  },
+  "PHY 2243": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "PHY 2244": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "PHY 2251": {
+    "text": "None Corequisite: PHY 2253 Prerequisite/Corequisite: None",
+    "courses": [
+      "PHY 2253"
+    ]
+  },
+  "PHY 2253": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "PHY 2254": {
+    "text": "MAT 1133 or MAT 1134 or higher",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134"
+    ]
+  },
+  "PHY 2411": {
+    "text": "None Corequisite: PHY 2413 Prerequisite/Corequisite: None",
+    "courses": [
+      "PHY 2413"
+    ]
+  },
+  "PHY 2413": {
+    "text": "MAT 1313 and MAT 1323 Corequisite: PHY 2411 Prerequisite/Corequisite: None",
+    "courses": [
+      "MAT 1313",
+      "MAT 1323",
+      "PHY 2411"
+    ]
+  },
+  "PHY 2414": {
+    "text": "MAT 1313 and MAT 1323 or special consent of instructor. (4,3,2)",
+    "courses": [
+      "MAT 1313",
+      "MAT 1323"
+    ]
+  },
+  "PHY 2421": {
+    "text": "None Corequisite: PHY 2423 Prerequisite/Corequisite: None",
+    "courses": [
+      "PHY 2423"
+    ]
+  },
+  "PHY 2423": {
+    "text": "PHY 2413 Corequisite: PHY 2421 Prerequisite/Corequisite: None",
+    "courses": [
+      "PHY 2413",
+      "PHY 2421"
+    ]
+  },
+  "PHY 2424": {
+    "text": "PHY 2414 . (4,3,2)",
+    "courses": [
+      "PHY 2414"
+    ]
+  },
+  "PHY 2513": {
+    "text": "MAT 1613 (PHY 2513 and PHY 2511 must be taken concurrently)",
+    "courses": [
+      "MAT 1613",
+      "PHY 2511"
+    ]
+  },
+  "PHY 2514": {
+    "text": "MAT 1613 . (4,3,2)",
+    "courses": [
+      "MAT 1613"
+    ]
+  },
+  "PHY 2515": {
+    "text": "MAT 1623 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "MAT 1623"
+    ]
+  },
+  "PHY 2521": {
+    "text": "MAT 1613",
+    "courses": [
+      "MAT 1613"
+    ]
+  },
+  "PHY 2523": {
+    "text": "A score of “C” or better in PHY 2513 and PHY 2511 are required before taking this class",
+    "courses": [
+      "PHY 2511",
+      "PHY 2513"
+    ]
+  },
+  "PHY 2524": {
+    "text": "PHY 2514 . (4,3,2)",
+    "courses": [
+      "PHY 2514"
+    ]
+  },
+  "PHY 2525": {
+    "text": "PHY 2515 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "PHY 2515"
+    ]
+  },
+  "PNV 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PNV 1216": {
+    "text": "PNV 1115",
+    "courses": [
+      "PNV 1115"
+    ]
+  },
+  "PNV 1312": {
+    "text": "PNV 1115",
+    "courses": [
+      "PNV 1115"
+    ]
+  },
+  "PNV 1412": {
+    "text": "PNV 1216",
+    "courses": [
+      "PNV 1216"
+    ]
+  },
+  "PNV 1426": {
+    "text": "BIO 2511 , BIO 2513 ,BIO 2521 , BIO 2523 with a grade of “C” or above in each course (Corequisites: PNV 1436 This course provides the student with the basic knowledge and skills necessary to care for the individual in wellness and illness and is applicable across the life span. A passing grade in PNV 1426 and PNV 1436 is required in order to progress in the Practical Nursing Program. If a passing grade is not maintained, both courses must be repeated upon readmission. (6 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "PNV 1436"
+    ]
+  },
+  "PNV 1436": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 with a grade of “C” or above in each course or PNV 1213 ) (Corequisites: PNV 1426 ) This course provides demonstration of and supervised practice of the fundamental skills related to practical nursing. A passing grade in PNV 1426 and PNV 1436 is required in order to progress in the Practical Nursing Program. If a passing grade is not maintained, both courses must be repeated upon readmission. (8 hr lab, 6 hr clinical)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "PNV 1213",
+      "PNV 1426"
+    ]
+  },
+  "PNV 1443": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PNV 1516": {
+    "text": "PNV 1312",
+    "courses": [
+      "PNV 1312"
+    ]
+  },
+  "PNV 1524": {
+    "text": "MA-to-LPN Program Acceptance. (4,3,2)",
+    "courses": []
+  },
+  "PNV 1614": {
+    "text": "PNV 1213 , PNV 1426 , PNV 1436",
+    "courses": [
+      "PNV 1213",
+      "PNV 1426",
+      "PNV 1436"
+    ]
+  },
+  "PNV 1622": {
+    "text": "PNV 1213 , PNV 1426 , PNV 1436",
+    "courses": [
+      "PNV 1213",
+      "PNV 1426",
+      "PNV 1436"
+    ]
+  },
+  "PNV 1634": {
+    "text": "PNV 1213 , PNV 1426 , PNV 1436 , PNV 1524 , PNV 1614 , PNV 1622 , PNV 1714 , PNV 1814 ) (Corequisites: PNV 1642 , PNV 1914 ) This course provides the student with the basic nursing theory and skills to provide safe and effective care for a client experiencing acute, chronic, or life-threatening physical health conditions in selected body systems. Pharmacological and nutritional therapy considerations for various disorders are included. The systems not covered in this course are taught in Medical/Surgical Nursing Theory (PNV 1614 ). Concurrent registration in PNV 1642 is required. A passing grade in PNV 1634 and PNV 1642 is required to progress in the Practical Nursing Program. If a passing grade is not maintained, both courses must be repeated concurrently upon readmission. (4 hr lecture)",
+    "courses": [
+      "PNV 1213",
+      "PNV 1426",
+      "PNV 1436",
+      "PNV 1524",
+      "PNV 1614",
+      "PNV 1622",
+      "PNV 1642",
+      "PNV 1714",
+      "PNV 1814",
+      "PNV 1914"
+    ]
+  },
+  "PNV 1642": {
+    "text": "PNV 1213 , PNV 1426 , PNV 1436 , PNV 1524 , PNV 1614 , PNV 1622 , PNV 1714 , PNV 1814 ) (Corequisites: PNV 1634 , PNV 1914 ) This course includes clinical experiences for application of nursing theory and skills for safe, effective care of the adult client experiencing acute, chronic or life-threatening physical health conditions. Concurrent registration in PNV 1634 is required. A passing grade in PNV 1642 and PNV 1634 is required to progress in the Practical Nursing Program. If a passing grade is not maintained, both courses must be repeated concurrently upon readmission. (6 hr clinical)",
+    "courses": [
+      "PNV 1213",
+      "PNV 1426",
+      "PNV 1436",
+      "PNV 1524",
+      "PNV 1614",
+      "PNV 1622",
+      "PNV 1634",
+      "PNV 1714",
+      "PNV 1814",
+      "PNV 1914"
+    ]
+  },
+  "PNV 1676": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; PSY 1513 ; BIO 2514 ; BIO 2524 ; BIO 2924 . (6,4,6)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113",
+      "PSY 1513"
+    ]
+  },
+  "PNV 1682": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PNV 1714": {
+    "text": "PNV 1213 , PNV 1426 , PNV 1436 , PNV 1524 , PNV 1614 , PNV 1622 ) (Corequisites: PNV 1814 ) This course provides the student with a basic knowledge and skills to promote and/or provide safe and effective care for clients and families during antepartum, intrapartum and post-partum periods as well as infancy through adolescence. (3.7 hr lecture, 1 hr clinical)",
+    "courses": [
+      "PNV 1213",
+      "PNV 1426",
+      "PNV 1436",
+      "PNV 1524",
+      "PNV 1614",
+      "PNV 1622",
+      "PNV 1814"
+    ]
+  },
+  "PNV 1715": {
+    "text": "All first semester Practical Nursing courses Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PNV 1813": {
+    "text": "Admission Criteria and coursework: ENG 1113 ; PSY 1513 ; BIO 2514 ; BIO 2524 ; BIO 2924 . (3,2.67,1)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113",
+      "PSY 1513"
+    ]
+  },
+  "PNV 1814": {
+    "text": "PNV 1213 , PNV 1426 , PNV 1436 , PNV 1524 , PNV 1614 , PNV 1622 ) (Corequisites: PNV 1714 ) This course provides the student with basic knowledge and skills to assist in the promotion of the emotional, mental and social well-being of the client and family experiencing a mental health alteration. (3.7 hr lecture, 1 hr clinical)",
+    "courses": [
+      "PNV 1213",
+      "PNV 1426",
+      "PNV 1436",
+      "PNV 1524",
+      "PNV 1614",
+      "PNV 1622",
+      "PNV 1714"
+    ]
+  },
+  "PNV 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PNV 1914": {
+    "text": "ENG 1113, PSY 1513, BIO 2514, BIO 2924, BIO 2524, ENG 1123, EPY 2533, NUR 1118, NUR 1121, NUR 1131, NUR 1100, NUR 1217, NUR 1223, NUR 1200. Corequisites: PNV 1301, PNV 1676, PNV 1813. (4,3,3)",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524",
+      "BIO 2924",
+      "ENG 1113",
+      "ENG 1123",
+      "EPY 2533",
+      "NUR 1100",
+      "NUR 1118",
+      "NUR 1121",
+      "NUR 1131",
+      "NUR 1200",
+      "NUR 1217",
+      "NUR 1223",
+      "PNV 1301",
+      "PNV 1676",
+      "PNV 1813",
+      "PSY 1513"
+    ]
+  },
+  "PNV 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PPT 2333": {
+    "text": "PPT 2323 (3,1,4)",
+    "courses": [
+      "PPT 2323"
+    ]
+  },
+  "PPT 2443": {
+    "text": "PPT 1433 (3,2,2)",
+    "courses": [
+      "PPT 1433"
+    ]
+  },
+  "PPT 2723": {
+    "text": "PPT 1713 . (3,3,0)",
+    "courses": [
+      "PPT 1713"
+    ]
+  },
+  "PPV 1425": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PSC 1113": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "PSC 1123": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "PSY 1513": {
+    "text": "ENG 1114 or ENG 1113",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114"
+    ]
+  },
+  "PSY 2113": {
+    "text": "PSY 1513 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "PSY 1513"
+    ]
+  },
+  "PSY 2223": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PSY 2323": {
+    "text": "MAT 1233 or higher or Math ACT subscore of 19 or higher",
+    "courses": [
+      "MAT 1233"
+    ]
+  },
+  "PSY 2513": {
+    "text": "ENG 0124 or higher; MAT 1133 /MAT 1134 or higher; REA 1213 ; PSY 1513 ) A study of the various aspects of human growth and development during childhood and emerging adolescence. Topics include biological, psychosocial, & cognitive development. (3 hr lecture)",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "PSY 1513",
+      "REA 1213"
+    ]
+  },
+  "PSY 2523": {
+    "text": "ENG 0124 or higher; MAT 1133 /MAT 1134 or higher; PSY 1513",
+    "courses": [
+      "ENG 0124",
+      "MAT 1133",
+      "MAT 1134",
+      "PSY 1513"
+    ]
+  },
+  "PSY 2533": {
+    "text": "MAT 1133 or MAT 1134 or higher; PSY 1513",
+    "courses": [
+      "MAT 1133",
+      "MAT 1134",
+      "PSY 1513"
+    ]
+  },
+  "PSY 2553": {
+    "text": "PSY 1513 . (3,3,0)",
+    "courses": [
+      "PSY 1513"
+    ]
+  },
+  "PTA 1111": {
+    "text": "PTA 1213 , PTA 1314 , PTA 2513",
+    "courses": [
+      "PTA 1213",
+      "PTA 1314",
+      "PTA 2513"
+    ]
+  },
+  "PTA 1123": {
+    "text": "Admission to Physical Therapist Assistant Program, PTA 1213 , PTA 1314 , PTA 2513",
+    "courses": [
+      "PTA 1213",
+      "PTA 1314",
+      "PTA 2513"
+    ]
+  },
+  "PTA 1151": {
+    "text": "PTA 1111 , PTA 1123 , PTA 1213 , PTA 1224 , PTA 1314 , PTA 2234 , PTA 2513 ) (Corequisites: PTA 2334 , PTA 2413 ) This course is designed to provide the student with observation/overview with limited participation in physical therapy activities. The student has the opportunity to gain additional knowledge of the health care delivery system and physical therapy’s place within that system. (1 hr lecture)",
+    "courses": [
+      "PTA 1111",
+      "PTA 1123",
+      "PTA 1213",
+      "PTA 1224",
+      "PTA 1314",
+      "PTA 2234",
+      "PTA 2334",
+      "PTA 2413",
+      "PTA 2513"
+    ]
+  },
+  "PTA 1213": {
+    "text": "Admission to Physical Therapist Assistant Program",
+    "courses": []
+  },
+  "PTA 1214": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 1224": {
+    "text": "PTA 1213 , PTA 1314 , PTA 2513",
+    "courses": [
+      "PTA 1213",
+      "PTA 1314",
+      "PTA 2513"
+    ]
+  },
+  "PTA 1315": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 1324": {
+    "text": "PTA 1213 , PTA 1314 , PTA 2513",
+    "courses": [
+      "PTA 1213",
+      "PTA 1314",
+      "PTA 2513"
+    ]
+  },
+  "PTA 1911": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum. Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 1921": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 2234": {
+    "text": "PTA 1111 , PTA 1213 , PTA 1224 , PTA 1314 , PTA 1324 , PTA 2513 ) This course emphasizes theory and practical application of electrotherapy and other therapeutic procedures. Indications and contraindications of biophysical agents are also discussed. (3 hr lecture, 2 hr lab)",
+    "courses": [
+      "PTA 1111",
+      "PTA 1213",
+      "PTA 1224",
+      "PTA 1314",
+      "PTA 1324",
+      "PTA 2513"
+    ]
+  },
+  "PTA 2334": {
+    "text": "PTA 1111 , PTA 1123 , PTA 1213 , PTA 1224 , PTA 1314 , PTA 2234 , PTA 2513 ) (Corequisites: PTA 1151 , PTA 2413 ) This course presents theory, principles, and techniques of therapeutic exercise and rehabilitation for primarily neurological conditions. Methods of functional, motor, and sensory assessment and intervention techniques are included. Principles of prosthetics and orthotics, functional training, and other techniques are covered. (2 hr lecture, 4 hr lab)",
+    "courses": [
+      "PTA 1111",
+      "PTA 1123",
+      "PTA 1151",
+      "PTA 1213",
+      "PTA 1224",
+      "PTA 1314",
+      "PTA 2234",
+      "PTA 2413",
+      "PTA 2513"
+    ]
+  },
+  "PTA 2413": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 2424": {
+    "text": "PTA 2413",
+    "courses": [
+      "PTA 2413"
+    ]
+  },
+  "PTA 2425": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum. Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "PTA 2434": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 2444": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 2456": {
+    "text": "Instructor Approved; Satisfactory completion of Clinical Education I and II and prior didactic coursework. Corequisite: NONE Prerequisite/Corequisite: NONE",
+    "courses": []
+  },
+  "PTA 2458": {
+    "text": "PTA 2424 (Corequisites: PTA 2523 This course provides an opportunity for terminal, full-time learning experience which includes supervised clinical experiences in demonstrating the attributes and applying the skills which prepare students for entry into the Physical Therapy profession. (24 hr Clinical)",
+    "courses": [
+      "PTA 2424",
+      "PTA 2523"
+    ]
+  },
+  "PTA 2513": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "PTA 2523": {
+    "text": "PTA 2413",
+    "courses": [
+      "PTA 2413"
+    ]
+  },
+  "PTA 2911": {
+    "text": "Successful completion of all courses in prior semester(s) of the PTA curriculum Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "RCT 1011": {
+    "text": "None Corequisite: RCT 1213 , RCT 1313 , RCT 1223 , and RCT 1613 Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 1213",
+      "RCT 1223",
+      "RCT 1313",
+      "RCT 1613"
+    ]
+  },
+  "RCT 1021": {
+    "text": "None Corequisite: RCT 1515 , RCT 1424 , and RCT 2333 Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 1424",
+      "RCT 1515",
+      "RCT 2333"
+    ]
+  },
+  "RCT 1213": {
+    "text": "Admission to the RCT Program",
+    "courses": []
+  },
+  "RCT 1223": {
+    "text": "Admission to the RCT Program",
+    "courses": []
+  },
+  "RCT 1313": {
+    "text": "Admission to the RCT Program",
+    "courses": []
+  },
+  "RCT 1322": {
+    "text": "RCT 1313 - Cardiopulmonary Anatomy and Physiology , or instructor approval. (2,1,2)",
+    "courses": [
+      "RCT 1313"
+    ]
+  },
+  "RCT 1323": {
+    "text": "RCT 1515 , RCT 1424 , RCT 2333 , and RCT 1021 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 1021",
+      "RCT 1424",
+      "RCT 1515",
+      "RCT 2333"
+    ]
+  },
+  "RCT 1415": {
+    "text": "program admission",
+    "courses": []
+  },
+  "RCT 1416": {
+    "text": "BIO 2514 , BIO 2524 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524"
+    ]
+  },
+  "RCT 1424": {
+    "text": "RCT 1415",
+    "courses": [
+      "RCT 1415"
+    ]
+  },
+  "RCT 1425": {
+    "text": "RCT 1416 - Respiratory Care Technology I . (5,3,4)",
+    "courses": [
+      "RCT 1416"
+    ]
+  },
+  "RCT 1515": {
+    "text": "RCT 1213 , RCT 1223 , RCT 1313 , RCT 1611",
+    "courses": [
+      "RCT 1213",
+      "RCT 1223",
+      "RCT 1313",
+      "RCT 1611"
+    ]
+  },
+  "RCT 1516": {
+    "text": "Anatomy and Physiology I and II (BIO 2513 and BIO 2523 ), RCT 1223 - Patient Assessment And Planning , RCT 1213 - Respiratory Care Science , and RCT 1313 - Cardiopulmonary Anatomy And Physiology",
+    "courses": [
+      "BIO 2513",
+      "BIO 2523",
+      "RCT 1213",
+      "RCT 1223",
+      "RCT 1313"
+    ]
+  },
+  "RCT 1523": {
+    "text": "RCT 1516",
+    "courses": [
+      "RCT 1516"
+    ]
+  },
+  "RCT 1611": {
+    "text": "Admission to the RCT Program",
+    "courses": []
+  },
+  "RCT 1613": {
+    "text": "BIO 2514 , BIO 2524 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "BIO 2514",
+      "BIO 2524"
+    ]
+  },
+  "RCT 2031": {
+    "text": "None Corequisite: RCT 2534 and RCT 2434 Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 2434",
+      "RCT 2534"
+    ]
+  },
+  "RCT 2333": {
+    "text": "RCT 1313",
+    "courses": [
+      "RCT 1313"
+    ]
+  },
+  "RCT 2434": {
+    "text": "Clinical Practice II (RCT 1523 ). (4,3,2)",
+    "courses": [
+      "RCT 1523"
+    ]
+  },
+  "RCT 2533": {
+    "text": "RCT 1523",
+    "courses": [
+      "RCT 1523"
+    ]
+  },
+  "RCT 2534": {
+    "text": "RCT 1323 and RCT 1524 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 1323",
+      "RCT 1524"
+    ]
+  },
+  "RCT 2545": {
+    "text": "RCT 1515 , RCT 1523 , RCT 2533",
+    "courses": [
+      "RCT 1515",
+      "RCT 1523",
+      "RCT 2533"
+    ]
+  },
+  "RCT 2546": {
+    "text": "Clinical Practice I (RCT 1516 ), Clinical Practice II (RCT 1523 ), Clinical Practice III (RCT 2534 )",
+    "courses": [
+      "RCT 1516",
+      "RCT 1523",
+      "RCT 2534"
+    ]
+  },
+  "RCT 2613": {
+    "text": "Respiratory Care Practitioner II (RCT 1424 ) or instructor’s approval",
+    "courses": [
+      "RCT 1424"
+    ]
+  },
+  "RCT 2614": {
+    "text": "RCT 2534 , RCT 2434 , and RCT 2031 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 2031",
+      "RCT 2434",
+      "RCT 2534"
+    ]
+  },
+  "RCT 2622": {
+    "text": "RCT 1611 , RCT 1213 , RCT 1313 , RCT 1223",
+    "courses": [
+      "RCT 1213",
+      "RCT 1223",
+      "RCT 1313",
+      "RCT 1611"
+    ]
+  },
+  "RCT 2712": {
+    "text": "RCT 2434",
+    "courses": [
+      "RCT 2434"
+    ]
+  },
+  "RCT 2713": {
+    "text": "RCT 2534 , RCT 2434 , and RCT 2031 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "RCT 2031",
+      "RCT 2434",
+      "RCT 2534"
+    ]
+  },
+  "REA 1213": {
+    "text": "ACT® Reading subscore of 1-16, or ACCUPLACER Reading score of 1-75, or Next-Generation ACCUPLACER Reading score of 200-245",
+    "courses": []
+  },
+  "RET 2723": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "RGT 1113": {
+    "text": "CPR-Health Care Provider must be completed before Clinical Education I experience begins. (3,0,9)",
+    "courses": []
+  },
+  "RGT 1114": {
+    "text": "RGT 1212 , RGT 1223 , HIT 1213 , ENG 1113",
+    "courses": [
+      "ENG 1113",
+      "HIT 1213",
+      "RGT 1212",
+      "RGT 1223"
+    ]
+  },
+  "RGT 1124": {
+    "text": "RGT 1114 , RGT 1513 , RGT 1613 , RGT 1322",
+    "courses": [
+      "RGT 1114",
+      "RGT 1322",
+      "RGT 1513",
+      "RGT 1613"
+    ]
+  },
+  "RGT 1134": {
+    "text": "RGT 1124 , RGT 1312 , RGT 1333 , RGT 1523 , Humanities/Fine Arts Elective",
+    "courses": [
+      "RGT 1124",
+      "RGT 1312",
+      "RGT 1333",
+      "RGT 1523"
+    ]
+  },
+  "RGT 1136": {
+    "text": "RGT 1125 (6,0,18)",
+    "courses": [
+      "RGT 1125"
+    ]
+  },
+  "RGT 1137": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "RGT 1139": {
+    "text": "RGT 1124",
+    "courses": [
+      "RGT 1124"
+    ]
+  },
+  "RGT 1212": {
+    "text": "BIO 2511 , BIO 2513 , BIO 2521 , BIO 2523 , MAT 1313 ) (Corequisites: HIT 1213 , ENG 1113 ) This course is an introduction to Radiologic Technology including professional, departmental, and historical aspects. Included are terminology, medical ethics, and fundamental legal responsibilities. (2 hr lecture)",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "ENG 1113",
+      "HIT 1213",
+      "MAT 1313"
+    ]
+  },
+  "RGT 1222": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "RGT 1223": {
+    "text": "RGT 1212",
+    "courses": [
+      "RGT 1212"
+    ]
+  },
+  "RGT 1312": {
+    "text": "RGT 1114 , RGT 1513 , RGT 1613 , RGT 1322",
+    "courses": [
+      "RGT 1114",
+      "RGT 1322",
+      "RGT 1513",
+      "RGT 1613"
+    ]
+  },
+  "RGT 1322": {
+    "text": "RGT 1212 , RGT 1223 , HIT 1213 , ENG 1113",
+    "courses": [
+      "ENG 1113",
+      "HIT 1213",
+      "RGT 1212",
+      "RGT 1223"
+    ]
+  },
+  "RGT 1323": {
+    "text": "RGT 1213",
+    "courses": [
+      "RGT 1213"
+    ]
+  },
+  "RGT 1333": {
+    "text": "RGT 1114 , RGT 1322 , RGT 1513 , RGT 1613",
+    "courses": [
+      "RGT 1114",
+      "RGT 1322",
+      "RGT 1513",
+      "RGT 1613"
+    ]
+  },
+  "RGT 1513": {
+    "text": "RGT 1212 , RGT 1223 , HIT 1213 , ENG 1113",
+    "courses": [
+      "ENG 1113",
+      "HIT 1213",
+      "RGT 1212",
+      "RGT 1223"
+    ]
+  },
+  "RGT 1523": {
+    "text": "RGT 1513 (3,2,2)",
+    "courses": [
+      "RGT 1513"
+    ]
+  },
+  "RGT 1613": {
+    "text": "RGT 1212 , RGT 1223 , HIT 1213 , ENG 1113",
+    "courses": [
+      "ENG 1113",
+      "HIT 1213",
+      "RGT 1212",
+      "RGT 1223"
+    ]
+  },
+  "RGT 2132": {
+    "text": "RGT 1212 (2,2,0)",
+    "courses": [
+      "RGT 1212"
+    ]
+  },
+  "RGT 2146": {
+    "text": "RGT 1136 . (6,0,18)",
+    "courses": [
+      "RGT 1136"
+    ]
+  },
+  "RGT 2147": {
+    "text": "RGT 1139",
+    "courses": [
+      "RGT 1139"
+    ]
+  },
+  "RGT 2156": {
+    "text": "RGT 2146 . (6,0,18)",
+    "courses": [
+      "RGT 2146"
+    ]
+  },
+  "RGT 2157": {
+    "text": "RGT 2147",
+    "courses": [
+      "RGT 2147"
+    ]
+  },
+  "RGT 2532": {
+    "text": "RGT 1523 (2,1,2)",
+    "courses": [
+      "RGT 1523"
+    ]
+  },
+  "RGT 2533": {
+    "text": "RGT 1523",
+    "courses": [
+      "RGT 1523"
+    ]
+  },
+  "RGT 2542": {
+    "text": "RGT 2532 (2,2,0)",
+    "courses": [
+      "RGT 2532"
+    ]
+  },
+  "RGT 2911": {
+    "text": "RGT 1312 , RGT 2146 , RGT 2532 , RGT 2132 , RGT 2922 , Social/Behavioral Science Elective, CSC 1113 or IST 1264 ) (Corequisites: RGT 2156 , RGT 2542 , RGT 2933 , SPT 1113 or SPT 2173 ) This course is a study of the biological effects of radiation upon living matter. It includes genetic and somatic effects. (1 hr lecture)",
+    "courses": [
+      "CSC 1113",
+      "IST 1264",
+      "RGT 1312",
+      "RGT 2132",
+      "RGT 2146",
+      "RGT 2156",
+      "RGT 2532",
+      "RGT 2542",
+      "RGT 2922",
+      "RGT 2933",
+      "SPT 1113",
+      "SPT 2173"
+    ]
+  },
+  "RGT 2912": {
+    "text": "RGT 1312",
+    "courses": [
+      "RGT 1312"
+    ]
+  },
+  "RGT 2922": {
+    "text": "RGT 1134",
+    "courses": [
+      "RGT 1134"
+    ]
+  },
+  "RGT 2933": {
+    "text": "RGT 2146 , RGT 2532 , RGT 2132 , RGT 2922 , Social/Behavioral Science Elective, CSC 1113 or IST 1264 ) (Corequisites: RGT 2156 , RGT 2542 , RGT 2911 , SPT 1113 or SPT 2173 ) This course is designed to correlate scientific components of radiography to entry-level knowledge required by the profession. (3 hr lecture)",
+    "courses": [
+      "CSC 1113",
+      "IST 1264",
+      "RGT 2132",
+      "RGT 2146",
+      "RGT 2156",
+      "RGT 2532",
+      "RGT 2542",
+      "RGT 2911",
+      "RGT 2922",
+      "SPT 1113",
+      "SPT 2173"
+    ]
+  },
+  "ROT 1113": {
+    "text": "EET 1123 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "EET 1123"
+    ]
+  },
+  "ROT 1213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "RST 2213": {
+    "text": "Sophomore standing and Instructor approval",
+    "courses": []
+  },
+  "RST 2223": {
+    "text": "RST 2213",
+    "courses": [
+      "RST 2213"
+    ]
+  },
+  "RST 2323": {
+    "text": "RST 2313",
+    "courses": [
+      "RST 2313"
+    ]
+  },
+  "SOC 1112": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "SOC 1113": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "SOC 2113": {
+    "text": "ENG 0124 or higher",
+    "courses": [
+      "ENG 0124"
+    ]
+  },
+  "SOC 2133": {
+    "text": "SOC 2113 ; ENG 0124 or higher",
+    "courses": [
+      "ENG 0124",
+      "SOC 2113"
+    ]
+  },
+  "SOC 2143": {
+    "text": "ENG 1113 or ENG 1114 ; SOC 2113",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "SOC 2113"
+    ]
+  },
+  "SOC 2213": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SOC 2223": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SOC 2313": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 1113": {
+    "text": "ENG 1114 or ENG 1113 ; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 1123": {
+    "text": "SPT 1113",
+    "courses": [
+      "SPT 1113"
+    ]
+  },
+  "SPT 1153": {
+    "text": "ENG 1114 or ENG 1113 ; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 1233": {
+    "text": "ENG 1114 or ENG 1113 or higher; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 1241": {
+    "text": "ENG 1114 or ENG 1113 ; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 1242": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 1252": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 1273": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 2143": {
+    "text": "ENG 1114 or ENG 1113 or higher; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 2173": {
+    "text": "ENG 1114 or ENG 1113 or higher; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 2223": {
+    "text": "ENG 0124 or higher; REA 1213",
+    "courses": [
+      "ENG 0124",
+      "REA 1213"
+    ]
+  },
+  "SPT 2233": {
+    "text": "ENG 1114 or ENG 1113 or higher; REA 1213",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "REA 1213"
+    ]
+  },
+  "SPT 2242": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 2252": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 2263": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SPT 2283": {
+    "text": "SPT 1233",
+    "courses": [
+      "SPT 1233"
+    ]
+  },
+  "SUT 1113": {
+    "text": "BIO 2511 ; BIO 2513 ; BIO 2521 ; BIO 2523 ; ENG 1113 ; MAT 1233 or MAT 1134 or MAT 1133 ; and Humanities Elective",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "ENG 1113",
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1233"
+    ]
+  },
+  "SUT 1216": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SUT 1217": {
+    "text": "BIO 2511 ; BIO 2513 ; BIO 2521 ; BIO 2523 ; ENG 1113 ; MAT 1233 or MAT 1134 or MAT 1133 ; and Humanities Elective",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "ENG 1113",
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1233"
+    ]
+  },
+  "SUT 1313": {
+    "text": "BIO 2511 ; BIO 2513 ; BIO 2521 ; BIO 2523 ; ENG 1113 ; MAT 1233 or MAT 1134 or MAT 1133 ; and Humanities Elective",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "ENG 1113",
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1233"
+    ]
+  },
+  "SUT 1314": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SUT 1413": {
+    "text": "BIO 2511 ; BIO 2513 ; BIO 2521 ; BIO 2523 ; ENG 1113 ; MAT 1233 or MAT 1134 or MAT 1133 ; and Humanities Elective",
+    "courses": [
+      "BIO 2511",
+      "BIO 2513",
+      "BIO 2521",
+      "BIO 2523",
+      "ENG 1113",
+      "MAT 1133",
+      "MAT 1134",
+      "MAT 1233"
+    ]
+  },
+  "SUT 1517": {
+    "text": "All First Semester Courses",
+    "courses": []
+  },
+  "SUT 1518": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SUT 1527": {
+    "text": "SUT 1517",
+    "courses": [
+      "SUT 1517"
+    ]
+  },
+  "SUT 1528": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SUT 1529": {
+    "text": "CPR-Health Care Provider and all first semester courses",
+    "courses": []
+  },
+  "SUT 1538": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SUT 1539": {
+    "text": "All Spring Semester Courses",
+    "courses": []
+  },
+  "SUT 1614": {
+    "text": "SUT 1113 , SUT 1217 , SUT 1413 . Corequisites: SUT 1624 , SUT 1714 (4,4,0)",
+    "courses": [
+      "SUT 1113",
+      "SUT 1217",
+      "SUT 1413",
+      "SUT 1624",
+      "SUT 1714"
+    ]
+  },
+  "SUT 1624": {
+    "text": "SUT 1113 , SUT 1217 , SUT 1413 . Corequisites: SUT 1614 , SUT 1714 (4,4,0)",
+    "courses": [
+      "SUT 1113",
+      "SUT 1217",
+      "SUT 1413",
+      "SUT 1614",
+      "SUT 1714"
+    ]
+  },
+  "SUT 1634": {
+    "text": "SUT 1113 , SUT 1217 , SUT 1413 , SUT 1614 , SUT 1624 , SUT 1714 Corequisites: SUT 1703 , SUT 1724 , SUT 1735 (4,4,0)",
+    "courses": [
+      "SUT 1113",
+      "SUT 1217",
+      "SUT 1413",
+      "SUT 1614",
+      "SUT 1624",
+      "SUT 1703",
+      "SUT 1714",
+      "SUT 1724",
+      "SUT 1735"
+    ]
+  },
+  "SUT 1703": {
+    "text": "All 1st and 2nd semester coursework. Corequisites: SUT 1634 , SUT 1724 , SUT 1735 (3,3,0)",
+    "courses": [
+      "SUT 1634",
+      "SUT 1724",
+      "SUT 1735"
+    ]
+  },
+  "SUT 1714": {
+    "text": "SUT 1113 , SUT 1217 , SUT 1413 . Corequisites: SUT 1614 , SUT 1624 (4,0,12)",
+    "courses": [
+      "SUT 1113",
+      "SUT 1217",
+      "SUT 1413",
+      "SUT 1614",
+      "SUT 1624"
+    ]
+  },
+  "SUT 1724": {
+    "text": "All 1st and 2nd semester coursework. Corequisites: SUT 1634 , SUT 1703 , SUT 1735 (4,0,12)",
+    "courses": [
+      "SUT 1634",
+      "SUT 1703",
+      "SUT 1735"
+    ]
+  },
+  "SUT 1735": {
+    "text": "All 1st and 2nd semester coursework. Corequisites: SUT 1634 , SUT 1703 , SUT 1724 (5,0,15)",
+    "courses": [
+      "SUT 1634",
+      "SUT 1703",
+      "SUT 1724"
+    ]
+  },
+  "SUT 1911": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SUT 1921": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SWK 1113": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "SWK 2223": {
+    "text": "ENG 1113 or ENG 1114 or higher; PSY 1513 ; SOC 2113",
+    "courses": [
+      "ENG 1113",
+      "ENG 1114",
+      "PSY 1513",
+      "SOC 2113"
+    ]
+  },
+  "TCT 1113": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 1910": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 1920": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 1930": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 1940": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2243": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2353": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2364": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2413": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2414": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "TCT 2424": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2911": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2912": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2913": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2914": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "TCT 2921": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2922": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2923": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2924": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2925": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "TCT 2926": {
+    "text": "Instructor Approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "UTL 1132": {
+    "text": "Instructor approval Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "UTL 1192": {
+    "text": "Instructor approved Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "UTL 1213": {
+    "text": "Instructor approved Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "UTL 1413": {
+    "text": "Instructor approved Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "UTL 1513": {
+    "text": "Instructor approved Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "VAT 1112": {
+    "text": "Must be accepted into Veterinary Technology program to enroll in this course. ACT® English subscore of 14 or higher",
+    "courses": []
+  },
+  "VAT 1122": {
+    "text": "Must be accepted into Veterinary Technology program to enroll in this course. ACT® English subscore of 14 or higher",
+    "courses": []
+  },
+  "VAT 1212": {
+    "text": "Must be accepted into Veterinary Technology program to enroll in this course. ACT® English subscore of 14 or higher",
+    "courses": []
+  },
+  "VAT 1314": {
+    "text": "Must be accepted into Veterinary Technology program to enroll in this course. ACT® English subscore of 14 or higher",
+    "courses": []
+  },
+  "VAT 1413": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 1433": {
+    "text": "Must be accepted into Veterinary Technology program to enroll in this course. ACT® English subscore of 14 or higher",
+    "courses": []
+  },
+  "VAT 1443": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2113": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2122": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2133": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2143": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2152": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2172": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2183": {
+    "text": "Successful completion of all academic and technical courses in the Veterinary Technology curriculum with an overall GPA of 2.0 and a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2192": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2223": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2272": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "VAT 2283": {
+    "text": "Successful completion of previous Veterinary Technology semesters with a grade of “C” or higher on each individual VAT course",
+    "courses": []
+  },
+  "WBL 1911": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1912": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1913": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1921": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1922": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1923": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1924": {
+    "text": "One from WBL 1911 , WBL 1912 , WBL 1913 , or WBL 1914",
+    "courses": [
+      "WBL 1911",
+      "WBL 1912",
+      "WBL 1913",
+      "WBL 1914"
+    ]
+  },
+  "WBL 1931": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1932": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1933": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 1934": {
+    "text": "One from WBL 1911 , WBL 1912 , WBL 1913 , or WBL 1914 ; and One from WBL 1921 , WBL 1922 , WBL 1923 , or WBL 1924 )",
+    "courses": [
+      "WBL 1911",
+      "WBL 1912",
+      "WBL 1913",
+      "WBL 1914",
+      "WBL 1921",
+      "WBL 1922",
+      "WBL 1923",
+      "WBL 1924"
+    ]
+  },
+  "WBL 2911": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2912": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2913": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2914": {
+    "text": "One from WBL 1911 , WBL 1912 , WBL 1913 , or WBL 1914 ; One from WBL 1921 , WBL 1922 , WBL 1923 , or WBL 1924 ; and One from WBL 1931 , WBL 1932 , WBL 1933 , or WBL 1934 ) A structured work-site learning experience in which the student, program area teacher, Work-Based Learning Coordinator, and work-site supervisor/mentor develop and implement an educational training agreement. This site is designed to integrate the student’s academic and technical skills into a work environment, and may include regular meetings and seminars with school personnel for supplemental instruction and progress reviews. (12 hr externship)",
+    "courses": [
+      "WBL 1911",
+      "WBL 1912",
+      "WBL 1913",
+      "WBL 1914",
+      "WBL 1921",
+      "WBL 1922",
+      "WBL 1923",
+      "WBL 1924",
+      "WBL 1931",
+      "WBL 1932",
+      "WBL 1933",
+      "WBL 1934"
+    ]
+  },
+  "WBL 2921": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2922": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2923": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2931": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2932": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WBL 2933": {
+    "text": "None Corequisite: Enrollment in Career and Technical Education program area courses. Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WDT 1414": {
+    "text": "WDT 1123",
+    "courses": [
+      "WDT 1123"
+    ]
+  },
+  "WLT 1114": {
+    "text": "WLT 1173 . (4,1,6)",
+    "courses": [
+      "WLT 1173"
+    ]
+  },
+  "WLT 1115": {
+    "text": "WLT 1173 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "WLT 1173"
+    ]
+  },
+  "WLT 1124": {
+    "text": "WLT 1225 . (4,1,6)",
+    "courses": [
+      "WLT 1225"
+    ]
+  },
+  "WLT 1135": {
+    "text": "WLT 1143 . (5,1,8)",
+    "courses": [
+      "WLT 1143"
+    ]
+  },
+  "WLT 1143": {
+    "text": "WLT 1225 . (3,1,4)",
+    "courses": [
+      "WLT 1225"
+    ]
+  },
+  "WLT 1155": {
+    "text": "WLT 1135 . (5,1,8)",
+    "courses": [
+      "WLT 1135"
+    ]
+  },
+  "WLT 1162": {
+    "text": "WLT 1124 . (2,1,2)",
+    "courses": [
+      "WLT 1124"
+    ]
+  },
+  "WLT 1173": {
+    "text": "None Corequisite: None Prerequisite/Corequisite: None",
+    "courses": []
+  },
+  "WLT 1225": {
+    "text": "WLT 1114 . (5,1,8)",
+    "courses": [
+      "WLT 1114"
+    ]
+  },
+  "WLT 1232": {
+    "text": "WLT 1173 Corequisite: None Prerequisite/Corequisite: None",
+    "courses": [
+      "WLT 1173"
+    ]
+  },
+  "WLT 1252": {
+    "text": "WLT 1155 . (2,1,2)",
+    "courses": [
+      "WLT 1155"
+    ]
+  },
+  "WLT 1313": {
+    "text": "WLT 1173 . (3,1,4)",
+    "courses": [
+      "WLT 1173"
+    ]
+  },
+  "WLT 1914": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "WLT 1921": {
+    "text": "Consent of Instructor",
+    "courses": []
+  },
+  "WLT 2524": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "WLT 2812": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "WLT 2913": {
+    "text": "Instructor Approval",
+    "courses": []
   }
 }

--- a/scripts/ms/scrape-catalog-prereqs.ts
+++ b/scripts/ms/scrape-catalog-prereqs.ts
@@ -30,6 +30,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { chromium } from "playwright";
 import { discoverAcalogCatoid } from "../lib/discover-catalog.js";
 
 const UA =
@@ -107,16 +108,53 @@ interface CourseDetail {
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+// Per-domain WAF cookies acquired via Playwright.
+const wafCookies = new Map<string, string>();
+
+async function acquireWafCookies(baseUrl: string): Promise<string> {
+  const cached = wafCookies.get(baseUrl);
+  if (cached) return cached;
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const ctx = await browser.newContext({ userAgent: UA });
+    const page = await ctx.newPage();
+    await page.goto(baseUrl, { waitUntil: "networkidle", timeout: 30_000 });
+    const cookies = await ctx.cookies();
+    const cookieStr = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    wafCookies.set(baseUrl, cookieStr);
+    return cookieStr;
+  } finally {
+    await browser.close();
+  }
+}
+
+async function retryFetch(
+  url: string,
+  label: string,
+  attempts = 3,
+  baseUrl?: string,
+): Promise<string> {
   let lastErr: unknown;
   for (let i = 0; i < attempts; i++) {
     try {
-      const res = await fetch(url, {
-        headers: {
-          "User-Agent": UA,
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        },
-      });
+      const headers: Record<string, string> = {
+        "User-Agent": UA,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      };
+      if (baseUrl) {
+        const cookies = wafCookies.get(baseUrl);
+        if (cookies) headers["Cookie"] = cookies;
+      }
+      const res = await fetch(url, { headers });
+
+      // 202 = Imperva WAF challenge — acquire cookies via Playwright and retry
+      if (res.status === 202 && baseUrl && i === 0) {
+        console.log(`  WAF challenge on ${label}, acquiring cookies via browser...`);
+        await acquireWafCookies(baseUrl);
+        continue;
+      }
+
       if (res.ok) return res.text();
       if (res.status >= 500) {
         lastErr = new Error(`HTTP ${res.status}`);
@@ -266,6 +304,21 @@ async function scrapeCollege(
   console.log(`\n--- ${config.name} (${slug}) ---`);
   console.log(`  Base: ${config.base}`);
 
+  // Pre-acquire WAF cookies before any fetch (including catoid discovery)
+  try {
+    const probe = await fetch(config.base, {
+      headers: { "User-Agent": UA },
+      redirect: "follow",
+    });
+    if (probe.status === 202) {
+      console.log(`  WAF detected, acquiring cookies via browser...`);
+      await acquireWafCookies(config.base);
+    }
+  } catch {
+    console.log(`  Probe failed (network error), trying WAF acquisition anyway...`);
+    await acquireWafCookies(config.base);
+  }
+
   let catoid = config.catoid;
   try {
     const discovered = await discoverAcalogCatoid(config.base, config.catoid);
@@ -281,6 +334,8 @@ async function scrapeCollege(
     const html = await retryFetch(
       listUrl(config.base, catoid, config.navoid, cpage),
       `${slug}/list(cpage=${cpage})`,
+      3,
+      config.base,
     );
     const coids = extractCoids(html);
     if (coids.length === 0) break;
@@ -302,6 +357,8 @@ async function scrapeCollege(
     const html = await retryFetch(
       detailUrl(config.base, catoid, coid),
       `${slug}/detail(${coid})`,
+      3,
+      config.base,
     );
     if (!html) return;
     const code = extractCourseCode(html);


### PR DESCRIPTION
## What changes for site users

Mississippi course pages now show prerequisite information for 1,848 courses (up from 216). Students searching for classes at Hinds CC, JCJC, Meridian CC, or Northwest MS CC will see prereq requirements they couldn't before.

## What changed technically

5 of 6 MS college Acalog catalogs sit behind an Imperva WAF that returns `202 Accepted` + a JavaScript challenge, blocking Node's `fetch()`. The scraper now launches a headless Playwright browser to solve the WAF challenge, extracts cookies, and reuses them for subsequent `fetch()` calls.

| College | Before | After |
|---------|--------|-------|
| MGCCC | 213 | 291 (+78 new from full page fetch) |
| Hinds CC | 0 | 928 |
| JCJC | 0 | 230 |
| Meridian CC | 0 | 1,035 |
| Northwest MS CC | 0 | 209 |
| East MS CC | 0 | 0 (stricter WAF — TLS fingerprint blocks even with valid cookies) |
| **Total** | **216** | **1,848** |

East MS CC is the remaining gap — its WAF blocks Node entirely at the TLS level. A future PR could use Playwright's in-browser `page.evaluate(fetch(...))` to scrape it.

## Test plan
- [x] Ran `npx tsx scripts/ms/scrape-catalog-prereqs.ts` — 5/6 colleges succeed
- [x] Verified `data/ms/prereqs.json` contains 1,848 entries with valid text + course arrays
- [ ] Load `/ms` in local dev, search for a course with prereqs (e.g. BIO 2424), confirm prereqs display

🤖 Generated with [Claude Code](https://claude.com/claude-code)