### PR TITLE
feat(oh): wire courses + prereqs to scheduled cron

### DIFF
--- a/lib/states/oh/config.ts
+++ b/lib/states/oh/config.ts
@@ -46,9 +46,16 @@ const ohConfig: StateConfig = {
     ],
   },
   scrapers: {
-    // manual-only: courses — mixed-platform state, 8 colleges scraped via banner-ssb-9 / colleague / banner-8 templates per-college; per-state cron not yet wired.
+    // Five of OH's eight scrapable colleges are wired across three
+    // platforms. The other three (committed during auto-add-state but
+    // not represented in data/oh/courses today) need re-fingerprint.
+    courses: [
+      { scripts: ["scripts/oh/scrape-banner-ssb.ts"], runner: "http" },
+      { scripts: ["scripts/oh/scrape-colleague.ts"], runner: "playwright" },
+      { scripts: ["scripts/oh/scrape-banner8.ts"], runner: "http" },
+    ],
     // manual-only: transfers — no articulation portal registered for OH yet.
-    // manual-only: prereqs — runs as part of course aggregation.
+    prereqs: { source: "aggregate-from-courses" },
     // manual-only: programs — Phase 5+.
   },
 };

--- a/scripts/oh/scrape-banner-ssb.ts
+++ b/scripts/oh/scrape-banner-ssb.ts
@@ -1,0 +1,32 @@
+/**
+ * Ohio — Banner SSB 9 scrape
+ *
+ * Thin wrapper around the shared Banner SSB 9 template for the three
+ * Ohio colleges with public Banner Self-Service Banner 9 instances.
+ * Originally scraped via auto-add-state (#363) without a committed
+ * per-state wrapper; this restores the entry point so the unified
+ * scheduled-scrape workflow can re-run them on cron.
+ *
+ *   cuyahoga-community-college-district   → banstup.tri-c.edu
+ *   stark-state-college                   → selfservice-registration.starkstate.edu
+ *   terra-state-community-college         → banxe.terra.edu
+ *
+ * (Terra State was originally classified as Colleague by auto-add-state's
+ * fingerprinter, but my.terra.edu's official Links page points "Banner
+ * Self-Service" at banxe.terra.edu/BannerGeneralSsb — Banner, not
+ * Colleague. The wrapper here treats it as Banner SSB 9.)
+ *
+ * Usage:
+ *   npx tsx scripts/oh/scrape-banner-ssb.ts
+ *   npx tsx scripts/oh/scrape-banner-ssb.ts --college stark-state-college
+ */
+import { scrapeBannerSsbState } from "../lib/scrape-banner-ssb";
+
+await scrapeBannerSsbState({
+  state: "oh",
+  hosts: {
+    "cuyahoga-community-college-district": "https://banstup.tri-c.edu",
+    "stark-state-college": "https://selfservice-registration.starkstate.edu",
+    "terra-state-community-college": "https://banxe.terra.edu",
+  },
+});

--- a/scripts/oh/scrape-banner8.ts
+++ b/scripts/oh/scrape-banner8.ts
@@ -1,0 +1,44 @@
+/**
+ * Ohio — Banner 8 SSB scrape
+ *
+ * Thin wrapper around the shared Banner 8 template for Ohio colleges
+ * running the classic (bwck*) Banner 8 self-service. Originally scraped
+ * via auto-add-state (#363) without a committed per-state wrapper.
+ *
+ *   james-a-rhodes-state-college → banner-prod.rhodesstate.edu/PRD9
+ *
+ * Rhodes State's host serves the standard Banner 8 endpoints
+ * (bwckschd.p_disp_dyn_sched / bwckschd.p_get_crse_unsec).
+ *
+ * Usage:
+ *   npx tsx scripts/oh/scrape-banner8.ts
+ *   npx tsx scripts/oh/scrape-banner8.ts --college james-a-rhodes-state-college
+ *   npx tsx scripts/oh/scrape-banner8.ts --no-import
+ */
+import { scrapeBanner8ByHost } from "../lib/scrape-banner-8";
+
+const HOSTS: Record<string, string> = {
+  "james-a-rhodes-state-college": "https://banner-prod.rhodesstate.edu/PRD9",
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeIdx = args.indexOf("--college");
+  const collegeFilter = collegeIdx >= 0 ? args[collegeIdx + 1] : undefined;
+  const noImport = args.includes("--no-import");
+
+  console.log("🌰 Ohio Banner 8 scraper");
+  console.log(`   Colleges: ${Object.keys(HOSTS).length}`);
+
+  await scrapeBanner8ByHost({
+    state: "oh",
+    hosts: HOSTS,
+    collegeFilter,
+    noImport,
+  });
+}
+
+main().catch((err) => {
+  console.error("❌ Ohio Banner 8 scraper failed:", err);
+  process.exit(1);
+});

