### PR TITLE
fix(.claude/hooks): keep branch-lock when tracked changes are in flight

### DIFF
--- a/.claude/hooks/post-git-checkout.sh
+++ b/.claude/hooks/post-git-checkout.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
 # PostToolUse hook: after a `git checkout -b NAME` Bash call completes
-# successfully, write NAME into .claude/branch-lock. This sets up the
-# branch guard so subsequent commits/pushes are validated against this
-# branch — preventing the silent-branch-swap mistakes that produced
-# cherry-pick rescues on PRs #460, #462, and #465.
+# successfully, write NAME into .claude/branch-lock — but only when it's
+# SAFE to overwrite the previous lock. "Safe" means the working tree has
+# no uncommitted changes to tracked files at the moment the hook runs.
 #
-# Only fires on `git checkout -b NAME` (new-branch creation), not on
-# regular `git checkout BRANCH`, because the latter is often used to
-# move between branches the user has already chosen, and locking would
-# fight that workflow. If you want to lock after a plain checkout,
-# write to .claude/branch-lock manually.
+# Why the safety check: parallel skills / sessions can run `git checkout
+# -b OTHER_BRANCH` in this same workspace. Without the check, that
+# parallel checkout would silently overwrite the lock with OTHER_BRANCH,
+# and the subsequent commit (still on the *real* current branch, but
+# guarded against the new lock) would pass the guard and land on the
+# wrong branch. PR #469 (Alamo) hit exactly this and needed a
+# cherry-pick rescue.
+#
+# With the check: if I have uncommitted Alamo work in the tree and some
+# parallel session runs `git checkout -b foo`, this hook sees the dirty
+# tree, refuses to overwrite the lock, and the next `git commit` aborts
+# with the BRANCH GUARD banner — exactly the desired behavior.
+#
+# Notes:
+#   - `git status --porcelain` excludes untracked (?? entries are reported
+#     but we filter them out). We only care about M/A/D/R/C — actual
+#     changes to tracked files. Untracked files (worktrees, scratch dirs)
+#     are normal and shouldn't block.
+#   - Only fires on `git checkout -b NAME` (new-branch creation), not on
+#     regular `git checkout BRANCH`. The latter is often used to move
+#     between branches the user has already chosen; auto-locking those
+#     would fight that workflow.
 
 set -euo pipefail
 
@@ -24,6 +40,18 @@ CMD=$(echo "$PAYLOAD" | /usr/bin/python3 -c "import sys, json; print(json.load(s
 if [[ "$CMD" =~ git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+([A-Za-z0-9._/-]+) ]]; then
   BRANCH="${BASH_REMATCH[1]}"
   cd "$REPO_ROOT" || exit 0
+
+  # Count uncommitted changes to TRACKED files (exclude untracked '??').
+  TRACKED_CHANGES=$(git status --porcelain 2>/dev/null | awk '/^[^?]/' | wc -l | tr -d '[:space:]')
+
+  if [ "$TRACKED_CHANGES" -gt 0 ]; then
+    echo "⚠️  branch-lock NOT updated to '$BRANCH' — working tree has $TRACKED_CHANGES uncommitted change(s)." >&2
+    echo "    Existing lock kept: $(cat .claude/branch-lock 2>/dev/null || echo '(none)')" >&2
+    echo "    This protects against parallel sessions overwriting the lock while I have in-flight work." >&2
+    echo "    If you really mean to lock '$BRANCH', commit / stash first, then: echo $BRANCH > .claude/branch-lock" >&2
+    exit 0
+  fi
+
   echo "$BRANCH" > .claude/branch-lock
   echo "🔒 branch-lock written: $BRANCH" >&2
 fi


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-visible. This is a fix to the `.claude/` branch-lock hook system.

## What changes on the technical front

Two PRs needed cherry-pick rescues this week because the post-checkout hook overwrote `.claude/branch-lock` when a parallel session ran `git checkout -b` — even though there was in-flight, uncommitted work in the tree that didn't belong on the new branch:

- **PR #465** (HI UHCC) — Alamo work was being prepared, parallel HI session checked out, lock got swapped, Alamo commit landed on HI branch.
- **PR #469** (TX Alamo) — Alamo work in flight, parallel WV session checked out, lock got swapped, Alamo commit landed on WV branch. (We literally hit this in a continuous chain.)

The original guard, landed in PR #465, has a `PreToolUse` hook that aborts `git commit` / `push` / `cherry-pick` if `git branch --show-current` ≠ `cat .claude/branch-lock`. That part works fine. The flaw is in the **companion** `PostToolUse` hook that *writes* the lock on every `git checkout -b NAME`:

```bash
# before: unconditional
echo "$BRANCH" > .claude/branch-lock
```

When a parallel session ran `git checkout -b OTHER_BRANCH`, the hook fired with the same authority and rewrote the lock to `OTHER_BRANCH`. Subsequently, on the now-WRONG branch (because the parallel session also swapped the working tree's HEAD), `git commit` saw `lock == current branch == OTHER_BRANCH` and let the commit through. Wrong tree, wrong branch.

The fix: refuse to overwrite the lock when there are **tracked-file changes** (modifications or staged work) in the tree. Untracked entries (e.g. `.claude/worktrees/`) are excluded — those are parallel-session scratch and shouldn't block. Concretely:

```bash
TRACKED_CHANGES=$(git status --porcelain 2>/dev/null | awk '/^[^?]/' | wc -l | tr -d '[:space:]')
if [ "$TRACKED_CHANGES" -gt 0 ]; then
  # keep existing lock; emit a warning
  exit 0
fi
echo "$BRANCH" > .claude/branch-lock
```

After this change, the same scenario plays out cleanly:

| Step | Before this PR | After this PR |
|---|---|---|
| 1. I have Alamo work in tree, `lock=alamo` | — | — |
| 2. Parallel session: `git checkout -b WV` | Hook overwrites lock to `WV` | Hook sees dirty tree, keeps `lock=alamo` |
| 3. Workspace HEAD silently moves to WV | — | — |
| 4. I run `git commit` | `lock=WV`, current=`WV`, **pass** (wrong!) | `lock=alamo`, current=`WV`, **ABORT** |
| 5. Result | Commit lands on WV, cherry-pick rescue needed | I reconcile explicitly, no bad commit |

If I genuinely want to lock to the new branch (e.g. I just deliberately switched contexts), the warning explicitly tells me to commit/stash and then `echo NEW_BRANCH > .claude/branch-lock` manually.

### Tested locally
- Clean tree + `git checkout -b foo` → lock updates ✓
- Dirty tree + `git checkout -b bar` → lock preserved, warning printed ✓

## Test plan

- [x] Unit test against clean tree (`git stash` first, fire hook) — lock updates as expected.
- [x] Unit test against dirty tree — lock preserved, warning prints to stderr.
- [ ] Once merged: deliberately replicate the failure mode (start work, simulate a parallel checkout) and verify the guard now aborts instead of silently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
