### PR TITLE
feat(me): MaineStreet PeopleSoft scraper — 43K in-state transfers

### DIFF
--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -20,20 +20,12 @@ const meConfig: StateConfig = {
       "Maine law allows residents aged 65+ to audit credit courses at Maine Community College System institutions tuition-free on a space-available basis.",
   },
 
-  // CollegeTransfer.Net is the wrong source for ME: across the 4 MCCS
-  // colleges that fit under the free-tier API quota (CMCC/EMCC/KVCC/NMCC),
-  // 1,649 raw equivalencies target zero in-state institutions. The
-  // authoritative in-state source is UMaine's MaineStreet Transfer
-  // Equivalency Guest portal at
-  // https://mainestreetcs.maine.edu/psp/CSPRDG/EMPLOYEE/SA/c/UM_SA.UM_TRNSFER_GUEST.GBL
-  // — PeopleSoft, no login required, ~49 (MCCS-sender × UMS-receiver)
-  // pairs. Building that scraper is tracked separately. Until then, the
-  // me-transfers cron job is removed from `scrapers` below (2026-05) so
-  // empty output stops being flagged as a regression. Flip
-  // `transferSupported` back to true once a MaineStreet scraper lands.
-  // The CT.Net script `scripts/me/scrape-transfer.ts` is retained for
-  // manual use if the in-state rule is ever relaxed.
-  transferSupported: false,
+  // In-state transfers sourced from UMaine's MaineStreet Transfer
+  // Equivalency Guest portal (PeopleSoft, no login required). The
+  // old CollegeTransfer.Net script (`scripts/me/scrape-transfer.ts`)
+  // is retained manual-only for out-of-state use if the in-state rule
+  // is ever relaxed.
+  transferSupported: true,
   popularCourses: ["ENG 101", "MAT 101", "BIO 101", "PSY 101", "HIS 101", "SOC 101"],
   defaultZip: "04101",
   defaultZipCity: "Portland",
