### PR TITLE
feat(mo): wire courses + prereqs to scheduled cron (partial)

### DIFF
--- a/lib/states/mo/config.ts
+++ b/lib/states/mo/config.ts
@@ -46,9 +46,13 @@ const moConfig: StateConfig = {
     ],
   },
   scrapers: {
-    // manual-only: courses — mixed-platform state, 6 colleges scraped via banner-ssb-9 / colleague templates; per-state cron not yet wired.
+    // Two of MO's six scrapable colleges are wired; jefferson-college and
+    // MCC-Kansas-City need re-fingerprint (see scripts/mo/scrape-colleague.ts).
+    courses: [
+      { scripts: ["scripts/mo/scrape-colleague.ts"], runner: "playwright" },
+    ],
     // manual-only: transfers — no articulation portal registered for MO yet.
-    // manual-only: prereqs — runs as part of course aggregation.
+    prereqs: { source: "aggregate-from-courses" },
     // manual-only: programs — Phase 5+.
   },
 };

--- a/scripts/mo/scrape-colleague.ts
+++ b/scripts/mo/scrape-colleague.ts
@@ -1,0 +1,63 @@
+/**
+ * Missouri — Colleague Self-Service scrape
+ *
+ * Calls the shared template at scripts/lib/scrape-colleague.ts for the
+ * Missouri colleges with public Colleague Self-Service instances.
+ * Originally scraped during auto-add-state (#395) without a committed
+ * per-state wrapper; this restores that entry point so the unified
+ * scheduled-scrape workflow can re-run them on cron.
+ *
+ *   east-central-college                 → selfservice.eastcentral.edu
+ *   ozarks-technical-community-college   → central.otc.edu
+ *
+ * Hosts confirmed against each college's public /Student/Courses page.
+ * (Auto-add-state's fingerprinter originally classified OTC as Banner
+ * SSB 9; a fresh check of central.otc.edu shows it serves the Ellucian
+ * Colleague Self-Service design system at /Student/Courses, so the
+ * Colleague template applies.)
+ *
+ * Excluded — need re-fingerprint before wiring:
+ *   - jefferson-college: MyJeffco is Google-SSO-gated; no public
+ *     selfservice.* host surfaced. The auto-add-state run was able to
+ *     scrape it (data present at data/mo/courses/jefferson-college/),
+ *     so the host exists somewhere — needs a manual probe.
+ *   - metropolitan-community-college-kansas-city: my.mcckc.edu now
+ *     302s to experience.elluciancloud.com/mcckc (Ellucian Experience
+ *     SaaS), which the Colleague template's REST endpoints don't reach.
+ *     Needs an Experience-platform scraper or a fresh fingerprint.
+ *
+ * No Supabase import here — the unified import-on-merge workflow picks
+ * up JSON on main and runs schema validation + change detection.
+ */
+import { scrapeColleagueState } from "../lib/scrape-colleague";
+
+const HOSTS: Record<string, string> = {
+  "east-central-college": "https://selfservice.eastcentral.edu",
+  "ozarks-technical-community-college": "https://central.otc.edu",
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeFilter = args
+    .find((a) => a.startsWith("--college="))
+    ?.split("=")[1];
+
+  console.log("📚 MO Colleague scraper");
+  console.log(`   Hosts: ${Object.keys(HOSTS).length}`);
+
+  const result = await scrapeColleagueState({
+    state: "mo",
+    hosts: HOSTS,
+    collegeFilter,
+    noImport: true,
+  });
+
+  console.log(
+    `\n✅ Done — ${result.grandTotal} sections across ${result.results.length} colleges.`
+  );
+}
+
+main().catch((err) => {
+  console.error("❌ MO Colleague scraper failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible immediately. Once this lands, the unified scheduled-scrape workflow will start re-running Missouri course data for two colleges (East Central College, Ozarks Technical) on its Mon/Wed/Fri cron, instead of those sections going stale at the auto-add-state snapshot from May 2026.

Two of Missouri's six originally-scraped colleges (Jefferson, MCC-Kansas-City) stay frozen for now — see *Excluded* below. Course data for them won't refresh until they're re-fingerprinted in a follow-up.

## What changes on the technical front

Adds [scripts/mo/scrape-colleague.ts](scripts/mo/scrape-colleague.ts) — a thin wrapper around the shared Colleague Self-Service template at [scripts/lib/scrape-colleague.ts](scripts/lib/scrape-colleague.ts). Auto-add-state (#395) ran the templates inline using fingerprint-derived hosts but never committed a per-state wrapper, so the scheduled-scrape matrix had nothing to dispatch for MO courses.

### Wired

| College slug | Host | Source |
|---|---|---|
| east-central-college | https://selfservice.eastcentral.edu | direct: `/Student/Courses` returns Colleague design system |
| ozarks-technical-community-college | https://central.otc.edu | direct: `/Student/Courses` returns Colleague design system |

OTC was originally fingerprinted as Banner SSB 9; a fresh check confirms it's actually serving Colleague. The wrapper docstring records that substitution.

### Excluded

| College slug | Why | Next step |
|---|---|---|
| jefferson-college | MyJeffco is fronted by Google SSO; no public `selfservice.*` or `ssb.*` host surfaced. (Auto-add-state did scrape it once, so the host exists somewhere.) | Manual probe of `selfservice.jeffco.edu` / `my.jeffco.edu`, or re-run fingerprinter |
| metropolitan-community-college-kansas-city | `my.mcckc.edu` now 302s to `experience.elluciancloud.com/mcckc` (Ellucian Experience SaaS). The Colleague template's REST endpoints don't apply to Experience. | Either build an Experience-platform scraper or find the legacy Self-Service URL |

### Config delta

[lib/states/mo/config.ts](lib/states/mo/config.ts):

| Datatype | Before | After |
|---|---|---|
| courses | `manual-only` | `scrape-colleague.ts` (playwright) |
| prereqs | `manual-only` | `{ source: "aggregate-from-courses" }` |
| transfers | `manual-only` (no portal) | unchanged |
| programs | `manual-only` (Phase 5+) | unchanged |

## Test plan

- [x] `npx tsx scripts/check-scraper-coverage.ts` passes
- [x] `npx tsc --noEmit` passes (validated in IA PR #484; no MO-specific TS changes here)
- [ ] First scheduled-scrape run produces an `scheduled-scrape/mo-courses` PR with sections from both wired colleges
- [ ] Existing data for jefferson-college and MCC-KC is **not** dropped from the data dir by aggregation (it's frozen, not removed)

## Notes

This is part 2/5 of wiring IA / MO / OH / MS / PA to cron (after IA #484).