### PR TITLE
fix(cron): wire 4 prereq scrapers into scheduled runs

### DIFF
--- a/lib/states/ky/config.ts
+++ b/lib/states/ky/config.ts
@@ -45,7 +45,9 @@ const kyConfig: StateConfig = {
     courses: [
       { scripts: ["scripts/ky/scrape-courses.ts"], runner: "http" },
     ],
-    prereqs: { source: "aggregate-from-courses" },
+    prereqs: [
+      { scripts: ["scripts/ky/scrape-catalog-prereqs.ts"], runner: "http" },
+    ],
     // manual-only: transfers — no entry in data/articulation-portals.json for KY.
     //   Fallback options: KYTransfer.org (transfer.ky.gov) state portal, or
     //   CollegeTransfer.Net per-college lookup.

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -62,7 +62,7 @@ const meConfig: StateConfig = {
   scrapers: {
     courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
     transfers: [{ scripts: ["scripts/me/scrape-transfer-mainestreet.ts"], runner: "playwright" }],
-    // manual-only: prereqs — ME prereq scraper not yet built. Tracked in #106.
+    prereqs: [{ scripts: ["scripts/me/scrape-catalog-prereqs.ts"], runner: "http" }],
     // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };

--- a/lib/states/ms/config.ts
+++ b/lib/states/ms/config.ts
@@ -36,14 +36,12 @@ const msConfig: StateConfig = {
     ],
   },
   scrapers: {
-    // manual-only: courses — Phase 2 (course scraper) not yet wired up.
-    //   MS colleges use a mix of platforms (Colleague, Banner SSB 9,
-    //   Banner 8, Jenzabar, custom). SIS fingerprinting identifies each
-    //   college's platform for targeted scraping.
-    // manual-only: transfers — Phase 3. Mississippi runs MTAG
-    //   (Mississippi Transfer Agreement Guide) — check as a potential
-    //   Phase 3 source for state-level articulation data.
-    // manual-only: prereqs — Phase 4.
+    // manual-only: courses — MS colleges use a mix of platforms (Colleague,
+    //   Banner SSB 9, Banner 8, Jenzabar, custom). SIS fingerprinting
+    //   identifies each college's platform for targeted scraping.
+    // manual-only: transfers — Mississippi runs MTAG (Mississippi Transfer
+    //   Agreement Guide) — check as a potential source for articulation data.
+    prereqs: [{ scripts: ["scripts/ms/scrape-catalog-prereqs.ts"], runner: "playwright" }],
     // manual-only: programs — Phase 5+.
   },
 };

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -80,7 +80,9 @@ const vaConfig: StateConfig = {
         runner: "http",
       },
     ],
-    prereqs: { source: "aggregate-from-courses" },
+    prereqs: [
+      { scripts: ["scripts/va/scrape-catalog-prereqs.ts"], runner: "http" },
+    ],
     programs: [
       { scripts: ["scripts/va/scrape-programs.ts"], runner: "http" },
       {


### PR DESCRIPTION
## What changes for site users

Nothing visible immediately — prereq data is already live. But going forward, the weekly prereq cron will automatically refresh prereqs for VA, KY, ME, and MS instead of relying on manual runs.

## What changed technically

Four states had catalog prereq scrapers that were built but never declared in `StateConfig.scrapers`, so the `scheduled-scrape.yml` cron never picked them up. This PR wires them in:

| State | Scraper | Runner | Was |
|-------|---------|--------|-----|
| VA | `scrape-catalog-prereqs.ts` | http | `aggregate-from-courses` |
| KY | `scrape-catalog-prereqs.ts` | http | `aggregate-from-courses` |
| ME | `scrape-catalog-prereqs.ts` | http | `manual-only` comment |
| MS | `scrape-catalog-prereqs.ts` | playwright | `manual-only` comment |

MS uses `playwright` runner because 5/6 college catalogs sit behind an Imperva WAF that requires browser-based cookie acquisition.

## Test plan
- [x] `npm run check:scrapers` passes — all 26 states × 4 datatypes accounted for
- [x] Verified each scraper file exists at the declared path

🤖 Generated with [Claude Code](https://claude.com/claude-code)