### PR TITLE
fix(states): curate TX + HI configs so they light up on the homepage map

### DIFF
--- a/lib/states/hi/config.ts
+++ b/lib/states/hi/config.ts
@@ -2,36 +2,48 @@ import type { StateConfig } from "../registry";
 
 const hiConfig: StateConfig = {
   slug: "hi",
-  name: "Hi",
-  systemName: "Public 2-year",
-  systemFullName: "Hi Public 2-year Colleges",
-  systemUrl: "",
+  name: "Hawaii",
+  systemName: "UHCC",
+  systemFullName: "University of Hawaiʻi Community Colleges",
+  systemUrl: "https://uhcc.hawaii.edu/",
   collegeCount: 6,
 
-  // TODO: research senior-waiver statute for Hi.
-  // Set to null if no waiver exists, or fill in per the SeniorWaiverConfig shape.
-  seniorWaiver: null,
+  // UH Board of Regents Policy 6.205 ("Tuition Reduction for Senior
+  // Citizens") waives tuition for Hawaiʻi residents aged 60 and over in
+  // regular credit courses at UH campuses, on a space-available basis.
+  seniorWaiver: {
+    ageThreshold: 60,
+    legalCitation: "UH Board of Regents Policy 6.205",
+    description:
+      "Hawaiʻi residents aged 60 and older may enroll tuition-free in regular University of Hawaiʻi credit courses on a space-available basis. Some fees still apply; each campus sets registration timing for senior space-available seats.",
+    bannerTitle: "Hawaiʻi Senior Tuition Waiver",
+    bannerSummary:
+      "Over 60 in Hawaiʻi? UH credit courses may be tuition-free on a space-available basis.",
+    bannerDetail:
+      "University of Hawaiʻi Board of Regents Policy 6.205 lets Hawaiʻi residents aged 60+ enroll in regular UH credit courses without paying tuition, on a space-available basis. Some fees still apply, and seats are allocated after regular registration — contact your campus registrar for the timing.",
+  },
 
   transferSupported: false,
   popularCourses: [],
-  defaultZip: "",
-  defaultZipCity: "",
+  defaultZip: "96813",
+  defaultZipCity: "Honolulu",
 
   courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
-    "https://www.example.edu/",
+    "https://uhcc.hawaii.edu/",
 
   collegeCoursesUrl: (_collegeSlug: string) =>
-    "https://www.example.edu/",
+    "https://uhcc.hawaii.edu/",
 
   branding: {
-    siteName: "Community College Path Hi",
-    tagline: "Search Public 2-year courses across all 6 colleges.",
-    footerText: "Community College Path Hi — Find courses across all 6 Public 2-year colleges.",
-    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by Hi Public 2-year Colleges.",
+    siteName: "Community College Path Hawaiʻi",
+    tagline: "Search University of Hawaiʻi Community Colleges courses across all 6 campuses.",
+    footerText: "Community College Path Hawaiʻi — Find courses across all 6 UH Community Colleges.",
+    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by the University of Hawaiʻi Community Colleges.",
     metaKeywords: [
-      "Hi community college courses",
-      "Public 2-year course search",
-      "Hi Public 2-year Colleges",
+      "Hawaii community college courses",
+      "UHCC course search",
+      "University of Hawaiʻi Community Colleges",
+      "Hawaii senior tuition waiver",
     ],
   },
   scrapers: {

--- a/lib/states/tx/config.ts
+++ b/lib/states/tx/config.ts
@@ -2,36 +2,54 @@ import type { StateConfig } from "../registry";
 
 const txConfig: StateConfig = {
   slug: "tx",
-  name: "Tx",
-  systemName: "Public 2-year",
-  systemFullName: "Tx Public 2-year Colleges",
-  systemUrl: "",
+  name: "Texas",
+  systemName: "Texas Community Colleges",
+  systemFullName: "Texas Public Community Colleges",
+  // Texas has no single statewide CC system — 50 independent districts
+  // overseen by the Texas Higher Education Coordinating Board. The Texas
+  // Association of Community Colleges (TACC) is the closest thing to a
+  // unified portal.
+  systemUrl: "https://www.tacc.org/",
   collegeCount: 59,
 
-  // TODO: research senior-waiver statute for Tx.
-  // Set to null if no waiver exists, or fill in per the SeniorWaiverConfig shape.
-  seniorWaiver: null,
+  // Texas Education Code § 54.365 ("Tuition Exemption for Persons 65
+  // Years of Age or Older") — Texas residents 65+ may take up to 6 credit
+  // hours per semester at any state-funded institution tuition-free, on a
+  // space-available basis. Each college applies the waiver on top of its
+  // own registration timing.
+  seniorWaiver: {
+    ageThreshold: 65,
+    legalCitation: "Tex. Educ. Code § 54.365",
+    description:
+      "Texas residents aged 65 and older may enroll in up to 6 credit hours per semester at any state-funded community college tuition-free, on a space-available basis. Fees may still apply; each college sets registration timing for senior space-available seats.",
+    bannerTitle: "Texas Senior Tuition Exemption",
+    bannerSummary:
+      "Over 65 in Texas? Up to 6 credit hours per semester may be tuition-free at any state-funded college.",
+    bannerDetail:
+      "Texas Education Code § 54.365 lets Texas residents aged 65+ take up to 6 credit hours per semester at any state-funded community college without paying tuition, on a space-available basis. Fees still apply; seats are allocated after regular registration. Contact your college's registrar for the timing.",
+  },
 
   transferSupported: false,
   popularCourses: [],
-  defaultZip: "",
-  defaultZipCity: "",
+  defaultZip: "77002",
+  defaultZipCity: "Houston",
 
   courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
-    "https://www.example.edu/",
+    "https://www.tacc.org/",
 
   collegeCoursesUrl: (_collegeSlug: string) =>
-    "https://www.example.edu/",
+    "https://www.tacc.org/",
 
   branding: {
-    siteName: "Community College Path Tx",
-    tagline: "Search Public 2-year courses across all 59 colleges.",
-    footerText: "Community College Path Tx — Find courses across all 59 Public 2-year colleges.",
-    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by Tx Public 2-year Colleges.",
+    siteName: "Community College Path Texas",
+    tagline: "Search Texas community college courses across all 59 public colleges.",
+    footerText: "Community College Path Texas — Find courses across all 59 Texas public community colleges.",
+    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by the Texas Higher Education Coordinating Board, the Texas Association of Community Colleges, or any Texas community college.",
     metaKeywords: [
-      "Tx community college courses",
-      "Public 2-year course search",
-      "Tx Public 2-year Colleges",
+      "Texas community college courses",
+      "Texas community college schedule",
+      "Texas community colleges",
+      "Texas senior tuition exemption",
     ],
   },
   scrapers: {


### PR DESCRIPTION
## What changes for someone using the site

The homepage US map currently renders Texas and Hawaii as grey "coming soon" states, even though both states are live with thousands of courses. After this PR, both states render in the active teal fill with a click-through to `/tx` and `/hi`.

Same fix also corrects every placeholder string that was leaking through to users:

| Where | Before | After |
|---|---|---|
| `/tx` page title (`<title>` + `<h1>`) | "Find Tx Community College Courses" | "Find Texas Community College Courses" |
| `/hi` page title | "Find Hi Community College Courses" | "Find Hawaiʻi Community College Courses" |
| State footer | "Community College Path Tx — Find courses across all 59 Public 2-year colleges." | "Community College Path Texas — Find courses across all 59 Texas public community colleges." |
| Disclaimer | "...not affiliated with...Tx Public 2-year Colleges." | "...not affiliated with...the Texas Higher Education Coordinating Board, the Texas Association of Community Colleges, or any Texas community college." |
| Senior-waiver banner | Hidden (set to null) | TX: "Over 65 in Texas? Up to 6 credit hours per semester may be tuition-free..."  ·  HI: "Over 60 in Hawaiʻi? UH credit courses may be tuition-free on a space-available basis." |

## What changes on the technical front

`components/USMap.tsx` looks up each topojson feature by its full name:

```tsx
const byName = new Map(states.map((s) => [s.name, ...]));
const active = byName.get(name);                  // "Texas", "Hawaii"...
if (active) { /* render teal active path */ }
else        { /* render grey coming-soon path  */ }
```

The `auto-add-state` orchestrator's `bootstrap-state.ts` had been writing `name: "Tx"` / `name: "Hi"` (title-cased 2-letter slug) into the generated `lib/states/{slug}/config.ts` as a placeholder, with a TODO comment expecting human curation before merge. Both states' PRs (#453 TX, #459 HI) merged without that curation step happening, so the map lookup missed both.

This PR doesn't change the bootstrap script — it just curates the two configs by hand. A follow-up improvement to the orchestrator could read full state names from a curated dictionary (we already have `data/state-metadata.json` for this purpose; it just lacked entries for TX and HI) and avoid the manual step on future state additions.

Per-state research that went into this PR:

- **TX senior waiver:** Texas Education Code § 54.365 — residents 65+, up to 6 credit hours per semester at any state-funded community college, space-available basis. (Texas has 50 independent CC districts overseen by THECB; no single statewide CC system.)
- **HI senior waiver:** UH Board of Regents Policy 6.205 — Hawaiʻi residents 60+, regular UH credit courses, space-available basis. (HI's 6 community colleges are all part of the University of Hawaiʻi system.)

## Test plan

- [x] Loaded `/` locally — DOM check confirms `<title>` on the Texas and Hawaii paths reads `"Texas — 59 colleges · click to browse"` and `"Hawaii — 6 colleges · click to browse"` (the active-state title format), not the grey coming-soon variant.
- [x] Loaded `/tx` locally — `<h1>` reads "Find Texas Community College Courses", `<title>` reads "Texas Community College Course Finder | Community College Path".
- [ ] Vercel preview deploy renders the map with TX + HI teal.
- [ ] After deploy: senior-waiver banners visible on `/tx` and `/hi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
