### PR TITLE
seo: add server-rendered directory to /[state]/courses landing page

### DIFF
--- a/app/[state]/courses/page.tsx
+++ b/app/[state]/courses/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import CourseSearchClient from "./CourseSearchClient";
 import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { loadInstitutions } from "@/lib/institutions";
+import { getDistinctSubjects } from "@/lib/courses";
+import { getCurrentTerm, termLabel } from "@/lib/terms";
+import { subjectName } from "@/lib/subjects";
 
 type Props = {
   params: Promise<{ state: string }>;
@@ -27,6 +31,18 @@ export default async function CoursesPage({ params }: Props) {
   const { state } = await params;
   const config = requireStateConfig(state);
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+  const currentTerm = await getCurrentTerm(state);
+
+  // Server-render a subject directory + college list below the client search
+  // widget. Before this change the only server-rendered content on /{state}/
+  // courses was the H1 + form rendered by CourseSearchClient — too thin for
+  // Google to index as a meaningful landing page (GSC audit 2026-05 flagged
+  // these as candidates for "Discovered – not indexed"). The subject and
+  // college links also seed internal crawl paths to the per-state subject
+  // and college hub pages.
+  const subjects = await getDistinctSubjects(currentTerm, state).catch(
+    () => [] as string[]
+  );
 
   const breadcrumbLd = {
     "@context": "https://schema.org",
@@ -76,6 +92,85 @@ export default async function CoursesPage({ params }: Props) {
         courseUrlMap={courseUrlMap}
         defaultZip={config.defaultZip}
       />
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+        <section className="mt-4 border-t border-gray-200 dark:border-slate-700 pt-10">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-2">
+            Browse {config.systemName} courses by subject
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-slate-400 mb-5">
+            {subjects.length > 0
+              ? `${subjects.length} subjects offered across ${config.collegeCount} ${config.name} community colleges for ${termLabel(currentTerm)}.`
+              : `Browse ${config.name} community college subjects — every department offered across the ${config.collegeCount}-college ${config.systemName} system.`}
+          </p>
+          {subjects.length > 0 && (
+            <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-1.5">
+              {subjects.map((p) => (
+                <li key={p}>
+                  <Link
+                    href={`/${state}/subject/${p.toLowerCase()}`}
+                    className="block rounded-md px-2 py-1 text-sm text-gray-700 dark:text-slate-300 hover:bg-teal-50 dark:hover:bg-teal-900/30 hover:text-teal-700 dark:hover:text-teal-400 transition"
+                  >
+                    <span className="font-mono text-xs text-gray-500 dark:text-slate-400 mr-1.5">
+                      {p}
+                    </span>
+                    {subjectName(p)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="mt-10 pt-10 border-t border-gray-200 dark:border-slate-700">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-2">
+            Browse by college
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-slate-400 mb-5">
+            Course schedules, transfer credit, and program details for each of
+            the {institutions.length} {config.systemName} community colleges.
+          </p>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-1.5">
+            {institutions.map((inst) => (
+              <li key={inst.id}>
+                <Link
+                  href={`/${state}/college/${inst.id}`}
+                  className="block rounded-md px-2 py-1 text-sm text-gray-700 dark:text-slate-300 hover:bg-teal-50 dark:hover:bg-teal-900/30 hover:text-teal-700 dark:hover:text-teal-400 transition"
+                >
+                  {inst.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {config.popularCourses.length > 0 && (
+          <section className="mt-10 pt-10 border-t border-gray-200 dark:border-slate-700">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-2">
+              Popular {config.name} community college courses
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-slate-400 mb-5">
+              High-enrollment courses students search for first — see every
+              section, every college, and transfer credit at a glance.
+            </p>
+            <ul className="flex flex-wrap gap-2">
+              {config.popularCourses.map((c) => {
+                const slug = c.toLowerCase().replace(/\s+/g, "-");
+                return (
+                  <li key={c}>
+                    <Link
+                      href={`/${state}/course/${slug}`}
+                      className="inline-block rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-mono font-medium text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-700 hover:text-teal-700 dark:hover:text-teal-400 transition"
+                    >
+                      {c}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## What changes for someone using the site

Below the existing search widget on every state's **Find a Course** page (e.g. [communitycollegepath.com/va/courses](https://communitycollegepath.com/va/courses)), three new sections now appear:

1. **Browse VCCS courses by subject** — every subject offered in the state, linked to its subject hub page.
2. **Browse by college** — all 23 colleges linked to their college detail pages.
3. **Popular Virginia community college courses** — chips for the state's curated popular courses linked to course-detail pages.

Same layout for every state, populated from each state's config + live course data. Search widget at the top is unchanged.

## What changes on the technical front

The page (`app/[state]/courses/page.tsx`) previously rendered nothing server-side except the `CourseSearchClient` widget — Google saw an H1 + empty form and no body content. This is one reason GSC's audit (2026-05) flagged these URLs as "Discovered – not indexed".

This PR adds three server-rendered `<section>` blocks below the client widget, sourced from:

- `getDistinctSubjects(currentTerm, state)` (already exists in `lib/courses.ts`)
- `loadInstitutions(state)` (already in use elsewhere on the page)
- `config.popularCourses` (per-state config)

Adds ~150 KB of crawlable internal links per state. Subject and college links seed crawl paths into the deeper per-state hub pages (`/[state]/subject/...` and `/[state]/college/...`), which are content-rich but historically harder for Google to discover.

The two sibling landing pages flagged in the same audit (`/online`, `/transfer`) were already content-rich on inspection — no change needed there.

## Test plan

- [x] `npx tsc --noEmit` — clean (one pre-existing NV error on main, unrelated)
- [x] Local dev: `GET /va/courses` returns 214 KB HTML, includes all three H2 headings, 124 subject links, 23 college links, 8 popular-course chips
- [ ] After merge: spot-check `/va/courses`, `/me/courses`, `/nc/courses` on prod render the new sections
- [ ] Watch GSC: indexing status on `/[state]/courses` URLs over the next 2-3 weeks