### PR TITLE
chore(va): disable VA scrapers from scheduled cron

### DIFF
--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -61,43 +61,10 @@ const vaConfig: StateConfig = {
     { slug: "liberty", names: ["Liberty", "Liberty University"] },
   ],
   scrapers: {
-    courses: [
-      { scripts: ["scripts/va/scrape-vccs.ts"], runner: "http", termSystem: "vccs" },
-      { scripts: ["scripts/va/scrape-peoplesoft.ts", "scripts/va/enrich-peoplesoft.ts"], runner: "playwright", termSystem: "vccs-ps" },
-    ],
-    transfers: [
-      {
-        scripts: [
-          "scripts/va/scrape-transfer-equiv.ts",
-          "scripts/va/scrape-transfer-gmu.ts",
-          "scripts/va/scrape-transfer-odu.ts",
-          "scripts/va/scrape-transfer-uva.ts",
-          "scripts/va/scrape-transfer-vcu.ts",
-          "scripts/va/scrape-transfer-vsu.ts",
-          "scripts/va/scrape-transfer-umw.ts",
-          "scripts/va/scrape-transfer-vwu.ts",
-        ],
-        runner: "http",
-      },
-    ],
-    prereqs: [
-      { scripts: ["scripts/va/scrape-catalog-prereqs.ts"], runner: "http" },
-    ],
-    programs: [
-      { scripts: ["scripts/va/scrape-programs.ts"], runner: "http" },
-      {
-        scripts: ["scripts/va/scrape-courseleaf-programs.ts"],
-        runner: "http",
-      },
-      {
-        scripts: ["scripts/va/scrape-vhcc-pdf-programs.ts"],
-        runner: "http",
-      },
-      {
-        scripts: ["scripts/va/scrape-camp-pdf-programs.ts"],
-        runner: "http",
-      },
-    ],
+    // manual-only: courses — VA PeopleSoft scraper consistently exceeds the 6h GitHub Actions timeout; run manually when needed.
+    // manual-only: transfers — disabled alongside courses to avoid partial-refresh drift.
+    // manual-only: prereqs — disabled alongside courses.
+    // manual-only: programs — disabled alongside courses.
   },
 };
 


### PR DESCRIPTION
## Summary

Removes all VA scraper entries from `StateConfig.scrapers` so the scheduled-scrape workflow no longer includes Virginia.

**What changes for someone using the site:** Nothing — VA data stays exactly as-is. No courses, transfers, or prereqs are deleted.

**What changes on the technical front:** VA's PeopleSoft course scraper consistently exceeds the 6-hour GitHub Actions timeout, causing the entire `Scheduled scrape (unified)` run to report as failed even when every other state succeeds. Marking all VA scrapers as `manual-only` removes VA from the cron matrix. Run VA scrapers manually with `npx tsx scripts/va/scrape-*.ts` when a refresh is needed.

## Test plan

- [x] `npm run typecheck` passes
- [x] Scraper matrix emits 0 VA entries for both `courses` and `transfers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)