### PR TITLE
feat(trust): About + Contact pages, sitewide Footer

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getAllStates } from "@/lib/states/registry";
+
+export const metadata: Metadata = {
+  title: "About — Community College Path",
+  description:
+    "Community College Path is a free course finder and transfer guide for community college students. Search courses, check transfers, plan schedules — across 26 states in one place.",
+  alternates: { canonical: "/about" },
+};
+
+export default function AboutPage() {
+  const states = getAllStates();
+  const totalColleges = states.reduce((sum, s) => sum + s.collegeCount, 0);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <Link
+        href="/"
+        className="text-sm text-teal-600 hover:text-teal-700 mb-6 inline-block"
+      >
+        &larr; Back to home
+      </Link>
+
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-8">
+        About Community College Path
+      </h1>
+
+      <div className="space-y-8 text-gray-600 dark:text-slate-400">
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            What It Is
+          </h2>
+          <p className="mb-3">
+            Community College Path is a free course navigator covering {totalColleges}+ community
+            colleges across {states.length} states. Search for courses, compare sections across
+            campuses, check transfer credit, and plan your schedule — without bouncing between
+            a dozen different college websites.
+          </p>
+          <p>
+            No account required. No paywall. Everything is free.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            What You Can Do Here
+          </h2>
+          <ul className="space-y-3">
+            <li className="flex gap-3">
+              <span className="text-teal-600 font-bold shrink-0 mt-0.5">—</span>
+              <span>
+                <strong className="text-gray-700 dark:text-slate-300">Search courses</strong> —
+                find sections by subject, keyword, or course code across every college in a state.
+                Filter by delivery mode, days, or time of day.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-teal-600 font-bold shrink-0 mt-0.5">—</span>
+              <span>
+                <strong className="text-gray-700 dark:text-slate-300">Check transfer credit</strong> —
+                see exactly which community college courses count toward a degree at in-state
+                universities, sourced from official state articulation agreements.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-teal-600 font-bold shrink-0 mt-0.5">—</span>
+              <span>
+                <strong className="text-gray-700 dark:text-slate-300">Look up prerequisites</strong> —
+                understand what you need before enrolling, shown as a plain-English chain so
+                there are no surprises at registration.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-teal-600 font-bold shrink-0 mt-0.5">—</span>
+              <span>
+                <strong className="text-gray-700 dark:text-slate-300">Build a schedule</strong> —
+                drag courses into a weekly calendar to find combinations that actually fit your life.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-teal-600 font-bold shrink-0 mt-0.5">—</span>
+              <span>
+                <strong className="text-gray-700 dark:text-slate-300">Find late-start classes</strong> —
+                browse sections that begin after the main semester start date and are still open
+                for enrollment.
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            Why We Built It
+          </h2>
+          <p className="mb-3">
+            Navigating community college is harder than it should be. Registration portals
+            are difficult to search, each campus has its own website, and there&apos;s rarely
+            a clear answer to the most important questions: Will this course transfer? Do I
+            have the prerequisites? Can I find a section that fits my schedule?
+          </p>
+          <p>
+            Community College Path puts all of that information in one place. We built it
+            especially with first-generation students in mind — people who don&apos;t have
+            a parent, advisor, or older sibling who has already figured this out.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            Who We Are
+          </h2>
+          <p className="mb-3">
+            Community College Path is an independent project, not affiliated with any college
+            or college system. Course data is pulled directly from each college&apos;s
+            registration system and updated regularly throughout the semester.
+          </p>
+          <p>
+            We are expanding state by state. If you notice missing data, a college that
+            should be here, or anything that looks wrong, please{" "}
+            <a
+              href="https://github.com/rohan-c0de/cc-coursemap/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300"
+            >
+              open an issue on GitHub
+            </a>
+            .
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            A Note on Accuracy
+          </h2>
+          <p>
+            Course schedules and transfer policies change every semester. We update data as
+            frequently as possible, but always confirm details directly with the college
+            before enrolling. Every college page includes a link to the official
+            registration portal.
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-12 flex flex-col sm:flex-row gap-4">
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center px-6 py-3 bg-teal-600 text-white rounded-lg font-semibold hover:bg-teal-700 transition-colors"
+        >
+          Find Courses
+        </Link>
+        <Link
+          href="/contact"
+          className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 rounded-lg font-semibold hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors"
+        >
+          Contact Us
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -25,26 +25,41 @@ export default function ContactPage() {
       <div className="space-y-8 text-gray-600 dark:text-slate-400">
         <section>
           <p className="mb-6">
-            Community College Path is a small independent project. We read every message
-            and do our best to respond quickly.
+            Have a question, found something wrong, or want to suggest a college? We read
+            every message and do our best to respond quickly.
           </p>
 
-          <div className="bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 rounded-lg p-6">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
-              GitHub Issues
-            </h2>
-            <p className="mb-3">
-              The best way to reach us is to open an issue on GitHub. It keeps
-              the conversation public so others can follow along or add context:
-            </p>
-            <a
-              href="https://github.com/rohan-c0de/cc-coursemap/issues"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300 font-medium"
-            >
-              github.com/rohan-c0de/cc-coursemap/issues →
-            </a>
+          <div className="grid sm:grid-cols-2 gap-4">
+            <div className="bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 rounded-lg p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
+                Email
+              </h2>
+              <p className="mb-3">For general questions or private inquiries:</p>
+              <a
+                href="mailto:hello@communitycollegepath.com"
+                className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300 font-medium"
+              >
+                hello@communitycollegepath.com
+              </a>
+            </div>
+
+            <div className="bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 rounded-lg p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
+                GitHub Issues
+              </h2>
+              <p className="mb-3">
+                For bug reports, missing data, or feature requests — keeps the
+                conversation public so others can add context:
+              </p>
+              <a
+                href="https://github.com/rohan-c0de/cc-coursemap/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300 font-medium"
+              >
+                github.com/rohan-c0de/cc-coursemap/issues →
+              </a>
+            </div>
           </div>
         </section>
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Contact — Community College Path",
+  description:
+    "Get in touch with Community College Path. Report missing data, suggest a college, or ask a question.",
+  alternates: { canonical: "/contact" },
+};
+
+export default function ContactPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <Link
+        href="/"
+        className="text-sm text-teal-600 hover:text-teal-700 mb-6 inline-block"
+      >
+        &larr; Back to home
+      </Link>
+
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-8">
+        Contact Us
+      </h1>
+
+      <div className="space-y-8 text-gray-600 dark:text-slate-400">
+        <section>
+          <p className="mb-6">
+            Community College Path is a small independent project. We read every message
+            and do our best to respond quickly.
+          </p>
+
+          <div className="bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
+              GitHub Issues
+            </h2>
+            <p className="mb-3">
+              The best way to reach us is to open an issue on GitHub. It keeps
+              the conversation public so others can follow along or add context:
+            </p>
+            <a
+              href="https://github.com/rohan-c0de/cc-coursemap/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300 font-medium"
+            >
+              github.com/rohan-c0de/cc-coursemap/issues →
+            </a>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            Common Reasons to Reach Out
+          </h2>
+          <ul className="space-y-2 list-disc list-inside">
+            <li>A college or course is missing from our data</li>
+            <li>Course information looks incorrect or out of date</li>
+            <li>Transfer equivalency data needs a correction</li>
+            <li>You want to suggest a feature or improvement</li>
+            <li>You have a question about how the site works</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            Privacy
+          </h2>
+          <p>
+            We only use your email to respond to your message. We never share it
+            with third parties. See our{" "}
+            <Link
+              href="/privacy"
+              className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300"
+            >
+              privacy policy
+            </Link>{" "}
+            for full details.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import ThemeProvider from "@/components/ThemeProvider";
 import AuthProvider from "@/components/AuthProvider";
 import LoginModal from "@/components/auth/LoginModal";
 import JsonLd from "@/components/JsonLd";
+import Footer from "@/components/Footer";
 import { getAllStates } from "@/lib/states/registry";
 import "./globals.css";
 
@@ -108,6 +109,7 @@ export default function RootLayout({
             <GoogleAnalytics />
             <AdSenseScript />
             {children}
+            <Footer />
             <LoginModal />
           </AuthProvider>
         </ThemeProvider>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 mt-auto">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          <p className="text-sm text-gray-500 dark:text-slate-400">
+            © {new Date().getFullYear()} Community College Path. Free course finder for community college students.
+          </p>
+          <nav className="flex items-center gap-6 text-sm text-gray-500 dark:text-slate-400">
+            <Link href="/about" className="hover:text-teal-600 transition-colors">
+              About
+            </Link>
+            <Link href="/blog" className="hover:text-teal-600 transition-colors">
+              Blog
+            </Link>
+            <Link href="/contact" className="hover:text-teal-600 transition-colors">
+              Contact
+            </Link>
+            <Link href="/privacy" className="hover:text-teal-600 transition-colors">
+              Privacy
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -92,7 +92,7 @@ const nextConfig: NextConfig = {
       { source: "/schedule", destination: "/va/schedule", permanent: true },
       { source: "/transfer", destination: "/va/transfer", permanent: true },
       { source: "/results", destination: "/va/results", permanent: true },
-      { source: "/about", destination: "/va/about", permanent: true },
+      // /about is now a sitewide page — no redirect needed
       { source: "/program/:slug", destination: "/va/program/:slug", permanent: true },
     ];
   },


### PR DESCRIPTION
## What changes for users

Every page now has a footer with links to About, Blog, Contact, and Privacy.

- **/about** — explains what Community College Path does (course search, transfer lookup, prereq chains, schedule builder, late-start finder) and who it's for. Written for a first-generation student, no prior college experience assumed.
- **/contact** — directs users to open a GitHub issue for missing data, incorrect courses, transfer corrections, or feature requests.
- **Footer** — persistent across every page; gives the site a consistent structure and makes policy pages discoverable.

These pages are required for Google AdSense re-review (current rejection: "Low value content" — insufficient About/Contact/Privacy signals).

## What changes technically

- `app/about/page.tsx` — new sitewide route; takes `getAllStates()` data to show live college + state counts in copy.
- `app/contact/page.tsx` — new sitewide route; links to GitHub issues rather than email.
- `components/Footer.tsx` — client-safe server component, added to root layout.
- `app/layout.tsx` — imports and renders `<Footer />`.
- `next.config.ts` — removes the legacy `/about → /va/about` permanent redirect that was intercepting the new page.

## Test plan

- [ ] `/about` loads without redirect; shows correct college + state counts
- [ ] `/contact` loads; GitHub issues link is correct
- [ ] Footer appears on homepage, college pages, and course pages
- [ ] `/va/about` still works (state-specific about page is unaffected)
- [ ] Dark mode footer renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)