--- a/scripts/oh/scrape-colleague.ts
+++ b/scripts/oh/scrape-colleague.ts
@@ -1,0 +1,48 @@
+/**
+ * Ohio — Colleague Self-Service scrape
+ *
+ * Thin wrapper around the shared Colleague template for the Ohio
+ * colleges with public Colleague Self-Service instances. Originally
+ * scraped via auto-add-state (#363) without a committed per-state
+ * wrapper.
+ *
+ *   cincinnati-state-technical-and-community-college → selfservice.cincinnatistate.edu
+ *
+ * (Cincinnati State was originally fingerprinted as Banner SSB 9 by
+ * auto-add-state, but selfservice.cincinnatistate.edu serves Colleague
+ * Self-Service at /Student/Courses. The Colleague template applies.)
+ *
+ * No Supabase import here — the unified import-on-merge workflow picks
+ * up JSON on main and runs schema validation + change detection.
+ */
+import { scrapeColleagueState } from "../lib/scrape-colleague";
+
+const HOSTS: Record<string, string> = {
+  "cincinnati-state-technical-and-community-college": "https://selfservice.cincinnatistate.edu",
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeFilter = args
+    .find((a) => a.startsWith("--college="))
+    ?.split("=")[1];
+
+  console.log("📚 OH Colleague scraper");
+  console.log(`   Hosts: ${Object.keys(HOSTS).length}`);
+
+  const result = await scrapeColleagueState({
+    state: "oh",
+    hosts: HOSTS,
+    collegeFilter,
+    noImport: true,
+  });
+
+  console.log(
+    `\n✅ Done — ${result.grandTotal} sections across ${result.results.length} colleges.`
+  );
+}
+
+main().catch((err) => {
+  console.error("❌ OH Colleague scraper failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible immediately. After this lands, Ohio's course data refreshes on cron (Mon/Wed/Fri 06:00 UTC) instead of staying frozen at the auto-add-state snapshot from May 2026. Five OH colleges go live on the schedule — the other three originally captured in #363 stay frozen until they're re-fingerprinted (see *Excluded*).

## What changes on the technical front

Adds three wrapper scripts under [scripts/oh/](scripts/oh/), one per SIS platform. All call shared templates in [scripts/lib/](scripts/lib/). Auto-add-state (#363) ran those templates inline using fingerprint-derived hosts but never committed per-state wrappers, so the scheduled-scrape matrix had nothing to dispatch for OH courses.

### Wired

| Wrapper | Platform | College | Host |
|---|---|---|---|
| [scrape-banner-ssb.ts](scripts/oh/scrape-banner-ssb.ts) | Banner SSB 9 | cuyahoga-community-college-district | https://banstup.tri-c.edu |
| | Banner SSB 9 | stark-state-college | https://selfservice-registration.starkstate.edu |
| | Banner SSB 9 | terra-state-community-college | https://banxe.terra.edu |
| [scrape-colleague.ts](scripts/oh/scrape-colleague.ts) | Colleague | cincinnati-state-technical-and-community-college | https://selfservice.cincinnatistate.edu |
| [scrape-banner8.ts](scripts/oh/scrape-banner8.ts) | Banner 8 | james-a-rhodes-state-college | https://banner-prod.rhodesstate.edu/PRD9 |

Two platform classifications were corrected vs. the original auto-add-state fingerprint based on a fresh check of each college's public endpoints:

- **terra-state-community-college** — was Colleague in the original fingerprint, but my.terra.edu's official Links page points "Banner Self-Service" at `banxe.terra.edu/BannerGeneralSsb`. Wired here as Banner SSB 9.
- **cincinnati-state-technical-and-community-college** — was Banner SSB 9 in the original fingerprint, but `selfservice.cincinnatistate.edu/Student/Courses` returns Colleague's Ellucian design system. Wired here as Colleague.

### Excluded

The original auto-add-state commit message reported 8 colleges scraped, but only 5 college directories exist under `data/oh/courses/` today. The other 3 (cuyahoga is in data; the unaccounted ones include candidates like lakeland-community-college and owens-community-college) have no current data and are not wired here — they need re-fingerprint to confirm a working host.

### Config delta

[lib/states/oh/config.ts](lib/states/oh/config.ts):

| Datatype | Before | After |
|---|---|---|
| courses | `manual-only` | 3 parallel ScrapeJobs (banner-ssb / colleague / banner-8) |
| prereqs | `manual-only` (note: "runs as part of course aggregation") | `{ source: "aggregate-from-courses" }` |
| transfers | `manual-only` (no portal) | unchanged |
| programs | `manual-only` (Phase 5+) | unchanged |

## Test plan

- [x] `npx tsx scripts/check-scraper-coverage.ts` passes
- [x] Typecheck passes
- [ ] First scheduled-scrape run produces three parallel matrix entries under `scheduled-scrape/oh-courses` PR
- [ ] Each platform's job completes without auth wall — if any host has moved or now requires SSO, the logs surface a clean error rather than silent drop

## Notes

Part 3/5 of wiring IA / MO / OH / MS / PA to cron (after [IA #484](https://github.com/rohan-c0de/cc-coursemap/pull/484) and [MO #485](https://github.com/rohan-c0de/cc-coursemap/pull/485)).