### PR TITLE
feat(ia): wire courses + prereqs to scheduled cron

### DIFF
--- a/lib/states/ia/config.ts
+++ b/lib/states/ia/config.ts
@@ -41,9 +41,11 @@ const iaConfig: StateConfig = {
     ],
   },
   scrapers: {
-    // manual-only: courses — mixed-platform state, 2 colleges scraped via colleague template; per-state cron not yet wired.
+    courses: [
+      { scripts: ["scripts/ia/scrape-colleague.ts"], runner: "playwright" },
+    ],
     // manual-only: transfers — no articulation portal registered for IA yet.
-    // manual-only: prereqs — runs as part of course aggregation.
+    prereqs: { source: "aggregate-from-courses" },
     // manual-only: programs — Phase 5+.
   },
 };

--- a/scripts/ia/scrape-colleague.ts
+++ b/scripts/ia/scrape-colleague.ts
@@ -1,0 +1,49 @@
+/**
+ * Iowa — Colleague Self-Service scrape (2 colleges)
+ *
+ * Calls the shared template at scripts/lib/scrape-colleague.ts for the
+ * two Iowa colleges currently producing data under data/ia/courses/.
+ * Both were scraped successfully during the auto-add-state run for IA
+ * (PR #386) but no per-state wrapper was committed, so the unified
+ * scheduled-scrape workflow had no entry point to re-run them on cron.
+ *
+ *   eastern-iowa-community-college-district → selfservice.eicc.edu
+ *   iowa-western-community-college          → iwcc-ss.colleague.elluciancloud.com
+ *
+ * Hosts confirmed against each college's public /Student/Courses page.
+ *
+ * No Supabase import here — the unified import-on-merge workflow picks
+ * up JSON on main and runs schema validation + change detection.
+ */
+import { scrapeColleagueState } from "../lib/scrape-colleague";
+
+const HOSTS: Record<string, string> = {
+  "eastern-iowa-community-college-district": "https://selfservice.eicc.edu",
+  "iowa-western-community-college": "https://iwcc-ss.colleague.elluciancloud.com",
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeFilter = args
+    .find((a) => a.startsWith("--college="))
+    ?.split("=")[1];
+
+  console.log("📚 IA Colleague scraper");
+  console.log(`   Hosts: ${Object.keys(HOSTS).length}`);
+
+  const result = await scrapeColleagueState({
+    state: "ia",
+    hosts: HOSTS,
+    collegeFilter,
+    noImport: true,
+  });
+
+  console.log(
+    `\n✅ Done — ${result.grandTotal} sections across ${result.results.length} colleges.`
+  );
+}
+
+main().catch((err) => {
+  console.error("❌ IA Colleague scraper failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible immediately. This change lets the unified scheduled-scrape workflow re-run Iowa's course scrape on its Mon/Wed/Fri cron, so Iowa course data won't go stale. Today the data committed during the original auto-add-state run (#386) is frozen at scrape time; after this lands, fresh sections appear in PRs the same way they do for VA / MA / OH peers.

## What changes on the technical front

Adds [scripts/ia/scrape-colleague.ts](scripts/ia/scrape-colleague.ts) — a thin wrapper around the shared Colleague Self-Service template at [scripts/lib/scrape-colleague.ts](scripts/lib/scrape-colleague.ts). The auto-add-state orchestrator ran the template inline (with hosts derived from in-memory fingerprint results) but never persisted a per-state wrapper, so the scheduled-scrape matrix had nothing to dispatch for IA courses.

Hosts (confirmed against each college's public `/Student/Courses` page):

| College slug | Host |
|---|---|
| eastern-iowa-community-college-district | https://selfservice.eicc.edu |
| iowa-western-community-college | https://iwcc-ss.colleague.elluciancloud.com |

Config delta in [lib/states/ia/config.ts](lib/states/ia/config.ts):

| Datatype | Before | After |
|---|---|---|
| courses | `manual-only` | `scrape-colleague.ts` (playwright) |
| prereqs | `manual-only` (note: "runs as part of course aggregation") | `{ source: "aggregate-from-courses" }` |
| transfers | `manual-only` (no portal) | unchanged |
| programs | `manual-only` (Phase 5+) | unchanged |

## Test plan

- [x] `npx tsx scripts/check-scraper-coverage.ts` passes
- [x] `npx tsc --noEmit` passes
- [ ] First scheduled-scrape run (Mon/Wed/Fri 06:00 UTC) produces an `scheduled-scrape/ia-courses` PR with the expected ~4,800 sections across both colleges (matches the original auto-add-state numbers from #386)
- [ ] If a host has moved since auto-add-state ran (auto-add-state was 2026-05-11; URLs can drift), the per-college job logs will surface a clean error and the other college's data still merges. No silent staleness.

## Notes

- The other 14 Iowa colleges remain unscrapable today — fingerprinted as `custom`, `unknown`, or `jenzabar` (jenzabar template exists but no IA wrapper yet). Tracked under the ongoing fingerprint-sweep work.
- This is part of a series wiring IA / MO / OH / MS / PA to cron — IA is the simplest (single platform, 2 colleges) and goes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)