### PR TITLE
feat(ms): wire courses (Meridian CC) to scheduled cron

### DIFF
--- a/lib/states/ms/config.ts
+++ b/lib/states/ms/config.ts
@@ -36,9 +36,10 @@ const msConfig: StateConfig = {
     ],
   },
   scrapers: {
-    // manual-only: courses — MS colleges use a mix of platforms (Colleague,
-    //   Banner SSB 9, Banner 8, Jenzabar, custom). SIS fingerprinting
-    //   identifies each college's platform for targeted scraping.
+    // Only Meridian CC is wired today (Banner 8). The other 14 MS colleges
+    // remain fingerprinted but unscrapped pending wrapper work for the
+    // mixed-platform mix (Colleague, Banner SSB 9, Jenzabar, custom).
+    courses: [{ scripts: ["scripts/ms/scrape-banner8.ts"], runner: "http" }],
     // manual-only: transfers — Mississippi runs MTAG (Mississippi Transfer
     //   Agreement Guide) — check as a potential source for articulation data.
     prereqs: [{ scripts: ["scripts/ms/scrape-catalog-prereqs.ts"], runner: "playwright" }],

--- a/scripts/ms/scrape-banner8.ts
+++ b/scripts/ms/scrape-banner8.ts
@@ -1,0 +1,45 @@
+/**
+ * Mississippi — Banner 8 SSB scrape
+ *
+ * Thin wrapper around the shared Banner 8 template. Currently covers
+ * the single MS college producing data — Meridian Community College —
+ * originally bootstrapped during MS (#290) without a per-state course
+ * wrapper.
+ *
+ *   meridian-community-college → ssb.meridiancc.edu/ssb/prod
+ *
+ * Meridian's host serves the classic (bwsk*/bwck*) Banner 8 endpoints;
+ * page header reports "Banner Web Self-Service Release: 8.7.2.11".
+ *
+ * Usage:
+ *   npx tsx scripts/ms/scrape-banner8.ts
+ *   npx tsx scripts/ms/scrape-banner8.ts --college meridian-community-college
+ *   npx tsx scripts/ms/scrape-banner8.ts --no-import
+ */
+import { scrapeBanner8ByHost } from "../lib/scrape-banner-8";
+
+const HOSTS: Record<string, string> = {
+  "meridian-community-college": "https://ssb.meridiancc.edu/ssb/prod",
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeIdx = args.indexOf("--college");
+  const collegeFilter = collegeIdx >= 0 ? args[collegeIdx + 1] : undefined;
+  const noImport = args.includes("--no-import");
+
+  console.log("🌲 Mississippi Banner 8 scraper");
+  console.log(`   Colleges: ${Object.keys(HOSTS).length}`);
+
+  await scrapeBanner8ByHost({
+    state: "ms",
+    hosts: HOSTS,
+    collegeFilter,
+    noImport,
+  });
+}
+
+main().catch((err) => {
+  console.error("❌ Mississippi Banner 8 scraper failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible immediately. After this lands, Meridian Community College's course sections refresh on the Mon/Wed/Fri cron instead of staying frozen at the Phase-1 bootstrap snapshot (#290). The other 14 Mississippi colleges remain unscrapped — they need wrappers for their respective platforms before joining cron.

## What changes on the technical front

Adds [scripts/ms/scrape-banner8.ts](scripts/ms/scrape-banner8.ts) — a thin wrapper around the shared Banner 8 template at [scripts/lib/scrape-banner-8.ts](scripts/lib/scrape-banner-8.ts). MS Phase 1 (#290) added Meridian's course data but never committed a course-side wrapper; only prereqs and programs scrapers were wired.

### Wired

| College slug | Host | Source |
|---|---|---|
| meridian-community-college | https://ssb.meridiancc.edu/ssb/prod | direct: page header reports "Banner Web Self-Service Release: 8.7.2.11" with classic `bwsk*/bwck*` endpoints |

### Config delta

[lib/states/ms/config.ts](lib/states/ms/config.ts):

| Datatype | Before | After |
|---|---|---|
| courses | `manual-only` (mixed-platform note) | `scripts/ms/scrape-banner8.ts` (http) |
| transfers | `manual-only` (MTAG — to investigate) | unchanged |
| prereqs | `scripts/ms/scrape-catalog-prereqs.ts` | unchanged |
| programs | `scripts/ms/scrape-programs.ts` | unchanged |

## Test plan

- [x] `npx tsx scripts/check-scraper-coverage.ts` passes
- [x] Typecheck passes
- [ ] First scheduled-scrape run produces an `scheduled-scrape/ms-courses` PR with Meridian's sections refreshed

## Notes

Part 4/5 of wiring IA / MO / OH / MS / PA to cron (after [IA #484](https://github.com/rohan-c0de/cc-coursemap/pull/484), [MO #485](https://github.com/rohan-c0de/cc-coursemap/pull/485), [OH #486](https://github.com/rohan-c0de/cc-coursemap/pull/486)).