### PR TITLE
feat(ui): courses-first college page redesign (Option A)

### DIFF
--- a/app/[state]/college/[id]/CollegeDetailClient.tsx
+++ b/app/[state]/college/[id]/CollegeDetailClient.tsx
@@ -25,6 +25,8 @@ interface Props {
   systemName?: string;
   courseListingUrl?: string;
   state?: string;
+  defaultStatusFilter?: string;
+  defaultModeFilter?: string;
 }
 
 export default function CollegeDetailClient({
@@ -35,6 +37,8 @@ export default function CollegeDetailClient({
   transferLookup,
   courseListingUrl,
   state,
+  defaultStatusFilter,
+  defaultModeFilter,
 }: Props) {
   const [selectedCourse, setSelectedCourse] = useState<CourseSection | null>(
     null
@@ -78,6 +82,9 @@ export default function CollegeDetailClient({
         onTogglePin={togglePin}
         transferLookup={transferLookup}
         state={state}
+        groupBySubject
+        defaultStatusFilter={defaultStatusFilter}
+        defaultModeFilter={defaultModeFilter}
       />
 
       <ScheduleBuilder

--- a/app/[state]/college/[id]/CollegeTermSection.tsx
+++ b/app/[state]/college/[id]/CollegeTermSection.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import CollegeDetailClient from "./CollegeDetailClient";
-import TermSelector from "./TermSelector";
 import { termLabel } from "@/lib/term-label";
 import { isInProgress } from "@/lib/course-status";
 import { subjectName } from "@/lib/subjects";
@@ -122,11 +121,19 @@ export default function CollegeTermSection({
   const upcoming = courses.filter((c) => !isInProgress(c.start_date)).length;
   const started = courses.length - upcoming;
 
+  // Quick-filter chip state — drives defaultStatusFilter / defaultModeFilter on
+  // CollegeDetailClient. Keying CollegeDetailClient on this resets CourseTable
+  // filter state each time the chip changes.
+  const [quickFilter, setQuickFilter] = useState<"" | "open" | "online">("");
+
+  const quickStatusFilter = quickFilter === "open" ? "upcoming" : "";
+  const quickModeFilter = quickFilter === "online" ? "online" : "";
+
   return (
     <>
       {/* Staleness warning */}
       {stale && courses.length > 0 && (
-        <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg p-4 mb-6">
+        <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg p-4 mb-4">
           <p className="text-amber-800 dark:text-amber-300 text-sm">
             <strong>Note:</strong> Course data may be outdated (last updated
             more than 3 days ago). Check{" "}
@@ -143,69 +150,94 @@ export default function CollegeTermSection({
         </div>
       )}
 
-      {/* Course Listings */}
-      <section>
-        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-          <div className="flex items-center gap-3">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100">
-              {termLabel(currentTerm)} Courses{" "}
-              <span className="text-gray-500 dark:text-slate-400 font-normal text-base">
-                ({courses.length} sections)
-              </span>
-            </h2>
-            {termsWithData.length > 1 && (
-              <TermSelector
-                terms={termsWithData.map((t) => ({
-                  code: t,
-                  label: termLabel(t),
-                }))}
-                currentTerm={currentTerm}
-                onTermChange={handleTermChange}
-              />
+      {/* TERM BRIDGE BAR — term tabs + section counts + quick-filter chips */}
+      <section className="border-y border-gray-200 dark:border-slate-700 bg-gradient-to-b from-teal-50/50 dark:from-teal-900/10 to-transparent -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 py-4 mb-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          {/* Left: term picker + counts */}
+          <div className="flex flex-wrap items-end gap-4">
+            {/* Term tabs */}
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-slate-500 mb-1.5">Term</p>
+              <div className="flex items-center gap-1">
+                {termsWithData.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => handleTermChange(t)}
+                    className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                      t === currentTerm
+                        ? "bg-gray-900 dark:bg-slate-100 text-white dark:text-slate-900"
+                        : "text-gray-600 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700"
+                    }`}
+                  >
+                    {termLabel(t)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Section counts */}
+            {courses.length > 0 && (
+              <div className="hidden sm:flex items-baseline gap-2 pb-0.5">
+                <span className="w-px h-8 bg-gray-200 dark:bg-slate-700 self-center" />
+                <span className="text-3xl font-semibold tracking-tight text-gray-900 dark:text-slate-100">{courses.length}</span>
+                <span className="text-sm text-gray-500 dark:text-slate-400">sections</span>
+                {upcoming > 0 && (
+                  <>
+                    <span className="text-gray-300 dark:text-slate-600">·</span>
+                    <span className="text-sm font-medium text-emerald-700 dark:text-emerald-400">{upcoming} open</span>
+                    <span className="text-gray-300 dark:text-slate-600">·</span>
+                    <span className="text-sm text-gray-500 dark:text-slate-400">{started} in progress</span>
+                  </>
+                )}
+              </div>
             )}
           </div>
-          <a
-            href={systemCollegeCoursesUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-teal-600 hover:text-teal-700"
-          >
-            {`View on ${systemName} →`}
-          </a>
+
+          {/* Right: quick-filter chips */}
+          {courses.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              {(["", "open", "online"] as const).map((f) => {
+                const label = f === "" ? "All" : f === "open" ? "Open only" : "Online";
+                const active = quickFilter === f;
+                return (
+                  <button
+                    key={f}
+                    type="button"
+                    onClick={() => setQuickFilter(f)}
+                    className={`text-xs px-3 py-1.5 rounded-full border font-medium transition-colors ${
+                      active
+                        ? "border-teal-600 bg-teal-600 text-white"
+                        : "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:border-teal-400 dark:hover:border-teal-600"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+              <a
+                href={systemCollegeCoursesUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 ml-1"
+              >
+                {systemName} ↗
+              </a>
+            </div>
+          )}
         </div>
 
         {/* Loading indicator while fetching a non-default term */}
         {loadingTerm && (
-          <div className="mb-4 flex items-center gap-2 text-sm text-gray-500 dark:text-slate-400">
+          <div className="mt-3 flex items-center gap-2 text-sm text-gray-500 dark:text-slate-400">
             <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-teal-600" />
             Loading courses…
           </div>
         )}
+      </section>
 
-        {/* Registration status summary */}
-        {courses.length > 0 &&
-          (upcoming > 0 ? (
-            <div className="mb-4 flex items-center gap-2 rounded-lg border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-4 py-2.5 text-sm">
-              <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
-              <span className="text-emerald-800 dark:text-emerald-400">
-                <strong>{upcoming}</strong>{" "}
-                {upcoming === 1 ? "section" : "sections"} still open for
-                registration
-              </span>
-              <span className="text-emerald-600">·</span>
-              <span className="text-emerald-600">
-                {started} already in progress
-              </span>
-            </div>
-          ) : (
-            <div className="mb-4 flex items-center gap-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 px-4 py-2.5 text-sm">
-              <span className="inline-block h-2 w-2 rounded-full bg-gray-300 dark:bg-slate-600" />
-              <span className="text-gray-600 dark:text-slate-400">
-                All {started} sections have already started
-              </span>
-            </div>
-          ))}
-
+      {/* Course Listings */}
+      <section>
         {courses.length === 0 ? (
           <div className="bg-gray-50 dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg p-8 text-center">
             <p className="text-gray-600 dark:text-slate-400 mb-2">
@@ -222,10 +254,8 @@ export default function CollegeTermSection({
           </div>
         ) : (
           <CollegeDetailClient
-            // keyed on term so filter/sort state in the inner tree resets when
-            // the user switches terms (pinned CRNs from another term wouldn't
-            // match the new course list)
-            key={currentTerm}
+            // keyed on term+quickFilter so filter/sort state resets on both changes
+            key={`${currentTerm}-${quickFilter}`}
             courses={courses}
             institution={institution}
             collegeSlug={collegeSlug}
@@ -233,6 +263,8 @@ export default function CollegeTermSection({
             systemName={systemName}
             courseListingUrl={courseListingUrl}
             state={state}
+            defaultStatusFilter={quickStatusFilter}
+            defaultModeFilter={quickModeFilter}
           />
         )}
       </section>

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -9,7 +9,6 @@ import {
   trimCoursesForClient,
 } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
-import CollegeMap from "./CollegeMap";
 import CollegeScorecardSection from "./CollegeScorecardSection";
 import CollegeTermSection from "./CollegeTermSection";
 import TopProgramsSection from "./TopProgramsSection";
@@ -29,6 +28,11 @@ import {
   getCollegeLastUpdated,
   formatLastUpdated,
 } from "@/lib/data-freshness";
+import {
+  getScorecard,
+  formatDollar,
+  formatPercent,
+} from "@/lib/scorecard";
 
 // Revalidate every 24 hours — course data only changes when re-scraped
 export const revalidate = 86400;
@@ -175,6 +179,9 @@ export default async function CollegeDetailPage(props: PageProps) {
 
   const lastUpdated = getCollegeLastUpdated(state, institution.college_slug);
 
+  // Scorecard data for the hero stat card (students, tuition, completion rate)
+  const scorecard = getScorecard(state, id);
+
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
   const stateAbbr = state.toUpperCase();
   const jsonLd = {
@@ -215,8 +222,18 @@ export default async function CollegeDetailPage(props: PageProps) {
     ],
   };
 
+  // Derive audit cost stat for hero card
+  const sd = institution.audit_policy.eligibility.senior_discount;
+  const auditCostStat = sd.available
+    ? `Free ${sd.age_threshold ?? 60}+`
+    : institution.audit_policy.allowed === false
+    ? "N/A"
+    : institution.audit_policy.cost_note
+    ? institution.audit_policy.cost_note.slice(0, 14)
+    : "—";
+
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
       <TrackView
         event="college_detail_view"
         params={{ state, college: id }}
@@ -229,88 +246,92 @@ export default async function CollegeDetailPage(props: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
+
       {/* Breadcrumb */}
       <Link
-        href={`/${state}`}
-        className="text-sm text-teal-600 hover:text-teal-700 mb-4 inline-block"
+        href={`/${state}/colleges`}
+        className="text-sm text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300 mb-5 inline-block"
       >
-        &larr; Back to search
+        &larr; {config.name} colleges
       </Link>
 
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
-          {institution.name}
-        </h1>
-        <p className="text-gray-600 dark:text-slate-400 mt-1">
-          {institution.campuses.map((c) => c.name).join(" · ")}
-        </p>
-        {lastUpdated && (
-          <p className="text-xs text-gray-400 dark:text-slate-500 mt-1">
-            {formatLastUpdated(lastUpdated)}
-          </p>
-        )}
-
-        {/* Status badge */}
-        <div className="mt-3">
-          {institution.audit_policy.allowed === true && (
-            <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400">
-              Verified
+      {/* COMPACT HERO */}
+      <section className="mb-0 pb-7 grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-end">
+        {/* Left — identity */}
+        <div className="lg:col-span-7">
+          <div className="flex flex-wrap items-center gap-3 mb-2">
+            <span className="text-xs font-mono font-medium uppercase tracking-wider text-teal-700 dark:text-teal-400">
+              {config.systemName}
             </span>
+            {lastUpdated && (
+              <span className="text-xs font-mono text-gray-400 dark:text-slate-500">
+                {formatLastUpdated(lastUpdated)}
+              </span>
+            )}
+          </div>
+          <h1 className="text-4xl font-semibold tracking-tight leading-tight text-gray-900 dark:text-slate-100">
+            {institution.name}
+          </h1>
+          {institution.campuses.length > 0 && (
+            <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600 dark:text-slate-400">
+              {institution.campuses.map((c) => (
+                <span key={c.name} className="inline-flex items-center gap-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-teal-500 shrink-0" />
+                  {c.name}
+                </span>
+              ))}
+            </div>
           )}
-          {institution.audit_policy.allowed === null && (
-            <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400">
-              Contact to Confirm
-            </span>
-          )}
-          {institution.audit_policy.allowed === false && (
-            <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400">
-              Auditing Not Available
-            </span>
-          )}
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            {institution.audit_policy.allowed === true && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-400 px-3 py-1 text-xs font-medium">
+                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-8 8a1 1 0 01-1.4 0l-4-4a1 1 0 011.4-1.4L8 12.6l7.3-7.3a1 1 0 011.4 0z" clipRule="evenodd" />
+                </svg>
+                Audit verified
+              </span>
+            )}
+            {institution.audit_policy.allowed === null && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-400 px-3 py-1 text-xs font-medium">
+                Contact to confirm
+              </span>
+            )}
+            {sd.available && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-400 px-3 py-1 text-xs font-medium">
+                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 1.5l2.6 5.3 5.9.9-4.3 4.1 1 5.8L10 14.9l-5.2 2.7 1-5.8L1.5 7.7l5.9-.9L10 1.5z" />
+                </svg>
+                Free for {sd.age_threshold ?? 60}+ {state.toUpperCase()} residents
+              </span>
+            )}
+            <Link
+              href={`/${state}/college/${id}/programs`}
+              className="text-sm text-teal-600 dark:text-teal-400 hover:underline inline-flex items-center gap-1"
+            >
+              View programs &rarr;
+            </Link>
+          </div>
         </div>
 
-        <div className="mt-3">
-          <Link
-            href={`/${state}/college/${id}/programs`}
-            className="inline-flex items-center gap-1 text-sm text-teal-600 dark:text-teal-400 hover:underline"
-          >
-            View degree &amp; certificate programs
-            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
+        {/* Right — stat card */}
+        <div className="lg:col-span-5">
+          <div className="grid grid-cols-4 gap-px rounded-xl overflow-hidden border border-gray-200 dark:border-slate-700 bg-gray-200 dark:bg-slate-700">
+            {[
+              { label: "Students", value: scorecard?.size ? scorecard.size.toLocaleString() : "—" },
+              { label: "In-state/yr", value: scorecard?.cost?.tuitionInState != null ? formatDollar(scorecard.cost.tuitionInState) : "—" },
+              { label: "Completion", value: scorecard?.completion?.completionRate150nt != null ? formatPercent(scorecard.completion.completionRate150nt) : "—" },
+              { label: "Audit cost", value: auditCostStat },
+            ].map(({ label, value }) => (
+              <div key={label} className="bg-white dark:bg-slate-800 px-3 py-4">
+                <p className="text-[10px] font-mono font-medium uppercase tracking-wider text-gray-400 dark:text-slate-500">{label}</p>
+                <p className="text-xl font-semibold tracking-tight text-gray-900 dark:text-slate-100 mt-1">{value}</p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </section>
 
-      {/* Campus map */}
-      {institution.campuses.length > 0 && (
-        <div className="mb-8 h-[250px] rounded-lg overflow-hidden border border-gray-200 dark:border-slate-700 isolate">
-          <CollegeMap institution={institution} />
-        </div>
-      )}
-
-      {/* Cost & outcomes — federal Scorecard data. Renders nothing when
-          the institution lacks a Scorecard mapping (2 of 382 today). */}
-      <CollegeScorecardSection
-        state={state}
-        collegeId={id}
-        collegeName={institution.name}
-      />
-
-      {/* Top programs at this college — bridges the per-college page to
-          the state-wide program comparison hub at /[state]/program/[slug].
-          Driven by federal IPEDS award counts in the scorecard-programs
-          data ingested by #410. See issue #414. */}
-      <TopProgramsSection
-        state={state}
-        collegeId={id}
-        collegeName={institution.name}
-      />
-
-      {/* Term-dependent content (staleness, term picker, course table, subject
-          browser, instructor browser) — client-rendered so ?term= switches
-          happen without a server round-trip. */}
+      {/* COURSES — immediately after hero (courses-first layout) */}
       <CollegeTermSection
         coursesByTerm={coursesByTerm}
         termsWithData={termsWithData}
@@ -327,147 +348,92 @@ export default async function CollegeDetailPage(props: PageProps) {
         systemCollegeCoursesUrl={systemCollegeCoursesUrl}
       />
 
-      {/* Audit Policy — collapsed by default, below courses */}
-      <section id="audit-policy" className="mt-8">
-        <details className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg">
-          <summary className="px-6 py-4 cursor-pointer select-none flex items-center justify-between text-lg font-semibold text-gray-900 dark:text-slate-100 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors rounded-lg">
-            <span>Audit Policy</span>
-            <svg className="w-5 h-5 text-gray-400 dark:text-slate-500 transition-transform details-open:rotate-180" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </summary>
-          <div className="px-6 pb-6">
-            {institution.audit_policy.allowed === null ? (
-              <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
-                <p className="text-yellow-800 dark:text-yellow-400">
-                  We haven&apos;t verified this college&apos;s audit policy yet.
-                  Contact the registrar to confirm whether auditing is available.
-                </p>
-                {institution.audit_policy.application_process.contact_email && (
-                  <p className="mt-2 text-yellow-800 dark:text-yellow-400">
-                    Email:{" "}
-                    <a
-                      href={`mailto:${institution.audit_policy.application_process.contact_email}`}
-                      className="underline"
-                    >
-                      {institution.audit_policy.application_process.contact_email}
-                    </a>
-                  </p>
-                )}
-                {institution.audit_policy.application_process.contact_phone && (
-                  <p className="mt-1 text-yellow-800 dark:text-yellow-400">
-                    Phone:{" "}
-                    {institution.audit_policy.application_process.contact_phone}
-                  </p>
-                )}
-              </div>
-            ) : (
-              <div className="space-y-6">
-                {/* Cost */}
-                <div>
-                  <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">Cost</h3>
-                  <p className="text-gray-600 dark:text-slate-400">
-                    {institution.audit_policy.cost_note}
-                  </p>
-                  {institution.audit_policy.eligibility.senior_discount
-                    .available && (
-                    <div className="mt-2 bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 rounded p-3">
-                      <p className="text-teal-800 dark:text-teal-300 text-sm font-medium">
-                        {institution.audit_policy.eligibility.senior_discount.age_threshold ?? 60}+ Senior Discount:{" "}
-                        {institution.audit_policy.eligibility.senior_discount.cost}
-                      </p>
-                      <p className="text-teal-700 dark:text-teal-400 text-xs mt-1">
-                        {institution.audit_policy.eligibility.senior_discount.notes}
-                      </p>
-                    </div>
-                  )}
-                </div>
+      {/* CONTEXT CARDS — 3-col grid below courses */}
+      <section className="mt-12 grid grid-cols-1 md:grid-cols-3 gap-5">
+        {/* Top programs */}
+        <div className="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="text-base font-semibold tracking-tight text-gray-900 dark:text-slate-100">Top programs</h3>
+            <span className="text-[10px] font-mono font-medium uppercase tracking-wider text-gray-400 dark:text-slate-500">awards · IPEDS</span>
+          </div>
+          <TopProgramsSection
+            state={state}
+            collegeId={id}
+            collegeName={institution.name}
+          />
+        </div>
 
-                {/* Eligibility */}
-                <div>
-                  <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">Eligibility</h3>
-                  <ul className="text-gray-600 dark:text-slate-400 text-sm space-y-1">
-                    <li>Minimum age: {institution.audit_policy.eligibility.minimum_age}</li>
-                    <li>Residency required: {institution.audit_policy.eligibility.residency_required ? "Yes" : "No"}</li>
-                  </ul>
-                </div>
+        {/* Cost & outcomes */}
+        <div className="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="text-base font-semibold tracking-tight text-gray-900 dark:text-slate-100">Cost &amp; outcomes</h3>
+            <span className="text-[10px] font-mono font-medium uppercase tracking-wider text-gray-400 dark:text-slate-500">federal scorecard</span>
+          </div>
+          <CollegeScorecardSection
+            state={state}
+            collegeId={id}
+            collegeName={institution.name}
+          />
+        </div>
 
-                {/* Application process */}
-                {institution.audit_policy.application_process.steps.length > 0 && (
-                  <div>
-                    <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-2">How to Apply</h3>
-                    <ol className="list-decimal list-inside text-gray-600 dark:text-slate-400 text-sm space-y-2">
-                      {institution.audit_policy.application_process.steps.map((step, i) => (
-                        <li key={i}>{step}</li>
-                      ))}
-                    </ol>
-                    {institution.audit_policy.application_process.timing && (
-                      <p className="mt-2 text-sm text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded p-2">
-                        Deadline: {institution.audit_policy.application_process.timing}
-                      </p>
-                    )}
-                  </div>
-                )}
-
-                {/* Contact */}
-                <div>
-                  <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">Contact</h3>
-                  <div className="text-sm text-gray-600 dark:text-slate-400 space-y-1">
-                    {institution.audit_policy.application_process.contact_email && (
-                      <p>
-                        Email:{" "}
-                        <a href={`mailto:${institution.audit_policy.application_process.contact_email}`} className="text-teal-600 hover:underline">
-                          {institution.audit_policy.application_process.contact_email}
-                        </a>
-                      </p>
-                    )}
-                    {institution.audit_policy.application_process.contact_phone && (
-                      <p>Phone: {institution.audit_policy.application_process.contact_phone}</p>
-                    )}
-                    {institution.audit_policy.application_process.form_url && (
-                      <p>
-                        <a href={institution.audit_policy.application_process.form_url} target="_blank" rel="noopener noreferrer" className="text-teal-600 hover:underline">
-                          Audit Request Form &rarr;
-                        </a>
-                      </p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Restrictions */}
-                {institution.audit_policy.restrictions.length > 0 && (
-                  <div>
-                    <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">Restrictions</h3>
-                    <ul className="text-gray-600 dark:text-slate-400 text-sm space-y-1 list-disc list-inside">
-                      {institution.audit_policy.restrictions.map((r, i) => (
-                        <li key={i}>{r}</li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                {/* Verification */}
-                <div className="border-t border-gray-200 dark:border-slate-700 pt-4 text-xs text-gray-400 dark:text-slate-500">
-                  Last verified: {institution.audit_policy.last_verified}
-                  {institution.audit_policy.source_url && (
-                    <>
-                      {" · "}
-                      <a href={institution.audit_policy.source_url} target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-600 dark:hover:text-slate-400">
-                        Source
-                      </a>
-                    </>
-                  )}
-                </div>
-              </div>
+        {/* Audit policy */}
+        <div id="audit-policy" className="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="text-base font-semibold tracking-tight text-gray-900 dark:text-slate-100">Audit policy</h3>
+            {institution.audit_policy.last_verified && (
+              <span className="text-[10px] font-mono font-medium uppercase tracking-wider text-gray-400 dark:text-slate-500">
+                verified {institution.audit_policy.last_verified}
+              </span>
             )}
           </div>
-        </details>
+          {institution.audit_policy.allowed === null ? (
+            <p className="text-sm text-yellow-800 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-3">
+              We haven&apos;t verified this college&apos;s audit policy yet. Contact the registrar to confirm.
+              {institution.audit_policy.application_process.contact_email && (
+                <> Email: <a href={`mailto:${institution.audit_policy.application_process.contact_email}`} className="underline">{institution.audit_policy.application_process.contact_email}</a></>
+              )}
+            </p>
+          ) : (
+            <div className="text-sm text-gray-700 dark:text-slate-300 space-y-2 leading-relaxed">
+              {institution.audit_policy.allowed === false ? (
+                <p className="text-red-700 dark:text-red-400">Auditing is not available at this college.</p>
+              ) : (
+                <p>
+                  <strong>Auditing allowed.</strong>{" "}
+                  {institution.audit_policy.cost_note}
+                </p>
+              )}
+              {sd.available && (
+                <p className="text-teal-700 dark:text-teal-400 font-medium">
+                  Free for residents {sd.age_threshold ?? 60}+ (space-available).
+                </p>
+              )}
+              {institution.audit_policy.application_process.steps.length > 0 && (
+                <ul className="space-y-1 text-gray-600 dark:text-slate-400">
+                  {institution.audit_policy.application_process.steps.slice(0, 3).map((step, i) => (
+                    <li key={i}>· {step}</li>
+                  ))}
+                </ul>
+              )}
+              {institution.audit_policy.application_process.contact_email && (
+                <p>
+                  Contact:{" "}
+                  <a href={`mailto:${institution.audit_policy.application_process.contact_email}`} className="text-teal-600 dark:text-teal-400 hover:underline">
+                    {institution.audit_policy.application_process.contact_email}
+                  </a>
+                </p>
+              )}
+              {institution.audit_policy.source_url && (
+                <a href={institution.audit_policy.source_url} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-400 dark:text-slate-500 hover:underline block mt-2">
+                  Source &rarr;
+                </a>
+              )}
+            </div>
+          )}
+        </div>
       </section>
 
-      {/* Course Offering Profile — server-rendered summary of this term's
-          mode breakdown, start-date diversity, and top subjects. Gives
-          Googlebot substantive unique content per-college that doesn't
-          require running the client-side course catalog component. */}
+      {/* Course Offering Profile — server-rendered summary for SEO */}
       {offeringProfile && offeringProfile.total > 0 && (
         <section className="mt-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
           <SectionHeading id="offering-profile" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
@@ -481,91 +447,53 @@ export default async function CollegeDetailPage(props: PageProps) {
           </p>
 
           <div className="grid sm:grid-cols-2 gap-6">
-            {/* Format mix */}
             <div>
-              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
-                Format mix
-              </h3>
+              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">Format mix</h3>
               <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
                 {Object.entries(offeringProfile.modes.modes)
                   .sort((a, b) => b[1] - a[1])
                   .map(([mode, count]) => (
                     <li key={mode} className="flex justify-between">
-                      <span className="capitalize">
-                        {mode.replace("-", " ")}
-                      </span>
+                      <span className="capitalize">{mode.replace("-", " ")}</span>
                       <span>
-                        <span className="font-medium text-gray-900 dark:text-slate-100">
-                          {count}
-                        </span>{" "}
-                        <span className="text-xs text-gray-500 dark:text-slate-400">
-                          ({offeringProfile.modes.modePcts[mode].toFixed(0)}
-                          %)
-                        </span>
+                        <span className="font-medium text-gray-900 dark:text-slate-100">{count}</span>{" "}
+                        <span className="text-xs text-gray-500 dark:text-slate-400">({offeringProfile.modes.modePcts[mode].toFixed(0)}%)</span>
                       </span>
                     </li>
                   ))}
               </ul>
             </div>
 
-            {/* Section start dates */}
             <div>
-              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
-                Section start dates
-              </h3>
+              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">Section start dates</h3>
               {offeringProfile.distinctStartDates > 0 ? (
                 <p className="text-sm text-gray-700 dark:text-slate-300">
                   Sections begin on{" "}
-                  <span className="font-medium text-gray-900 dark:text-slate-100">
-                    {offeringProfile.distinctStartDates}
-                  </span>{" "}
-                  distinct date
-                  {offeringProfile.distinctStartDates === 1 ? "" : "s"} this
-                  term.
+                  <span className="font-medium text-gray-900 dark:text-slate-100">{offeringProfile.distinctStartDates}</span>{" "}
+                  distinct date{offeringProfile.distinctStartDates === 1 ? "" : "s"} this term.
                   {offeringProfile.lateStartCount > 0 && (
-                    <>
-                      {" "}
-                      <Link
-                        href={`/${state}/starting-soon`}
-                        className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
-                      >
-                        {offeringProfile.lateStartCount} late-start sections
-                      </Link>{" "}
-                      begin more than two weeks after the term starts.
-                    </>
+                    <>{" "}<Link href={`/${state}/starting-soon`} className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300">{offeringProfile.lateStartCount} late-start sections</Link>{" "}begin more than two weeks after the term starts.</>
                   )}
                 </p>
               ) : (
-                <p className="text-sm text-gray-500 dark:text-slate-400">
-                  Start-date data not available for this term.
-                </p>
+                <p className="text-sm text-gray-500 dark:text-slate-400">Start-date data not available for this term.</p>
               )}
             </div>
           </div>
 
-          {/* Top subjects */}
           {offeringProfile.topSubjects.length > 0 && (
             <div className="mt-6 pt-4 border-t border-gray-100 dark:border-slate-700">
-              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
-                Most-offered subjects this term
-              </h3>
+              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">Most-offered subjects this term</h3>
               <div className="flex flex-wrap gap-2">
                 {offeringProfile.topSubjects.map((s) => {
                   const label = subjectName(s.prefix);
-                  const display =
-                    label && label !== s.prefix
-                      ? `${label} (${s.prefix})`
-                      : s.prefix;
+                  const display = label && label !== s.prefix ? `${label} (${s.prefix})` : s.prefix;
                   return (
-                    <Link
-                      key={s.prefix}
-                      href={`/${state}/college/${id}/courses/${s.prefix.toLowerCase()}`}
+                    <Link key={s.prefix} href={`/${state}/college/${id}/courses/${s.prefix.toLowerCase()}`}
                       className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-700 hover:text-teal-700 dark:hover:text-teal-400 transition-colors"
                     >
                       <span>{display}</span>
-                      <span className="text-gray-400 dark:text-slate-500">
-                        {s.sections}
-                      </span>
+                      <span className="text-gray-400 dark:text-slate-500">{s.sections}</span>
                     </Link>
                   );
                 })}
@@ -575,12 +503,12 @@ export default async function CollegeDetailPage(props: PageProps) {
         </section>
       )}
 
-      {/* In-page ad (well after main content per AdSense policy) */}
+      {/* In-page ad */}
       <div className="mt-8">
         <AdUnit slot="3816492750" format="auto" className="min-h-[100px]" />
       </div>
 
-      {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+      {/* Related blog posts */}
       <RelatedBlogPosts
         articles={getBlogRecommendations({
           state,
@@ -590,43 +518,42 @@ export default async function CollegeDetailPage(props: PageProps) {
         heading={`Related ${config.name} guides`}
       />
 
-      {/* Other colleges in this state — internal linking for SEO */}
+      {/* OTHER COLLEGES — footer band */}
       {(() => {
         const allInstitutions = loadInstitutions(state);
         const others = allInstitutions
           .filter((i) => i.id !== id)
           .sort((a, b) => a.name.localeCompare(b.name))
-          .slice(0, 6);
+          .slice(0, 8);
         if (others.length === 0) return null;
         return (
-          <section className="mt-8">
-            <SectionHeading id="other-colleges" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
-              Other {config.systemName} Colleges
-            </SectionHeading>
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-              {others.map((inst) => (
-                <Link
-                  key={inst.id}
-                  href={`/${state}/college/${inst.id}`}
-                  className="group block rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 transition hover:shadow-md hover:border-teal-300"
-                >
-                  <h3 className="font-medium text-sm text-gray-900 dark:text-slate-100 group-hover:text-teal-700 transition-colors">
-                    {inst.name}
-                  </h3>
-                  <p className="text-[11px] text-gray-400 dark:text-slate-500 truncate mt-0.5">
-                    {inst.campuses?.map((c) => c.name).join(", ")}
-                  </p>
+          <section className="mt-12 -mx-4 sm:-mx-6 lg:-mx-8 border-t border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+              <div className="flex items-baseline justify-between mb-4">
+                <h3 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-slate-100">
+                  Other {config.name} community colleges
+                </h3>
+                <Link href={`/${state}/colleges`} className="text-sm text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300">
+                  View all {config.collegeCount} &rarr;
                 </Link>
-              ))}
+              </div>
+              <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                {others.map((inst) => (
+                  <Link
+                    key={inst.id}
+                    href={`/${state}/college/${inst.id}`}
+                    className="group block rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-sm transition"
+                  >
+                    <p className="font-medium text-sm text-gray-900 dark:text-slate-100 group-hover:text-teal-700 dark:group-hover:text-teal-400 transition-colors">
+                      {inst.name}
+                    </p>
+                    <p className="text-[11px] text-gray-400 dark:text-slate-500 mt-0.5">
+                      {inst.audit_policy.allowed === true ? "Audit verified" : "Contact to confirm"}
+                    </p>
+                  </Link>
+                ))}
+              </div>
             </div>
-            <p className="text-center mt-3">
-              <Link
-                href={`/${state}/colleges`}
-                className="text-sm text-teal-600 hover:text-teal-700 transition-colors"
-              >
-                View all {config.collegeCount} {config.systemName} colleges &rarr;
-              </Link>
-            </p>
           </section>
         );
       })()}

--- a/components/CourseTable.tsx
+++ b/components/CourseTable.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import type { CourseSection, CourseMode } from "@/lib/types";
 import { getCourseStatus, formatStartInfo, isInProgress, type CourseStatus } from "@/lib/course-status";
 import { expandDays } from "@/lib/time-utils";
 import DayToggle from "@/components/DayToggle";
 import PrereqChain from "@/components/PrereqChain";
+import { subjectName } from "@/lib/subjects";
 
 type TransferLookup = Record<
   string,
@@ -23,6 +24,12 @@ interface CourseTableProps {
   transferLookup?: TransferLookup;
   /** State slug for prereq chain API calls (e.g., "tn", "de") */
   state?: string;
+  /** Group rows by subject prefix with divider headers */
+  groupBySubject?: boolean;
+  /** Pre-select the status filter ("upcoming" | "in-progress" | "") */
+  defaultStatusFilter?: string;
+  /** Pre-select the mode filter ("online" | "in-person" | "hybrid" | "") */
+  defaultModeFilter?: string;
 }
 
 /** Build external URL for a specific course section by replacing template sentinels */
@@ -254,11 +261,136 @@ function TransferBadge({ prefix, number, lookup }: { prefix: string; number: str
   );
 }
 
-export default function CourseTable({ courses, collegeSlug, courseListingUrl, systemName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state }: CourseTableProps) {
+interface CourseRowProps {
+  course: CourseSection;
+  collegeSlug: string;
+  courseListingUrl?: string;
+  systemName?: string;
+  onAuditClick?: (course: CourseSection) => void;
+  pinnedCRNs?: Set<string>;
+  onTogglePin?: (crn: string) => void;
+  transferLookup?: TransferLookup;
+  state?: string;
+}
+
+function CourseRow({ course, collegeSlug, courseListingUrl, systemName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state }: CourseRowProps) {
+  const style = MODE_STYLES[course.mode];
+  const status = getCourseStatus(course.start_date);
+  const statusStyle = STATUS_STYLES[status];
+  const started = status === "in-progress";
+  return (
+    <tr
+      className={`transition hover:bg-gray-50 dark:hover:bg-slate-800 ${started ? "opacity-50" : ""}`}
+    >
+      <td className="whitespace-nowrap px-3 py-3 font-mono text-xs text-gray-600 dark:text-slate-400 max-w-[100px] truncate">
+        {course.crn}
+      </td>
+      <td className="whitespace-nowrap px-3 py-3 font-medium text-gray-900 dark:text-slate-100">
+        {course.course_prefix} {course.course_number}
+      </td>
+      <td className="px-3 py-3 text-gray-700 dark:text-slate-300">
+        <div className="max-w-[280px]">
+          <div className="truncate">{course.course_title}</div>
+          {transferLookup && (
+            <div className="mt-0.5">
+              <TransferBadge prefix={course.course_prefix} number={course.course_number} lookup={transferLookup} />
+            </div>
+          )}
+          {course.prerequisite_text && (
+            <div className="mt-1">
+              {state ? (
+                <PrereqChain
+                  state={state}
+                  course={`${course.course_prefix} ${course.course_number}`}
+                  prereqText={course.prerequisite_text}
+                />
+              ) : (
+                <span className="inline-flex items-center gap-0.5 rounded bg-amber-50 border border-amber-200 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:border-amber-800">
+                  <svg className="h-2.5 w-2.5 shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                  </svg>
+                  Requires: {course.prerequisite_text}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </td>
+      <td className="whitespace-nowrap px-3 py-3 text-xs text-gray-600 dark:text-slate-400">
+        {formatSchedule(course)}
+      </td>
+      <td className="whitespace-nowrap px-3 py-3">
+        <span className={`inline-flex items-center gap-1.5 text-xs ${statusStyle.text}`}>
+          <span className={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${statusStyle.dot}`} />
+          {formatStartInfo(course.start_date)}
+        </span>
+      </td>
+      <td className="whitespace-nowrap px-3 py-3 text-xs text-gray-600 max-w-[130px] truncate dark:text-slate-400">
+        {course.instructor || <span className="text-gray-300 dark:text-slate-600">&mdash;</span>}
+      </td>
+      <td className="whitespace-nowrap px-3 py-3 text-xs text-gray-600 max-w-[100px] truncate dark:text-slate-400">
+        {course.campus || "---"}
+      </td>
+      <td className="whitespace-nowrap px-3 py-3">
+        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${style.bg} ${style.text} ${
+          course.mode === "in-person" ? "dark:bg-emerald-900/30" :
+          course.mode === "online" ? "dark:bg-blue-900/30" :
+          course.mode === "hybrid" ? "dark:bg-purple-900/30" :
+          "dark:bg-orange-900/30"
+        }`}>
+          {style.label}
+        </span>
+      </td>
+      <td className="whitespace-nowrap px-2 py-3">
+        <div className="flex items-center justify-end gap-1.5">
+          <ShareButton course={course} collegeSlug={collegeSlug} />
+          {onTogglePin && (
+            <button
+              type="button"
+              onClick={() => onTogglePin(course.crn)}
+              className={`inline-flex items-center justify-center w-7 h-7 rounded-md border transition ${
+                pinnedCRNs?.has(course.crn)
+                  ? "bg-teal-100 border-teal-300 text-teal-700"
+                  : "bg-white border-gray-300 text-gray-400 hover:text-teal-600 hover:border-teal-300 dark:bg-slate-800 dark:border-slate-600 dark:text-slate-500"
+              }`}
+              title={pinnedCRNs?.has(course.crn) ? "Remove from schedule" : "Add to schedule"}
+            >
+              <svg className="h-3.5 w-3.5" fill={pinnedCRNs?.has(course.crn) ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+            </button>
+          )}
+          {onAuditClick && (
+            <button
+              type="button"
+              onClick={() => onAuditClick(course)}
+              className="text-xs font-medium text-teal-600 hover:text-teal-800 hover:underline"
+            >
+              Audit
+            </button>
+          )}
+          <a
+            href={buildCourseUrl(collegeSlug, course, courseListingUrl)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline dark:text-slate-400 dark:hover:text-slate-300"
+          >
+            {systemName} &rarr;
+          </a>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export default function CourseTable({ courses, collegeSlug, courseListingUrl, systemName, onAuditClick, pinnedCRNs, onTogglePin, transferLookup, state, groupBySubject, defaultStatusFilter = "", defaultModeFilter = "" }: CourseTableProps) {
   const [subjectFilter, setSubjectFilter] = useState("");
   const [dayFilters, setDayFilters] = useState<string[]>([]);
-  const [modeFilter, setModeFilter] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
+  const [modeFilter, setModeFilter] = useState(defaultModeFilter);
+  const [statusFilter, setStatusFilter] = useState(defaultStatusFilter);
+
+  useEffect(() => { setStatusFilter(defaultStatusFilter); }, [defaultStatusFilter]);
+  useEffect(() => { setModeFilter(defaultModeFilter); }, [defaultModeFilter]);
 
   const subjects = useMemo(() => getUniqueSubjects(courses), [courses]);
   const modes = useMemo(() => getUniqueModes(courses), [courses]);
@@ -391,120 +523,36 @@ export default function CourseTable({ courses, collegeSlug, courseListingUrl, sy
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100 dark:divide-slate-700">
-                {filtered.map((course) => {
-                  const style = MODE_STYLES[course.mode];
-                  const status = getCourseStatus(course.start_date);
-                  const statusStyle = STATUS_STYLES[status];
-                  const started = status === "in-progress";
-                  return (
-                    <tr
-                      key={`${course.crn}-${course.course_prefix}${course.course_number}-${course.days}-${course.start_time}`}
-                      className={`transition hover:bg-gray-50 dark:hover:bg-slate-800 ${started ? "opacity-50" : ""}`}
-                    >
-                      <td className="whitespace-nowrap px-3 py-3 font-mono text-xs text-gray-600 dark:text-slate-400 max-w-[100px] truncate">
-                        {course.crn}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3 font-medium text-gray-900 dark:text-slate-100">
-                        {course.course_prefix} {course.course_number}
-                      </td>
-                      <td className="px-3 py-3 text-gray-700 dark:text-slate-300">
-                        <div className="max-w-[280px]">
-                          <div className="truncate">{course.course_title}</div>
-                          {transferLookup && (
-                            <div className="mt-0.5">
-                              <TransferBadge prefix={course.course_prefix} number={course.course_number} lookup={transferLookup} />
-                            </div>
-                          )}
-                          {course.prerequisite_text && (
-                            <div className="mt-1">
-                              {state ? (
-                                <PrereqChain
-                                  state={state}
-                                  course={`${course.course_prefix} ${course.course_number}`}
-                                  prereqText={course.prerequisite_text}
-                                />
-                              ) : (
-                                <span
-                                  className="inline-flex items-center gap-0.5 rounded bg-amber-50 border border-amber-200 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:border-amber-800"
-                                >
-                                  <svg className="h-2.5 w-2.5 shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                                  </svg>
-                                  Requires: {course.prerequisite_text}
-                                </span>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3 text-xs text-gray-600 dark:text-slate-400">
-                        {formatSchedule(course)}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3">
-                        <span className={`inline-flex items-center gap-1.5 text-xs ${statusStyle.text}`}>
-                          <span className={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${statusStyle.dot}`} />
-                          {formatStartInfo(course.start_date)}
-                        </span>
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3 text-xs text-gray-600 max-w-[130px] truncate dark:text-slate-400">
-                        {course.instructor || <span className="text-gray-300 dark:text-slate-600">&mdash;</span>}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3 text-xs text-gray-600 max-w-[100px] truncate dark:text-slate-400">
-                        {course.campus || "---"}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3">
-                        <span
-                          className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${style.bg} ${style.text} ${
-                            course.mode === "in-person" ? "dark:bg-emerald-900/30" :
-                            course.mode === "online" ? "dark:bg-blue-900/30" :
-                            course.mode === "hybrid" ? "dark:bg-purple-900/30" :
-                            "dark:bg-orange-900/30"
-                          }`}
-                        >
-                          {style.label}
-                        </span>
-                      </td>
-                      <td className="whitespace-nowrap px-2 py-3">
-                        <div className="flex items-center justify-end gap-1.5">
-                          <ShareButton course={course} collegeSlug={collegeSlug} />
-                          {onTogglePin && (
-                            <button
-                              type="button"
-                              onClick={() => onTogglePin(course.crn)}
-                              className={`inline-flex items-center justify-center w-7 h-7 rounded-md border transition ${
-                                pinnedCRNs?.has(course.crn)
-                                  ? "bg-teal-100 border-teal-300 text-teal-700"
-                                  : "bg-white border-gray-300 text-gray-400 hover:text-teal-600 hover:border-teal-300 dark:bg-slate-800 dark:border-slate-600 dark:text-slate-500"
-                              }`}
-                              title={pinnedCRNs?.has(course.crn) ? "Remove from schedule" : "Add to schedule"}
-                            >
-                              <svg className="h-3.5 w-3.5" fill={pinnedCRNs?.has(course.crn) ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                              </svg>
-                            </button>
-                          )}
-                          {onAuditClick && (
-                            <button
-                              type="button"
-                              onClick={() => onAuditClick(course)}
-                              className="text-xs font-medium text-teal-600 hover:text-teal-800 hover:underline"
-                            >
-                              Audit
-                            </button>
-                          )}
-                          <a
-                            href={buildCourseUrl(collegeSlug, course, courseListingUrl)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline dark:text-slate-400 dark:hover:text-slate-300"
-                          >
-                            {systemName} &rarr;
-                          </a>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
+                {groupBySubject ? (() => {
+                  const prefixes = Array.from(new Set(filtered.map(c => c.course_prefix))).sort();
+                  return prefixes.flatMap((prefix) => {
+                    const group = filtered.filter(c => c.course_prefix === prefix);
+                    const label = subjectName(prefix);
+                    const displayLabel = label && label !== prefix ? `${label} · ${prefix}` : prefix;
+                    return [
+                      <tr key={`group-${prefix}`} className="border-t border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800/60">
+                        <td colSpan={9} className="px-3 py-2">
+                          <span className="font-mono text-xs font-semibold uppercase tracking-wider text-gray-700 dark:text-slate-300">{displayLabel}</span>
+                          <span className="ml-3 text-xs text-gray-400 dark:text-slate-500">{group.length} {group.length === 1 ? "section" : "sections"}</span>
+                        </td>
+                      </tr>,
+                      ...group.map((course) => <CourseRow key={`${course.crn}-${course.course_prefix}${course.course_number}-${course.days}-${course.start_time}`} course={course} collegeSlug={collegeSlug} courseListingUrl={courseListingUrl} systemName={systemName} onAuditClick={onAuditClick} pinnedCRNs={pinnedCRNs} onTogglePin={onTogglePin} transferLookup={transferLookup} state={state} />),
+                    ];
+                  });
+                })() : filtered.map((course) => (
+                  <CourseRow
+                    key={`${course.crn}-${course.course_prefix}${course.course_number}-${course.days}-${course.start_time}`}
+                    course={course}
+                    collegeSlug={collegeSlug}
+                    courseListingUrl={courseListingUrl}
+                    systemName={systemName}
+                    onAuditClick={onAuditClick}
+                    pinnedCRNs={pinnedCRNs}
+                    onTogglePin={onTogglePin}
+                    transferLookup={transferLookup}
+                    state={state}
+                  />
+                ))}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## What changes for someone using the site

The college page (e.g. `/va/college/nova`) now leads with courses the moment you land — no scrolling past a map, scorecard, and programs section to find what you came for. The page opens with a compact header and the course catalog front-and-center.

Specific visible changes:
- **Compact hero**: college name, campus dots, and audit/senior-discount badges on the left; a 4-stat tile (students enrolled, in-state tuition, completion rate, audit cost) on the right. The campus map is removed.
- **Term bridge bar**: term selector is now inline tab buttons (Fall / Spring / Summer) with a live count — "437 sections · 142 open · 295 in progress" — and **All / Open only / Online** quick-filter chips that instantly pre-filter the table below.
- **Subject-grouped course table**: courses are grouped by prefix (English · ENG, Biology · BIO, etc.) with divider header rows showing section count per group.
- **3-col context grid** below courses: Cost & outcomes (Scorecard), Top programs (IPEDS), and Audit policy side by side instead of stacked full-width sections.
- **Other colleges footer band**: full-width teal-on-gray strip showing 8 peer colleges in a 4-col grid.
- Breadcrumb updated from "← Back to search" to "← {state} colleges".

## Technical notes

- `CourseTable`: added `groupBySubject` prop (subject-divider rows), `defaultStatusFilter`/`defaultModeFilter` props (driven by bridge-bar chips via `useEffect` sync), and extracted an inner `CourseRow` component shared by both grouped and flat render paths.
- `CollegeTermSection`: replaced `TermSelector` dropdown + status summary with the new bridge bar; manages a `quickFilter` state (`"" | "open" | "online"`) passed down to `CollegeDetailClient`; keys `CollegeDetailClient` on `${term}-${quickFilter}` so filter state resets on both changes.
- `page.tsx`: loads Scorecard data server-side for the hero stat card (reuses the `getScorecard` call already happening in `CollegeScorecardSection`); removes `CollegeMap` import entirely; reorders sections (hero → courses → context grid → offering profile → ad → blog → footer).

## Test plan

- [ ] Load a college page (`/va/college/nova`, `/nc/college/cpcc`, etc.) and confirm courses appear immediately after the hero
- [ ] Verify the 4-stat card shows real values (students, tuition, completion, audit cost)
- [ ] Click "Open only" chip — confirm table filters to upcoming sections only; click "All" to clear
- [ ] Click "Online" chip — confirm table filters to online mode only
- [ ] Switch terms using the inline tab buttons — confirm course data loads and filter state resets
- [ ] Confirm subject group headers appear between prefix groups in the table
- [ ] Scroll to bottom — confirm 3-col context cards and footer band render correctly
- [ ] Test on a college with no Scorecard data — stat card shows "—" gracefully
- [ ] Test on a college with `audit_policy.allowed === null` — audit card shows yellow unverified state

🤖 Generated with [Claude Code](https://claude.com/claude-code)