@@ -60,15 +52,16 @@ const meConfig: StateConfig = {
     ],
   },
   universityAliases: [
-    { slug: "umaine", names: ["UMaine", "University of Maine", "Maine"] },
+    { slug: "uma", names: ["UMA", "University of Maine at Augusta"] },
+    { slug: "umf", names: ["UMF", "University of Maine at Farmington"] },
+    { slug: "umfk", names: ["UMFK", "University of Maine at Fort Kent"] },
+    { slug: "umaine", names: ["UMaine", "University of Maine", "University of Maine & University of Maine at Machias"] },
     { slug: "usm", names: ["USM", "University of Southern Maine"] },
-    { slug: "bowdoin", names: ["Bowdoin", "Bowdoin College"] },
-    { slug: "bates", names: ["Bates", "Bates College"] },
-    { slug: "colby", names: ["Colby", "Colby College"] },
+    { slug: "umpi", names: ["UMPI", "University of Maine at Presque Isle"] },
   ],
   scrapers: {
     courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
-    // manual-only: transfers — CT.Net has zero in-state targets for ME; MaineStreet PeopleSoft scraper is the real fix. See `transferSupported` comment above.
+    transfers: [{ scripts: ["scripts/me/scrape-transfer-mainestreet.ts"], runner: "playwright" }],
     // manual-only: prereqs — ME prereq scraper not yet built. Tracked in #106.
     // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },

--- a/scripts/me/scrape-transfer-mainestreet.ts
+++ b/scripts/me/scrape-transfer-mainestreet.ts
@@ -1,0 +1,339 @@
+/**
+ * scrape-transfer-mainestreet.ts
+ *
+ * Scrapes in-state transfer equivalencies from UMaine's MaineStreet
+ * Transfer Equivalency Guest portal (PeopleSoft Classic, no login).
+ *
+ * For each combination of MCCS sending college (7) × UMS receiving
+ * campus (6), navigates the stateful PeopleSoft form, clicks
+ * "Show All Subjects", and extracts the equivalency grid.
+ *
+ * Usage:
+ *   npx tsx scripts/me/scrape-transfer-mainestreet.ts
+ *   npx tsx scripts/me/scrape-transfer-mainestreet.ts --no-import
+ */
+
+import fs from "fs";
+import path from "path";
+import { chromium, type Page, type Frame } from "playwright";
+import { importTransfersToSupabase } from "../lib/supabase-import.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TransferMapping {
+  cc_prefix: string;
+  cc_number: string;
+  cc_course: string;
+  cc_title: string;
+  cc_credits: string;
+  university: string;
+  university_name: string;
+  univ_course: string;
+  univ_title: string;
+  univ_credits: string;
+  notes: string;
+  no_credit: boolean;
+  is_elective: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PORTAL_URL =
+  "https://mainestreetcs.maine.edu/psp/CSPRDG/EMPLOYEE/SA/c/UM_SA.UM_TRNSFER_GUEST.GBL";
+
+interface UmsTarget {
+  radioId: string;
+  slug: string;
+  name: string;
+}
+
+const UMS_TARGETS: UmsTarget[] = [
+  { radioId: "UM_TRNEQUIV_DRV_UM_SFOE", slug: "uma", name: "University of Maine at Augusta" },
+  { radioId: "UM_TRNEQUIV_DRV_UM_SFOE$112$", slug: "umf", name: "University of Maine at Farmington" },
+  { radioId: "UM_TRNEQUIV_DRV_UM_SFOE$113$", slug: "umfk", name: "University of Maine at Fort Kent" },
+  { radioId: "UM_TRNEQUIV_DRV_UM_SFOE$115$", slug: "umaine", name: "University of Maine & University of Maine at Machias" },
+  { radioId: "UM_TRNEQUIV_DRV_UM_SFOE$116$", slug: "usm", name: "University of Southern Maine" },
+  { radioId: "UM_TRNEQUIV_DRV_UM_SFOE$117$", slug: "umpi", name: "University of Maine at Presque Isle" },
+];
+
+interface MccsCollege {
+  slug: string;
+  name: string;
+  portalName: string;
+  letter: string;
+}
+
+const MCCS_COLLEGES: MccsCollege[] = [
+  { slug: "cmcc", name: "Central Maine Community College", portalName: "Central Maine Cmty College", letter: "C" },
+  { slug: "emcc", name: "Eastern Maine Community College", portalName: "Eastern Maine Cmty College", letter: "E" },
+  { slug: "kvcc", name: "Kennebec Valley Community College", portalName: "Kennebec Valley Cmty Coll", letter: "K" },
+  { slug: "nmcc", name: "Northern Maine Community College", portalName: "Northern Maine Cmty College", letter: "N" },
+  { slug: "smcc", name: "Southern Maine Community College", portalName: "Southern Maine Cmty College", letter: "S" },
+  { slug: "wccc", name: "Washington County Community College", portalName: "Washington County Cmty Coll", letter: "W" },
+  { slug: "yccc", name: "York County Community College", portalName: "York County Cmty College", letter: "Y" },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function normalizeCourse(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim();
+}
+
+function isElectiveCourse(course: string, title: string): boolean {
+  if (/X{2,}$/.test(course.split(" ").pop() || "")) return true;
+  const t = title.toLowerCase();
+  if (/^(elective|transfer\s+credit|general\s+elective)/.test(t)) return true;
+  if (/elective\s*-?\s*\d{3}\s*level/i.test(t)) return true;
+  return false;
+}
+
+async function getFrame(page: Page): Promise<Frame> {
+  const frame = page.frame("TargetContent");
+  if (!frame) throw new Error("TargetContent frame not found");
+  return frame;
+}
+
+async function waitForPS(page: Page, ms = 5000): Promise<void> {
+  await page.waitForTimeout(ms);
+}
+
+// ---------------------------------------------------------------------------
+// Scrape one (MCCS college → UMS campus) pair
+// ---------------------------------------------------------------------------
+
+async function scrapePair(
+  page: Page,
+  cc: MccsCollege,
+  ums: UmsTarget,
+): Promise<TransferMapping[]> {
+  // Step 1: Navigate to landing and click "Transfer courses..."
+  await page.goto(PORTAL_URL, { waitUntil: "networkidle", timeout: 60000 });
+  await waitForPS(page, 4000);
+
+  const contentFrame = await getFrame(page);
+  await contentFrame.click("#UM_TRNEQUIV_DRV_UM_CLEAR_PB");
+  await waitForPS(page, 5000);
+
+  // Step 2: Select UMS target radio button
+  const f2 = await getFrame(page);
+  await f2.click(`[id="${ums.radioId}"]`);
+  await waitForPS(page, 1000);
+
+  // Step 3: Click letter for MCCS college
+  await f2.click(`#UM_TRSFR1_WRK_SSR_ALPHANUM_${cc.letter}`);
+  await waitForPS(page, 5000);
+
+  // Step 4: Find and click the MCCS college in the institution list
+  const f3 = await getFrame(page);
+  const ccLinkId = await f3.evaluate((portalName: string) => {
+    const links = Array.from(document.querySelectorAll("a"));
+    for (const link of links) {
+      const text = link.textContent?.trim() || "";
+      if (text === portalName || text.includes(portalName)) {
+        return link.id;
+      }
+    }
+    return null;
+  }, cc.portalName);
+
+  if (!ccLinkId) {
+    console.log(`    ${cc.slug} not found in ${ums.slug}'s list under letter ${cc.letter} — skipping`);
+    return [];
+  }
+
+  await f3.click(`[id="${ccLinkId}"]`);
+  await waitForPS(page, 5000);
+
+  // Step 5: Click "Show All Subjects"
+  const f4 = await getFrame(page);
+  const hasShowAll = await f4.evaluate(() => !!document.getElementById("UM_TRSFR1_WRK_ALL_VALUES"));
+  if (!hasShowAll) {
+    console.log(`    ${cc.slug} → ${ums.slug}: no subject page — skipping`);
+    return [];
+  }
+  await f4.click("#UM_TRSFR1_WRK_ALL_VALUES");
+  await waitForPS(page, 10000);
+
+  // Step 6: Extract all rows from the equivalency grid
+  const f5 = await getFrame(page);
+  const rows = await f5.evaluate(() => {
+    const results: {
+      fromCourse: string;
+      fromTitle: string;
+      fromUnits: string;
+      toCourse: string;
+      toTitle: string;
+      toUnits: string;
+      genEd: string;
+      isMore: boolean;
+    }[] = [];
+
+    let i = 0;
+    while (true) {
+      const fromEl = document.getElementById(`UM_TRNS_EXT_VW_UM_FROM_COURSE$${i}`);
+      if (!fromEl) break;
+
+      const fromCourse = fromEl.textContent?.trim() || "";
+      const fromTitle = document.getElementById(`UM_TRNS_EXT_VW_DESCR$${i}`)?.textContent?.trim() || "";
+      const fromUnits = document.getElementById(`UM_TRNS_EXT_VW_EXT_UNITS$${i}`)?.textContent?.trim() || "";
+      const toCourse = document.getElementById(`EDIT_PB$span$${i}`)?.textContent?.trim() || "";
+      const toTitle = document.getElementById(`UM_TRNS_EXT_VW_DESCR1$${i}`)?.textContent?.trim() || "";
+      const toUnits = document.getElementById(`UM_TRNS_EXT_VW_UM_UM_UNITS$${i}`)?.textContent?.trim() || "";
+      const genEd = document.getElementById(`UM_TRNS_EXT_VW_DESCRFORMAL$${i}`)?.textContent?.trim() || "";
+      const isMore = toCourse === "More...";
+
+      results.push({ fromCourse, fromTitle, fromUnits, toCourse, toTitle, toUnits, genEd, isMore });
+      i++;
+    }
+    return results;
+  });
+
+  // Convert to TransferMapping format
+  const mappings: TransferMapping[] = [];
+  for (const row of rows) {
+    if (row.isMore) continue;
+
+    const normalized = normalizeCourse(row.toCourse);
+    if (!row.fromCourse || !normalized) continue;
+
+    const srcParts = row.fromCourse.match(/^([A-Z]+)\s+(.+)$/);
+    if (!srcParts) continue;
+    const ccPrefix = srcParts[1];
+    const ccNumber = srcParts[2];
+
+    const isElective = isElectiveCourse(normalized, row.toTitle);
+
+    const notesParts: string[] = [`[${cc.slug}]`];
+    if (row.genEd) notesParts.push(`Gen Ed: ${row.genEd}`);
+    const notes = notesParts.join(" ");
+
+    mappings.push({
+      cc_prefix: ccPrefix,
+      cc_number: ccNumber,
+      cc_course: `${ccPrefix} ${ccNumber}`,
+      cc_title: row.fromTitle,
+      cc_credits: row.fromUnits,
+      university: ums.slug,
+      university_name: ums.name,
+      univ_course: normalized,
+      univ_title: row.toTitle,
+      univ_credits: row.toUnits,
+      notes,
+      no_credit: false,
+      is_elective: isElective,
+    });
+  }
+
+  return mappings;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const skipImport = args.includes("--no-import");
+
+  console.log("MaineStreet Transfer Equivalency Scraper\n");
+  console.log(`  ${MCCS_COLLEGES.length} MCCS colleges × ${UMS_TARGETS.length} UMS targets = ${MCCS_COLLEGES.length * UMS_TARGETS.length} pairs\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const all: TransferMapping[] = [];
+  let pairCount = 0;
+  const pairTotal = MCCS_COLLEGES.length * UMS_TARGETS.length;
+
+  for (const ums of UMS_TARGETS) {
+    for (const cc of MCCS_COLLEGES) {
+      pairCount++;
+      process.stdout.write(`  [${pairCount}/${pairTotal}] ${cc.slug} → ${ums.slug}…`);
+
+      try {
+        const mappings = await scrapePair(page, cc, ums);
+        all.push(...mappings);
+        console.log(` ${mappings.length} mappings`);
+      } catch (err) {
+        console.log(` FAILED: ${(err as Error).message.slice(0, 100)}`);
+      }
+
+      await sleep(500);
+    }
+  }
+
+  await browser.close();
+
+  // Summary
+  const transferable = all.filter((m) => !m.no_credit);
+  const direct = transferable.filter((m) => !m.is_elective).length;
+  const elective = transferable.filter((m) => m.is_elective).length;
+
+  const byUniv = new Map<string, number>();
+  for (const m of transferable) {
+    byUniv.set(m.university_name, (byUniv.get(m.university_name) || 0) + 1);
+  }
+
+  const bySource = new Map<string, number>();
+  for (const m of all) {
+    const slug = m.notes.match(/^\[(\w+)\]/)?.[1] || "?";
+    bySource.set(slug, (bySource.get(slug) || 0) + 1);
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`  Total mappings: ${all.length}`);
+  console.log(`  Transferable: ${transferable.length}`);
+  console.log(`    Direct equivalencies: ${direct}`);
+  console.log(`    Elective credit: ${elective}`);
+  console.log(`  Unique target universities: ${byUniv.size}`);
+  console.log("\n  Per-target counts:");
+  for (const [univ, count] of byUniv) {
+    console.log(`    ${univ}: ${count}`);
+  }
+  console.log("\n  Per-source counts:");
+  for (const [slug, count] of bySource) {
+    console.log(`    ${slug}: ${count}`);
+  }
+
+  // Write output
+  const outPath = path.join(process.cwd(), "data", "me", "transfer-equiv.json");
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(all, null, 2) + "\n");
+  console.log(`\nSaved ${all.length} mappings → ${outPath}`);
+
+  // Import to Supabase
+  if (!skipImport) {
+    try {
+      const imported = await importTransfersToSupabase("me");
+      if (imported > 0) {
+        console.log(`Imported ${imported} rows to Supabase`);
+      }
+    } catch (err) {
+      console.log(`Supabase import skipped: ${(err as Error).message}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Maine's transfer page was empty — every equivalency from CollegeTransfer.Net targeted out-of-state schools, so the in-state filter stripped everything to zero. Now it has **43,027 transfer mappings** covering all 7 MCCS community colleges transferring to all 6 UMaine System campuses. A student at Southern Maine CC can look up how their ENG 101 transfers to USM, UMA, UMaine, etc.

## What changed technically

Built a new Playwright scraper that navigates UMaine's **MaineStreet Transfer Equivalency Guest portal** — a PeopleSoft Classic page with guest access (no login). The portal is stateful: select a UMS receiving campus → pick a letter → click a sending institution → "Show All Subjects" → extract the grid. The scraper runs all 42 pairs (7 MCCS senders × 6 UMS receivers) sequentially, fresh-navigating for each pair to avoid PeopleSoft session state issues.

## Files changed

| File | What |
|---|---|
| `scripts/me/scrape-transfer-mainestreet.ts` | New Playwright scraper for MaineStreet PeopleSoft portal |
| `data/me/transfer-equiv.json` | 43,027 transfer mappings (was empty `[]`) |
| `lib/states/me/config.ts` | `transferSupported: true`, scraper wired into `scrapers.transfers`, university aliases updated for 6 UMS campuses |

## Data breakdown

| UMS Target | Mappings |
|---|---|
| UMaine at Augusta | 9,982 |
| UMaine at Presque Isle | 9,494 |
| UMaine at Fort Kent | 8,389 |
| Southern Maine | 6,301 |
| UMaine & UMaine at Machias | 5,158 |
| UMaine at Farmington | 3,703 |

| MCCS Source | Mappings |
|---|---|
| SMCC (Southern Maine) | 13,517 |
| EMCC (Eastern Maine) | 6,646 |
| CMCC (Central Maine) | 6,320 |
| KVCC (Kennebec Valley) | 5,084 |
| NMCC (Northern Maine) | 4,710 |
| WCCC (Washington County) | 4,165 |
| YCCC (York County) | 2,585 |

- 18,831 direct equivalencies (specific course → specific course)
- 24,196 elective credit (course → `XXX` department elective)
- The old CollegeTransfer.Net scraper (`scrape-transfer.ts`) is retained manual-only

## Test plan

- [x] Scraper ran successfully for all 42 pairs
- [x] Output validates against TransferMapping schema (all required fields present)
- [x] No empty `cc_course` or `univ_course` values
- [x] Elective detection correctly flags `XXX` suffix courses
- [x] TypeScript typecheck passes
- [ ] Verify transfer page renders on local dev after merge

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)