### PR TITLE
fix(ms): remove stray */ in JSDoc that broke Vercel build

### DIFF
--- a/scripts/ms/scrape-banner8.ts
+++ b/scripts/ms/scrape-banner8.ts
@@ -8,7 +8,7 @@
  *
  *   meridian-community-college → ssb.meridiancc.edu/ssb/prod
  *
- * Meridian's host serves the classic (bwsk*/bwck*) Banner 8 endpoints;
+ * Meridian's host serves the classic (bwsk/bwck) Banner 8 endpoints;
  * page header reports "Banner Web Self-Service Release: 8.7.2.11".
  *
  * Usage:


### PR DESCRIPTION
## What changed

One-character fix: the JSDoc comment in `scripts/ms/scrape-banner8.ts` contained `(bwsk*/bwck*)` — the `*/` prematurely closed the block comment, leaving `bwck` as a bare identifier that failed TypeScript's type check. Changed to `(bwsk/bwck)`.

This was blocking the Vercel production build after the NV merge.

## Test plan

- [ ] Vercel build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)