### PR TITLE
feat(nv): scrape catalog prereqs — 1,176 courses

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -16,7 +16,8 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
 - Phase 2b — course scraping via the right template
   (`scripts/lib/scrape-{banner-ssb,colleague,banner-8}.ts`)
 - Phase 3 — articulation lookup (`data/articulation-portals.json`)
-- Phase 4 — prereq aggregation (`scripts/lib/aggregate-prereqs.ts`)
+- Phase 4 — prereq aggregation (`scripts/lib/aggregate-prereqs.ts`),
+  with catalog-prereq fallback if aggregation yields 0 entries
 - Phase 5 — Scorecard ingest (`scripts/scorecard-map.ts` + `scripts/ingest-scorecard.ts`).
   Maps each new college to its IPEDS unitid then fetches federal cost / aid /
   completion data into `data/{slug}/scorecard/`. Auto-skips if
@@ -62,6 +63,47 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
    supported by IPEDS sector ∈ {1,4} + cat ∈ {3,4} (rare; e.g. AK has
    only one CC and may need manual handling). Don't commit. Don't push.
 
+6b. **Catalog-prereq fallback** — if `prereqs.aggregated === 0` (the course
+    SIS doesn't expose prereqs), scrape prereqs from each college's catalog
+    platform. This is mandatory, not optional — don't ship a state with
+    empty prereqs if catalog data is available.
+
+    Many SIS platforms (PeopleSoft Community Access, some Banner instances)
+    don't include prerequisite data in course search results. But the same
+    colleges almost always publish prereqs in a separate catalog system
+    (Acalog, Courseleaf, Coursedog, or custom HTML).
+
+    **Discovery per college:**
+    1. Check common catalog URLs: `catalog.{domain}`, `{domain}/catalog`,
+       `{domain}/academics/catalog`
+    2. Identify the platform:
+       - **Acalog**: page source contains "acalog", URLs like
+         `preview_course_nopop.php?catoid=X&coid=Y`
+       - **Courseleaf**: page source contains "courseleaf" or "leepfrog",
+         URLs like `/coursesaz/{subject}/`
+       - **Coursedog**: page source contains "coursedog" or
+         `static.catalog.prod.coursedog.com`
+       - **Custom HTML**: course descriptions with inline prereq text in
+         `<strong>Prerequisite:</strong>` blocks
+    3. Check whether individual course pages show "Prerequisite:" text
+
+    **Building the scraper:**
+    - Pattern-match against existing catalog prereq scrapers:
+      - Acalog → `scripts/tn/scrape-catalog-prereqs.ts`
+      - Courseleaf → parse `/coursesaz/{subject}/` pages for
+        `Enrollment Requirements:` blocks
+      - Custom HTML → parse subject pages for `<strong>Prerequisite:`
+      - Coursedog SPA → skip (requires headless browser; defer as TODO)
+    - Output format: `{ "PREFIX NUMBER": { "text": "...", "courses": [...] } }`
+    - Merge all colleges into one `data/{slug}/prereqs.json`
+    - Update `StateConfig.scrapers.prereqs` from
+      `{ source: "aggregate-from-courses" }` to
+      `{ source: "catalog-scrape", scripts: ["scripts/{slug}/scrape-catalog-prereqs.ts"] }`
+
+    **When to skip:** Only skip a college's catalog if it's auth-gated (SSO
+    login wall) or uses a Coursedog SPA that can't be scraped without
+    Playwright. Always note skipped colleges in the PR body.
+
 7. **Pre-PR feature check** (per `CLAUDE.md`'s three-checks-in-order rule).
    Per Section "Verifying your work" item 1: load `/{slug}/colleges` in
    local dev. Use the preview tools:
@@ -90,8 +132,9 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
    git commit -m "feat: scrape {state} courses — {sections} sections across {N} colleges"
 
    # Phase 3 + 4 (if any transfer / prereq data)
-   git add data/{slug}/prereqs.json
-   git commit -m "feat: aggregate {state} prereqs — {N} courses"
+   git add data/{slug}/prereqs.json scripts/{slug}/scrape-catalog-prereqs.ts
+   git commit -m "feat: {state} prereqs — {N} courses (via {source})"
+   # {source} is "aggregate-from-courses" or "catalog-scrape (Acalog/Courseleaf/...)"
 
    # Phase 5 (if any scorecard data — only when COLLEGE_SCORECARD_API_KEY is set)
    git add data/{slug}/scorecard/ data/{slug}/institutions.json data/scorecard-mapping.json
@@ -185,9 +228,10 @@ The orchestrator's `manualTodos[]` is the most important output. Categories:
   SourceInstitutionIds (one-time research per college). Or the user adds a
   registry entry once they identify the state's articulation portal.
 
-- **`[prereqs]`** — aggregation failed. Usually means Phase 2 produced no
-  data (every college had a custom platform). Re-run after Phase 2 issues
-  are resolved.
+- **`[prereqs]`** — aggregation yielded 0 entries. This is expected when
+  the course-search SIS (PeopleSoft, certain Banner instances) doesn't
+  expose prerequisite data. **Do not leave prereqs empty** — proceed to
+  the catalog-prereq fallback (step 6b).
 
 ## Failure modes
 

--- a/data/nv/prereqs.json
+++ b/data/nv/prereqs.json
@@ -1,1 +1,7013 @@
-{}
+{
+  "AAD 180": {
+    "text": "Corequisite: AAD 181",
+    "courses": [
+      "AAD 181"
+    ]
+  },
+  "AAD 181": {
+    "text": "Corequisite: AAD 180",
+    "courses": [
+      "AAD 180"
+    ]
+  },
+  "AAD 203": {
+    "text": "Prerequisite: AAD 201",
+    "courses": [
+      "AAD 201"
+    ]
+  },
+  "AAD 223": {
+    "text": "Prerequisite: AAE 180. Corequisite: AAE 280",
+    "courses": [
+      "AAE 180",
+      "AAE 280"
+    ]
+  },
+  "AAD 232": {
+    "text": "Prerequisite: AAD 100",
+    "courses": [
+      "AAD 100"
+    ]
+  },
+  "AAD 265": {
+    "text": "Prerequisite: Instructor permission required",
+    "courses": []
+  },
+  "AAD 268": {
+    "text": "Prerequisite: AAD 223",
+    "courses": [
+      "AAD 223"
+    ]
+  },
+  "AAD 350": {
+    "text": "Prerequisite: AAE 283",
+    "courses": [
+      "AAE 283"
+    ]
+  },
+  "AAD 351": {
+    "text": "Prerequisite: AAD 350",
+    "courses": [
+      "AAD 350"
+    ]
+  },
+  "AAD 413": {
+    "text": "Prerequisite: AAD 410",
+    "courses": [
+      "AAD 410"
+    ]
+  },
+  "AAD 452": {
+    "text": "Prerequisite: AAD 351",
+    "courses": [
+      "AAD 351"
+    ]
+  },
+  "AAD 453": {
+    "text": "Prerequisite: AAD 452",
+    "courses": [
+      "AAD 452"
+    ]
+  },
+  "AAD 455": {
+    "text": "Prerequisite: AAD 453. Co-requisite: AAD 480",
+    "courses": [
+      "AAD 453",
+      "AAD 480"
+    ]
+  },
+  "AAD 462": {
+    "text": "Prerequisite: AAD 461",
+    "courses": [
+      "AAD 461"
+    ]
+  },
+  "AAD 475": {
+    "text": "Co-requisite: AAD 485",
+    "courses": [
+      "AAD 485"
+    ]
+  },
+  "AAD 480": {
+    "text": "Co-requisite: AAD 455",
+    "courses": [
+      "AAD 455"
+    ]
+  },
+  "AAD 485": {
+    "text": "Prerequisite: AAD 455. Co-requisite: AAD 475",
+    "courses": [
+      "AAD 455",
+      "AAD 475"
+    ]
+  },
+  "AAE 280": {
+    "text": "Prerequisite: AAE 180. Corequisite: AAD 223",
+    "courses": [
+      "AAD 223",
+      "AAE 180"
+    ]
+  },
+  "AAE 282": {
+    "text": "Prerequisite: AAE 280",
+    "courses": [
+      "AAE 280"
+    ]
+  },
+  "AAE 283": {
+    "text": "Prerequisite: AAE 282",
+    "courses": [
+      "AAE 282"
+    ]
+  },
+  "ABS 323": {
+    "text": "Prerequisite: ABS 321",
+    "courses": [
+      "ABS 321"
+    ]
+  },
+  "ABS 332": {
+    "text": "Prerequisite: ABS 331",
+    "courses": [
+      "ABS 331"
+    ]
+  },
+  "ABS 341": {
+    "text": "Prerequisites: PHYS 100 and MATH 124",
+    "courses": [
+      "MATH 124",
+      "PHYS 100"
+    ]
+  },
+  "AC 106": {
+    "text": "Prerequisite: AC 102 and AC 107",
+    "courses": [
+      "AC 102",
+      "AC 107"
+    ]
+  },
+  "AC 108": {
+    "text": "Prerequisite: AC 107",
+    "courses": [
+      "AC 107"
+    ]
+  },
+  "AC 150": {
+    "text": "Prerequisite: AC 102 and AC 107",
+    "courses": [
+      "AC 102",
+      "AC 107"
+    ]
+  },
+  "AC 200": {
+    "text": "Prerequisite: AC 150 or approval of instructor",
+    "courses": [
+      "AC 150"
+    ]
+  },
+  "AC 205": {
+    "text": "AC 201 Automatic Controls",
+    "courses": [
+      "AC 201"
+    ]
+  },
+  "AC 206": {
+    "text": "Prerequisites: AC 201 HVAC Automatic Controls & AC 205 Commercial HVAC Systems 2",
+    "courses": [
+      "AC 201",
+      "AC 205"
+    ]
+  },
+  "ACC 105": {
+    "text": "Must have completed ACC 201",
+    "courses": [
+      "ACC 201"
+    ]
+  },
+  "ACC 136": {
+    "text": "Prerequisite: ACC 135",
+    "courses": [
+      "ACC 135"
+    ]
+  },
+  "ACC 201": {
+    "text": "Mathematics: Pre- or co-requisite of BUS 117 or MATH 120 or higher or qualifying placement scores; And English: pre-requisite of ENG 100 or pre- or co-requisite of ENG 101 or BUS 107, or qualifying placement scores; or permission of the instructor",
+    "courses": [
+      "BUS 107",
+      "BUS 117",
+      "ENG 100",
+      "ENG 101",
+      "MATH 120"
+    ]
+  },
+  "ACC 202": {
+    "text": "Must have completed ACC 201",
+    "courses": [
+      "ACC 201"
+    ]
+  },
+  "ACC 203": {
+    "text": "Must have completed ACC 201 and ACC 202",
+    "courses": [
+      "ACC 201",
+      "ACC 202"
+    ]
+  },
+  "ACC 204": {
+    "text": "Must have completed ACC 203",
+    "courses": [
+      "ACC 203"
+    ]
+  },
+  "ACC 205": {
+    "text": "Prerequisite: ACC 136 or ACC 201 or ACC 202",
+    "courses": [
+      "ACC 136",
+      "ACC 201",
+      "ACC 202"
+    ]
+  },
+  "ACC 220": {
+    "text": "Must have completed ACC 201",
+    "courses": [
+      "ACC 201"
+    ]
+  },
+  "ACC 222": {
+    "text": "Prerequisites: ACC 135 or ACC 201",
+    "courses": [
+      "ACC 135",
+      "ACC 201"
+    ]
+  },
+  "ACC 261": {
+    "text": "Must have completed ACC 201",
+    "courses": [
+      "ACC 201"
+    ]
+  },
+  "ACC 290": {
+    "text": "Must have completed ACC 201 and ACC 202",
+    "courses": [
+      "ACC 201",
+      "ACC 202"
+    ]
+  },
+  "ACC 295": {
+    "text": "Core and Major requirement completed. Minimum 2.5 GPA",
+    "courses": []
+  },
+  "ADT 202": {
+    "text": "ADT 201B or Instructor Approval",
+    "courses": [
+      "ADT 201B"
+    ]
+  },
+  "AES 110": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 111": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 120": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 121": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 230": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 231": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 240": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AES 241": {
+    "text": "Current enrollment in UNLV AFROTC and department chair approval",
+    "courses": []
+  },
+  "AGSC 206": {
+    "text": "Prerequisite: AGSC 100 and CHEM 121",
+    "courses": [
+      "AGSC 100",
+      "CHEM 121"
+    ]
+  },
+  "AGSC 255": {
+    "text": "Prerequisites: AGSC 100",
+    "courses": [
+      "AGSC 100"
+    ]
+  },
+  "AM 146": {
+    "text": "Must have completed AM 145",
+    "courses": [
+      "AM 145"
+    ]
+  },
+  "AM 147": {
+    "text": "Must have completed AM 146",
+    "courses": [
+      "AM 146"
+    ]
+  },
+  "AM 148": {
+    "text": "Must have completed AM 147",
+    "courses": [
+      "AM 147"
+    ]
+  },
+  "AMI 201": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "AMI 203": {
+    "text": "Current American Registry of Radiologic Technologists (ARRT) Certification Associate Degree or Higher in Radiologic Technology or comparable subject Acceptance into the Computed Tomography Program",
+    "courses": []
+  },
+  "AMI 216": {
+    "text": "Current American Registry of Radiologic Technologists (ARRT) Certification Associate Degree or Higher in Radiologic Technology or comparable subject Acceptance into the Computed Tomography Program",
+    "courses": []
+  },
+  "AMI 218": {
+    "text": "Current American Registry of Radiologic Technologists (ARRT) Certification Associate Degree or Higher in Radiologic Technology or comparable subject Acceptance into the Computed Tomography Program",
+    "courses": []
+  },
+  "AMI 226": {
+    "text": "Current American Registry of Radiologic Technologists (ARRT) Certification Associate Degree or Higher in Radiologic Technology or comparable subject Acceptance into the Computed Tomography Program",
+    "courses": []
+  },
+  "AMI 228": {
+    "text": "Current American Registry of Radiologic Technologists (ARRT) Certification Associate Degree or Higher in Radiologic Technology or comparable subject Acceptance into the Computed Tomography Program",
+    "courses": []
+  },
+  "AMI 236": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "AMI 238": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "AMI 246": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "AMI 248": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "AMI 256": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "AMI 259": {
+    "text": "Current American Registry of Radiologic Technologists (ARRT) Certification Associate Degree or Higher in Radiologic Technology or comparable subject Acceptance into the Computed Tomography Program",
+    "courses": []
+  },
+  "AMI 290": {
+    "text": "Students must be ARRT credentialed, or have an Associate degree in an Allied Health field with permission of the program director",
+    "courses": []
+  },
+  "ANTH 102": {
+    "text": "Co-requisite: ANTH 110L",
+    "courses": [
+      "ANTH 110L"
+    ]
+  },
+  "ANTH 110L": {
+    "text": "Corequisite: ANTH 102",
+    "courses": [
+      "ANTH 102"
+    ]
+  },
+  "ANTH 225": {
+    "text": "Prerequisite: ANTH 202 or permission of instructor",
+    "courses": [
+      "ANTH 202"
+    ]
+  },
+  "ANTH 226": {
+    "text": "Prerequisite: ANTH 202 or permission of instructor",
+    "courses": [
+      "ANTH 202"
+    ]
+  },
+  "ANTH 227": {
+    "text": "Prerequisite: ANTH 202 or permission of instructor",
+    "courses": [
+      "ANTH 202"
+    ]
+  },
+  "ANTH 290": {
+    "text": "Prerequisite: Student must have 30 credits of completed coursework prior to enrollment in ANTH 290. Student must have a minimum GPA of 2.5. Student must have permission of faculty member and internship coordinator",
+    "courses": []
+  },
+  "ANTH 307": {
+    "text": "Must have completed 40 or more credits or instructor approval",
+    "courses": []
+  },
+  "ANTH 332": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher or STAT 152)",
+    "courses": [
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "ANTH 400A": {
+    "text": "Must have completed 40 or more credits including one of the following: ANTH 101 or ANTH 201 or ANTH 202",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "ANTH 202"
+    ]
+  },
+  "ANTH 400B": {
+    "text": "Must have completed 40 or more credits including one of the following: ANTH 101 or ANTH 201 or ANTH 202",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "ANTH 202"
+    ]
+  },
+  "ANTH 406": {
+    "text": "Must have completed ANTH 101 or ANTH 201 or GEOG 106",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "GEOG 106"
+    ]
+  },
+  "ANTH 423": {
+    "text": "Must have completed 40 credits including ANTH 101, SOC 101, or GEOG 106",
+    "courses": [
+      "ANTH 101",
+      "GEOG 106",
+      "SOC 101"
+    ]
+  },
+  "ANTH 439": {
+    "text": "Must have completed 40 or more credits including one of the following: ANTH 101 or ANTH 201 or ANTH 202",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "ANTH 202"
+    ]
+  },
+  "ANTH 440B": {
+    "text": "Must have completed 40 or more credits including one of the following: ANTH 101 or ANTH 201 or ANTH 202",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "ANTH 202"
+    ]
+  },
+  "ANTH 458": {
+    "text": "Must have completed ANTH 101 or ANTH 201 or ANTH 202 or GEOG 106 or SOC 101",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "ANTH 202",
+      "GEOG 106",
+      "SOC 101"
+    ]
+  },
+  "ANTH 459": {
+    "text": "Must have completed 40 or more credits including one of the following: ANTH 101 or ANTH 201 or ANTH 202",
+    "courses": [
+      "ANTH 101",
+      "ANTH 201",
+      "ANTH 202"
+    ]
+  },
+  "APST 207": {
+    "text": "MATH 120 or equivalent or higher",
+    "courses": [
+      "MATH 120"
+    ]
+  },
+  "ARA 212": {
+    "text": "ARA 211 or Department approval",
+    "courses": [
+      "ARA 211"
+    ]
+  },
+  "ART 102": {
+    "text": "Must have completed ART 101",
+    "courses": [
+      "ART 101"
+    ]
+  },
+  "ART 142": {
+    "text": "Must have completed ART 141",
+    "courses": [
+      "ART 141"
+    ]
+  },
+  "ART 160H": {
+    "text": "Admission to the Honors program",
+    "courses": []
+  },
+  "ART 201": {
+    "text": "Must have completed ART 101",
+    "courses": [
+      "ART 101"
+    ]
+  },
+  "ART 209": {
+    "text": "Prerequisite: ART 100 and instructor approval",
+    "courses": [
+      "ART 100"
+    ]
+  },
+  "ART 212": {
+    "text": "Prerequisite: ART 211",
+    "courses": [
+      "ART 211"
+    ]
+  },
+  "ART 213": {
+    "text": "Prerequisite: ART 211",
+    "courses": [
+      "ART 211"
+    ]
+  },
+  "ART 231": {
+    "text": "Prerequisite: ART 101",
+    "courses": [
+      "ART 101"
+    ]
+  },
+  "ART 232": {
+    "text": "Must have completed ART 231",
+    "courses": [
+      "ART 231"
+    ]
+  },
+  "ART 235": {
+    "text": "Must have completed ART 135",
+    "courses": [
+      "ART 135"
+    ]
+  },
+  "ART 236": {
+    "text": "Prerequisite: ART 135",
+    "courses": [
+      "ART 135"
+    ]
+  },
+  "ART 260": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "ART 261": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "ART 288": {
+    "text": "Prerequisite: ART 141",
+    "courses": [
+      "ART 141"
+    ]
+  },
+  "ART 298": {
+    "text": "Department approval required",
+    "courses": []
+  },
+  "AST 101": {
+    "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "AST 104": {
+    "text": "Prerequisite: MATH 120 or equivalent or qualifying ACCUPLACER, ACT/SAT test result",
+    "courses": [
+      "MATH 120"
+    ]
+  },
+  "AUTO 111": {
+    "text": "Prerequisite: AUTO 101 or DT 101 or DT 250. AUTO 101 may be taken as a co-requisite",
+    "courses": [
+      "AUTO 101",
+      "DT 101",
+      "DT 250"
+    ]
+  },
+  "AUTO 112": {
+    "text": "Co-requisite/Prerequisite: AUTO 111 or instructor permission. Course may be taken concurrently with AUTO 111",
+    "courses": [
+      "AUTO 111"
+    ]
+  },
+  "AUTO 136": {
+    "text": "Prerequisite: AUTO 101 or instructor permission",
+    "courses": [
+      "AUTO 101"
+    ]
+  },
+  "AUTO 145": {
+    "text": "Prerequisite: AUTO 101 or instructor permission",
+    "courses": [
+      "AUTO 101"
+    ]
+  },
+  "AUTO 150": {
+    "text": "Prerequisite: AUTO 101 or instructor permission",
+    "courses": [
+      "AUTO 101"
+    ]
+  },
+  "AUTO 165": {
+    "text": "Prerequisite: AUTO 111 or instructor permission",
+    "courses": [
+      "AUTO 111"
+    ]
+  },
+  "AUTO 185": {
+    "text": "Prerequisite: AUTO 227 or instructor permission",
+    "courses": [
+      "AUTO 227"
+    ]
+  },
+  "AUTO 205": {
+    "text": "Prerequisite: AUTO 101 or instructor permission",
+    "courses": [
+      "AUTO 101"
+    ]
+  },
+  "AUTO 216": {
+    "text": "Prerequisite: AUTO 101 or instructor permission",
+    "courses": [
+      "AUTO 101"
+    ]
+  },
+  "AUTO 225": {
+    "text": "Prerequisite: AUTO 111 or instructor permission",
+    "courses": [
+      "AUTO 111"
+    ]
+  },
+  "AUTO 227": {
+    "text": "Co-requisite/Prerequisite: AUTO 225",
+    "courses": [
+      "AUTO 225"
+    ]
+  },
+  "AUTO 235": {
+    "text": "Co-requisite/Prerequisite: AUTO 227 or instructor permission. Course may be taken concurrently with AUTO 227",
+    "courses": [
+      "AUTO 227"
+    ]
+  },
+  "AUTO 265": {
+    "text": "Co-requisite/Prerequisite: AUTO 112 or instructor permission. Course may be taken concurrently with AUTO 112",
+    "courses": [
+      "AUTO 112"
+    ]
+  },
+  "AUTO 285": {
+    "text": "Prerequisite: AUTO 185 or instructor permission",
+    "courses": [
+      "AUTO 185"
+    ]
+  },
+  "AUTO 291B": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "AV 111": {
+    "text": "Instructor approval (or the corequisite)",
+    "courses": []
+  },
+  "AV 210": {
+    "text": "Prerequisite: AV 110",
+    "courses": [
+      "AV 110"
+    ]
+  },
+  "AV 250B": {
+    "text": "AV 210B with a grade of C or higher",
+    "courses": [
+      "AV 210B"
+    ]
+  },
+  "BCH 400": {
+    "text": "Must have completed BIOL 190 and CHEM 242 or have completed BIOL 190 and be enrolled in CHEM 242 with instructor's permission",
+    "courses": [
+      "BIOL 190",
+      "CHEM 242"
+    ]
+  },
+  "BIOL 100": {
+    "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "BIOL 137": {
+    "text": "Co-requisite or Pre-requisite: ENG 100 or ENG 101",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "BIOL 189A": {
+    "text": "MATH 120 as a prerequisite or MATH 124 or MATH 126 or higher as a prerequisite or co-requisite and ENG 100, 101 or ENG 113 as a prerequisite or co-requisite; MATH 126 or higher is required for AS degrees",
+    "courses": [
+      "ENG 100",
+      "ENG 113",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "BIOL 190": {
+    "text": "Must have completed with a \"C\" or better: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher; or be currently enrolled in MATH 116 or MATH 120 or MATH 126 or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "BIOL 190A": {
+    "text": "MATH 120 as a prerequisite or MATH 124 or MATH 126 or higher as a prerequisite or co-requisite and ENG 100, 101 or ENG 113 as a prerequisite or co-requisite; MATH 126 or higher is required for AS degrees",
+    "courses": [
+      "ENG 100",
+      "ENG 113",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "BIOL 190L": {
+    "text": "MATH 120 as a prerequisite or MATH 124 or MATH 126 or higher as a prerequisite or co-requisite and ENG 100, 101 or ENG 113 as a prerequisite or co-requisite; MATH 126 or higher is required for AS degrees",
+    "courses": [
+      "ENG 100",
+      "ENG 113",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "BIOL 191": {
+    "text": "Must have completed BIOL 190",
+    "courses": [
+      "BIOL 190"
+    ]
+  },
+  "BIOL 191A": {
+    "text": "MATH 120 as a prerequisite or MATH 124 or MATH 126 or higher as a prerequisite or co-requisite and ENG 100, 101 or ENG 113 as a prerequisite or co-requisite; MATH 126 or higher is required for AS degrees",
+    "courses": [
+      "ENG 100",
+      "ENG 113",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "BIOL 191L": {
+    "text": "MATH 120 as a prerequisite or MATH 124 or MATH 126 or higher as a prerequisite or co-requisite and ENG 100, 101 or ENG 113 as a prerequisite or co-requisite; MATH 126 or higher is required for AS degrees",
+    "courses": [
+      "ENG 100",
+      "ENG 113",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "BIOL 207": {
+    "text": "Instructor Approval",
+    "courses": []
+  },
+  "BIOL 217": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "BIOL 223": {
+    "text": "BIOL 189 with a grade of C or better",
+    "courses": [
+      "BIOL 189"
+    ]
+  },
+  "BIOL 224": {
+    "text": "Must have completed BIOL 223",
+    "courses": [
+      "BIOL 223"
+    ]
+  },
+  "BIOL 234": {
+    "text": "Prerequisite: BIOL 191A and BIOL 191L",
+    "courses": [
+      "BIOL 191A",
+      "BIOL 191L"
+    ]
+  },
+  "BIOL 251": {
+    "text": "Must have completed or be taking BIOL 190",
+    "courses": [
+      "BIOL 190"
+    ]
+  },
+  "BIOL 273": {
+    "text": "Prerequisite: A grade of 'B' or better in BIOL 190A and BIOL 190L and permission of the instructor",
+    "courses": [
+      "BIOL 190A",
+      "BIOL 190L"
+    ]
+  },
+  "BIOL 275": {
+    "text": "Prerequisite: A grade of B or better in BIOL 223 AND permission of the instructor",
+    "courses": [
+      "BIOL 223"
+    ]
+  },
+  "BIOL 290": {
+    "text": "Instructor permission",
+    "courses": []
+  },
+  "BIOL 298": {
+    "text": "Prerequisite: A grade of 'B' or better in BIOL 190A and BIOL 190L and permission of instructor",
+    "courses": [
+      "BIOL 190A",
+      "BIOL 190L"
+    ]
+  },
+  "BIOL 299": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "BIOL 300": {
+    "text": "Must have completed BIOL 190 and CHEM 122 and STAT 152 and be sophomore or higher standing",
+    "courses": [
+      "BIOL 190",
+      "CHEM 122",
+      "STAT 152"
+    ]
+  },
+  "BIOL 305": {
+    "text": "Must have completed BIOL 190 or BIOL 191",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191"
+    ]
+  },
+  "BIOL 315": {
+    "text": "Must have completed BIOL 190 and CHEM 122",
+    "courses": [
+      "BIOL 190",
+      "CHEM 122"
+    ]
+  },
+  "BIOL 320": {
+    "text": "Must have completed BIOL 190 and BIOL 191 and be sophomore standing or higher",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191"
+    ]
+  },
+  "BIOL 325": {
+    "text": "For Fall 2023:",
+    "courses": []
+  },
+  "BIOL 331": {
+    "text": "BIOL 330",
+    "courses": [
+      "BIOL 330"
+    ]
+  },
+  "BIOL 341": {
+    "text": "CHEM 122 ; and BIOL 191 with a grade of C or higher",
+    "courses": [
+      "BIOL 191",
+      "CHEM 122"
+    ]
+  },
+  "BIOL 394": {
+    "text": "Must have completed BIOL 191 and STAT 152 and be enrolled in or have completed BIOL 341",
+    "courses": [
+      "BIOL 191",
+      "BIOL 341",
+      "STAT 152"
+    ]
+  },
+  "BIOL 401": {
+    "text": "Must have completed BIOL 191",
+    "courses": [
+      "BIOL 191"
+    ]
+  },
+  "BIOL 410": {
+    "text": "Must have completed BIOL 190 and BIOL 191 and CHEM 122 and be sophomore standing",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191",
+      "CHEM 122"
+    ]
+  },
+  "BIOL 415": {
+    "text": "Must have completed ENG 102 and BIOL 190 and BIOL 191 and BIOL 300 and be in junior or senior standing",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191",
+      "BIOL 300",
+      "ENG 102"
+    ]
+  },
+  "BIOL 421": {
+    "text": "BIOL 305 ; and BIOL 341 with C or better",
+    "courses": [
+      "BIOL 305",
+      "BIOL 341"
+    ]
+  },
+  "BIOL 432": {
+    "text": "BIOL 341 with a C or better",
+    "courses": [
+      "BIOL 341"
+    ]
+  },
+  "BIOL 433": {
+    "text": "BIOL 341 with a C or better",
+    "courses": [
+      "BIOL 341"
+    ]
+  },
+  "BIOL 434": {
+    "text": "BIOL 341 with a C or better",
+    "courses": [
+      "BIOL 341"
+    ]
+  },
+  "BIOL 447": {
+    "text": "Student must have completed BIOL 190 and BIOL 191 and CHEM 122",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191",
+      "CHEM 122"
+    ]
+  },
+  "BIOL 492": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "BIOL 496": {
+    "text": "Must have completed BIOL 190 or BIOL 191",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191"
+    ]
+  },
+  "BRL 151": {
+    "text": "Prerequisite: BRL 101",
+    "courses": [
+      "BRL 101"
+    ]
+  },
+  "BRL 201": {
+    "text": "Prerequisite: BRL 151",
+    "courses": [
+      "BRL 151"
+    ]
+  },
+  "BUS 101": {
+    "text": "Prerequisite: ENG 100, 101, ENG 113, BUS 108, or equivalent",
+    "courses": [
+      "BUS 108",
+      "ENG 100",
+      "ENG 113"
+    ]
+  },
+  "BUS 108": {
+    "text": "Prerequisite: BUS 106 or ENG 100 or above or qualifying ACCUPLACER, ACT/SAT test results",
+    "courses": [
+      "BUS 106",
+      "ENG 100"
+    ]
+  },
+  "BUS 176": {
+    "text": "Must enroll concurrently in BUS 76",
+    "courses": []
+  },
+  "BUS 201": {
+    "text": "Must have completed BUS 101 or BUS 102",
+    "courses": [
+      "BUS 101",
+      "BUS 102"
+    ]
+  },
+  "BUS 225": {
+    "text": "Prerequisite: MATH 120; or qualifying Accuplacer, ACT, SAT scores; or permission of the instructor",
+    "courses": [
+      "MATH 120"
+    ]
+  },
+  "BUS 274": {
+    "text": "Must have completed BUS 273",
+    "courses": [
+      "BUS 273"
+    ]
+  },
+  "BUS 290": {
+    "text": "Available to students who have completed all core and major requirements and have a 2.5 GPA",
+    "courses": []
+  },
+  "BUS 325": {
+    "text": "Prerequisite: ENG 102 or equivalent; or BAS Applied Business Management Majors; or permission of the instructor",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "BUS 330": {
+    "text": "Prerequisite: ENG 102 or ENG 114; or BAS Applied Business Management Majors; or instructor's approval",
+    "courses": [
+      "ENG 102",
+      "ENG 114"
+    ]
+  },
+  "BUS 76": {
+    "text": "Qualifying ACCUPLACER, SAT, or ACT test score (within 2 years) --OR-- high school overall unweighted GPA > 3.0 and a grade of B or higher in Intermediate Algebra (within 2 years). A graphing calculator is required. Must enroll concurrently with BUS 176",
+    "courses": [
+      "BUS 176"
+    ]
+  },
+  "CADD 142": {
+    "text": "CADD 140",
+    "courses": [
+      "CADD 140"
+    ]
+  },
+  "CADD 299B": {
+    "text": "Program Director approval",
+    "courses": []
+  },
+  "CADD 421": {
+    "text": "CADD 105",
+    "courses": [
+      "CADD 105"
+    ]
+  },
+  "CH 201": {
+    "text": "Prerequisite: ENG 101, 100 or ENG 113 or completion of CH 202 or CH 203 with a 'D' or better",
+    "courses": [
+      "CH 202",
+      "CH 203",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "CH 202": {
+    "text": "Prerequisite: ENG 101, 100 or ENG 113 or completion of CH 201 or CH 203 with a 'D' or better",
+    "courses": [
+      "CH 201",
+      "CH 203",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "CH 203": {
+    "text": "Prerequisite: ENG 101, 100 or higher or ENG 113; or completion of CH 201 or CH 202 with a 'D' or better",
+    "courses": [
+      "CH 201",
+      "CH 202",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "CHEM 100": {
+    "text": "Must have completed with a C or better: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 124 or MATH 126 or MATH 126E or higher; or be currently enrolled in MATH 116 or MATH 120 or MATH 126 or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 124",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "CHEM 108": {
+    "text": "High school chemistry or Instructor approval",
+    "courses": []
+  },
+  "CHEM 121": {
+    "text": "A grade of C or better in",
+    "courses": []
+  },
+  "CHEM 122": {
+    "text": "Must have completed CHEM 121",
+    "courses": [
+      "CHEM 121"
+    ]
+  },
+  "CHEM 220": {
+    "text": "Prerequisite: CHEM 121. Recommended: CHEM 122",
+    "courses": [
+      "CHEM 121",
+      "CHEM 122"
+    ]
+  },
+  "CHEM 241": {
+    "text": "Must have completed CHEM 122 and be enrolled in CHEM 241L",
+    "courses": [
+      "CHEM 122",
+      "CHEM 241L"
+    ]
+  },
+  "CHEM 241L": {
+    "text": "Must be enrolled in CHEM 241",
+    "courses": [
+      "CHEM 241"
+    ]
+  },
+  "CHEM 242": {
+    "text": "Must have completed CHEM 241 and be enrolled in CHEM 242L",
+    "courses": [
+      "CHEM 241",
+      "CHEM 242L"
+    ]
+  },
+  "CHEM 242L": {
+    "text": "Must be enrolled in CHEM 242",
+    "courses": [
+      "CHEM 242"
+    ]
+  },
+  "CHEM 341": {
+    "text": "Prerequisite: CHEM 122 or CHEM 202 (Taught at other NSHE Institutions)",
+    "courses": [
+      "CHEM 122",
+      "CHEM 202"
+    ]
+  },
+  "CHEM 342": {
+    "text": "Prerequisite: CHEM 341 or CHEM 241 (Taught at other NSHE Institutions) with a grade 'C' or higher",
+    "courses": [
+      "CHEM 241",
+      "CHEM 341"
+    ]
+  },
+  "CHEM 492": {
+    "text": "Must have completed CHEM 242",
+    "courses": [
+      "CHEM 242"
+    ]
+  },
+  "CHEM 495": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "CIT 130": {
+    "text": "Must have completed CIT 129",
+    "courses": [
+      "CIT 129"
+    ]
+  },
+  "CIT 136": {
+    "text": "Pre-requisites: CIT 135 - Introduction to Swift Coding",
+    "courses": [
+      "CIT 135"
+    ]
+  },
+  "CIT 144": {
+    "text": "CIT 129 or Instructor approval",
+    "courses": [
+      "CIT 129"
+    ]
+  },
+  "CIT 152": {
+    "text": "Must have completed CIT 129 and CIT 151",
+    "courses": [
+      "CIT 129",
+      "CIT 151"
+    ]
+  },
+  "CIT 164": {
+    "text": "A grade of C or better in CIT 105 , CS 138 , and CIT 144",
+    "courses": [
+      "CIT 105",
+      "CIT 144",
+      "CS 138"
+    ]
+  },
+  "CIT 176": {
+    "text": "Prerequisite: CIT 173",
+    "courses": [
+      "CIT 173"
+    ]
+  },
+  "CIT 202": {
+    "text": "Must have completed IS 201",
+    "courses": [
+      "IS 201"
+    ]
+  },
+  "CIT 203": {
+    "text": "Must have completed IS 201",
+    "courses": [
+      "IS 201"
+    ]
+  },
+  "CIT 212": {
+    "text": "Prerequisite or corequisite: CIT 211",
+    "courses": [
+      "CIT 211"
+    ]
+  },
+  "CIT 213": {
+    "text": "Prerequisite: CIT 212",
+    "courses": [
+      "CIT 212"
+    ]
+  },
+  "CIT 214": {
+    "text": "Prerequisite: CIT 212",
+    "courses": [
+      "CIT 212"
+    ]
+  },
+  "CIT 216": {
+    "text": "Prerequisite: CIT 114",
+    "courses": [
+      "CIT 114"
+    ]
+  },
+  "CIT 217": {
+    "text": "Prerequisite: CIT 112 or CSCO 120 or instructor approval",
+    "courses": [
+      "CIT 112",
+      "CSCO 120"
+    ]
+  },
+  "CIT 222": {
+    "text": "Prerequisites: CIT 112 and CIT 114; Recommended corequisite: CS 151",
+    "courses": [
+      "CIT 112",
+      "CIT 114",
+      "CS 151"
+    ]
+  },
+  "CIT 223": {
+    "text": "CIT 164",
+    "courses": [
+      "CIT 164"
+    ]
+  },
+  "CIT 224": {
+    "text": "CIT 164",
+    "courses": [
+      "CIT 164"
+    ]
+  },
+  "CIT 227": {
+    "text": "CIT 223 and CIT 224",
+    "courses": [
+      "CIT 223",
+      "CIT 224"
+    ]
+  },
+  "CIT 228": {
+    "text": "CIT 223 and CIT 224",
+    "courses": [
+      "CIT 223",
+      "CIT 224"
+    ]
+  },
+  "CIT 230": {
+    "text": "Prerequisite: CIT 130 with a 'C' or better",
+    "courses": [
+      "CIT 130"
+    ]
+  },
+  "CIT 234": {
+    "text": "Prerequisite: CIT 134 with a grade of 'C' or better",
+    "courses": [
+      "CIT 134"
+    ]
+  },
+  "CIT 235": {
+    "text": "Prerequisite: CIT 234 and CIT 180 with a grade of C or better",
+    "courses": [
+      "CIT 180",
+      "CIT 234"
+    ]
+  },
+  "CIT 236": {
+    "text": "Prerequisite: CIT 230 or CIT 234 with a grade of C or better",
+    "courses": [
+      "CIT 230",
+      "CIT 234"
+    ]
+  },
+  "CIT 237": {
+    "text": "Prerequisite: CIT 230 or CIT 234 with a grade of C or better",
+    "courses": [
+      "CIT 230",
+      "CIT 234"
+    ]
+  },
+  "CIT 240": {
+    "text": "Must have completed CIT 129 or Instructor Approval",
+    "courses": [
+      "CIT 129"
+    ]
+  },
+  "CIT 242": {
+    "text": "Must have completed CIT 129 or Instructor Approval",
+    "courses": [
+      "CIT 129"
+    ]
+  },
+  "CIT 248": {
+    "text": "Completion of CIT 148 with a \"C\" or higher",
+    "courses": [
+      "CIT 148"
+    ]
+  },
+  "CIT 251": {
+    "text": "Prerequisite: CIT 151 and CIT 152",
+    "courses": [
+      "CIT 151",
+      "CIT 152"
+    ]
+  },
+  "CIT 252": {
+    "text": "Must have completed IS 201 or CIT 151 or CIT 129 or CIT 203 or GRC 188",
+    "courses": [
+      "CIT 129",
+      "CIT 151",
+      "CIT 203",
+      "GRC 188",
+      "IS 201"
+    ]
+  },
+  "CIT 257": {
+    "text": "Prerequisite: CIT 152 or instructor approval",
+    "courses": [
+      "CIT 152"
+    ]
+  },
+  "CIT 261": {
+    "text": "Must have completed CIT 129 or CIT 202 or CIT 203",
+    "courses": [
+      "CIT 129",
+      "CIT 202",
+      "CIT 203"
+    ]
+  },
+  "CIT 263": {
+    "text": "Prerequisite: CIT 114 or instructor approval",
+    "courses": [
+      "CIT 114"
+    ]
+  },
+  "CIT 274": {
+    "text": "Prerequisite: C or better in CIT 112, or C or better in CSCO 120",
+    "courses": [
+      "CIT 112",
+      "CSCO 120"
+    ]
+  },
+  "CIT 280": {
+    "text": "Prerequisite: MATH 124 or higher",
+    "courses": [
+      "MATH 124"
+    ]
+  },
+  "CIT 281": {
+    "text": "Prerequisite: MATH 124 and CIT 280",
+    "courses": [
+      "CIT 280",
+      "MATH 124"
+    ]
+  },
+  "CIT 303": {
+    "text": "Must have completed an AAS degree and either COT 204 or CIT 211",
+    "courses": [
+      "CIT 211",
+      "COT 204"
+    ]
+  },
+  "CIT 361": {
+    "text": "Must have completed (CIT 112 or CIT 301 or CIT 303) and MATH 116 or higher",
+    "courses": [
+      "CIT 112",
+      "CIT 301",
+      "CIT 303",
+      "MATH 116"
+    ]
+  },
+  "CIT 454": {
+    "text": "Must have declared AAS - Web Specialist Emphasis or have completed COT 301 or CIT 303",
+    "courses": [
+      "CIT 303",
+      "COT 301"
+    ]
+  },
+  "CIT 480": {
+    "text": "Must have completed CIT 180",
+    "courses": [
+      "CIT 180"
+    ]
+  },
+  "CLS 155": {
+    "text": "Program Director or Instructor approval",
+    "courses": []
+  },
+  "CLS 161": {
+    "text": "Acceptance into CLS program",
+    "courses": []
+  },
+  "CLS 241": {
+    "text": "Acceptance into the AAS Medical Laboratory Technician or BAS Medical Laboratory Scientist program; or Program Director approval",
+    "courses": []
+  },
+  "CLS 242": {
+    "text": "Acceptance into the AAS Medical Laboratory Technician or BAS Medical Laboratory Scientist program; or Program Director approval",
+    "courses": []
+  },
+  "CLS 251": {
+    "text": "Acceptance into program",
+    "courses": []
+  },
+  "CLS 265": {
+    "text": "Acceptance into MLT/MLS program",
+    "courses": []
+  },
+  "CLS 271": {
+    "text": "Acceptance into CLS program",
+    "courses": []
+  },
+  "CLS 291": {
+    "text": "Acceptance into program and",
+    "courses": []
+  },
+  "CLS 295": {
+    "text": "Acceptance into the AAS Medical Laboratory Technician program or Program Director approval",
+    "courses": []
+  },
+  "CLS 446": {
+    "text": "Acceptance into the BAS Medical Laboratory Scientist program or Program Director approval",
+    "courses": []
+  },
+  "CLS 447": {
+    "text": "Acceptance into the BAS Medical Laboratory Scientist program or Program Director approval",
+    "courses": []
+  },
+  "CLS 456": {
+    "text": "Admission to CLS Program",
+    "courses": []
+  },
+  "CLS 476": {
+    "text": "Acceptance into CLS Program or Program Director permission",
+    "courses": []
+  },
+  "CLS 477": {
+    "text": "Acceptance into the CLS Program or Program Director permission",
+    "courses": []
+  },
+  "CLS 486": {
+    "text": "Admission to CLS program or Instructor consent",
+    "courses": []
+  },
+  "CLS 487": {
+    "text": "Admission to CLS program or Instructor consent",
+    "courses": []
+  },
+  "CLS 488": {
+    "text": "Admission to CLS program or Instructor consent",
+    "courses": []
+  },
+  "CLS 489": {
+    "text": "Admission to CLS program or Instructor consent",
+    "courses": []
+  },
+  "CLS 490": {
+    "text": "Admission to CLS program or Instructor consent",
+    "courses": []
+  },
+  "CLS 491": {
+    "text": "Acceptance into the BAS Medical Laboratory Scientist program or Program Director approval",
+    "courses": []
+  },
+  "CMI 350": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 351": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 352": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 353": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 354": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 366": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 376": {
+    "text": "Must have completed BIOL 223 or EMS 204 or instructor permission",
+    "courses": [
+      "BIOL 223",
+      "EMS 204"
+    ]
+  },
+  "CMI 378": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 400": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 486": {
+    "text": "Must have completed CMI 350 and CMI 351 and CMI 353 with a 'C' or higher",
+    "courses": [
+      "CMI 350",
+      "CMI 351",
+      "CMI 353"
+    ]
+  },
+  "CMI 487": {
+    "text": "Must have completed CMI 486 with a 'C' or higher",
+    "courses": [
+      "CMI 486"
+    ]
+  },
+  "CMI 488": {
+    "text": "Must have completed CMI 487 with a 'C' or higher",
+    "courses": [
+      "CMI 487"
+    ]
+  },
+  "CMI 491": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "CMI 492": {
+    "text": "Must be admitted into the Sonography Program",
+    "courses": []
+  },
+  "COM 101H": {
+    "text": "Admission to the Honors program",
+    "courses": []
+  },
+  "COM 196": {
+    "text": "Approval of the station, newspaper, agency or firm where internship will be completed; and approval from the Department of Communication Internship Coordinator",
+    "courses": []
+  },
+  "COM 212": {
+    "text": "Prerequisite: ENG 102 or concurrently enrolled",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "COM 340": {
+    "text": "Admission to a CSN Bachelor’s Program",
+    "courses": []
+  },
+  "CONS 109": {
+    "text": "Prerequisite: CONS 108",
+    "courses": [
+      "CONS 108"
+    ]
+  },
+  "CONS 129B": {
+    "text": "CONS 113B",
+    "courses": [
+      "CONS 113B"
+    ]
+  },
+  "CONS 221": {
+    "text": "Prerequisite: CONS 121",
+    "courses": [
+      "CONS 121"
+    ]
+  },
+  "CONS 285B": {
+    "text": "Prerequisite:",
+    "courses": []
+  },
+  "CONS 295": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "COT 240": {
+    "text": "Prerequisite: BUS 106 or BUS 108; or qualifying Accuplacer score; or with instructor approval",
+    "courses": [
+      "BUS 106",
+      "BUS 108"
+    ]
+  },
+  "COT 301": {
+    "text": "Must have completed an AAS degree",
+    "courses": []
+  },
+  "CPD 290": {
+    "text": "CSN Addiction Program Director approval",
+    "courses": []
+  },
+  "CPE 201": {
+    "text": "Prerequisite: CS 135 with a 'C' or better; MATH 127 or higher or qualifying SAT, ACT, or Accuplacer score",
+    "courses": [
+      "CS 135",
+      "MATH 127"
+    ]
+  },
+  "CPT 151": {
+    "text": "Prerequisite CPT 101",
+    "courses": [
+      "CPT 101"
+    ]
+  },
+  "CPT 201": {
+    "text": "Prerequisite CPT 151",
+    "courses": [
+      "CPT 151"
+    ]
+  },
+  "CPT 251": {
+    "text": "Prerequisite CPT 201",
+    "courses": [
+      "CPT 201"
+    ]
+  },
+  "CRJ 103": {
+    "text": "Prerequisite: CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 110": {
+    "text": "Students must be accepted to the Northern Nevada Law Enforcement Academy",
+    "courses": []
+  },
+  "CRJ 201": {
+    "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 220": {
+    "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 222": {
+    "text": "Prerequisite: CRJ 101 or CRJ 104",
+    "courses": [
+      "CRJ 101",
+      "CRJ 104"
+    ]
+  },
+  "CRJ 230": {
+    "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 232": {
+    "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 260": {
+    "text": "Co-requisite: COT 101",
+    "courses": [
+      "COT 101"
+    ]
+  },
+  "CRJ 263": {
+    "text": "Must have completed CRJ 262",
+    "courses": [
+      "CRJ 262"
+    ]
+  },
+  "CRJ 270": {
+    "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 289": {
+    "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 299": {
+    "text": "Prerequisite: CRJ 101 or CRJ 104",
+    "courses": [
+      "CRJ 101",
+      "CRJ 104"
+    ]
+  },
+  "CRJ 444": {
+    "text": "Must have completed CRJ 270 and ENG 102, or instructor approval",
+    "courses": [
+      "CRJ 270",
+      "ENG 102"
+    ]
+  },
+  "CRJ 469": {
+    "text": "Must have completed CRJ 104 and PSY 101, or instructor approval",
+    "courses": [
+      "CRJ 104",
+      "PSY 101"
+    ]
+  },
+  "CRS 100": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 111": {
+    "text": "Admission to the Associate of Applied Science Cardiorespiratory Sciences degree program",
+    "courses": []
+  },
+  "CRS 115": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 116": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 123": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 124": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 125": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 215": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 216": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 218": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 219": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 223": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 225": {
+    "text": "Must be accepted in to the Cardiorespiratory Care Science program",
+    "courses": []
+  },
+  "CRS 302": {
+    "text": "Admission to the Bachelor of Applied Science Cardiorespiratory Sciences degree program",
+    "courses": []
+  },
+  "CRS 313": {
+    "text": "Admission to the Bachelor of Applied Science Cardiorespiratory Sciences degree program",
+    "courses": []
+  },
+  "CRS 412": {
+    "text": "Admission to the Bachelor of Applied Science Cardiorespiratory Sciences degree program",
+    "courses": []
+  },
+  "CRS 421": {
+    "text": "Admission to the Bachelor of Applied Science Cardiorespiratory Sciences degree program",
+    "courses": []
+  },
+  "CRS 424": {
+    "text": "Admission to the Bachelor of Applied Science Cardiorespiratory Sciences degree program",
+    "courses": []
+  },
+  "CS 135": {
+    "text": "A grade of C or better in either",
+    "courses": []
+  },
+  "CS 138": {
+    "text": "Prerequisite: MATH 124 or higher, or instructor approval",
+    "courses": [
+      "MATH 124"
+    ]
+  },
+  "CS 202": {
+    "text": "A grade of C or better in either",
+    "courses": []
+  },
+  "CS 219": {
+    "text": "Prerequisite: CS 202 or CPE 201",
+    "courses": [
+      "CPE 201",
+      "CS 202"
+    ]
+  },
+  "CS 252": {
+    "text": "Prerequisite: C or better in CIT 112, or C or better in CSCO 120",
+    "courses": [
+      "CIT 112",
+      "CSCO 120"
+    ]
+  },
+  "CSCO 121": {
+    "text": "Must have completed CSCO 120 with a 'C' or better",
+    "courses": [
+      "CSCO 120"
+    ]
+  },
+  "CSCO 130": {
+    "text": "Must have completed CSCO 121 with a 'C' or better",
+    "courses": [
+      "CSCO 121"
+    ]
+  },
+  "CSCO 220": {
+    "text": "Must have completed CSCO 121 with a 'C' or better",
+    "courses": [
+      "CSCO 121"
+    ]
+  },
+  "CSCO 230": {
+    "text": "Must have completed CSCO 121",
+    "courses": [
+      "CSCO 121"
+    ]
+  },
+  "CSCO 480": {
+    "text": "Must have completed CSCO 220 or instructor approval",
+    "courses": [
+      "CSCO 220"
+    ]
+  },
+  "CSCO 482": {
+    "text": "Must have completed CSCO 480 or instructor approval",
+    "courses": [
+      "CSCO 480"
+    ]
+  },
+  "CSCO 483": {
+    "text": "Must have completed CSCO 482",
+    "courses": [
+      "CSCO 482"
+    ]
+  },
+  "CSEC 250": {
+    "text": "CIT 112 or CSEC 112B or CSCO 120",
+    "courses": [
+      "CIT 112",
+      "CSCO 120",
+      "CSEC 112B"
+    ]
+  },
+  "CSEC 290B": {
+    "text": "Program Director approval",
+    "courses": []
+  },
+  "CUL 105": {
+    "text": "Prerequisite or Corequisite: ENG 100 or higher",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "CUL 106": {
+    "text": "Prerequisite: CUL 100, CUL 105, and ENG 100 (or ENG 113) or higher or equivalent/qualifying test scores",
+    "courses": [
+      "CUL 100",
+      "CUL 105",
+      "ENG 100",
+      "ENG 113"
+    ]
+  },
+  "CUL 108": {
+    "text": "Prerequisite: CUL 100 and 106",
+    "courses": [
+      "CUL 100"
+    ]
+  },
+  "CUL 114": {
+    "text": "Prerequisite: CUL 100 and 106",
+    "courses": [
+      "CUL 100"
+    ]
+  },
+  "CUL 125": {
+    "text": "Prerequisite: CUL 100 and 106",
+    "courses": [
+      "CUL 100"
+    ]
+  },
+  "CUL 130": {
+    "text": "Prerequisite: CUL 100 and 108",
+    "courses": [
+      "CUL 100"
+    ]
+  },
+  "CUL 170": {
+    "text": "Prerequisites: CUL 100, CUL 106 and CUL 125",
+    "courses": [
+      "CUL 100",
+      "CUL 106",
+      "CUL 125"
+    ]
+  },
+  "CUL 200": {
+    "text": "Prerequisites: CUL 100, CUL 108, CUL 125, CUL 245 and CUL 250",
+    "courses": [
+      "CUL 100",
+      "CUL 108",
+      "CUL 125",
+      "CUL 245",
+      "CUL 250"
+    ]
+  },
+  "CUL 210": {
+    "text": "Prerequisite: CUL 108",
+    "courses": [
+      "CUL 108"
+    ]
+  },
+  "CUL 220": {
+    "text": "Prerequisite: CUL 108",
+    "courses": [
+      "CUL 108"
+    ]
+  },
+  "CUL 225": {
+    "text": "Prerequisites: CUL 100, CUL 106 and CUL 125",
+    "courses": [
+      "CUL 100",
+      "CUL 106",
+      "CUL 125"
+    ]
+  },
+  "CUL 230": {
+    "text": "Prerequisite: CUL 125 and CUL 225",
+    "courses": [
+      "CUL 125",
+      "CUL 225"
+    ]
+  },
+  "CUL 245": {
+    "text": "Prerequisite: ENG 100 or higher",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "CUL 250": {
+    "text": "Prerequisites: CUL 100, CUL 106 and CUL 108 (or department approval)",
+    "courses": [
+      "CUL 100",
+      "CUL 106",
+      "CUL 108"
+    ]
+  },
+  "CUL 295": {
+    "text": "Prerequisite: CUL 100, CUL 106, CUL 125 and department approval",
+    "courses": [
+      "CUL 100",
+      "CUL 106",
+      "CUL 125"
+    ]
+  },
+  "DA 108B": {
+    "text": "Admission to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 110": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 111": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 112": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 114": {
+    "text": "Prerequisite: DA 113",
+    "courses": [
+      "DA 113"
+    ]
+  },
+  "DA 115": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 115B": {
+    "text": "Admission to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 116": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 117": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 118B": {
+    "text": "Admission to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 119": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 121": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 122": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 123": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 124B": {
+    "text": "Admission to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 125": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 127": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 135": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 137": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DA 285": {
+    "text": "Prerequisite: Acceptance to the Dental Assisting Program",
+    "courses": []
+  },
+  "DAN 188": {
+    "text": "Successful completion of at least one dance technique course in Jazz, Ballet or Modern or instructor approval",
+    "courses": []
+  },
+  "DAN 232": {
+    "text": "Prerequisite: DAN 132",
+    "courses": [
+      "DAN 132"
+    ]
+  },
+  "DAN 235": {
+    "text": "Prerequisite: DAN 135",
+    "courses": [
+      "DAN 135"
+    ]
+  },
+  "DAN 238": {
+    "text": "Prerequisite: DAN 138 or equivalent",
+    "courses": [
+      "DAN 138"
+    ]
+  },
+  "DAN 244": {
+    "text": "Prerequisite: DAN 144",
+    "courses": [
+      "DAN 144"
+    ]
+  },
+  "DAN 281": {
+    "text": "Prerequisite: Audition and/or approval of instructor",
+    "courses": []
+  },
+  "DAN 288": {
+    "text": "Prerequisite: DAN 188",
+    "courses": [
+      "DAN 188"
+    ]
+  },
+  "DAN 295": {
+    "text": "Prerequisite: Approval of instructor",
+    "courses": []
+  },
+  "DATA 220": {
+    "text": "Prerequisites: DATA 101 and DATA 210",
+    "courses": [
+      "DATA 101",
+      "DATA 210"
+    ]
+  },
+  "DH 102": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 103": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 104": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 105": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 107": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 110": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 112": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 122": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 202": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 208": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 209": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 216": {
+    "text": "Admission to the Associate of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 297B": {
+    "text": "Program Director approval",
+    "courses": []
+  },
+  "DH 298B": {
+    "text": "Program Director approval",
+    "courses": []
+  },
+  "DH 299": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 299B": {
+    "text": "Instructor and Department Chair approval",
+    "courses": []
+  },
+  "DH 303": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 304": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 305": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 306": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 307": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 308": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 310": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 311": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 312": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 313": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 314": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 315": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 401": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 403": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 404": {
+    "text": "Admission to Dental Hygiene Bachelor of Science Degree Program",
+    "courses": []
+  },
+  "DH 405": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 406": {
+    "text": "Admission to the Bachelor of Science Dental Hygiene Degree Program",
+    "courses": []
+  },
+  "DH 407": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 408": {
+    "text": "Admission to Bachelor of Science Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 409": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 410": {
+    "text": "Current enrollment in the dental hygiene program and successful completion of all first year dental hygiene courses",
+    "courses": []
+  },
+  "DH 411": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 413": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 414": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 415": {
+    "text": "Admission to the B.S. Dental Hygiene program",
+    "courses": []
+  },
+  "DH 416": {
+    "text": "Current enrollment in the dental hygiene program and successful completion of DH 410 Foundations of Inter-Professional Collaborative Practice",
+    "courses": [
+      "DH 410"
+    ]
+  },
+  "DH 417": {
+    "text": "Prerequisite: Acceptance into Dental Hygiene Program and passing grade in DH 407",
+    "courses": [
+      "DH 407"
+    ]
+  },
+  "DH 420": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 440": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program",
+    "courses": []
+  },
+  "DH 442": {
+    "text": "Prerequisite: Acceptance into the Dental Hygiene Program and a passing grade in DH 440",
+    "courses": [
+      "DH 440"
+    ]
+  },
+  "DT 100": {
+    "text": "Must have been accepted into the Diesel Technology Program",
+    "courses": []
+  },
+  "DT 101": {
+    "text": "Must have completed DT 100",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 102": {
+    "text": "Must have completed DT 100",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 104": {
+    "text": "DT 100 as a prerequisite or corequisite, or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 105": {
+    "text": "Must have completed DT 100",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 106": {
+    "text": "Must have completed DT 100",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 107": {
+    "text": "Prerequisite/corequisite: DT 100 or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 110": {
+    "text": "Corequisite/prerequisite: DT 100 and DT 102 (or AUTO 111) or instructor permission",
+    "courses": [
+      "AUTO 111",
+      "DT 100",
+      "DT 102"
+    ]
+  },
+  "DT 115": {
+    "text": "DT 102 as a prerequisite or corequisite, or instructor permission",
+    "courses": [
+      "DT 102"
+    ]
+  },
+  "DT 117": {
+    "text": "DT 102 as a prerequisite or corequisite, or instructor permission",
+    "courses": [
+      "DT 102"
+    ]
+  },
+  "DT 130": {
+    "text": "Prerequisite/corequisite: DT 100 or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 145": {
+    "text": "DT 100 as a prerequisite or corequisite or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 150": {
+    "text": "DT 130 as a prerequisite or corequisite, or instructor permission",
+    "courses": [
+      "DT 130"
+    ]
+  },
+  "DT 201": {
+    "text": "Must have completed DT 100",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 205": {
+    "text": "DT 100 as a prerequisite or corequisite or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 210": {
+    "text": "Co-requisite/Prerequisite: DT 100, 101 or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 215": {
+    "text": "Must have completed DT 100 and DT 101 and DT 102",
+    "courses": [
+      "DT 100",
+      "DT 101",
+      "DT 102"
+    ]
+  },
+  "DT 217": {
+    "text": "Co-requisite/Prerequisite: DT 100, 101 and DT 210 or instructor permission",
+    "courses": [
+      "DT 100",
+      "DT 210"
+    ]
+  },
+  "DT 235": {
+    "text": "Prerequisite/corequisite: DT 100 or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 250": {
+    "text": "Prerequisite/corequisite: DT 100 or instructor permission",
+    "courses": [
+      "DT 100"
+    ]
+  },
+  "DT 290": {
+    "text": "Prerequisite: DT 100 and DT 101, with 2.0 average and approval of the instructor",
+    "courses": [
+      "DT 100",
+      "DT 101"
+    ]
+  },
+  "ECE 210": {
+    "text": "Must have completed ECE 200 and ECE 204 and ECE 250 and ECE 251",
+    "courses": [
+      "ECE 200",
+      "ECE 204",
+      "ECE 250",
+      "ECE 251"
+    ]
+  },
+  "ECE 231": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "ECE 232": {
+    "text": "For the AA Early Childhood Education:",
+    "courses": []
+  },
+  "ECE 235": {
+    "text": "Must have completed ECE 200 and ECE 250",
+    "courses": [
+      "ECE 200",
+      "ECE 250"
+    ]
+  },
+  "ECE 240": {
+    "text": "Prerequisite: ECE 190, ECE 250, ECE 251, and HDFS 201, or permission of the instructor",
+    "courses": [
+      "ECE 190",
+      "ECE 250",
+      "ECE 251",
+      "HDFS 201"
+    ]
+  },
+  "ECE 244": {
+    "text": "Prerequisite: MGT 171, ECE 231 (2 units in previous fall semester with a C or better); Prerequisite or Corequisite: MGT 212, ECE 240",
+    "courses": [
+      "ECE 231",
+      "ECE 240",
+      "MGT 171",
+      "MGT 212"
+    ]
+  },
+  "ECE 245": {
+    "text": "Instructor approval",
+    "courses": []
+  },
+  "ECE 251": {
+    "text": "Must have completed ECE 250",
+    "courses": [
+      "ECE 250"
+    ]
+  },
+  "ECE 252": {
+    "text": "Prerequisite: ECE 127, ECE 129, ECE 130, ECE 190, ECE 204, ECE 210, and HDFS 201",
+    "courses": [
+      "ECE 127",
+      "ECE 129",
+      "ECE 130",
+      "ECE 190",
+      "ECE 204",
+      "ECE 210",
+      "HDFS 201"
+    ]
+  },
+  "ECE 262": {
+    "text": "Must have completed ECE 250",
+    "courses": [
+      "ECE 250"
+    ]
+  },
+  "ECE 441": {
+    "text": "Must have completed ECE 250 and ECE 251 and ECE 262",
+    "courses": [
+      "ECE 250",
+      "ECE 251",
+      "ECE 262"
+    ]
+  },
+  "ECE 453": {
+    "text": "Must have completed ECE 200 and ECE 250 and ECE 251 and ECE 262",
+    "courses": [
+      "ECE 200",
+      "ECE 250",
+      "ECE 251",
+      "ECE 262"
+    ]
+  },
+  "ECE 454": {
+    "text": "Must have completed ECE 200 and ECE 250 and ECE 251 and ECE 262",
+    "courses": [
+      "ECE 200",
+      "ECE 250",
+      "ECE 251",
+      "ECE 262"
+    ]
+  },
+  "ECE 461": {
+    "text": "Must have completed ECE 200 and ECE 204 and ECE 210 and ECE 250 and ECE 251 and HDFS 202",
+    "courses": [
+      "ECE 200",
+      "ECE 204",
+      "ECE 210",
+      "ECE 250",
+      "ECE 251",
+      "HDFS 202"
+    ]
+  },
+  "ECE 483": {
+    "text": "Program Supervisor and Teaching Education Committee Approval, and must be enrolled in ECE 493 Supervised Internship in ECE",
+    "courses": [
+      "ECE 493"
+    ]
+  },
+  "ECE 493": {
+    "text": "Must have completed the ECE AA and be authorized to student teach in ECE by the Teacher Education Committee by applying by Sept. 15 or Feb. 15 the preceding semester",
+    "courses": []
+  },
+  "ECON 102": {
+    "text": "Prerequisite: BUS 117, MATH 120, MATH 124, MATH 126 or higher. Or co-requisite: BUS 117, MATH 124, MATH 126, or MATH 120 without support",
+    "courses": [
+      "BUS 117",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "ECON 103": {
+    "text": "Prerequisite: BUS 117, MATH 120, MATH 124, MATH 126 or higher. Or co-requisite: BUS 117, MATH 124, MATH 126, or MATH 120 without support",
+    "courses": [
+      "BUS 117",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "ECON 261": {
+    "text": "Prerequisite: MATH 124 or MATH 126 or equivalent or qualifying Accuplacer, ACT/SAT test results",
+    "courses": [
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "ECON 262": {
+    "text": "Prerequisite: ECON 261 or approval of instructor",
+    "courses": [
+      "ECON 261"
+    ]
+  },
+  "ECON 307": {
+    "text": "Must have completed an associate's degree",
+    "courses": []
+  },
+  "ECON 365": {
+    "text": "Must have completed an associate's degree",
+    "courses": []
+  },
+  "EDCT 302": {
+    "text": "Admission to the Career and Technical Education and Leadership program or instructor permission",
+    "courses": []
+  },
+  "EDCT 305": {
+    "text": "Admission to the Career and Technical Education and Leadership program, the BAS Applied Business Management program or instructor permission",
+    "courses": []
+  },
+  "EDCT 306": {
+    "text": "Acceptance to the Career and Technical Education and Leadership Program and completion of EDCT 447 or Instructor permission",
+    "courses": [
+      "EDCT 447"
+    ]
+  },
+  "EDCT 402": {
+    "text": "Admission to the Career and Technical Education and Leadership Program and completion of EDCT 306 or instructor permission",
+    "courses": [
+      "EDCT 306"
+    ]
+  },
+  "EDCT 411": {
+    "text": "Admission to the Career and Technical Education and Leadership Program and completion or co-enrollment of EDCT 301, 447, 304, 306, and 439 or instructor permission",
+    "courses": [
+      "EDCT 301"
+    ]
+  },
+  "EDCT 413": {
+    "text": "Admission to the Career and Technical Education and Leadership Program and completion of EDCT 301, 447, 304 and 306 or instructor permission",
+    "courses": [
+      "EDCT 301"
+    ]
+  },
+  "EDCT 416": {
+    "text": "Admission to the Career and Technical Education and Leadership program or instructor permission",
+    "courses": []
+  },
+  "EDCT 426": {
+    "text": "Admission to the Career and Technical Education and Leadership Program. Completion or co-enrollment of EDCT 416 or instructor permission",
+    "courses": [
+      "EDCT 416"
+    ]
+  },
+  "EDCT 447": {
+    "text": "Admission to the Career and Technical Education and Leadership program or instructor permission",
+    "courses": []
+  },
+  "EDCT 463": {
+    "text": "Must be admitted into Teacher Education Program and be taking EDSC 315",
+    "courses": [
+      "EDSC 315"
+    ]
+  },
+  "EDEL 311": {
+    "text": "Must be enrolled in EDU 250",
+    "courses": [
+      "EDU 250"
+    ]
+  },
+  "EDEL 313": {
+    "text": "Must be enrolled in EDUC 406",
+    "courses": [
+      "EDUC 406"
+    ]
+  },
+  "EDEL 315": {
+    "text": "Must be admitted into the Teacher Education Program and be enrolled in EDEL 433 or EDEL 443 or EDEL 453 or EDRL 442 or EDRL 443",
+    "courses": [
+      "EDEL 433",
+      "EDEL 443",
+      "EDEL 453",
+      "EDRL 442",
+      "EDRL 443"
+    ]
+  },
+  "EDEL 433": {
+    "text": "Must have been admitted into the Teacher Education Program and be taking EDEL315",
+    "courses": [
+      "EDEL 315"
+    ]
+  },
+  "EDEL 443": {
+    "text": "Must be admitted into the Teacher Education Program and have completed EDU 214 and be taking EDEL 315",
+    "courses": [
+      "EDEL 315",
+      "EDU 214"
+    ]
+  },
+  "EDEL 453": {
+    "text": "Must have been admitted into the Teacher Education Program and be taking EDEL315",
+    "courses": [
+      "EDEL 315"
+    ]
+  },
+  "EDEL 483": {
+    "text": "Must be admitted into the Teacher Education Program and be taking EDEL 491",
+    "courses": [
+      "EDEL 491"
+    ]
+  },
+  "EDEL 491": {
+    "text": "Must be admitted into the Teaching Internship program and be enrolled in EDEL 483 or EDSP 495",
+    "courses": [
+      "EDEL 483",
+      "EDSP 495"
+    ]
+  },
+  "EDES 300": {
+    "text": "Must have completed ECE 250 and ECE 251 and ECE 262",
+    "courses": [
+      "ECE 250",
+      "ECE 251",
+      "ECE 262"
+    ]
+  },
+  "EDRL 442": {
+    "text": "Must have been admitted into the Teacher Education Program and be taking EDEL315",
+    "courses": [
+      "EDEL 315"
+    ]
+  },
+  "EDRL 443": {
+    "text": "Must have been admitted into the Teacher Education Program and be taking EDEL315",
+    "courses": [
+      "EDEL 315"
+    ]
+  },
+  "EDSC 311": {
+    "text": "Must be enrolled in EDU 250",
+    "courses": [
+      "EDU 250"
+    ]
+  },
+  "EDSC 313": {
+    "text": "Must be enrolled in EDUC 406",
+    "courses": [
+      "EDUC 406"
+    ]
+  },
+  "EDSC 315": {
+    "text": "Must be admitted into Teacher Education Program and be taking EDSC 473 or EDSC 463 or EDSC 453 or EDSC 433 or EDCT 463 or EDCT 439",
+    "courses": [
+      "EDCT 439",
+      "EDCT 463",
+      "EDSC 433",
+      "EDSC 453",
+      "EDSC 463",
+      "EDSC 473"
+    ]
+  },
+  "EDSC 425": {
+    "text": "Must be admitted to the Teacher Education Program or by instructor permission.",
+    "courses": []
+  },
+  "EDSC 433": {
+    "text": "Must be admitted into Teacher Education Program and be taking EDSC 315",
+    "courses": [
+      "EDSC 315"
+    ]
+  },
+  "EDSC 453": {
+    "text": "Must be admitted into Teacher Education Program and be taking EDSC 315",
+    "courses": [
+      "EDSC 315"
+    ]
+  },
+  "EDSC 463": {
+    "text": "Must be admitted into Teacher Education Program and be taking EDSC 315",
+    "courses": [
+      "EDSC 315"
+    ]
+  },
+  "EDSC 473": {
+    "text": "Must be admitted into Teacher Education Program and be taking EDSC 315",
+    "courses": [
+      "EDSC 315"
+    ]
+  },
+  "EDSC 483": {
+    "text": "Must be admitted into the Teaching Internship program and be enrolled in EDSC 491",
+    "courses": [
+      "EDSC 491"
+    ]
+  },
+  "EDSC 491": {
+    "text": "Must be admitted into Teacher Internship program and be enrolled in EDSC 483",
+    "courses": [
+      "EDSC 483"
+    ]
+  },
+  "EDSP 428": {
+    "text": "Must have completed EDSP 418",
+    "courses": [
+      "EDSP 418"
+    ]
+  },
+  "EDSP 438": {
+    "text": "Must have completed EDSP 418 and EDSP 428",
+    "courses": [
+      "EDSP 418",
+      "EDSP 428"
+    ]
+  },
+  "EDSP 441": {
+    "text": "Must have taken EDSP 301",
+    "courses": [
+      "EDSP 301"
+    ]
+  },
+  "EDSP 443": {
+    "text": "Must have completed EDSP 301 and be enrolled in EDSP 484",
+    "courses": [
+      "EDSP 301",
+      "EDSP 484"
+    ]
+  },
+  "EDSP 448": {
+    "text": "Must have completed EDSP 418 and EDSP 428 and EDSP 438",
+    "courses": [
+      "EDSP 418",
+      "EDSP 428",
+      "EDSP 438"
+    ]
+  },
+  "EDSP 452": {
+    "text": "Must have taken EDSP 301",
+    "courses": [
+      "EDSP 301"
+    ]
+  },
+  "EDSP 453": {
+    "text": "Must have completed EDSP 301 and be enrolled in EDSP 485",
+    "courses": [
+      "EDSP 301",
+      "EDSP 485"
+    ]
+  },
+  "EDSP 464": {
+    "text": "Must have completed EDSP 301 and EDSP 453",
+    "courses": [
+      "EDSP 301",
+      "EDSP 453"
+    ]
+  },
+  "EDSP 484": {
+    "text": "Must have completed EDSP 301 and be enrolled in EDSP 443",
+    "courses": [
+      "EDSP 301",
+      "EDSP 443"
+    ]
+  },
+  "EDSP 485": {
+    "text": "Must have completed EDSP 301 and be enrolled in EDSP 453",
+    "courses": [
+      "EDSP 301",
+      "EDSP 453"
+    ]
+  },
+  "EDSP 495": {
+    "text": "Must be admitted into the Teacher Education Program and be taking EDEL 491",
+    "courses": [
+      "EDEL 491"
+    ]
+  },
+  "EDU 208": {
+    "text": "Prerequisite/Corequisite: EDU 203",
+    "courses": [
+      "EDU 203"
+    ]
+  },
+  "EDU 212": {
+    "text": "Current Teacher Licensure or Departmental approval",
+    "courses": []
+  },
+  "EDU 245": {
+    "text": "Departmental Approval",
+    "courses": []
+  },
+  "EDU 250": {
+    "text": "Must have completed ENG 100 or ENG 101 and be enrolled in EDEL 311 or EDEL 313 or EDSC 311 or EDSC 313",
+    "courses": [
+      "EDEL 311",
+      "EDEL 313",
+      "EDSC 311",
+      "EDSC 313",
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "EDU 299": {
+    "text": "Instructor permission",
+    "courses": []
+  },
+  "EDUC 406": {
+    "text": "Must be enrolled in EDEL 313 or EDSC 313",
+    "courses": [
+      "EDEL 313",
+      "EDSC 313"
+    ]
+  },
+  "EE 220": {
+    "text": "PR: PHYS 181",
+    "courses": [
+      "PHYS 181"
+    ]
+  },
+  "EE 220L": {
+    "text": "Must have completed PHYS 181 with a C or better and be currently enrolled in EE 220",
+    "courses": [
+      "EE 220",
+      "PHYS 181"
+    ]
+  },
+  "EIT 233": {
+    "text": "Must have been accepted into the Instrumentation Technology Program",
+    "courses": []
+  },
+  "EIT 240": {
+    "text": "Must have completed EIT 233",
+    "courses": [
+      "EIT 233"
+    ]
+  },
+  "EIT 315": {
+    "text": "Must have completed EIT 233",
+    "courses": [
+      "EIT 233"
+    ]
+  },
+  "EIT 323": {
+    "text": "Must have been accepted into the Instrumentation Technology Program",
+    "courses": []
+  },
+  "EIT 333": {
+    "text": "Must have completed EIT 233",
+    "courses": [
+      "EIT 233"
+    ]
+  },
+  "EIT 336": {
+    "text": "Must have completed EIT 233 and EIT 315 and EIT 323 and EIT 333 and EIT 368",
+    "courses": [
+      "EIT 233",
+      "EIT 315",
+      "EIT 323",
+      "EIT 333",
+      "EIT 368"
+    ]
+  },
+  "EIT 348": {
+    "text": "Must have completed an Associate of Applied Science or Certificate and EIT 315",
+    "courses": [
+      "EIT 315"
+    ]
+  },
+  "EIT 368": {
+    "text": "Must have completed EIT 233 and EIT 315",
+    "courses": [
+      "EIT 233",
+      "EIT 315"
+    ]
+  },
+  "EIT 437": {
+    "text": "Must have completed ELM 134 and ELM 136 and EIT 233 and EIT 315 and EIT 323 and EIT 333",
+    "courses": [
+      "EIT 233",
+      "EIT 315",
+      "EIT 323",
+      "EIT 333",
+      "ELM 134",
+      "ELM 136"
+    ]
+  },
+  "EIT 468": {
+    "text": "Must have completed an Associate of Applied Science degree or Certificate and EIT 348",
+    "courses": [
+      "EIT 348"
+    ]
+  },
+  "ELEC 151": {
+    "text": "Prerequisite: ELEC 101",
+    "courses": [
+      "ELEC 101"
+    ]
+  },
+  "ELEC 201": {
+    "text": "Prerequisite: ELEC 151",
+    "courses": [
+      "ELEC 151"
+    ]
+  },
+  "ELEC 251": {
+    "text": "Prerequisite: ELEC 201",
+    "courses": [
+      "ELEC 201"
+    ]
+  },
+  "ELEC 291": {
+    "text": "Prerequisite: ELEC 251",
+    "courses": [
+      "ELEC 251"
+    ]
+  },
+  "ELM 105": {
+    "text": "Must have completed ELM 104",
+    "courses": [
+      "ELM 104"
+    ]
+  },
+  "ELM 106": {
+    "text": "Must have completed ELM 105",
+    "courses": [
+      "ELM 105"
+    ]
+  },
+  "ELM 107": {
+    "text": "Must have completed ELM 106",
+    "courses": [
+      "ELM 106"
+    ]
+  },
+  "ELM 108": {
+    "text": "Must have completed ELM 107",
+    "courses": [
+      "ELM 107"
+    ]
+  },
+  "ELM 112": {
+    "text": "Must have been accepted into the Electrical Technology Program",
+    "courses": []
+  },
+  "ELM 120": {
+    "text": "Must have been accepted into the Electrical Technology Program",
+    "courses": []
+  },
+  "ELM 121": {
+    "text": "Must have completed ELM 112",
+    "courses": [
+      "ELM 112"
+    ]
+  },
+  "ELM 122": {
+    "text": "Must have completed ELM 112",
+    "courses": [
+      "ELM 112"
+    ]
+  },
+  "ELM 123": {
+    "text": "Must have completed ELM 122",
+    "courses": [
+      "ELM 122"
+    ]
+  },
+  "ELM 124": {
+    "text": "Must have completed ELM 122",
+    "courses": [
+      "ELM 122"
+    ]
+  },
+  "ELM 125": {
+    "text": "Must have completed ELM 124",
+    "courses": [
+      "ELM 124"
+    ]
+  },
+  "ELM 126": {
+    "text": "Must have completed ELM 125",
+    "courses": [
+      "ELM 125"
+    ]
+  },
+  "ELM 127": {
+    "text": "Must have completed ELM 125",
+    "courses": [
+      "ELM 125"
+    ]
+  },
+  "ELM 128": {
+    "text": "Must have completed ELM 122",
+    "courses": [
+      "ELM 122"
+    ]
+  },
+  "ELM 130": {
+    "text": "Must have completed ELM 120",
+    "courses": [
+      "ELM 120"
+    ]
+  },
+  "ELM 131": {
+    "text": "Must have completed ELM 122",
+    "courses": [
+      "ELM 122"
+    ]
+  },
+  "ELM 132": {
+    "text": "Must have completed ELM 123",
+    "courses": [
+      "ELM 123"
+    ]
+  },
+  "ELM 133": {
+    "text": "Must have completed ELM 127",
+    "courses": [
+      "ELM 127"
+    ]
+  },
+  "ELM 134": {
+    "text": "Must have completed ELM 127 and ELM 132",
+    "courses": [
+      "ELM 127",
+      "ELM 132"
+    ]
+  },
+  "ELM 135": {
+    "text": "Must have completed ELM 133",
+    "courses": [
+      "ELM 133"
+    ]
+  },
+  "ELM 136": {
+    "text": "Must have completed ELM 133 and ELM 134",
+    "courses": [
+      "ELM 133",
+      "ELM 134"
+    ]
+  },
+  "ELM 141": {
+    "text": "Must have completed ELM 121 and ELM 128",
+    "courses": [
+      "ELM 121",
+      "ELM 128"
+    ]
+  },
+  "ELM 142": {
+    "text": "Must have been accepted into the Electrical Technology Program",
+    "courses": []
+  },
+  "ELM 143": {
+    "text": "Must have completed ELM 128 and ELM 131 and ELM 141 and ELM 142",
+    "courses": [
+      "ELM 128",
+      "ELM 131",
+      "ELM 141",
+      "ELM 142"
+    ]
+  },
+  "ELM 240": {
+    "text": "Prerequisite or Co-requisite: ELM 134 or instructor's approval",
+    "courses": [
+      "ELM 134"
+    ]
+  },
+  "ELM 340": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "ELM 440": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program and ELM 340",
+    "courses": [
+      "ELM 340"
+    ]
+  },
+  "EMHS 300": {
+    "text": "Students must be provisionally or fully admitted to the EMHS program and have EMHS 200 as a prerequisite or corequisite",
+    "courses": [
+      "EMHS 200"
+    ]
+  },
+  "EMHS 302": {
+    "text": "Students must be provisionally or fully admitted to the EMHS program and have EMHS 200 as a prerequisite or corequisite",
+    "courses": [
+      "EMHS 200"
+    ]
+  },
+  "EMHS 304": {
+    "text": "Students must be provisionally or fully admitted to the EMHS program and have EMHS 200 as a prerequisite or corequisite",
+    "courses": [
+      "EMHS 200"
+    ]
+  },
+  "EMHS 306": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 311": {
+    "text": "Students must be provisionally or fully admitted to the EMHS program and have EMHS 200 as a prerequisite or corequisite",
+    "courses": [
+      "EMHS 200"
+    ]
+  },
+  "EMHS 313": {
+    "text": "Students must be provisionally or fully admitted to the EMHS program and have EMHS 200 as a prerequisite or corequisite",
+    "courses": [
+      "EMHS 200"
+    ]
+  },
+  "EMHS 320": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 321": {
+    "text": "Students must be provisionally or fully admitted to the EMHS program and have EMHS 200 as a prerequisite or corequisite",
+    "courses": [
+      "EMHS 200"
+    ]
+  },
+  "EMHS 322": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 323": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 325": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 410": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 412": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 414": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 416": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 420": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 421": {
+    "text": "Prerequisite: EMHS 300 or EMHS 311. Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": [
+      "EMHS 300",
+      "EMHS 311"
+    ]
+  },
+  "EMHS 422": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 423": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 425": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 427": {
+    "text": "Students must be admitted to the EMHS program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 429": {
+    "text": "Students must be admitted to the EMHS or the LOM bachelors program or have department approval at https://www.tmcc.edu/emergency-management-homeland-security/contact",
+    "courses": []
+  },
+  "EMHS 470": {
+    "text": "Prerequisite: Students must be admitted to the Emergency Management/Homeland Security program and have completed 30 program credits",
+    "courses": []
+  },
+  "EMHS 490": {
+    "text": "Students must be admitted to the Emergency Management/Homeland Security program and must have either already taken EMHS 425 or at a minimum take EMHS 425 and EMHS 490 concurrently",
+    "courses": [
+      "EMHS 425"
+    ]
+  },
+  "EMS 108": {
+    "text": "Prerequisite: Current American Heart Association Healthcare Provider CPR card",
+    "courses": []
+  },
+  "EMS 115": {
+    "text": "Prerequisite: Current Nevada EMT certification, immunizations, and American Heart Association Healthcare Provider CPR certification",
+    "courses": []
+  },
+  "EMS 200": {
+    "text": "EMT or AEMT and acceptance into the Paramedic Program",
+    "courses": []
+  },
+  "EMS 202": {
+    "text": "Prerequisite: Current enrollment in TMCC Paramedic Program",
+    "courses": []
+  },
+  "EMS 203": {
+    "text": "Prerequisite: Current enrollment in TMCC Paramedic Program",
+    "courses": []
+  },
+  "EMS 204": {
+    "text": "Must have been accepted into the Paramedic Program",
+    "courses": []
+  },
+  "EMS 205": {
+    "text": "Must have completed EMS 200",
+    "courses": [
+      "EMS 200"
+    ]
+  },
+  "EMS 206": {
+    "text": "Must have been accepted into the Paramedic Program",
+    "courses": []
+  },
+  "EMS 207": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 208": {
+    "text": "Successful completion of EMS 207, EMS 209, EMS 210",
+    "courses": [
+      "EMS 207",
+      "EMS 209",
+      "EMS 210"
+    ]
+  },
+  "EMS 209": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 210": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 211": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 212": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 214": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 215": {
+    "text": "Must have completed EMS 210 and EMS 211",
+    "courses": [
+      "EMS 210",
+      "EMS 211"
+    ]
+  },
+  "EMS 216": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "EMS 217": {
+    "text": "Prerequisite: Current enrollment in TMCC Paramedic Program",
+    "courses": []
+  },
+  "EMS 219": {
+    "text": "Must be admitted into the paramedic program",
+    "courses": []
+  },
+  "ENG 100": {
+    "text": "Pre-requisite: Qualifying ACCUPLACER Reading Comprehension (RC) score, SAT, or ACT placement. Successful completion of ENG 100 with a C- grade or better satisfies ENG 101/113 requirement and students can enroll in ENG 102/114",
+    "courses": [
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "ENG 101": {
+    "text": "ACCUPLACER, SAT, or ACT test score--OR--high school unweighted cumulative GPA of 3.0 or above--OR--AP English Course (grade of B or better). Students who have successfully completed ENG 100 do not need to take ENG 101/113; they may enroll in ENG 102/114",
+    "courses": [
+      "ENG 100",
+      "ENG 102"
+    ]
+  },
+  "ENG 102": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "ENG 107": {
+    "text": "Must have completed ENG 103 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 107",
+    "courses": [
+      "ENG 103"
+    ]
+  },
+  "ENG 108": {
+    "text": "Must have completed ENG 100 or ENG 101 or ENG 107",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 107"
+    ]
+  },
+  "ENG 113": {
+    "text": "Prerequisite: Qualifying high school GPA; ACCUPLACER, ACT/SAT, or AP placement score. Corequisite: READ 135 with qualifying ACCUPLACER test score",
+    "courses": [
+      "READ 135"
+    ]
+  },
+  "ENG 114": {
+    "text": "Prerequisite: A grade of C- or better in ENG 100/101/113 or equivalent or qualifying SAT/ACT score",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "ENG 203": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 205": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "ENG 221": {
+    "text": "Must have completed ENG 205",
+    "courses": [
+      "ENG 205"
+    ]
+  },
+  "ENG 222": {
+    "text": "Prerequisite: ENG 221 or permision of instructor",
+    "courses": [
+      "ENG 221"
+    ]
+  },
+  "ENG 223": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 224": {
+    "text": "Prerequisite: ENG 101 or ENG 113 or instructor approval",
+    "courses": [
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "ENG 240": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "ENG 250": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 258": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 259": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 261": {
+    "text": "Must have completed ENG 102 and ENG 205",
+    "courses": [
+      "ENG 102",
+      "ENG 205"
+    ]
+  },
+  "ENG 267": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 275": {
+    "text": "Prerequisite: ENG 101 or ENG 113 or instructor approval",
+    "courses": [
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "ENG 281": {
+    "text": "Prerequisite: ENG 101 or ENG 100 or ENG 113 or instructor approval",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "ENG 282": {
+    "text": "Prerequisite: ENG 101 or ENG 113 or instructor approval",
+    "courses": [
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "ENG 298": {
+    "text": "Prerequisite: ENG 101 or ENG 100 or ENG 113 or instructor approval",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "ENG 299": {
+    "text": "Prerequisite: ENG 101 or ENG 113 or instructor approval",
+    "courses": [
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "ENG 310": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 320": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 325": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203, or ENG 223, or ENG 231, or ENG 232, or ENG 250, or ENG 267, or ENG 275) or have completed ENG 102 and declared a B.A. in Social Science",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 327": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203, or ENG 223, or ENG 231, or ENG 232, or ENG 250, or ENG 267, or ENG 275) or have completed ENG 102 and declared a B.A. in Social Science",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 329": {
+    "text": "Must have completed ENG 102 and one of the following: ANTH 101 or SOC 101 or GEOG 106 or a 200 level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275)",
+    "courses": [
+      "ANTH 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275",
+      "GEOG 106",
+      "SOC 101"
+    ]
+  },
+  "ENG 333": {
+    "text": "Must have completed ENG 102 or ENG 108 with a grade of 'C-' or better",
+    "courses": [
+      "ENG 102",
+      "ENG 108"
+    ]
+  },
+  "ENG 402A": {
+    "text": "Must have completed ENG 205 and either ENG 221 or ENG 261",
+    "courses": [
+      "ENG 205",
+      "ENG 221",
+      "ENG 261"
+    ]
+  },
+  "ENG 411B": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 416C": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 418A": {
+    "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 433A": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275) or have completed ENG 102 and declared a B.A. in Soc. Sci. or a B.A. in Natural Resources",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 449A": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275) or have completed ENG 102 and declared a B.A. in Soc. Sci. or a B.A. in Natural Resources",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 449B": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275) or have completed ENG 102 and declared a B.A. in Soc. Sci. or a B.A. in Natural Resources",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 451A": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275) or have completed ENG 102 and declared a B.A. in Soc. Sci. or a B.A. in Natural Resources",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 451B": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275) or have completed ENG 102 and declared a B.A. in Soc. Sci. or a B.A. in Natural Resources",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 475B": {
+    "text": "Must have completed ENG 102 and (ENG 203 or ENG 223 or ENG 250 or ENG 267)",
+    "courses": [
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 250",
+      "ENG 267"
+    ]
+  },
+  "ENG 497A": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and a 200-level literature course (ENG 203 or ENG 223 or ENG 231 or ENG 232 or ENG 250 or ENG 267 or ENG 275) or have completed ENG 102 and declared a B.A. in Soc. Sci. or a B.A. in Natural Resources",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "ENG 203",
+      "ENG 223",
+      "ENG 231",
+      "ENG 232",
+      "ENG 250",
+      "ENG 267",
+      "ENG 275"
+    ]
+  },
+  "ENG 498B": {
+    "text": "Must be admitted into the B.A. in English program and have senior standing",
+    "courses": []
+  },
+  "ENGR 241": {
+    "text": "DR: PHYS 180/MATH 182",
+    "courses": [
+      "MATH 182",
+      "PHYS 180"
+    ]
+  },
+  "ENV 100": {
+    "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "EPD 350": {
+    "text": "Basic computer and word processing skills",
+    "courses": []
+  },
+  "FIN 310": {
+    "text": "Must have completed an associate's degree",
+    "courses": []
+  },
+  "FREN 102": {
+    "text": "Must have completed FREN 101",
+    "courses": [
+      "FREN 101"
+    ]
+  },
+  "FREN 112": {
+    "text": "Must have completed FREN 111",
+    "courses": [
+      "FREN 111"
+    ]
+  },
+  "FREN 211": {
+    "text": "Must have completed FREN 112",
+    "courses": [
+      "FREN 112"
+    ]
+  },
+  "FREN 212": {
+    "text": "Must have completed FREN 211",
+    "courses": [
+      "FREN 211"
+    ]
+  },
+  "FT 106": {
+    "text": "Prerequisite: FT 102. Corequisite courses: FT 131, EMS 101, FT 110, EMHS 200. Students will be concurrently enrolled in these courses during the academy",
+    "courses": [
+      "EMHS 200",
+      "EMS 101",
+      "FT 102",
+      "FT 110",
+      "FT 131"
+    ]
+  },
+  "FT 109": {
+    "text": "Prerequisite: Students must have completed all required core and major coursework in the Fire Technology program, possess a minimum GPA of 2.5, and obtain departmental approval",
+    "courses": []
+  },
+  "FT 146": {
+    "text": "Prerequisite: FT 110",
+    "courses": [
+      "FT 110"
+    ]
+  },
+  "FT 151": {
+    "text": "Prerequisite: MATH 96 or equivalent or Accuplacer, ACT/SAT test results",
+    "courses": []
+  },
+  "FT 206": {
+    "text": "Prerequisite: FT 106 or Firefighter I Certification",
+    "courses": [
+      "FT 106"
+    ]
+  },
+  "GEOG 103": {
+    "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "GEOG 200": {
+    "text": "Prerequisite: Completion of ENG 100, ENG 101, or ENG 113, or concurrent enrollment of ENG 100 or qualifying English placement score",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "GEOG 220": {
+    "text": "Co or Prerequisite: GEOG 210",
+    "courses": [
+      "GEOG 210"
+    ]
+  },
+  "GEOL 101": {
+    "text": "Must have completed with a C or better: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 124 or MATH 126 or MATH 126E or higher; or be currently enrolled in MATH 116 or MATH 120 or MATH 126 or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 124",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "GEOL 102": {
+    "text": "Must have completed GEOL 101",
+    "courses": [
+      "GEOL 101"
+    ]
+  },
+  "GEOL 260": {
+    "text": "Prerequisite: GEOL 101, or GEOL 102, or instructor approval",
+    "courses": [
+      "GEOL 101",
+      "GEOL 102"
+    ]
+  },
+  "GEOL 333": {
+    "text": "Must have completed GEOL 101",
+    "courses": [
+      "GEOL 101"
+    ]
+  },
+  "GIS 320": {
+    "text": "Must have completed CIT 303 or GIS 109 or GIS 301",
+    "courses": [
+      "CIT 303",
+      "GIS 109",
+      "GIS 301"
+    ]
+  },
+  "GRC 115": {
+    "text": "Prerequisites: C- or better in GRC 100, or approval of instructor",
+    "courses": [
+      "GRC 100"
+    ]
+  },
+  "GRC 116": {
+    "text": "Prerequisite: GRC 100, or can be taken concurrently",
+    "courses": [
+      "GRC 100"
+    ]
+  },
+  "GRC 117": {
+    "text": "Prerequisite or co-requisite: C- or better in GRC 116, or approval of instructor",
+    "courses": [
+      "GRC 116"
+    ]
+  },
+  "GRC 119": {
+    "text": "Must have completed ENG 100 or ENG 101",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "GRC 132": {
+    "text": "Prerequisite: ART 101 and C- or better in GRC 100, or approval of instructor",
+    "courses": [
+      "ART 101",
+      "GRC 100"
+    ]
+  },
+  "GRC 135": {
+    "text": "Prerequisite: C- or better in GRC 117",
+    "courses": [
+      "GRC 117"
+    ]
+  },
+  "GRC 153": {
+    "text": "Prerequisite: C- or better in GRC 116, or approval of instructor",
+    "courses": [
+      "GRC 116"
+    ]
+  },
+  "GRC 175": {
+    "text": "Prerequisites: C- or better in GRC 100 and GRC 116, or approval of instructor",
+    "courses": [
+      "GRC 100",
+      "GRC 116"
+    ]
+  },
+  "GRC 182": {
+    "text": "Prerequisite: C- or better in GRC 117 or instructor approval",
+    "courses": [
+      "GRC 117"
+    ]
+  },
+  "GRC 200": {
+    "text": "Prerequisite: C- or better in GRC 100 and GRC 116, or approval of instructor",
+    "courses": [
+      "GRC 100",
+      "GRC 116"
+    ]
+  },
+  "GRC 210": {
+    "text": "Prerequisites: C- or better in GRC 200, or approval of instructor",
+    "courses": [
+      "GRC 200"
+    ]
+  },
+  "GRC 220": {
+    "text": "Prerequisite: C- or better in GRC 200, or approval of instructor",
+    "courses": [
+      "GRC 200"
+    ]
+  },
+  "GRC 235": {
+    "text": "VIS 120, GRC 117",
+    "courses": [
+      "GRC 117",
+      "VIS 120"
+    ]
+  },
+  "GRC 245": {
+    "text": "GRC 235 Character Animation II",
+    "courses": [
+      "GRC 235"
+    ]
+  },
+  "GRC 275": {
+    "text": "Prerequisite: C- or better in GRC 175, or approval of instructor",
+    "courses": [
+      "GRC 175"
+    ]
+  },
+  "GRC 282": {
+    "text": "Prerequisite: C- or better in GRC 135, or instructor approval",
+    "courses": [
+      "GRC 135"
+    ]
+  },
+  "GRC 284": {
+    "text": "Prerequisite: C- or better in VIS 120 and GRC 132, or approval of instructor",
+    "courses": [
+      "GRC 132",
+      "VIS 120"
+    ]
+  },
+  "GRC 294": {
+    "text": "Prerequisite: Minimum 24 units of GRC classes or approval of instructor",
+    "courses": []
+  },
+  "GRC 300": {
+    "text": "Prerequisite: C- or better in GRC 100 and ENG 101 (or equivalent), or approval of instructor",
+    "courses": [
+      "ENG 101",
+      "GRC 100"
+    ]
+  },
+  "GRC 301": {
+    "text": "Must have completed an AAS degree",
+    "courses": []
+  },
+  "GRC 310": {
+    "text": "C- or better in GRC 210, or approval of instructor",
+    "courses": [
+      "GRC 210"
+    ]
+  },
+  "GRC 353": {
+    "text": "Prerequisite: C- or better in GRC 153 and GRC 200, or approval of instructor",
+    "courses": [
+      "GRC 153",
+      "GRC 200"
+    ]
+  },
+  "GRC 355": {
+    "text": "C- or better in GRC 220, or approval of instructor",
+    "courses": [
+      "GRC 220"
+    ]
+  },
+  "GRC 365": {
+    "text": "C- or better in GRC 275, or approval of instructor",
+    "courses": [
+      "GRC 275"
+    ]
+  },
+  "GRC 375": {
+    "text": "Prerequisite: C- or better in GRC 284, or instructor approval",
+    "courses": [
+      "GRC 284"
+    ]
+  },
+  "GRC 390": {
+    "text": "Must be taken during the last semester of Advanced Certificate program, departmental approval is required",
+    "courses": []
+  },
+  "GRC 490": {
+    "text": "Must have completed GRC 320 and GRC 350 and GRC 360",
+    "courses": [
+      "GRC 320",
+      "GRC 350",
+      "GRC 360"
+    ]
+  },
+  "HDFS 231": {
+    "text": "Prerequisites: HDFS 201, HDFS 202, HDFS 232, Students must work with the practicum instructor to arrange a practicum schedule and placement site",
+    "courses": [
+      "HDFS 201",
+      "HDFS 202",
+      "HDFS 232"
+    ]
+  },
+  "HDFS 428": {
+    "text": "Must have completed ECE 210 and ECE 200 and ECE 251 and ECE 453 and ECE 454 and EDES 300 and HDFS 201",
+    "courses": [
+      "ECE 200",
+      "ECE 210",
+      "ECE 251",
+      "ECE 453",
+      "ECE 454",
+      "EDES 300",
+      "HDFS 201"
+    ]
+  },
+  "HDFS 429": {
+    "text": "Must have completed HDFS 428",
+    "courses": [
+      "HDFS 428"
+    ]
+  },
+  "HDFS 435A": {
+    "text": "Must have completed HDFS 201",
+    "courses": [
+      "HDFS 201"
+    ]
+  },
+  "HIST 251": {
+    "text": "Prerequisite: Completion of 9.0 units in History with grades of 'C' or better",
+    "courses": []
+  },
+  "HIST 303": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 312": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 341": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 124 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "HIST 417C": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 434": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 441": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 458": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 478B": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIST 489B": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 124 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "HIST 489C": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 124 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 124",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "HIST 498": {
+    "text": "Must have completed 40 or more credits including one lower-division HIST course",
+    "courses": []
+  },
+  "HIT 100": {
+    "text": "Must have completed NURS 140",
+    "courses": [
+      "NURS 140"
+    ]
+  },
+  "HIT 101": {
+    "text": "Must have completed NURS 140",
+    "courses": [
+      "NURS 140"
+    ]
+  },
+  "HMD 203": {
+    "text": "Prerequisite: HMD 101",
+    "courses": [
+      "HMD 101"
+    ]
+  },
+  "HMD 220": {
+    "text": "Pre-requisite: HMD 101 and completion of ENG 101 or equivalent",
+    "courses": [
+      "ENG 101",
+      "HMD 101"
+    ]
+  },
+  "HMD 225": {
+    "text": "HMD 101 and ENG 102",
+    "courses": [
+      "ENG 102",
+      "HMD 101"
+    ]
+  },
+  "HMD 226": {
+    "text": "Prerequisite: HMD 101",
+    "courses": [
+      "HMD 101"
+    ]
+  },
+  "HMS 205": {
+    "text": "Must have completed HMS 101, 102, 200. Must earn a 'B' or higher in HMS 205 to count towards the degree program",
+    "courses": [
+      "HMS 101"
+    ]
+  },
+  "HMS 206": {
+    "text": "Must have completed HMS 205 with a 'B' or higher",
+    "courses": [
+      "HMS 205"
+    ]
+  },
+  "HMS 250": {
+    "text": "Must have completed HMS 101 and HMS 102",
+    "courses": [
+      "HMS 101",
+      "HMS 102"
+    ]
+  },
+  "HMS 322": {
+    "text": "Must have completed HMS 102 and HMS 200",
+    "courses": [
+      "HMS 102",
+      "HMS 200"
+    ]
+  },
+  "HMS 350": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 200",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 200"
+    ]
+  },
+  "HMS 405": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 105 and HMS 200 and HMS 322",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 105",
+      "HMS 200",
+      "HMS 322"
+    ]
+  },
+  "HMS 406": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 105 and HMS 200 and HMS 322 and HMS 405",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 105",
+      "HMS 200",
+      "HMS 322",
+      "HMS 405"
+    ]
+  },
+  "HMS 407": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 200",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 200"
+    ]
+  },
+  "HMS 427": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 200",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 200"
+    ]
+  },
+  "HMS 436": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 200",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 200"
+    ]
+  },
+  "HMS 439": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 105 and HMS 200 and HMS 322",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 105",
+      "HMS 200",
+      "HMS 322"
+    ]
+  },
+  "HMS 450": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 105 and HMS 200 and HMS 322",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 105",
+      "HMS 200",
+      "HMS 322"
+    ]
+  },
+  "HMS 465": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102",
+    "courses": [
+      "ENG 102",
+      "HMS 102"
+    ]
+  },
+  "HMS 475": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 105 and HMS 200 and HMS 322",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 105",
+      "HMS 200",
+      "HMS 322"
+    ]
+  },
+  "HMS 499": {
+    "text": "Must have completed ENG 102 (or higher) and HMS 102 and HMS 105 and HMS 200 and HMS 322",
+    "courses": [
+      "ENG 102",
+      "HMS 102",
+      "HMS 105",
+      "HMS 200",
+      "HMS 322"
+    ]
+  },
+  "HSC 300": {
+    "text": "Must have completed MATH 120 or higher with a grade of 'C' or higher",
+    "courses": [
+      "MATH 120"
+    ]
+  },
+  "HUM 105": {
+    "text": "Prerequisite: Completion of ENG 101 or equivalent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUM 106": {
+    "text": "Prerequisite: Completion of ENG 101 or equivalent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUM 207": {
+    "text": "Prerequisite: Completion of ENG 101 or equivalent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUM 301": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 126 or higher or STAT 152)",
+    "courses": [
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 126",
+      "STAT 152"
+    ]
+  },
+  "IDS 299": {
+    "text": "Student must have 30 credits of completed coursework prior to enrollment in IDS 299. Student must have a minimum GPA of 2.5. Student must have permission of faculty member and internship coordinator",
+    "courses": []
+  },
+  "INT 301": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 126 or MATH 126E or higher or AMS 310 or STAT 152) or instructor approval",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "INT 339": {
+    "text": "Must have completed 40 or more credits and (ENG 102 or ENG 333) and (MATH 116 or MATH 120 or MATH 126 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 116",
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "INT 349": {
+    "text": "Must have completed 40 or more credits and (ENG 102 or ENG 333) and (MATH 116 or MATH 120 or MATH 126 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 116",
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "INT 359": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 126 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "INT 369": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 126 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "INT 400": {
+    "text": "Must have senior standing and have declared Bachelor of Arts in Integrative Studies and have completed INT 301",
+    "courses": [
+      "INT 301"
+    ]
+  },
+  "INT 496": {
+    "text": "Must have senior standing, and have completed INT 301, and have declared a Bachelor of Arts in Integrative Studies, or a Bachelor of Arts-Social Science or a Bachelor of Arts-Natural Resources",
+    "courses": [
+      "INT 301"
+    ]
+  },
+  "IRW 151": {
+    "text": "Prerequisite: IRW 101",
+    "courses": [
+      "IRW 101"
+    ]
+  },
+  "IRW 201": {
+    "text": "Prerequisite: IRW 151",
+    "courses": [
+      "IRW 151"
+    ]
+  },
+  "IRW 251": {
+    "text": "Prerequisite: IRW 201",
+    "courses": [
+      "IRW 201"
+    ]
+  },
+  "IS 201": {
+    "text": "Prerequisite: IS 101 or equivalent",
+    "courses": [
+      "IS 101"
+    ]
+  },
+  "IS 301": {
+    "text": "Must have junior standing or higher",
+    "courses": []
+  },
+  "IS 378": {
+    "text": "Must have completed an associate's degree",
+    "courses": []
+  },
+  "IT 102": {
+    "text": "Must have completed IT 106 or have been accepted into the Industrial Millwright Program",
+    "courses": [
+      "IT 106"
+    ]
+  },
+  "IT 103": {
+    "text": "Must have completed IT 106 and IT 201 and IT 209 and IT 216 and TA 100",
+    "courses": [
+      "IT 106",
+      "IT 201",
+      "IT 209",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 105": {
+    "text": "Must have completed IT 103 and IT 106 and IT 201 and IT 209 and IT 214 and IT 216 and TA 100",
+    "courses": [
+      "IT 103",
+      "IT 106",
+      "IT 201",
+      "IT 209",
+      "IT 214",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 106": {
+    "text": "Must have been accepted into the Industrial Millwright Program",
+    "courses": []
+  },
+  "IT 201": {
+    "text": "Must have completed IT 106 and IT 216 and TA 100",
+    "courses": [
+      "IT 106",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 207": {
+    "text": "Must have completed IT 103 and IT 106 and IT 201 and IT 209 and IT 214 and IT 216 and TA 100",
+    "courses": [
+      "IT 103",
+      "IT 106",
+      "IT 201",
+      "IT 209",
+      "IT 214",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 208": {
+    "text": "Must have completed DT 100 or TA 100",
+    "courses": [
+      "DT 100",
+      "TA 100"
+    ]
+  },
+  "IT 209": {
+    "text": "Must have completed IT 106 and IT 216 and TA 100",
+    "courses": [
+      "IT 106",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 210": {
+    "text": "Must have completed IT 103 and IT 105 and IT 106 and IT 201 and IT 207 and IT 208 and IT 209 and IT 214 and IT 216 and TA 100",
+    "courses": [
+      "IT 103",
+      "IT 105",
+      "IT 106",
+      "IT 201",
+      "IT 207",
+      "IT 208",
+      "IT 209",
+      "IT 214",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 214": {
+    "text": "Must have completed IT 106 and IT 201 and IT 209 and IT 216 and TA 100",
+    "courses": [
+      "IT 106",
+      "IT 201",
+      "IT 209",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "IT 216": {
+    "text": "Must have completed IT 106",
+    "courses": [
+      "IT 106"
+    ]
+  },
+  "IT 220": {
+    "text": "Must have completed IT 103 and IT 105 and IT 106 and IT 201 and IT 207 and IT 208 and IT 209 and IT 214 and IT 216 and TA 100",
+    "courses": [
+      "IT 103",
+      "IT 105",
+      "IT 106",
+      "IT 201",
+      "IT 207",
+      "IT 208",
+      "IT 209",
+      "IT 214",
+      "IT 216",
+      "TA 100"
+    ]
+  },
+  "JOUR 108": {
+    "text": "Prerequisite: ENG 101 or ENG 100 with a grade of C- or better, or concurrent enrollment in ENG 100 or ENG 101",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "JOUR 298": {
+    "text": "Must have completed JOUR 205",
+    "courses": [
+      "JOUR 205"
+    ]
+  },
+  "LAW 198": {
+    "text": "Prerequisite: LAW 101",
+    "courses": [
+      "LAW 101"
+    ]
+  },
+  "LAW 203": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 204": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 205": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259, and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 231": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259, and LAW 261. This course can be taken concurrently with LAW 261",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 232": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 233": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 251": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 252": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 255": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 259 and LAW 261. This course can be taken concurrently with LAW 259",
+    "courses": [
+      "LAW 101",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 259": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better and LAW 261",
+    "courses": [
+      "LAW 101",
+      "LAW 261"
+    ]
+  },
+  "LAW 261": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better",
+    "courses": [
+      "LAW 101"
+    ]
+  },
+  "LAW 263": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better",
+    "courses": [
+      "LAW 101"
+    ]
+  },
+  "LAW 264": {
+    "text": "Prerequisite: LAW 101 with a grade of 'B' or better, LAW 231, LAW 259, LAW 261, and 12 additional semester LAW units. May be taken concurrently with LAW 231",
+    "courses": [
+      "LAW 101",
+      "LAW 231",
+      "LAW 259",
+      "LAW 261"
+    ]
+  },
+  "LAW 295": {
+    "text": "Prerequisite: LAW 101 with a 'B' or better, LAW 231, LAW 259, LAW 261, LAW 263 and 12 semester LAW units",
+    "courses": [
+      "LAW 101",
+      "LAW 231",
+      "LAW 259",
+      "LAW 261",
+      "LAW 263"
+    ]
+  },
+  "LGM 208": {
+    "text": "Prerequisite: LGM 201",
+    "courses": [
+      "LGM 201"
+    ]
+  },
+  "LGM 209": {
+    "text": "Prerequisite: LGM 208",
+    "courses": [
+      "LGM 208"
+    ]
+  },
+  "LGM 210": {
+    "text": "Corequisite: LGM 201",
+    "courses": [
+      "LGM 201"
+    ]
+  },
+  "LGM 320": {
+    "text": "Prerequisite: ENG 102 or ENG 114 and LGM 201; or instructor approval",
+    "courses": [
+      "ENG 102",
+      "ENG 114",
+      "LGM 201"
+    ]
+  },
+  "LGM 330": {
+    "text": "Prerequisite: MATH 120, ENG 102 or ENG 114, or qualifying test results, and LGM 201; or instructor approval",
+    "courses": [
+      "ENG 102",
+      "ENG 114",
+      "LGM 201",
+      "MATH 120"
+    ]
+  },
+  "LGM 340": {
+    "text": "Prerequisite: ENG 102 or ENG 114 and LGM 201; or instructor approval",
+    "courses": [
+      "ENG 102",
+      "ENG 114",
+      "LGM 201"
+    ]
+  },
+  "LGM 352": {
+    "text": "Prerequisite: Satisfied with one course BUS 225 or STAT 152 -OR- satisfied with two courses ECON 261 and ECON 262",
+    "courses": [
+      "BUS 225",
+      "ECON 261",
+      "ECON 262",
+      "STAT 152"
+    ]
+  },
+  "LGM 410": {
+    "text": "Prerequisite: MATH 120, MATH 124, MATH 126 or equivalent/qualifying test scores; or BAS Applied Business Management Majors; or instructor approval",
+    "courses": [
+      "MATH 120",
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "LGM 420": {
+    "text": "Prerequisite: BUS 225 and LGM 201, or BAS Applied Business Management Majors, or instructor approval",
+    "courses": [
+      "BUS 225",
+      "LGM 201"
+    ]
+  },
+  "LGM 440": {
+    "text": "Pre-requisite: LGM 340 and LGM 352 or BAS Applied Business Management Majors",
+    "courses": [
+      "LGM 340",
+      "LGM 352"
+    ]
+  },
+  "LGM 450": {
+    "text": "Prerequisite: BUS 225, LGM 352, and LGM 410",
+    "courses": [
+      "BUS 225",
+      "LGM 352",
+      "LGM 410"
+    ]
+  },
+  "LGM 460": {
+    "text": "Prerequisite: BUS 325, LGM 210, and LGM 212; or instructor approval",
+    "courses": [
+      "BUS 325",
+      "LGM 210",
+      "LGM 212"
+    ]
+  },
+  "LGM 470": {
+    "text": "Prerequisite: LGM 201, LGM 202, and LGM 320",
+    "courses": [
+      "LGM 201",
+      "LGM 202",
+      "LGM 320"
+    ]
+  },
+  "LGM 490": {
+    "text": "Prerequisite: C- or better in BUS 225, BUS 330, LGM 340, and LGM 420. Declared BAS - Logistics Operations Management and 45 credits completed in the core requirements with a cumulative 2.5 GPA or higher",
+    "courses": [
+      "BUS 225",
+      "BUS 330",
+      "LGM 340",
+      "LGM 420"
+    ]
+  },
+  "LGM 491": {
+    "text": "Prerequisite: Declared BAS - Logistics Operations Management and 45 credits completed in the core requirements with a cumulative 2.5 GPA or higher",
+    "courses": []
+  },
+  "MAPE 110": {
+    "text": "Must be accepted into the Medical Assistant with Phlebotomy Technician and EKG program",
+    "courses": []
+  },
+  "MAPE 120": {
+    "text": "Must have completed MAPE 110 be accepted into the Medical Assistant with Phlebotomy Technician and EKG program",
+    "courses": [
+      "MAPE 110"
+    ]
+  },
+  "MAPE 130": {
+    "text": "Must have completed MAPE 120 and be accepted into the Medical Assistant with Phlebotomy Technician and EKG program",
+    "courses": [
+      "MAPE 120"
+    ]
+  },
+  "MAPE 140": {
+    "text": "Must have completed MAPE 130 and be accepted into the Medical Assistant with Phlebotomy Technician and EKG program",
+    "courses": [
+      "MAPE 130"
+    ]
+  },
+  "MAPE 150": {
+    "text": "Must have completed MAPE 110 and MAPE 120 and be accepted into the Medical Assistant with Phlebotomy Technician and EKG program",
+    "courses": [
+      "MAPE 110",
+      "MAPE 120"
+    ]
+  },
+  "MASG 107": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 109": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 117": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 118": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 119": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 129": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 130": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 132": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 135": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 137": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 140": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 142": {
+    "text": "Prerequisite - Must be 18 years or older. Prerequisite or Corequisite - MASG 201 or demonstrate proof of previous massage training",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 198": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 201": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 202": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 203": {
+    "text": "Prerequisite: MASG 202, and must be 18 years or older",
+    "courses": [
+      "MASG 202"
+    ]
+  },
+  "MASG 205": {
+    "text": "Prerequisite: Must be 18 years or older. Prerequisite or Corequisite: MASG 202",
+    "courses": [
+      "MASG 202"
+    ]
+  },
+  "MASG 208": {
+    "text": "Prerequisite: MASG 202, and must be 18 years or older",
+    "courses": [
+      "MASG 202"
+    ]
+  },
+  "MASG 210": {
+    "text": "Prerequisite: Must be 18 years or older. Prerequisite: Students must complete MASG 201 and 75% of massage program requirements to take this course. Permission to enroll is given by program officer",
+    "courses": [
+      "MASG 201"
+    ]
+  },
+  "MASG 215": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MASG 216": {
+    "text": "Prerequisite - Must be 18 years or older",
+    "courses": []
+  },
+  "MATH 106": {
+    "text": "Prerequisite: Qualifying Accuplacer, ACT/SAT test results (taken within 2 years)",
+    "courses": []
+  },
+  "MATH 116": {
+    "text": "Must have completed MATH 95 or MATH 97 with a grade of 'C-' or higher or have earned a satisfactory score on the placement test, ACT, or SAT",
+    "courses": []
+  },
+  "MATH 119": {
+    "text": "Prerequisite: A grade of 'C' or better in MATH 19. A graphing calculator may be required",
+    "courses": []
+  },
+  "MATH 120": {
+    "text": "Must have completed MATH 96 or MATH 97 with a grade of 'C' or higher or have earned a satisfactory score on the placement test, ACT, or SAT or have completed MATH 95 and (ENG 100 or ENG 101) with a grade of 'C' or higher or have completed MATH 20",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "MATH 120E": {
+    "text": "Must have completed or be enrolled in MATH 20",
+    "courses": []
+  },
+  "MATH 122": {
+    "text": "Must have completed MATH 120 or above, including STAT 152, with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 120",
+      "STAT 152"
+    ]
+  },
+  "MATH 123": {
+    "text": "Must have completed MATH 120 or above, including STAT 152, with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 120",
+      "STAT 152"
+    ]
+  },
+  "MATH 124": {
+    "text": "Prerequisite: An S in MATH 24; or qualifying placement scores within 2 years. Students may enroll concurrently in MATH 24 without any prerequisite",
+    "courses": []
+  },
+  "MATH 126": {
+    "text": "Must have completed MATH 96 or MATH 97 with a grade of 'C' or higher or have earned a satisfactory score on the placement test, ACT, or SAT or have completed MATH 26 with a grade of 'P'",
+    "courses": []
+  },
+  "MATH 126E": {
+    "text": "Must have completed or be enrolled in MATH 26",
+    "courses": []
+  },
+  "MATH 127": {
+    "text": "Must have completed MATH 126 or MATH 126E with a grade of 'C-' or higher or have earned a satisfactory score on the placement test, ACT, or SAT",
+    "courses": [
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "MATH 128": {
+    "text": "Must have completed MATH 96 or MATH 97 or earned a satisfactory score in Accuplacer, ACT, or SAT tests for placement into MATH 126 or MATH 128",
+    "courses": [
+      "MATH 126"
+    ]
+  },
+  "MATH 176": {
+    "text": "Prerequisite: A grade of 'C' or better in MATH 124, MATH 126 or equivalent; or qualifying ACT/SAT test results (taken within 2 years). A graphing calculator may be required",
+    "courses": [
+      "MATH 124",
+      "MATH 126"
+    ]
+  },
+  "MATH 181": {
+    "text": "Must have completed [(MATH 126 or MATH 126E) AND MATH 127] or MATH 128 with a grade of 'C' or better or have earned a satisfactory score on the placement test, ACT, or SAT",
+    "courses": [
+      "MATH 126",
+      "MATH 126E",
+      "MATH 127",
+      "MATH 128"
+    ]
+  },
+  "MATH 182": {
+    "text": "Must have completed MATH 181 with a grade of 'C' or higher",
+    "courses": [
+      "MATH 181"
+    ]
+  },
+  "MATH 19": {
+    "text": "Prerequisite: Qualifying ACCUPLACER, ACT/SAT test results (within 2 years)",
+    "courses": []
+  },
+  "MATH 251": {
+    "text": "Must have completed MATH 182 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 182"
+    ]
+  },
+  "MATH 26": {
+    "text": "Must enroll concurrently with MATH 126. A qualifying placement test result is required",
+    "courses": [
+      "MATH 126"
+    ]
+  },
+  "MATH 283": {
+    "text": "Must have completed MATH 182 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 182"
+    ]
+  },
+  "MATH 285": {
+    "text": "Must have completed MATH 283 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 283"
+    ]
+  },
+  "MATH 295": {
+    "text": "Prerequisite: MATH 283 with a C or better",
+    "courses": [
+      "MATH 283"
+    ]
+  },
+  "MATH 310": {
+    "text": "Must have completed MATH 283 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 283"
+    ]
+  },
+  "MATH 314": {
+    "text": "Must have completed MATH 330 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 330"
+    ]
+  },
+  "MATH 330": {
+    "text": "Must have completed MATH 182 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 182"
+    ]
+  },
+  "MATH 331": {
+    "text": "Must have completed MATH 330 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 330"
+    ]
+  },
+  "MATH 333": {
+    "text": "Must have completed MATH 182 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 182"
+    ]
+  },
+  "MATH 352": {
+    "text": "Must have completed MATH 181 and MATH 182 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 181",
+      "MATH 182"
+    ]
+  },
+  "MATH 389": {
+    "text": "Must have completed 40 or more credits and have completed (ENG 102 or ENG 333) and (MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher or STAT 152)",
+    "courses": [
+      "ENG 102",
+      "ENG 333",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "MATH 475": {
+    "text": "Must have completed MATH 333 with a grade of 'C-' or higher",
+    "courses": [
+      "MATH 333"
+    ]
+  },
+  "MATH 90": {
+    "text": "Prerequisite: Qualifying Accuplacer score, ACT/SAT test results",
+    "courses": []
+  },
+  "MATH 96": {
+    "text": "Prerequisite: A grade of 'C' or better in MATH 95, or MATH 120, or equivalent or qualifying ACCUPLACER, ACT/SAT test results (taken within 2 years)",
+    "courses": [
+      "MATH 120"
+    ]
+  },
+  "MCOD 110": {
+    "text": "Must be admitted into the Medical Coding and Billing Program",
+    "courses": []
+  },
+  "MCOD 120": {
+    "text": "Must be admitted into the Medical Coding and Billing Program",
+    "courses": []
+  },
+  "MCOD 130": {
+    "text": "Must be admitted into the Medical Coding and Billing Program",
+    "courses": []
+  },
+  "MCOD 140": {
+    "text": "Must be admitted into the Medical Coding and Billing Program",
+    "courses": []
+  },
+  "MCOD 200": {
+    "text": "Must have completed MCOD 110 and MCOD 120 and MCOD 130 and MCOD 140",
+    "courses": [
+      "MCOD 110",
+      "MCOD 120",
+      "MCOD 130",
+      "MCOD 140"
+    ]
+  },
+  "MCOD 210": {
+    "text": "Must have completed MCOD 110 and MCOD 120 and MCOD 130 and MCOD 140",
+    "courses": [
+      "MCOD 110",
+      "MCOD 120",
+      "MCOD 130",
+      "MCOD 140"
+    ]
+  },
+  "MCOD 220": {
+    "text": "Must have completed MCOD 110 and MCOD 120 and MCOD 130 and MCOD 140",
+    "courses": [
+      "MCOD 110",
+      "MCOD 120",
+      "MCOD 130",
+      "MCOD 140"
+    ]
+  },
+  "ME 241": {
+    "text": "Prerequisites: PHYS 180 and Co or prerequisite: MATH 182",
+    "courses": [
+      "MATH 182",
+      "PHYS 180"
+    ]
+  },
+  "ME 242": {
+    "text": "DR: ENGR 241/MATH 283",
+    "courses": [
+      "ENGR 241",
+      "MATH 283"
+    ]
+  },
+  "MET 102": {
+    "text": "Must have completed MET 101",
+    "courses": [
+      "MET 101"
+    ]
+  },
+  "MGT 310": {
+    "text": "Must have sophomore standing or higher and have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "MGT 323": {
+    "text": "Must have sophomore standing or higher",
+    "courses": []
+  },
+  "MGT 330": {
+    "text": "Must have completed MGT 310",
+    "courses": [
+      "MGT 310"
+    ]
+  },
+  "MGT 367": {
+    "text": "Must have sophomore standing or higher",
+    "courses": []
+  },
+  "MGT 430": {
+    "text": "Must have completed MGT 310",
+    "courses": [
+      "MGT 310"
+    ]
+  },
+  "MGT 441": {
+    "text": "Must have completed MATH 181 or STAT 152",
+    "courses": [
+      "MATH 181",
+      "STAT 152"
+    ]
+  },
+  "MGT 469": {
+    "text": "BAS Applied Business Management Major",
+    "courses": []
+  },
+  "MGT 480": {
+    "text": "Must have sophomore standing or higher and have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "MGT 482": {
+    "text": "Must have sophomore standing and be accepted into the Bachelor of Applied Science - Management and Supervision program and successfully complete MGT 310",
+    "courses": [
+      "MGT 310"
+    ]
+  },
+  "MGT 485": {
+    "text": "Prerequisite: BUS 101; AND ENG 100 or higher or BUS 106 or BUS 107; OR BAS Applied Business Management Majors; OR permission of instructor",
+    "courses": [
+      "BUS 101",
+      "BUS 106",
+      "BUS 107",
+      "ENG 100"
+    ]
+  },
+  "MGT 487": {
+    "text": "Must have completed MGT 310",
+    "courses": [
+      "MGT 310"
+    ]
+  },
+  "MINE 102": {
+    "text": "Must have completed MINE 101",
+    "courses": [
+      "MINE 101"
+    ]
+  },
+  "MINE 210": {
+    "text": "Must have completed MINE 101 and MINE 102",
+    "courses": [
+      "MINE 101",
+      "MINE 102"
+    ]
+  },
+  "MKT 210": {
+    "text": "Prerequisite: ENG 101, ENG 113, BUS 108, BUS 111, or equivalent",
+    "courses": [
+      "BUS 108",
+      "BUS 111",
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "MPT 104": {
+    "text": "Pre or Co-requisite: MPT 102 or instructor approval",
+    "courses": [
+      "MPT 102"
+    ]
+  },
+  "MPT 112": {
+    "text": "Prerequisite or Co-requisite: MPT 111 or instructor approval",
+    "courses": [
+      "MPT 111"
+    ]
+  },
+  "MPT 114": {
+    "text": "Prerequisite or Co-requisite: MPT 112 or instructor approval",
+    "courses": [
+      "MPT 112"
+    ]
+  },
+  "MPT 305": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program and MATH 126",
+    "courses": [
+      "MATH 126"
+    ]
+  },
+  "MPT 311": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 312": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 325": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 340": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 343": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 351": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 363": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program",
+    "courses": []
+  },
+  "MPT 411": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science Cyber-Physical Manufacturing program and MPT 325",
+    "courses": [
+      "MPT 325"
+    ]
+  },
+  "MPT 412": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program and MPT 325",
+    "courses": [
+      "MPT 325"
+    ]
+  },
+  "MPT 415": {
+    "text": "Prerequisite: Admissions to the Bachelor of Applied Science, Cyber-Physical Manufacturing program and MPT 325",
+    "courses": [
+      "MPT 325"
+    ]
+  },
+  "MT 108": {
+    "text": "Pre or Co-requisite: ELM 110 or instructor approval",
+    "courses": [
+      "ELM 110"
+    ]
+  },
+  "MTT 105": {
+    "text": "Must be enrolled in MTT 106",
+    "courses": [
+      "MTT 106"
+    ]
+  },
+  "MTT 106": {
+    "text": "Must be enrolled in MTT 105",
+    "courses": [
+      "MTT 105"
+    ]
+  },
+  "MTT 110": {
+    "text": "Must have completed MTT 105 and MTT 106 and be enrolled in MTT 111",
+    "courses": [
+      "MTT 105",
+      "MTT 106",
+      "MTT 111"
+    ]
+  },
+  "MTT 111": {
+    "text": "Must have completed MTT 105 and MTT 106 and be enrolled in MTT 110",
+    "courses": [
+      "MTT 105",
+      "MTT 106",
+      "MTT 110"
+    ]
+  },
+  "MTT 230": {
+    "text": "Must have completed MTT 105 and MTT 110",
+    "courses": [
+      "MTT 105",
+      "MTT 110"
+    ]
+  },
+  "MTT 232": {
+    "text": "Must have completed MTT 230 and CADD 245",
+    "courses": [
+      "CADD 245",
+      "MTT 230"
+    ]
+  },
+  "MTT 234": {
+    "text": "Must have completed MTT 230 and MTT 232 and MTT 292 and CADD 245",
+    "courses": [
+      "CADD 245",
+      "MTT 230",
+      "MTT 232",
+      "MTT 292"
+    ]
+  },
+  "MTT 260": {
+    "text": "Prerequisite: MTT 250. Course may be taken concurrently with MTT 250",
+    "courses": [
+      "MTT 250"
+    ]
+  },
+  "MTT 261": {
+    "text": "Prerequisite: MTT 105 or MTT 110 or concurrent enrollment in either of these courses",
+    "courses": [
+      "MTT 105",
+      "MTT 110"
+    ]
+  },
+  "MTT 291": {
+    "text": "Must be enrolled in MTT 232 or MTT 292",
+    "courses": [
+      "MTT 232",
+      "MTT 292"
+    ]
+  },
+  "MTT 292": {
+    "text": "Must have completed MTT 230 and CADD 245",
+    "courses": [
+      "CADD 245",
+      "MTT 230"
+    ]
+  },
+  "MTT 293": {
+    "text": "Must have completed MTT 292",
+    "courses": [
+      "MTT 292"
+    ]
+  },
+  "MTT 296": {
+    "text": "Must be enrolled in MTT 293 or MTT 234",
+    "courses": [
+      "MTT 234",
+      "MTT 293"
+    ]
+  },
+  "MUS 107": {
+    "text": "Prerequisite: Student must supply own acoustic guitar",
+    "courses": []
+  },
+  "MUS 108": {
+    "text": "Prerequisite: Successful completion of Guitar I (MUS 107) or instructor approval. Student must supply own guitar",
+    "courses": [
+      "MUS 107"
+    ]
+  },
+  "MUS 111": {
+    "text": "Prerequisite: No previous musical training required",
+    "courses": []
+  },
+  "MUS 112": {
+    "text": "Prerequisite: MUS 111 or instructor approval",
+    "courses": [
+      "MUS 111"
+    ]
+  },
+  "MUS 203": {
+    "text": "Must have completed MUS 101",
+    "courses": [
+      "MUS 101"
+    ]
+  },
+  "MUS 204": {
+    "text": "Must have completed MUS 203",
+    "courses": [
+      "MUS 203"
+    ]
+  },
+  "MUS 211": {
+    "text": "Prerequisite: MUS 101 or instructor approval. Co-requisite: student must also be concurrently enrolled in MUS 203, Music Theory I",
+    "courses": [
+      "MUS 101",
+      "MUS 203"
+    ]
+  },
+  "MUS 212": {
+    "text": "Prerequisite: MUS 211 and MUS 203. Co-requisite: Student must also be concurrently enrolled in MUS 204, Music Theory II",
+    "courses": [
+      "MUS 203",
+      "MUS 204",
+      "MUS 211"
+    ]
+  },
+  "MUS 231": {
+    "text": "Co-requisite: MUS 239 Virtual Studio Technology I",
+    "courses": [
+      "MUS 239"
+    ]
+  },
+  "MUS 232": {
+    "text": "Prerequisite: MUS 231 Recording Technology I. Co-requisite: MUS 240 Virtual Studio Technology II",
+    "courses": [
+      "MUS 231",
+      "MUS 240"
+    ]
+  },
+  "MUS 239": {
+    "text": "Co-requisite: MUS 231 Recording Technology I",
+    "courses": [
+      "MUS 231"
+    ]
+  },
+  "MUS 240": {
+    "text": "Prerequisite: MUS 239, Co-requisite: MUS 232 Recording Technology II",
+    "courses": [
+      "MUS 232",
+      "MUS 239"
+    ]
+  },
+  "MUS 301": {
+    "text": "Must have completed MUS 203 and MUS 204",
+    "courses": [
+      "MUS 203",
+      "MUS 204"
+    ]
+  },
+  "MUSA 101": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 103": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 107": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 109": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 113": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 115": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 121": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 123": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 127": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 129": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 131": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 135": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 137": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 139": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 145": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "MUSA 147": {
+    "text": "Corequisite: Must also be enrolled in a music ensemble class or a theater or musical theater production class",
+    "courses": []
+  },
+  "MUSA 298": {
+    "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
+    "courses": []
+  },
+  "NRES 210": {
+    "text": "Prerequisite: MATH 126",
+    "courses": [
+      "MATH 126"
+    ]
+  },
+  "NRES 217": {
+    "text": "Prerequisite or Co-requisite: BIOL 190A or CHEM 122",
+    "courses": [
+      "BIOL 190A",
+      "CHEM 122"
+    ]
+  },
+  "NRES 310": {
+    "text": "Must have completed BIOL 190 or BIOL 191",
+    "courses": [
+      "BIOL 190",
+      "BIOL 191"
+    ]
+  },
+  "NRES 432": {
+    "text": "Must have completed CHEM 122",
+    "courses": [
+      "CHEM 122"
+    ]
+  },
+  "NURS 102": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 128": {
+    "text": "Must have a current CMA, DA, EMT, EMTA, or Paramedic certification, or a minimum of a B in BIOL 189A or BIOL 190A. A current American Heart Association Basic Life Support (BLS) CPR card is required upon registration",
+    "courses": [
+      "BIOL 189A",
+      "BIOL 190A"
+    ]
+  },
+  "NURS 130": {
+    "text": "MANDATORY STEPS OF ENROLLMENT: Background check, Drug Test, HCP CPR card, Major Medical Insurance and Immunizations",
+    "courses": []
+  },
+  "NURS 135": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 138": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 142": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 154": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 155": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 158": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 159": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 170": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 185": {
+    "text": "LPN currently licensed in the state of Nevada (LPN education obtained from an accredited school) OR successful completion of an accredited paramedic program with national certification and acceptance to the nursing program",
+    "courses": []
+  },
+  "NURS 202": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 209": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 212": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 252": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 253": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 257": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 258": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 273": {
+    "text": "Must be accepted to the Nursing Program",
+    "courses": []
+  },
+  "NURS 274": {
+    "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 326": {
+    "text": "Must be accepted to the RN-BSN program",
+    "courses": []
+  },
+  "NURS 330": {
+    "text": "Pre-requisite: MATH 124 or higher; admission to the RN-BSN program",
+    "courses": [
+      "MATH 124"
+    ]
+  },
+  "NURS 354": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 394": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 395": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 396": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 420": {
+    "text": "Must have completed or be enrolled in NURS 326 and be accepted to the RN-BSN program",
+    "courses": [
+      "NURS 326"
+    ]
+  },
+  "NURS 429": {
+    "text": "Must have completed or be taking NURS 326 and be accepted to the RN-BSN program",
+    "courses": [
+      "NURS 326"
+    ]
+  },
+  "NURS 436": {
+    "text": "Must have completed or be enrolled in NURS 429 and be accepted to the RN-BSN program",
+    "courses": [
+      "NURS 429"
+    ]
+  },
+  "NURS 443": {
+    "text": "Must have completed or be taking NURS 326 and be accepted to the RN-BSN program",
+    "courses": [
+      "NURS 326"
+    ]
+  },
+  "NURS 449": {
+    "text": "Must have completed NURS 443 and be accepted to the RN-BSN program",
+    "courses": [
+      "NURS 443"
+    ]
+  },
+  "NURS 456": {
+    "text": "Must have completed six (6) upper division NURS courses and be accepted to the RN-BSN program",
+    "courses": []
+  },
+  "NURS 478": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 479": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 480": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 482": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 489": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NURS 492": {
+    "text": "Prerequisite: Admission to RN-BSN Program",
+    "courses": []
+  },
+  "NUTR 121": {
+    "text": "Must have completed MATH 95 or higher or earned a satisfactory score in the placement test, ACT, SAT for placement into MATH 96 or MATH 116",
+    "courses": [
+      "MATH 116"
+    ]
+  },
+  "NUTR 143": {
+    "text": "Prerequisite: NUTR 121",
+    "courses": [
+      "NUTR 121"
+    ]
+  },
+  "NUTR 223": {
+    "text": "Prerequisite: BIOL 190A and BIOL 190L or permission of instructor",
+    "courses": [
+      "BIOL 190A",
+      "BIOL 190L"
+    ]
+  },
+  "NUTR 233": {
+    "text": "PR: NUTR 233",
+    "courses": []
+  },
+  "NUTR 243": {
+    "text": "Prerequisite: NUTR 223",
+    "courses": [
+      "NUTR 223"
+    ]
+  },
+  "NUTR 244": {
+    "text": "PR: NUTR 244",
+    "courses": []
+  },
+  "NUTR 291": {
+    "text": "Prerequisite: Department Consent Required",
+    "courses": []
+  },
+  "NUTR 292": {
+    "text": "PR: NUTR 292",
+    "courses": []
+  },
+  "NUTR 293": {
+    "text": "Prerequisite: Department Consent Required",
+    "courses": []
+  },
+  "OPE 150": {
+    "text": "Prerequisite: OPE 100",
+    "courses": [
+      "OPE 100"
+    ]
+  },
+  "OPE 200": {
+    "text": "Prerequisite: OPE 150",
+    "courses": [
+      "OPE 150"
+    ]
+  },
+  "OPE 250": {
+    "text": "Prerequisite: OPE 100, OPE 150 and OPE 200",
+    "courses": [
+      "OPE 100",
+      "OPE 150",
+      "OPE 200"
+    ]
+  },
+  "PBH 220": {
+    "text": "Prerequisite: PBH 101 or BIOL 100 or higher",
+    "courses": [
+      "BIOL 100",
+      "PBH 101"
+    ]
+  },
+  "PBH 234": {
+    "text": "Prerequisite: PBH 101 or BIOL 100 or higher, CHEM 100 or higher, or ENV 101 or higher",
+    "courses": [
+      "BIOL 100",
+      "CHEM 100",
+      "ENV 101",
+      "PBH 101"
+    ]
+  },
+  "PBH 281": {
+    "text": "Prerequisite: MATH 124 or higher",
+    "courses": [
+      "MATH 124"
+    ]
+  },
+  "PEX 126": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 180": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 184": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 193": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 198": {
+    "text": "Must be a member of the TMCC Intercollegiate Volleyball Team or have instructor permission",
+    "courses": []
+  },
+  "PEX 215": {
+    "text": "Must be a member of the TMCC Intercollegiate Volleyball Team or have instructor permission",
+    "courses": []
+  },
+  "PEX 226": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 230": {
+    "text": "Must be a member of the TMCC Intercollegiate Volleyball Team or have instructor permission",
+    "courses": []
+  },
+  "PEX 235": {
+    "text": "Must be a member of the TMCC Intercollegiate Volleyball Team or have instructor permission",
+    "courses": []
+  },
+  "PEX 280": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 284": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PEX 293": {
+    "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
+    "courses": []
+  },
+  "PHIL 129": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "PHIL 130": {
+    "text": "A grade of C- or better in ENG 100 or ENG 101 or equivalent or qualifying SAT/ACT score or instructor permission",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "PHIL 135": {
+    "text": "Prerequisite: Completion of or concurrent enrollment in ENG 101 or qualifying English placement score",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHIL 210": {
+    "text": "Prerequisite: Completion of or concurrent enrollment in ENG 101 or qualifying English placement score",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "PHIL 311": {
+    "text": "Must have completed an associate's degree",
+    "courses": []
+  },
+  "PHIL 361": {
+    "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102"
+    ]
+  },
+  "PHYS 100": {
+    "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "PHYS 107": {
+    "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
+    "courses": [
+      "MATH 116",
+      "MATH 116E",
+      "MATH 120",
+      "MATH 120E",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "PHYS 151": {
+    "text": "Must have completed MATH 127 or higher",
+    "courses": [
+      "MATH 127"
+    ]
+  },
+  "PHYS 152": {
+    "text": "Must have completed PHYS 151",
+    "courses": [
+      "PHYS 151"
+    ]
+  },
+  "PHYS 180": {
+    "text": "Must have completed MATH 181 with a grade of 'C' or higher",
+    "courses": [
+      "MATH 181"
+    ]
+  },
+  "PHYS 180L": {
+    "text": "Prerequisite: MATH 181; Corequisite: PHYS 180. Students must co-enroll in both PHYS 180 and PHYS 180L to receive credit",
+    "courses": [
+      "MATH 181",
+      "PHYS 180"
+    ]
+  },
+  "PHYS 181": {
+    "text": "Must have completed MATH 181 and PHYS 180",
+    "courses": [
+      "MATH 181",
+      "PHYS 180"
+    ]
+  },
+  "PHYS 181L": {
+    "text": "Prerequisite: PHYS 180 Corequisite: PHYS 181. Students must co-enroll in both PHYS 181 and PHYS 181L to receive credit",
+    "courses": [
+      "PHYS 180",
+      "PHYS 181"
+    ]
+  },
+  "PHYS 182": {
+    "text": "Must have completed PHYS 181",
+    "courses": [
+      "PHYS 181"
+    ]
+  },
+  "PHYS 182L": {
+    "text": "Prerequisite: PHYS 181 Co-Requisite: PHYS 182. Students must co-enroll in both PHYS 182 and PHYS 182L to receive credit",
+    "courses": [
+      "PHYS 181",
+      "PHYS 182"
+    ]
+  },
+  "PHYS 483": {
+    "text": "Must have completed PHYS 182",
+    "courses": [
+      "PHYS 182"
+    ]
+  },
+  "PLCM 150": {
+    "text": "Prerequisite: PLCM 100",
+    "courses": [
+      "PLCM 100"
+    ]
+  },
+  "PLCM 200": {
+    "text": "Prerequisite: PLCM 150",
+    "courses": [
+      "PLCM 150"
+    ]
+  },
+  "PLCM 250": {
+    "text": "Prerequisite: PLCM 200",
+    "courses": [
+      "PLCM 200"
+    ]
+  },
+  "PLST 151": {
+    "text": "Prerequisite: PLST 101",
+    "courses": [
+      "PLST 101"
+    ]
+  },
+  "PLST 201": {
+    "text": "Prerequisite: PLST 151",
+    "courses": [
+      "PLST 151"
+    ]
+  },
+  "PLST 251": {
+    "text": "Prerequisite: PLST 201",
+    "courses": [
+      "PLST 201"
+    ]
+  },
+  "PPF 150": {
+    "text": "Prerequisite: PPF 100",
+    "courses": [
+      "PPF 100"
+    ]
+  },
+  "PPF 200": {
+    "text": "Prerequisite: PPF 150",
+    "courses": [
+      "PPF 150"
+    ]
+  },
+  "PPF 250": {
+    "text": "Prerequisites: PPF 200",
+    "courses": [
+      "PPF 200"
+    ]
+  },
+  "PPF 290": {
+    "text": "Prerequisite: PPF 250",
+    "courses": [
+      "PPF 250"
+    ]
+  },
+  "PSC 295": {
+    "text": "Prerequisite: PSC 101 or approval of the instructor",
+    "courses": [
+      "PSC 101"
+    ]
+  },
+  "PSC 299": {
+    "text": "Prerequisite: PSC 101 plus one Political Science three-unit elective and consent of instructor",
+    "courses": [
+      "PSC 101"
+    ]
+  },
+  "PSC 401F": {
+    "text": "Must have completed 40 or more credits including PSC 101 or PSC 210",
+    "courses": [
+      "PSC 101",
+      "PSC 210"
+    ]
+  },
+  "PSC 401Z": {
+    "text": "Must have completed 40 or more credits including PSC 101 or PSC 210",
+    "courses": [
+      "PSC 101",
+      "PSC 210"
+    ]
+  },
+  "PSC 403C": {
+    "text": "Must have completed 40 or more credits including PSC 101 or PSC 210",
+    "courses": [
+      "PSC 101",
+      "PSC 210"
+    ]
+  },
+  "PSC 403K": {
+    "text": "Must have completed 40 or more credits including PSC 101 or PSC 210",
+    "courses": [
+      "PSC 101",
+      "PSC 210"
+    ]
+  },
+  "PSC 405G": {
+    "text": "Must have completed 40 or more credits including one 3 credit lower-division PSC",
+    "courses": []
+  },
+  "PSY 205": {
+    "text": "Prerequisite: PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 210": {
+    "text": "Prerequisite: Completion of PSY 101, or SOC 101; NGQAS score of 263-275, or equivalent ACT/SAT score, or completion of MATH 120 or higher",
+    "courses": [
+      "MATH 120",
+      "PSY 101",
+      "SOC 101"
+    ]
+  },
+  "PSY 240": {
+    "text": "Prerequisite: PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 241": {
+    "text": "Must have completed PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 275": {
+    "text": "Prerequisite: PSY 210 and PSY 240",
+    "courses": [
+      "PSY 210",
+      "PSY 240"
+    ]
+  },
+  "PSY 313": {
+    "text": "Must have completed 40 or more credits and (ENG 102 or ENG 333) and (MATH 116 or MATH 120 or MATH 126 or MATH 126E or higher or AMS 310 or STAT 152)",
+    "courses": [
+      "AMS 310",
+      "ENG 102",
+      "ENG 333",
+      "MATH 116",
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E",
+      "STAT 152"
+    ]
+  },
+  "PSY 412": {
+    "text": "Must have completed 40 or more credits including PSY 101 or PSY 208",
+    "courses": [
+      "PSY 101",
+      "PSY 208"
+    ]
+  },
+  "PSY 435": {
+    "text": "Must have completed 40 or more credits including PSY 101 or PSY 208",
+    "courses": [
+      "PSY 101",
+      "PSY 208"
+    ]
+  },
+  "PSY 460": {
+    "text": "Must have completed 40 or more credits including PSY 101 or PSY 208",
+    "courses": [
+      "PSY 101",
+      "PSY 208"
+    ]
+  },
+  "PTD 151": {
+    "text": "Prerequisite: PTD 101",
+    "courses": [
+      "PTD 101"
+    ]
+  },
+  "PTD 201": {
+    "text": "Prerequisite: PTD 151",
+    "courses": [
+      "PTD 151"
+    ]
+  },
+  "PTD 251": {
+    "text": "Prerequisite: PTD 201",
+    "courses": [
+      "PTD 201"
+    ]
+  },
+  "RAD 103": {
+    "text": "Prerequisite: Selection to the Radiological Technology Program and concurrent enrollment in all semester I courses",
+    "courses": []
+  },
+  "RAD 110": {
+    "text": "Prerequisite: Selection to the Radiological Technology Program and concurrent enrollment in all semester I courses",
+    "courses": []
+  },
+  "RAD 112": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 116": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 118": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 124": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 125": {
+    "text": "Prerequisite: Successful completion of all semester I Radiological Technology Program and support courses",
+    "courses": []
+  },
+  "RAD 126": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 128": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 220": {
+    "text": "Prerequisite: Successful completion of all previous Radiological Technology Program courses",
+    "courses": []
+  },
+  "RAD 225": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 226": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 227": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 230": {
+    "text": "Prerequisite: Successful completion of all previous Radiological Technology Program courses",
+    "courses": []
+  },
+  "RAD 236": {
+    "text": "Prerequisite: Successful completion of all previous Radiological Technology Program courses",
+    "courses": []
+  },
+  "RAD 238": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 240": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 242": {
+    "text": "Prerequisite: Successful completion of all previous program courses (second year, second semester program student) or ARRT certified radiographer",
+    "courses": []
+  },
+  "RAD 243": {
+    "text": "Must be admitted into the Radiology Technology Program",
+    "courses": []
+  },
+  "RAD 244": {
+    "text": "Prerequisite: Successful completion of all previous Radiological Technology Program courses",
+    "courses": []
+  },
+  "RAD 245": {
+    "text": "Prerequisite: Successful completion of all previous Radiological Technology Program courses",
+    "courses": []
+  },
+  "RAD 247": {
+    "text": "Prerequisite: Successful completion of all previous program courses (second year, second semester program student) or ARRT certified radiographer",
+    "courses": []
+  },
+  "RAD 259": {
+    "text": "Prerequisite: Current successful completion of all previous Radiological Technology Program courses or instructor approval",
+    "courses": []
+  },
+  "RAD 310": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 312": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 314": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 320": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 322": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 324": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 335": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 410": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 412": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 414": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 416": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RAD 430": {
+    "text": "Admission to the BAS radiologic technology program",
+    "courses": []
+  },
+  "RS 151": {
+    "text": "Prerequisite: RS 101",
+    "courses": [
+      "RS 101"
+    ]
+  },
+  "RS 201": {
+    "text": "Prerequisite: RS 151",
+    "courses": [
+      "RS 151"
+    ]
+  },
+  "RS 251": {
+    "text": "Prerequisite: RS 201",
+    "courses": [
+      "RS 201"
+    ]
+  },
+  "RS 291": {
+    "text": "Prerequisite: RS 251",
+    "courses": [
+      "RS 251"
+    ]
+  },
+  "RST 295": {
+    "text": "A grade of C- or better in ENG 100 or ENG 101 or equivalent or qualifying SAT/ACT score or instructor permission",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "SCM 474": {
+    "text": "Prerequisite: LGM 201, LGM 202, LGM 210, and LGM 352; or BAS Applied Business Management Majors",
+    "courses": [
+      "LGM 201",
+      "LGM 202",
+      "LGM 210",
+      "LGM 352"
+    ]
+  },
+  "SMTL 151": {
+    "text": "Prerequisite: SMTL 101",
+    "courses": [
+      "SMTL 101"
+    ]
+  },
+  "SMTL 201": {
+    "text": "Prerequisite: SMTL 151",
+    "courses": [
+      "SMTL 151"
+    ]
+  },
+  "SMTL 251": {
+    "text": "Prerequisite: SMTL 201",
+    "courses": [
+      "SMTL 201"
+    ]
+  },
+  "SOC 210": {
+    "text": "Prerequisite: Completion of PSY 101, or SOC 101; NGQAS score of 263-275, or equivalent ACT/SAT score, or completion of MATH 120 or higher",
+    "courses": [
+      "MATH 120",
+      "PSY 101",
+      "SOC 101"
+    ]
+  },
+  "SPAN 102": {
+    "text": "Must have completed SPAN 101",
+    "courses": [
+      "SPAN 101"
+    ]
+  },
+  "SPAN 112": {
+    "text": "Must have completed SPAN 111",
+    "courses": [
+      "SPAN 111"
+    ]
+  },
+  "SPAN 211": {
+    "text": "Must have completed SPAN 112",
+    "courses": [
+      "SPAN 112"
+    ]
+  },
+  "SPAN 212": {
+    "text": "Must have completed SPAN 111 and SPAN 112 and SPAN 211",
+    "courses": [
+      "SPAN 111",
+      "SPAN 112",
+      "SPAN 211"
+    ]
+  },
+  "SPAN 221": {
+    "text": "Prerequisite: ENG 101 or ENG 113",
+    "courses": [
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "SPAN 222": {
+    "text": "Prerequisite: ENG 101 or ENG 113",
+    "courses": [
+      "ENG 101",
+      "ENG 113"
+    ]
+  },
+  "SPAN 227": {
+    "text": "Prerequisite: Completion of SPAN 226",
+    "courses": [
+      "SPAN 226"
+    ]
+  },
+  "SPAN 305": {
+    "text": "Must have completed SPAN 212",
+    "courses": [
+      "SPAN 212"
+    ]
+  },
+  "SPAN 400": {
+    "text": "Must have completed SPAN 212 and be enrolled in SPAN 305",
+    "courses": [
+      "SPAN 212",
+      "SPAN 305"
+    ]
+  },
+  "SRGT 110": {
+    "text": "Co-requisite: SRGT 111 and SRGT 112",
+    "courses": [
+      "SRGT 111",
+      "SRGT 112"
+    ]
+  },
+  "SRGT 111": {
+    "text": "Co-requisite: SRGT 110 and SRGT 112",
+    "courses": [
+      "SRGT 110",
+      "SRGT 112"
+    ]
+  },
+  "SRGT 112": {
+    "text": "Co-requisite: SRGT 110 and SRGT 111",
+    "courses": [
+      "SRGT 110",
+      "SRGT 111"
+    ]
+  },
+  "STAT 152": {
+    "text": "Must have completed MATH 120 or MATH 126 or MATH 126E with a 'C-' or higher. MATH 126 or higher is strongly recommended",
+    "courses": [
+      "MATH 120",
+      "MATH 126",
+      "MATH 126E"
+    ]
+  },
+  "SUR 280": {
+    "text": "Must have completed (MATH 127 or MATH 128) and be enrolled in or have completed STAT 152 and CADD 121",
+    "courses": [
+      "CADD 121",
+      "MATH 127",
+      "MATH 128",
+      "STAT 152"
+    ]
+  },
+  "SUR 281": {
+    "text": "Must have completed SUR 280",
+    "courses": [
+      "SUR 280"
+    ]
+  },
+  "SUR 290": {
+    "text": "Must have completed CADD 121",
+    "courses": [
+      "CADD 121"
+    ]
+  },
+  "SUR 320": {
+    "text": "Must have completed GIS 109",
+    "courses": [
+      "GIS 109"
+    ]
+  },
+  "SUR 330": {
+    "text": "Must have completed MATH 181",
+    "courses": [
+      "MATH 181"
+    ]
+  },
+  "SUR 340": {
+    "text": "Must have completed (MATH 127 or MATH 128) and (PHYS 151 or PHYS 180)",
+    "courses": [
+      "MATH 127",
+      "MATH 128",
+      "PHYS 151",
+      "PHYS 180"
+    ]
+  },
+  "SUR 360": {
+    "text": "Must have completed MATH 127 or MATH 128",
+    "courses": [
+      "MATH 127",
+      "MATH 128"
+    ]
+  },
+  "SUR 365": {
+    "text": "Must have completed SUR 360",
+    "courses": [
+      "SUR 360"
+    ]
+  },
+  "SUR 440": {
+    "text": "Must have completed SUR 281 and SUR 330 and (PHYS 152 or PHYS 181)",
+    "courses": [
+      "PHYS 152",
+      "PHYS 181",
+      "SUR 281",
+      "SUR 330"
+    ]
+  },
+  "SUR 450": {
+    "text": "Must have completed SUR 281 and SUR 290",
+    "courses": [
+      "SUR 281",
+      "SUR 290"
+    ]
+  },
+  "SUR 456": {
+    "text": "Must have completed SUR 255 and SUR 440",
+    "courses": [
+      "SUR 255",
+      "SUR 440"
+    ]
+  },
+  "SUR 460": {
+    "text": "Must have completed SUR 365",
+    "courses": [
+      "SUR 365"
+    ]
+  },
+  "SW 230": {
+    "text": "Must have completed PSY 101",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "SW 250": {
+    "text": "Must have completed SW 101",
+    "courses": [
+      "SW 101"
+    ]
+  },
+  "SW 310": {
+    "text": "Must have completed ANTH 101 and BIOL 100 and PSY 101 and SOC 101 and SW 101 and (ECON 102 or ECON 103) and ((HIST 101 and HIST 102) or PSC 101)",
+    "courses": [
+      "ANTH 101",
+      "BIOL 100",
+      "ECON 102",
+      "ECON 103",
+      "HIST 101",
+      "HIST 102",
+      "PSC 101",
+      "PSY 101",
+      "SOC 101",
+      "SW 101"
+    ]
+  },
+  "SW 311": {
+    "text": "Must have completed SW 310",
+    "courses": [
+      "SW 310"
+    ]
+  },
+  "SW 321": {
+    "text": "Must have completed (ENG 100 or ENG 101) and ENG 102 and PSY 101 and SW 101",
+    "courses": [
+      "ENG 100",
+      "ENG 101",
+      "ENG 102",
+      "PSY 101",
+      "SW 101"
+    ]
+  },
+  "SW 351": {
+    "text": "Must have completed SW 250 with a 'C' or higher",
+    "courses": [
+      "SW 250"
+    ]
+  },
+  "TA 100": {
+    "text": "Must have completed IT 106",
+    "courses": [
+      "IT 106"
+    ]
+  },
+  "TCA 201": {
+    "text": "Prerequisite: ENG 100 or higher or qualifying ACT/SAT test scores or permission of instructor",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "THTR 176": {
+    "text": "Prerequisite: Successful audition or instructor permission",
+    "courses": []
+  },
+  "THTR 180": {
+    "text": "Prerequisite: Completion or concurrent enrollment of ENG 101 or equivalent",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "THTR 199": {
+    "text": "Prerequisite: THTR 100, or instructor approval",
+    "courses": [
+      "THTR 100"
+    ]
+  },
+  "THTR 205": {
+    "text": "Must have completed THTR 105",
+    "courses": [
+      "THTR 105"
+    ]
+  },
+  "THTR 214": {
+    "text": "Must have completed THTR 204",
+    "courses": [
+      "THTR 204"
+    ]
+  },
+  "THTR 240": {
+    "text": "THTR 105 Introduction to Acting I",
+    "courses": [
+      "THTR 105"
+    ]
+  },
+  "THTR 258": {
+    "text": "Prerequisite: Approval of instructor",
+    "courses": []
+  },
+  "THTR 276": {
+    "text": "Prerequisite: THTR 176, successful audition or instructor approval",
+    "courses": [
+      "THTR 176"
+    ]
+  },
+  "THTR 295": {
+    "text": "Prerequisite: Approval of instructor",
+    "courses": []
+  },
+  "THTR 306": {
+    "text": "Must have completed THTR 105 or THTR 205",
+    "courses": [
+      "THTR 105",
+      "THTR 205"
+    ]
+  },
+  "TLS 151": {
+    "text": "Prerequisite: TLS 101",
+    "courses": [
+      "TLS 101"
+    ]
+  },
+  "VETN 101": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 105": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program or the Veterinary Assistant Program",
+    "courses": []
+  },
+  "VETN 110": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 112": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program and successful completion of VETN 110",
+    "courses": [
+      "VETN 110"
+    ]
+  },
+  "VETN 120": {
+    "text": "Completion of VETN 100 with a C or better. Co-requisite: VETN 130",
+    "courses": [
+      "VETN 100",
+      "VETN 130"
+    ]
+  },
+  "VETN 125": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program or the Veterinary Assistant Program",
+    "courses": []
+  },
+  "VETN 128": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 130": {
+    "text": "Prerequisite: Completion of VETN 100 with a C or better. Co-requisite: VETN 120",
+    "courses": [
+      "VETN 100",
+      "VETN 120"
+    ]
+  },
+  "VETN 203": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 205": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 208": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 209": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 211": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 225": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 227": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 235": {
+    "text": "Prerequisite: VETN 110 and VETN 112. Corequisite: VETN 225. Must be admitted to the Veterinary Nursing Program",
+    "courses": [
+      "VETN 110",
+      "VETN 112",
+      "VETN 225"
+    ]
+  },
+  "VETN 240": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 250": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 266": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "VETN 267": {
+    "text": "Prerequisite: Must be admitted to the Veterinary Nursing Program",
+    "courses": []
+  },
+  "WELD 105": {
+    "text": "Must have been accepted into the Welding Technology Program",
+    "courses": []
+  },
+  "WELD 110": {
+    "text": "Must have been accepted into the Welding Technology Program",
+    "courses": []
+  },
+  "WELD 136": {
+    "text": "Must have been accepted into the Diesel Technology Program or have been accepted into the Industrial Millwright Program",
+    "courses": []
+  },
+  "WELD 150": {
+    "text": "Must have been accepted into the Welding Technology Program",
+    "courses": []
+  },
+  "WELD 160": {
+    "text": "Must have been accepted into the Welding Technology Program",
+    "courses": []
+  },
+  "WELD 205": {
+    "text": "Corequisite: WELD 206. 20/20 vision (corrected), good hand-eye coordination, general good health",
+    "courses": [
+      "WELD 206"
+    ]
+  },
+  "WELD 206": {
+    "text": "WELD 205 co-requisite, 20/20 vision(corrected), good eye-hand coordination, general good health",
+    "courses": [
+      "WELD 205"
+    ]
+  },
+  "WELD 210": {
+    "text": "Must have completed WELD 110",
+    "courses": [
+      "WELD 110"
+    ]
+  },
+  "WELD 211": {
+    "text": "Corequisite: WELD 212. 20/20 vision (corrected), good hand-eye coordination, general good health",
+    "courses": [
+      "WELD 212"
+    ]
+  },
+  "WELD 212": {
+    "text": "Prerequisite: WELD 211. May also be taken concurrently with WELD 211",
+    "courses": [
+      "WELD 211"
+    ]
+  },
+  "WELD 215": {
+    "text": "Prerequisite: Completion of 15 credits in welding and 1 drafting class excluding DFT 110",
+    "courses": [
+      "DFT 110"
+    ]
+  },
+  "WELD 220": {
+    "text": "Must have been accepted into the Welding Technology Program",
+    "courses": []
+  },
+  "WELD 221": {
+    "text": "Prerequisite: WELD 211 or instructor approval. Corequisite: WELD 222",
+    "courses": [
+      "WELD 211",
+      "WELD 222"
+    ]
+  },
+  "WELD 222": {
+    "text": "Corequisite: Weld 221",
+    "courses": []
+  },
+  "WELD 231": {
+    "text": "Prerequisite: WELD 211 or instructor approval. Corequisite: WELD 232",
+    "courses": [
+      "WELD 211",
+      "WELD 232"
+    ]
+  },
+  "WELD 232": {
+    "text": "Prerequisite: WELD 231. May be taken concurrently with WELD 231",
+    "courses": [
+      "WELD 231"
+    ]
+  },
+  "WELD 235": {
+    "text": "Must have completed WELD 135",
+    "courses": [
+      "WELD 135"
+    ]
+  },
+  "WELD 240": {
+    "text": "Must have been accepted into the Welding Technology Program",
+    "courses": []
+  },
+  "WELD 241": {
+    "text": "Prerequisite: WELD 211 or instructor approval. Corequisite: WELD 242",
+    "courses": [
+      "WELD 211",
+      "WELD 242"
+    ]
+  },
+  "WELD 242": {
+    "text": "Prerequisite: WELD 241. May be taken concurrently with WELD 241",
+    "courses": [
+      "WELD 241"
+    ]
+  },
+  "WELD 250": {
+    "text": "Must have completed WELD 210 and WELD 221",
+    "courses": [
+      "WELD 210",
+      "WELD 221"
+    ]
+  },
+  "WELD 255": {
+    "text": "Completion of WELD 205, WELD 206, WELD 211 and WELD 212",
+    "courses": [
+      "WELD 205",
+      "WELD 206",
+      "WELD 211",
+      "WELD 212"
+    ]
+  },
+  "WELD 256": {
+    "text": "Prerequisite: WELD 205 and WELD 206. Co-requisite: WELD 255. Must have 20/20 vision (corrected), good eye-hand coordination, general good health",
+    "courses": [
+      "WELD 205",
+      "WELD 206",
+      "WELD 255"
+    ]
+  },
+  "WELD 260": {
+    "text": "Must have completed WELD 210",
+    "courses": [
+      "WELD 210"
+    ]
+  },
+  "WELD 275": {
+    "text": "Must have completed WELD 220",
+    "courses": [
+      "WELD 220"
+    ]
+  },
+  "WF 205": {
+    "text": "S-110, S-130, S-190, L-180 , ICS 100 & 700 (FT 110)",
+    "courses": [
+      "FT 110",
+      "ICS 100"
+    ]
+  },
+  "WF 280": {
+    "text": "Prerequisite: FS 107",
+    "courses": [
+      "FS 107"
+    ]
+  },
+  "WLL 112": {
+    "text": "Must have completed WLL 111",
+    "courses": [
+      "WLL 111"
+    ]
+  },
+  "WMST 250": {
+    "text": "Dual Requisite: ENG 101 completed or concurrently enrolled",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "WOOD 221": {
+    "text": "Must have completed WOOD 197",
+    "courses": [
+      "WOOD 197"
+    ]
+  }
+}

--- a/lib/states/nv/config.ts
+++ b/lib/states/nv/config.ts
@@ -47,7 +47,10 @@ const nvConfig: StateConfig = {
       { scripts: ["scripts/nv/scrape-peoplesoft.ts"], runner: "playwright" },
     ],
     // manual-only: transfers — no articulation portal registered for NV yet.
-    prereqs: { source: "aggregate-from-courses" },
+    prereqs: {
+      source: "catalog-scrape",
+      scripts: ["scripts/nv/scrape-catalog-prereqs.ts"],
+    },
     // manual-only: programs — Phase 5+.
   },
 };

--- a/scripts/nv/scrape-catalog-prereqs.ts
+++ b/scripts/nv/scrape-catalog-prereqs.ts
@@ -1,0 +1,337 @@
+/**
+ * NV catalog prereq scraper
+ *
+ * Scrapes prerequisite data from each NV college's catalog platform:
+ *   - CSN: Acalog (catalog.csn.edu)
+ *   - GBC: Custom HTML (gbcnv.edu/catalog/current/courses/)
+ *   - TMCC: Courseleaf (catalog.tmcc.edu)
+ *   - WNC: Coursedog SPA — skipped (requires headless browser)
+ *
+ * Merges all prereqs into data/nv/prereqs.json keyed by "PREFIX NUMBER".
+ * When multiple colleges list the same course, first-seen wins.
+ *
+ * Usage:
+ *   npx tsx scripts/nv/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/nv/scrape-catalog-prereqs.ts --college csn
+ *   npx tsx scripts/nv/scrape-catalog-prereqs.ts --limit=20
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const CONCURRENCY = 6;
+const DELAY_MS = 50;
+const MAX_PAGES = 40;
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return "";
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(items: T[], n: number, fn: (item: T, idx: number) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+function extractCourseRefs(text: string, selfCode: string): string[] {
+  const courses = new Set<string>();
+  const codeRegex = /\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = codeRegex.exec(text)) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (code !== selfCode) courses.add(code);
+  }
+  return Array.from(courses).sort();
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isNonTrivialPrereq(text: string): boolean {
+  if (!text) return false;
+  if (/^none\b/i.test(text)) return false;
+  if (/^not applicable/i.test(text)) return false;
+  if (/^n\/a$/i.test(text)) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// CSN — Acalog (catalog.csn.edu)
+// ---------------------------------------------------------------------------
+
+async function scrapeCSN(limit: number): Promise<Record<string, PrereqEntry>> {
+  const BASE = "https://catalog.csn.edu";
+  const CATOID = 23;
+  const NAVOID = 7301;
+
+  console.log("\n📚 CSN (Acalog)");
+  console.log(`  ${BASE}, catoid=${CATOID}, navoid=${NAVOID}`);
+
+  const allCoids = new Set<string>();
+  for (let cpage = 1; cpage <= MAX_PAGES; cpage++) {
+    const url =
+      `${BASE}/content.php?catoid=${CATOID}&navoid=${NAVOID}` +
+      `&filter%5Bitem_type%5D=3&filter%5Bonly_active%5D=1&filter%5Bcpage%5D=${cpage}`;
+    const html = await retryFetch(url, `csn-list(${cpage})`);
+    const matches = html.match(/preview_course_nopop\.php\?catoid=\d+&(?:amp;)?coid=(\d+)/g) || [];
+    const coids = new Set<string>();
+    for (const m of matches) {
+      const mm = m.match(/coid=(\d+)/);
+      if (mm) coids.add(mm[1]);
+    }
+    console.log(`  page ${cpage}: ${coids.size} courses`);
+    if (coids.size === 0) break;
+    for (const c of coids) allCoids.add(c);
+    await sleep(100);
+  }
+
+  let coidList = Array.from(allCoids);
+  console.log(`  Total: ${coidList.length} courses`);
+  if (limit > 0) coidList = coidList.slice(0, limit);
+
+  const prereqs: Record<string, PrereqEntry> = {};
+  let seen = 0;
+  let withPrereqs = 0;
+
+  await pmap(coidList, CONCURRENCY, async (coid) => {
+    const html = await retryFetch(
+      `${BASE}/preview_course_nopop.php?catoid=${CATOID}&coid=${coid}`,
+      `csn-detail(${coid})`,
+    );
+    seen++;
+    if (seen % 200 === 0) console.log(`  ${seen}/${coidList.length} (${withPrereqs} with prereqs)`);
+    if (!html) return;
+
+    const titleMatch = html.match(/<h1[^>]*>\s*([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*-/);
+    if (!titleMatch) return;
+    const prefix = titleMatch[1];
+    const number = titleMatch[2];
+    const key = `${prefix} ${number}`;
+
+    const prereqMatch = html.match(
+      /<strong>\s*Prerequisite(?:s|\(s\))?\s*:?\s*<\/strong>\s*([\s\S]*?)(?:<br\s*\/?>\s*<br|<\/p>|<strong>)/i,
+    );
+    if (!prereqMatch) return;
+
+    const text = stripHtml(prereqMatch[1]).replace(/[.;,]\s*$/, "").trim();
+    if (!isNonTrivialPrereq(text)) return;
+    if (prereqs[key]) return;
+
+    prereqs[key] = { text, courses: extractCourseRefs(text, key) };
+    withPrereqs++;
+  });
+
+  console.log(`  ✓ ${withPrereqs} courses with prereqs (from ${seen} total)`);
+  return prereqs;
+}
+
+// ---------------------------------------------------------------------------
+// GBC — Custom HTML (gbcnv.edu/catalog/current/courses/)
+// ---------------------------------------------------------------------------
+
+async function scrapeGBC(limit: number): Promise<Record<string, PrereqEntry>> {
+  const BASE = "https://www.gbcnv.edu/catalog/current/courses";
+
+  console.log("\n📚 GBC (Custom HTML)");
+
+  const indexHtml = await retryFetch(`${BASE}/`, "gbc-index");
+  let subjects = Array.from(
+    new Set(
+      (indexHtml.match(/\/catalog\/current\/courses\/([a-z]+)\.html/g) || [])
+        .map((m) => m.match(/\/([a-z]+)\.html/)?.[1])
+        .filter((s): s is string => !!s && s !== "index"),
+    ),
+  );
+
+  console.log(`  ${subjects.length} subjects`);
+  if (limit > 0) subjects = subjects.slice(0, limit);
+
+  const prereqs: Record<string, PrereqEntry> = {};
+  let withPrereqs = 0;
+
+  await pmap(subjects, CONCURRENCY, async (subject) => {
+    const html = await retryFetch(`${BASE}/${subject}.html`, `gbc-${subject}`);
+    if (!html) return;
+
+    const rows = html.split(/<tr[^>]*>/);
+    let currentCode = "";
+    for (const row of rows) {
+      const codeMatch = row.match(/<td>\s*([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*<\/td>/);
+      if (codeMatch) {
+        currentCode = `${codeMatch[1]} ${codeMatch[2]}`;
+        continue;
+      }
+
+      if (!currentCode) continue;
+
+      const prereqMatch = row.match(/<strong>\s*Prerequisite[^:]*:\s*([\s\S]*?)<\/strong>/i);
+      if (prereqMatch) {
+        const text = stripHtml(prereqMatch[1]).replace(/[.;,]\s*$/, "").trim();
+        if (isNonTrivialPrereq(text) && !prereqs[currentCode]) {
+          prereqs[currentCode] = { text, courses: extractCourseRefs(text, currentCode) };
+          withPrereqs++;
+        }
+      }
+      currentCode = "";
+    }
+  });
+
+  console.log(`  ✓ ${withPrereqs} courses with prereqs`);
+  return prereqs;
+}
+
+// ---------------------------------------------------------------------------
+// TMCC — Courseleaf (catalog.tmcc.edu)
+// ---------------------------------------------------------------------------
+
+async function scrapeTMCC(limit: number): Promise<Record<string, PrereqEntry>> {
+  const BASE = "https://catalog.tmcc.edu";
+
+  console.log("\n📚 TMCC (Courseleaf)");
+
+  const indexHtml = await retryFetch(`${BASE}/coursesaz/`, "tmcc-index");
+  let subjects = Array.from(
+    new Set(
+      (indexHtml.match(/\/coursesaz\/([a-z]+)\//g) || [])
+        .map((m) => m.match(/\/coursesaz\/([a-z]+)\//)?.[1])
+        .filter((s): s is string => !!s),
+    ),
+  );
+
+  console.log(`  ${subjects.length} subjects`);
+  if (limit > 0) subjects = subjects.slice(0, limit);
+
+  const prereqs: Record<string, PrereqEntry> = {};
+  let withPrereqs = 0;
+
+  await pmap(subjects, CONCURRENCY, async (subject) => {
+    const html = await retryFetch(`${BASE}/coursesaz/${subject}/`, `tmcc-${subject}`);
+    if (!html) return;
+
+    const courseBlocks = html.split(/class="courseblock">/);
+    for (const block of courseBlocks) {
+      const titleMatch = block.match(
+        /class="courseblocktitle"[^>]*>\s*<strong>\s*([A-Z]{2,5})\s+(\d{1,4}[A-Z]?)\s/,
+      );
+      if (!titleMatch) continue;
+
+      const prefix = titleMatch[1];
+      const number = titleMatch[2];
+      const key = `${prefix} ${number}`;
+
+      const prereqMatch = block.match(
+        /Enrollment Requirements:\s*([\s\S]*?)(?:<\/em>|<\/p>)/i,
+      );
+      if (!prereqMatch) continue;
+
+      const text = stripHtml(prereqMatch[1]).replace(/[.;,]\s*$/, "").trim();
+      if (!isNonTrivialPrereq(text) || prereqs[key]) continue;
+
+      prereqs[key] = { text, courses: extractCourseRefs(text, key) };
+      withPrereqs++;
+    }
+  });
+
+  console.log(`  ✓ ${withPrereqs} courses with prereqs`);
+  return prereqs;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limit = parseInt(args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0", 10);
+  const collegeFilter = args.find((a) => a.startsWith("--college="))?.split("=")[1]?.toLowerCase();
+
+  console.log("NV catalog prereq scraper");
+  if (limit > 0) console.log(`  Limit: ${limit}`);
+  if (collegeFilter) console.log(`  Filter: ${collegeFilter}`);
+
+  const allPrereqs: Record<string, PrereqEntry> = {};
+  const colleges: Array<{ name: string; fn: () => Promise<Record<string, PrereqEntry>> }> = [
+    { name: "csn", fn: () => scrapeCSN(limit) },
+    { name: "gbc", fn: () => scrapeGBC(limit) },
+    { name: "tmcc", fn: () => scrapeTMCC(limit) },
+  ];
+
+  for (const { name, fn } of colleges) {
+    if (collegeFilter && name !== collegeFilter) continue;
+    const prereqs = await fn();
+    for (const [key, entry] of Object.entries(prereqs)) {
+      if (!allPrereqs[key]) allPrereqs[key] = entry;
+    }
+  }
+
+  const sorted = Object.fromEntries(
+    Object.entries(allPrereqs).sort(([a], [b]) => a.localeCompare(b)),
+  );
+
+  const outDir = path.join(process.cwd(), "data", "nv");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nevada now has prerequisite data. When a student looks at a course in the semester planner, they'll see what courses are required first — 1,176 courses across 3 colleges now have prereq chains resolved.

The original NV auto-add-state PR (#489) shipped with empty prereqs because PeopleSoft Community Access (the course search SIS) doesn't expose prerequisite data. This PR fills the gap by scraping each college's separate catalog platform instead.

## What changes technically

New scraper `scripts/nv/scrape-catalog-prereqs.ts` handles 3 different catalog platforms in one script:

| College | Platform | URL | Prereqs |
|---|---|---|---|
| CSN | Acalog | catalog.csn.edu | 121 |
| GBC | Custom HTML | gbcnv.edu/catalog/current/courses/ | 479 |
| TMCC | Courseleaf | catalog.tmcc.edu | 698 |
| WNC | Coursedog SPA | catalog.wnc.edu | Skipped (requires headless browser) |

770 of the 1,176 entries have parsed course-code references (e.g. "MATH 181" requires MATH 126/127/128). The rest have free-text prereqs (placement tests, instructor approval, etc.).

StateConfig.scrapers.prereqs updated from `aggregate-from-courses` to `catalog-scrape` with the new script.

## Test plan

- [x] Scraper runs clean, produces 1,176 entries
- [x] Sample spot-check: MATH 181, ENG 102, BIOL 190, ACC 202, CHEM 122 all correct
- [ ] Post-merge: verify prereq data loads in semester planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)