### PR TITLE
feat(nv): add WNC Coursedog prereqs — 1,398 total

### DIFF
--- a/data/nv/coursedog-catalog/western-nevada-college.json
+++ b/data/nv/coursedog-catalog/western-nevada-college.json
@@ -1,0 +1,8572 @@
+[
+  {
+    "prefix": "RE",
+    "number": "103",
+    "title": "Real Estate Law And Practice",
+    "credits": 4,
+    "description": "Prerequisites: RE101 Provides in-depth study of the real estate profession including Nevada real estate laws. Covers rules and regulations pertaining to NRS 645 and NRS 119, along with listing procedures, contracts, closing statements and office procedures.",
+    "prerequisite_text": "RE101 Provides in-depth study of the real estate profession including Nevada real estate laws. Covers rules and regulations pertaining to NRS 645 and NRS 119, along with listing procedures, contracts, closing statements and office procedures.",
+    "prerequisite_courses": [
+      "RE 101",
+      "NRS 645",
+      "NRS 119"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "242",
+    "title": "Welding IV Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 241Introduces fundamental pipe welding techniques and develops basic skills for the service and transmission fields in the shielded metal-arc section. Trains welders for work in either the pressure pipe industry or transmission pipeline work using the micro-wire weld.",
+    "prerequisite_text": "WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 241Introduces fundamental pipe welding techniques and develops basic skills for the service and transmission fields in the shielded metal-arc section. Trains welders for work in either the pressure pipe industry or transmission pipeline work using the micro-wire weld.",
+    "prerequisite_courses": [
+      "WELD 231",
+      "WELD 232"
+    ]
+  },
+  {
+    "prefix": "PHIL",
+    "number": "204",
+    "title": "Intro Comtemporary Phil",
+    "credits": 3,
+    "description": "Reviews the late 19th century movements as basis for the study of 20th century developments in thought from Nietzsche through existentialism, neopositivism, and American naturalism.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "220",
+    "title": "Prin of Educational Psych",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Introduces the application of psychology principles of learning and cognitive development.",
+    "prerequisite_text": "PSY101 or consent of instructor Introduces the application of psychology principles of learning and cognitive development.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "ACC",
+    "number": "295",
+    "title": "Work Experience I",
+    "credits": 6,
+    "description": "Prerequisites: consent of instructor Provides on-the-job supervised and educationally directed work experience.",
+    "prerequisite_text": "consent of instructor Provides on-the-job supervised and educationally directed work experience.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "145",
+    "title": "Religion in Amer Life",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "219",
+    "title": "Projects in Tech Theater",
+    "credits": 3,
+    "description": "Offers an in-depth study of some technical aspect of theater. Through practical application students can explore lighting, set art, set construction, sound, set design or rigging.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MKT",
+    "number": "262",
+    "title": "Intro to Advertising",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "prerequisite_text": "BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MKT 210"
+    ]
+  },
+  {
+    "prefix": "MGT",
+    "number": "412",
+    "title": "Change Management",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organizational and Project Management ProgramExplores critical issues in institutional change, including change management, change readiness and change resistance. Designed to provide techniques and principles on how to introduce change into organizations.",
+    "prerequisite_text": "Admission to BAS Organizational and Project Management ProgramExplores critical issues in institutional change, including change management, change readiness and change resistance. Designed to provide techniques and principles on how to introduce change into organizations.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "121",
+    "title": "Make-Up for the Actor",
+    "credits": 3,
+    "description": "Acquaints the student with the beginning principles of makeup and progresses to character makeup.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "116",
+    "title": "Fund Investig Correct Pol Acad",
+    "credits": 3,
+    "description": "Prerequisite: Acceptance to the Police Officers Standards and Training AcademyProvides the fundamental knowledge and training to conduct interrogations and basic criminal investigation for Category I peace officers. Overview of correctional institutions and supervision of offenders for Category I and III peace officers as required for Nevada POST certification.",
+    "prerequisite_text": "Acceptance to the Police Officers Standards and Training AcademyProvides the fundamental knowledge and training to conduct interrogations and basic criminal investigation for Category I peace officers. Overview of correctional institutions and supervision of offenders for Category I and III peace officers as required for Nevada POST certification.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "143",
+    "title": "Violin-Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for violin. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "106",
+    "title": "Intro to Corrections",
+    "credits": 3,
+    "description": "Studies the history and development of correctional agencies, particularly prisons. Examines ideas influencing contemporary correctional institutions. Explores the relationship of the Department of Corrections to other criminal justice system components.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "261",
+    "title": "Nurs Care of the Family Theory",
+    "credits": 4,
+    "description": "Prerequisite: successful completion of the first year of the nursing program. Corequsitie: NURS 262Focuses on basic concepts of nursing associated with care of the family experiencing pregnancy, birth, and the care of children. Incorporates knowledge of normal patterns of growth and development, health promotion, and disease prevention strategies. Students analyze care of patients with common health disruptions while continuing to develop the competencies of nursing judgement, use of evidenced-based practice, application of principles associated with professional identify, and the nurturing of a spirit of inquiry within the organizing framework of the nursing process.",
+    "prerequisite_text": "successful completion of the first year of the nursing program. Corequsitie: NURS 262Focuses on basic concepts of nursing associated with care of the family experiencing pregnancy, birth, and the care of children. Incorporates knowledge of normal patterns of growth and development, health promotion, and disease prevention strategies. Students analyze care of patients with common health disruptions",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "251",
+    "title": "Mach Shop Practice III",
+    "credits": 2,
+    "description": "Corequisites: MTT250Further develops student's manual skills by putting into practice the theories and user skills introduced in MTT 250. The emphasis will be a more practical, hands-on experience through the use of vertical mill work, layout techniques, vertical and horizontal band saws, measuring instruments and lathes. Shop safety and cleanup are always stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "111",
+    "title": "First Year Spanish I",
+    "credits": 4,
+    "description": "Develops language skills through practice in listening, speaking, reading, writing and structural analysis. Includes an introduction to Spanish culture.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "310",
+    "title": "Fndns of Mgmt Theory Practice",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organization and Project Management ProgramDevelops the theoretical foundation development for further study in any field involving management. Explores historical thought and the management of functions of planning, organizing, directing, and controlling. Provides a practical analysis of leadership, communications, and motivation techniques. Concludes with an exploration of current management challenges and trends.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management ProgramDevelops the theoretical foundation development for further study in any field involving management. Explores historical thought and the management of functions of planning, organizing, directing, and controlling. Provides a practical analysis of leadership, communications, and motivation techniques. Concludes with an exploration of curre",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSC",
+    "number": "101",
+    "title": "Intro to American Politics",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Studies American government and the discipline of political science; surveys participation, pursuit and use of power, constitution formation and contemporary political issues. Satisfies United States and Nevada Constitution requirements.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Studies American government and the discipline of political science; surveys participation, pursuit and use of power, constitution formation and contemporary political issues. Satisfies United States and Nevada Constitution requirements.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "EMS",
+    "number": "216",
+    "title": "Hosp Clin Exp for Paramedic",
+    "credits": 4,
+    "description": "Prerequisite: Admission to the Paramedicine ProgramOffers planned hospital clinical experience designed to meet and enhance the specific learning needs of the student. Each area of clinical experience has been selected to correspond with a specific area of didactic classroom instruction and to meet the clinical skill objectives outlined by the program. Students will function under the direction of a nurse or physician preceptor.",
+    "prerequisite_text": "Admission to the Paramedicine ProgramOffers planned hospital clinical experience designed to meet and enhance the specific learning needs of the student. Each area of clinical experience has been selected to correspond with a specific area of didactic classroom instruction and to meet the clinical skill objectives outlined by the program. Students will function under the direction of a nurse or ph",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "233",
+    "title": "Child Psychology",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Explains the growth and development of children from conception through early adolescence.",
+    "prerequisite_text": "PSY101 or consent of instructor Explains the growth and development of children from conception through early adolescence.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "CSCO",
+    "number": "130",
+    "title": "Fundamental Wireless Lans",
+    "credits": 4,
+    "description": "Introduces wireless LAN concepts and focuses on the design, planning, implementation, operation and troubleshooting of wireless networks. Covers a comprehensive overview of technologies, security and design best practices with particular emphasis on hands-on skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "115",
+    "title": "Auto Elect I",
+    "credits": 4,
+    "description": "Prerequisites: AUTO 101Topics include mastery of DC electricity, use of digital multimeters, troubleshooting electrical problems in starting, charging and accessory systems. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO 101Topics include mastery of DC electricity, use of digital multimeters, troubleshooting electrical problems in starting, charging and accessory systems. Prepares students for ASE certification.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "137",
+    "title": "Foundation Nursing Lab",
+    "credits": 1,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedures and the scientific rationale for performing the procedures correctly.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedure",
+    "prerequisite_courses": [
+      "NURS 136"
+    ]
+  },
+  {
+    "prefix": "CHEM",
+    "number": "241",
+    "title": "Organic Chemistry I",
+    "credits": 3,
+    "description": "Prerequisites: CHEM122 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Credit allowed in only one of CHEM 220 or 241. Three hours lecture.",
+    "prerequisite_text": "CHEM122 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Credit allowed in only one of CHEM 220 or 241. Three hours lecture.",
+    "prerequisite_courses": [
+      "CHEM 122",
+      "CHEM 220"
+    ]
+  },
+  {
+    "prefix": "BTO",
+    "number": "103",
+    "title": "BT Heavy Equipmnt Operator III",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 3 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 3 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPD",
+    "number": "410",
+    "title": "Contemporary Pedagogical Strat",
+    "credits": 3,
+    "description": "Prerequisite: Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
+    "prerequisite_text": "Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "253",
+    "title": "Mechatronics: PLCs",
+    "credits": 3,
+    "description": "3 units Prerequisite or Corequisite: AIT 252Covers the fundamentals of digital logic and an introduction to programmable logic controllers (PLCs) in a complex mechatronic system. Students will learn the role PLCs play within a mechatronic system or subsystem; students will explore basic elements of PLC functions by writing and testing programs to control them. Course teaches students how to identify malfunctioning PLCs, as well as to apply troubleshooting strategies to identify and localize problems caused by PLC hardware.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "367",
+    "title": "Human Resource Mgt",
+    "credits": 3,
+    "description": "Prerequisites: MGT 323Considers theoretical concepts and practical approaches relevant to management systems and processes; recruitment, training, appraisal, compensation and labor relations. Emphasis on legal constraints and international management.",
+    "prerequisite_text": "MGT 323Considers theoretical concepts and practical approaches relevant to management systems and processes; recruitment, training, appraisal, compensation and labor relations. Emphasis on legal constraints and international management.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "152A",
+    "title": "General Physics II - Lecture",
+    "credits": 3,
+    "description": "Prerequisites: PHYS151. For non-physical science majors. Topics include electricity, magnetism, electromagnetic waves, optics, relativity, introductory quantum physics, atomic physics, and nuclear physics.",
+    "prerequisite_text": "PHYS151. For non-physical science majors. Topics include electricity, magnetism, electromagnetic waves, optics, relativity, introductory quantum physics, atomic physics, and nuclear physics.",
+    "prerequisite_courses": [
+      "PHYS 151"
+    ]
+  },
+  {
+    "prefix": "MUS",
+    "number": "121",
+    "title": "Music Appreciation",
+    "credits": 3,
+    "description": "Analyzes styles and forms of music from the Middle Ages through the 20th century, and discusses musical instruments and major composers.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "109",
+    "title": "Cons Materials & Methods II",
+    "credits": 4,
+    "description": "Prerequisite: CONS 108Teaches students about the typical materials used in the construction of bridges, roads, pathways, and small commercial buildings. Includes testing procedures, material properties, design, specification, and installation methods using certification standards and guidelines.",
+    "prerequisite_text": "CONS 108Teaches students about the typical materials used in the construction of bridges, roads, pathways, and small commercial buildings. Includes testing procedures, material properties, design, specification, and installation methods using certification standards and guidelines.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "250",
+    "title": "Intro to Early Child Educ",
+    "credits": 3,
+    "description": "Introduces students to early childhood education. This course includes the history of child care, regulations, types of programs, legal issues, professional opportunities and current trends and issues. Emphasis is placed on the role of the preschool teacher in enhancing the social, emotional, physical and intellectual growth of preschool-aged children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELM",
+    "number": "136",
+    "title": "Prog Logic Controllers II",
+    "credits": 3,
+    "description": "Prerequisite(s): ELM 134A continuation of ELM 134. Provides intermediate level skills in Programmable Logic Control (PLC) programming instruction and control concepts. Explores the advanced elements of PLC functions by writing and testing programs to control them. Emphasis placed on programming structure, instructions, and execution. Utilize advanced simulation software to develop and execute various PLC programs. Apply troubleshooting strategies to identify and localize problems caused by PLC hardware.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "198",
+    "title": "Special Topics in Biology",
+    "credits": 3,
+    "description": "Prerequisites: NoneIncludes short courses and experimental classes covering a variety of subjects.",
+    "prerequisite_text": "NoneIncludes short courses and experimental classes covering a variety of subjects.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEP",
+    "number": "121",
+    "title": "Intro College Experience",
+    "credits": 1,
+    "description": "Covers study skills, time management, major selection, and other factors associated with success in college.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HDFS",
+    "number": "202",
+    "title": "Intro to Families",
+    "credits": 3,
+    "description": "Explores the dynamics of development, interaction, and intimacy of primary relationships in contextual and theoretical frameworks, societal issues and choices facing diverse family systems. This course is taught from a bio-psycho-social approach within the family ecological system context. It incorporates issues relevant to international families and diverse family arrangements within North America. Traditional issues of families are reframed, reconstructed, and questioned. Application of ideas to those working with families in a variety of settings including: physical health, mental health, economic and educational arenas.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "90",
+    "title": "Basic Writing I",
+    "credits": 3,
+    "description": "Provides instruction in basic English skills including grammar, parts of speech, agreement, syntax, punctuation, spelling, and sentence structure. Focuses on a variety of sentence patterns and types. Provides extensive practice in grammar and usage. Grading: pass/fail.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELM",
+    "number": "112",
+    "title": "Electrical Theory, DC",
+    "credits": 3,
+    "description": "Prerequisite(s): NoneThe study of matter, atomic structure, electron theory, source of electricity, and magnetism. Theory and shop application in Ohm's Law, voltage, current, resistance, and power in series, parallel, and series-parallel direct current circuits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ITAL",
+    "number": "212",
+    "title": "Second Year Italian II",
+    "credits": 3,
+    "description": "Prerequisites: ITAL211Continues structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_text": "ITAL211Continues structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "497",
+    "title": "Business Plan Creation",
+    "credits": 3,
+    "description": "Prerequisite Admission to BAS Organization and Project Management Program and MGT 310 and FIN 310Teaches how to create investor quality business plans. Follows a step-by-step process to develop a business plan from an opening executive summary to a financial offering.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "198",
+    "title": "Special Topics: Comp Info Tch",
+    "credits": 5,
+    "description": "Applies to assorted short courses and workshops covering a variety of subjects.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IT",
+    "number": "208",
+    "title": "Fluid Power",
+    "credits": 3,
+    "description": "Prerequisites: NoneReviews fluid power mechanics with an emphasis on schematic symbols, circuit operation and design, pneumatic and hydraulic component theory and operation, and industry terminology.",
+    "prerequisite_text": "NoneReviews fluid power mechanics with an emphasis on schematic symbols, circuit operation and design, pneumatic and hydraulic component theory and operation, and industry terminology.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "144",
+    "title": "Introduction to Data Analytics",
+    "credits": 3,
+    "description": "Prerequisites: CIT 128An introduction to data analysis that uses technologies and applications to analyze and clean up data; to classify, visualize, and summarize sets of sample data; and to determine if the sample data reflects characteristics of populations.",
+    "prerequisite_text": "CIT 128An introduction to data analysis that uses technologies and applications to analyze and clean up data; to classify, visualize, and summarize sets of sample data; and to determine if the sample data reflects characteristics of populations.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "176",
+    "title": "Musical Theatre Practicum I",
+    "credits": 3,
+    "description": "Performance ensemble, centered on public performance of musical theatre literature. Repeatable up to 9 units.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "271",
+    "title": "Mechatronics 2: Intro to TIA",
+    "credits": 3,
+    "description": "Prerequisites: AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Introduces the Siemens concept of Totally Integrated Automation by looking at field level analogue sensors and actuators and up to the control level with programming and networking Programmable Logic Controllers (PLCs). Hands-on lab work includes connecting devices and controls, evaluating and writing a PLC program with analogue values and STEP 7 software functions like comparison, memory, arithmetic, conversion, and jump. Including the basics of MPI-Bus and PROFIBUS system, and wire modules to a PLC. Maintenance and troubleshooting of these PLC programs and bus systems are essential components of the course.",
+    "prerequisite_text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Introduces the Siemens concept of Totally Integrated Automation by looking at field level analogue sensors and actuators and up to the control level with programming and ne",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MKT",
+    "number": "261",
+    "title": "Intro to Public Relations",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101 and MKT 210 or consent of instructorIntroduces the techniques of public relations for those holding supervisory or higher positions in management and marketing. Identifies the principles of creating and maintaining good public relations, including employee-employer relations. Customer-employee relations receive emphasis. Focuses on the programming of the total public relations effort and selecting of appropriate strategy, media and persuasive devices to accomplish objectives.",
+    "prerequisite_text": "BUS 101 and MKT 210 or consent of instructorIntroduces the techniques of public relations for those holding supervisory or higher positions in management and marketing. Identifies the principles of creating and maintaining good public relations, including employee-employer relations. Customer-employee relations receive emphasis. Focuses on the programming of the total public relations effort and s",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MKT 210"
+    ]
+  },
+  {
+    "prefix": "EDCT",
+    "number": "247",
+    "title": "Intro to CTE Curriculum & Inst",
+    "credits": 3,
+    "description": "Provides the foundation for developing curriculum and assessments in Career and Technical Education (CTE). Students will learn concepts and practices for developing standards-based course maps, unit and lesson plans, learning outcomes and assessments that support competency-based student learning.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "342",
+    "title": "Forensic Psychology",
+    "credits": 3,
+    "description": "Prerequisites: PSY 101 or consent of instructor; Demonstrate reason in criminal law and the difference between psychological syndromes and psychological profiles; identify the effects of unsupported scientific concepts in the US legal system; define the biological and ethological explanations of aggression and understand why antisocial and narcissistic personalities are prone to aggression; explain the various motive-based typologies of serial killers; describe the connection between terrorism and mental illness; produce reasoned arguments regarding cultural competence and multiculturalism in law enforcement; communicate the basics of the cognitive interview, its strengths and its weaknesses; explain the factors that make a person vulnerable to forced confessions and be define false memories and confabulation; identify the essential features of a psychological competency evaluation; describe how voir dire is used to determine juror bias and how juror personality attributes can affect jury verdicts; understand treatment techniques for child abuse, child sexual abuse offenders, domestic violence, PTSD, and terrorism-induced psychological disturbances.",
+    "prerequisite_text": "PSY 101 or consent of instructor; Demonstrate reason in criminal law and the difference between psychological syndromes and psychological profiles; identify the effects of unsupported scientific concepts in the US legal system; define the biological and ethological explanations of aggression and understand why antisocial and narcissistic personalities are prone to aggression; explain the various",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "ECE",
+    "number": "240",
+    "title": "Admin of Preschool",
+    "credits": 3,
+    "description": "Prerequisites: ECE250 Studies principles and practices in supervision and management of preschool and child care centers, including program planning, organization, budgeting, personnel records, relationships with community resources, regulatory agencies and working with parents.",
+    "prerequisite_text": "ECE250 Studies principles and practices in supervision and management of preschool and child care centers, including program planning, organization, budgeting, personnel records, relationships with community resources, regulatory agencies and working with parents.",
+    "prerequisite_courses": [
+      "ECE 250"
+    ]
+  },
+  {
+    "prefix": "NUTR",
+    "number": "121",
+    "title": "Human Nutrition",
+    "credits": 3,
+    "description": "Prerequisites: None. Offers a beginning course in the principles of human nutrition including a study of each of the major nutrients and how they relate to good health and a well balanced diet. Includes four laboratory experiences.",
+    "prerequisite_text": "None. Offers a beginning course in the principles of human nutrition including a study of each of the major nutrients and how they relate to good health and a well balanced diet. Includes four laboratory experiences.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "204",
+    "title": "Theatre Technology I",
+    "credits": 3,
+    "description": "Introduces the backstage world of the theatre by the study of lighting and sound systems and of technical stage riggings. Students will gain practical experience by serving as the crew for a college theatrical production.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "104",
+    "title": "Blueprint Reading",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "193",
+    "title": "Intercollegiate Soccer",
+    "credits": 3,
+    "description": "Prerequisites: must be a member of the WNC soccer team Participation on the intercollegiate soccer team. May be repeated for up to 6 credits.",
+    "prerequisite_text": "must be a member of the WNC soccer team Participation on the intercollegiate soccer team. May be repeated for up to 6 credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "129",
+    "title": "Intro to Programming",
+    "credits": 3,
+    "description": "Prerequisites: IS101 or consent of instructor Offers a language-independent, introductory course on computer program design and development. Emphasizes identification and solution of business problems through various design tools.",
+    "prerequisite_text": "IS101 or consent of instructor Offers a language-independent, introductory course on computer program design and development. Emphasizes identification and solution of business problems through various design tools.",
+    "prerequisite_courses": [
+      "IS 101"
+    ]
+  },
+  {
+    "prefix": "BTO",
+    "number": "101",
+    "title": "BT Heavy Equipment Operator I",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 1 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 1 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "250",
+    "title": "Machine Shop III",
+    "credits": 3,
+    "description": "Prerequisites: MTT110 and DFT110 or consent of instructor. Corequisite: MTT 251 or consent of instructor.Expands skills introduced in MTT 105 and MTT 110 to a more advanced level by developing projects that emphasize tolerances, plan of procedure and blueprint reading. Introduces further skills for surface grinding and tool and cutter grinding.",
+    "prerequisite_text": "MTT110 and DFT110 or consent of instructor. Corequisite: MTT 251 or consent of instructor.Expands skills introduced in MTT 105 and MTT 110 to a more advanced level by developing projects that emphasize tolerances, plan of procedure and blueprint reading. Introduces further skills for surface grinding and tool and cutter grinding.",
+    "prerequisite_courses": [
+      "MTT 110",
+      "DFT 110",
+      "MTT 251",
+      "MTT 105"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "114",
+    "title": "Comp II/Non-Native Eng Sp",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "296",
+    "title": "Comp Num Control Practice II",
+    "credits": 4,
+    "description": "Prerequisites: MTT 232This course allows for the further development of CNC skills with hands-on instruction related to the design and production of machined parts using CAD/CAM software, CNC milling machines, and CNC turning centers. Students will plan, program, set up, and produce a variety of precision-machined projects.",
+    "prerequisite_text": "MTT 232This course allows for the further development of CNC skills with hands-on instruction related to the design and production of machined parts using CAD/CAM software, CNC milling machines, and CNC turning centers. Students will plan, program, set up, and produce a variety of precision-machined projects.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "371",
+    "title": "Leadership Managerial Skills",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organizational and Project Management Program or permission of division director and MGT 310Focuses on the skills of effective leaders and managers. Emphasis on leadership emergence in work settings, how to lead and manage others effectively, and leadership challenges in the contemporary business landscape such as the intersection of leadership with ethics.",
+    "prerequisite_text": "Admission to BAS Organizational and Project Management Program or permission of division director and MGT 310Focuses on the skills of effective leaders and managers. Emphasis on leadership emergence in work settings, how to lead and manage others effectively, and leadership challenges in the contemporary business landscape such as the intersection of leadership with ethics.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "123",
+    "title": "Stat/Geom Cncpt Elem Tchr",
+    "credits": 3,
+    "description": "Prerequisites: MATH120 or consent of instructor Presents elementary problem solving with emphasis on patterns and geometric relationships. Designed for students seeking a teaching certificate in elementary education.",
+    "prerequisite_text": "MATH120 or consent of instructor Presents elementary problem solving with emphasis on patterns and geometric relationships. Designed for students seeking a teaching certificate in elementary education.",
+    "prerequisite_courses": [
+      "MATH 120"
+    ]
+  },
+  {
+    "prefix": "BTS",
+    "number": "108",
+    "title": "BT Const Sheet Metal VIII",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 8 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 8 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "241L",
+    "title": "Organic Chem Lab I",
+    "credits": 1,
+    "description": "Prerequisites: CHEM122 ; Corequisites: CHEM241 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Three hours laboratory.",
+    "prerequisite_text": "CHEM122 ; Corequisites: CHEM241 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Three hours laboratory.",
+    "prerequisite_courses": [
+      "CHEM 122",
+      "CHEM 241"
+    ]
+  },
+  {
+    "prefix": "MGT",
+    "number": "323",
+    "title": "Organizational Behavior",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Organization & Project Management program OR admission to the Construction Management program OR consent of Division Director. Examines behavioral influences which affect productivity, organizational effectiveness, and efficiency including: perception, motivation, decision making, communication, leadership, organizational design, group behavior and coping with stress.",
+    "prerequisite_text": "Admission to the Organization & Project Management program OR admission to the Construction Management program OR consent of Division Director. Examines behavioral influences which affect productivity, organizational effectiveness, and efficiency including: perception, motivation, decision making, communication, leadership, organizational design, group behavior and coping with stress.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "181",
+    "title": "Calculus I",
+    "credits": 4,
+    "description": "Prerequisites: MATH 127 or MATH 128 with a grade of C- or better; or, ACTMATH score of 28 or higher or SAT MATH score of 630 or higher; or, a grade ofB- or better in high school trigonometry and precalculus; or, appropriate scoreon the WNC placement exam; or, consent of instructor.Offers fundamental concepts of analytical geometry and calculus, functions, graphs, limits, derivatives, and integrals.",
+    "prerequisite_text": "MATH 127 or MATH 128 with a grade of C- or better; or, ACTMATH score of 28 or higher or SAT MATH score of 630 or higher; or, a grade ofB- or better in high school trigonometry and precalculus; or, appropriate scoreon the WNC placement exam; or, consent of instructor.Offers fundamental concepts of analytical geometry and calculus, functions, graphs, limits, derivatives, and integrals.",
+    "prerequisite_courses": [
+      "MATH 127",
+      "MATH 128"
+    ]
+  },
+  {
+    "prefix": "CPD",
+    "number": "129",
+    "title": "Communication Techniques",
+    "credits": 1,
+    "description": "Teaches skills to help students become more assertive and improve their ability to communicate effectively. Covers communication techniques that can be used in the workplace and a variety of situations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "120",
+    "title": "Blueprint Read/Spec",
+    "credits": 3,
+    "description": "Equips students with technical and practical interpretation of blueprints. Assignments are made in relation to complete sets of working drawings. Students study construction relationships between architectural, structural, electrical and mechanical drawings, bidding along with inspection procedure technique.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPD",
+    "number": "164",
+    "title": "PPST/Praxis I Math Review",
+    "credits": 1,
+    "description": "Prerequisites: NoneReview of math concepts, solving problems, quantitative reasoning, and test-taking strategies in preparation for taking the PPST/Praxis I Math Exam. This course is graded as Pass/Fail.",
+    "prerequisite_text": "NoneReview of math concepts, solving problems, quantitative reasoning, and test-taking strategies in preparation for taking the PPST/Praxis I Math Exam. This course is graded as Pass/Fail.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "101",
+    "title": "Bass-Lower Division",
+    "credits": 2,
+    "description": "Provides a personal introduction to the study and performance of music for bass. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "142",
+    "title": "Judo",
+    "credits": 6,
+    "description": "Provides students with the basic elements of the martial arts of Jujitsu and Judo, to enable them to gain greater control of their bodies and their emotions. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "272",
+    "title": "Mechatronics 2: Automation Sys",
+    "credits": 3,
+    "description": "Prerequisites: AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Course is divided into two main sections: Manufacturing Technologies, including CNC, CAD and CAM, and Microcontrollers and Programming, which constitute essential tools in modern manufacturing, particularly in mechatronic systems. Introduces through the microcontroller section the theory behind microcontroller and microprocessor architecture, and its ways of interaction with other electronic elements to explore applications. This theory is complemented with practical exercises that reflect the importance of microcontrollers in a mechatronic system. Covers an exploration of manufacturing automation and the concepts of Metal Cutting, Modal analysis, CNC, CAM and CAD. Provides students with part of the skill set necessary to maintain and improve mechatronic systems.",
+    "prerequisite_text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Course is divided into two main sections: Manufacturing Technologies, including CNC, CAD and CAM, and Microcontrollers and Programming, which constitute essential tools in",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "110",
+    "title": "A+ Hardware",
+    "credits": 3,
+    "description": "Introduces the fundamentals of computer system repair. Students learn the hardware and software elements that define an operating computing system. Troubleshooting methods and the use of diagnostic tools are taught with reinforcement provided using hands-on exercises. Successful completion of this course will place a student in good standing to take the nationally recognized A+ certification exam created by the computing industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "155",
+    "title": "AIT Hands On Lab",
+    "credits": 6,
+    "description": "Allows students of Applied Industrial Technology to use hands-on trainers and equipment as they become available for the study of various topics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NUTR",
+    "number": "223",
+    "title": "Prin of Nutrition",
+    "credits": 3,
+    "description": "Prerequisites: BIOL 190 and 190L with a grade of C or better or CHEM 121 with a grade of C or better Studies nutrient functions and basis for nutrient requirements at the cellular level. Three hours lecture.",
+    "prerequisite_text": "BIOL 190 and 190L with a grade of C or better or CHEM 121 with a grade of C or better Studies nutrient functions and basis for nutrient requirements at the cellular level. Three hours lecture.",
+    "prerequisite_courses": [
+      "BIOL 190",
+      "CHEM 121"
+    ]
+  },
+  {
+    "prefix": "THTR",
+    "number": "116",
+    "title": "Musical Theatre Dance",
+    "credits": 1,
+    "description": "Introduces beginning techniques of tap dance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SW",
+    "number": "101",
+    "title": "Intro to Social Work",
+    "credits": 3,
+    "description": "Introduces the profession of social work within a historical context. Emphasis on values, human diversity, analysis of social problem solving and fields of practice.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "211",
+    "title": "Paramedic Care Med Emgs & ACLS",
+    "credits": 4,
+    "description": "Prerequisite: Admission to the Paramedicine ProgramPrepares the Paramedic to identify, assess, manage, and treat various medical emergencies. Topics include Neurology, Endocrinology, Allergies and Anaphylaxis, Gastroenterology, Urology, Toxicology, Infectious and Communicable Diseases, Behavioral and Psychiatric Disorders, and associated pharmacological interventions.",
+    "prerequisite_text": "Admission to the Paramedicine ProgramPrepares the Paramedic to identify, assess, manage, and treat various medical emergencies. Topics include Neurology, Endocrinology, Allergies and Anaphylaxis, Gastroenterology, Urology, Toxicology, Infectious and Communicable Diseases, Behavioral and Psychiatric Disorders, and associated pharmacological interventions.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "469",
+    "title": "Managing Cultural Divrsty",
+    "credits": 3,
+    "description": "Prerequisites: Admission to the Construction Management program OR consent of Division Director. Provides an understanding of cultural diversity by studying the U.S. workforce. Emphasizes cultural differences in the workplace, valuing diversity, managing diversity in the workplace, and giving competitive advantages.",
+    "prerequisite_text": "Admission to the Construction Management program OR consent of Division Director. Provides an understanding of cultural diversity by studying the U.S. workforce. Emphasizes cultural differences in the workplace, valuing diversity, managing diversity in the workplace, and giving competitive advantages.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "141",
+    "title": "Chemical Operator",
+    "credits": 3,
+    "description": "This hands-on training program equips workers with the essential skills and knowledge to operate safely and effectively in chemical processing environments, particularly in battery recycling and manufacturing. Topics include process safety, PPE use, spill and emergency response, basic process variables (temperature, pressure, flow, etc.), equipment operation (tanks, pumps, valves), line breaking, liquid sampling, and cleanroom practices. This course also covers foundational science, root cause analysis, P&ID reading, and an introduction to process control systems (PLCs, HMIs, I/O).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "206",
+    "title": "Pharm/Medication Admim",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Prepares Paramedic students to understand and be able to integrate the principles of pathophysiological pharmacology and the assessment findings to formulate a field impression and implement a pharmacologic management plan for patients in the prehosptial environment. Introduces the Paramedic student to venous access, IO access, medication administration and drug calculations that will be used in treating patients in the prehosptial environment.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Prepares Paramedic students to understand and be able to integrate the principles of pathophysiological pharmacology and the assessment findings to formulate a field impression and implement a pharmacologic management plan for patients in the prehosptial environment. Introduces the Paramedic student to venous access, IO access, medication administration and d",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTO",
+    "number": "105",
+    "title": "BT Heavy Equipment Operator V",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 5 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 5 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "219",
+    "title": "Emergency Vehicle Operation",
+    "credits": 3,
+    "description": "Prerequisites: NoneTeaches police recruits methods of emergency vehicle operation and control in such areas as shuffle steering, steering motion dynamics and vehicle braking (lock-wheel, ABS, impending), pursuit driving and defensive techniques. This course only offered as part of the POST Academy.",
+    "prerequisite_text": "NoneTeaches police recruits methods of emergency vehicle operation and control in such areas as shuffle steering, steering motion dynamics and vehicle braking (lock-wheel, ABS, impending), pursuit driving and defensive techniques. This course only offered as part of the POST Academy.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ANTH",
+    "number": "110L",
+    "title": "Biological Anthropology Lab",
+    "credits": 1,
+    "description": "Corequisites: ANTH102 Provides practical experience in aspects of physical anthropology: the mechanisms of inheritance, osteology and forensic science, comparative anatomy and human evolution, and aspects of modern human variability.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "120",
+    "title": "Fund of College Math",
+    "credits": 3,
+    "description": "Prerequisite: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Studies probability, statistics, business, finance and consumer mathematics. Course is broad in scope and emphasizes applications.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Studies probability, statistics, business, finance and consumer mathematics. Course is broad in scope and emphasizes applications.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "199",
+    "title": "Independent Study",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "100",
+    "title": "Introduction to Economics",
+    "credits": 3,
+    "description": "Recommended prerequisite: MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "prerequisite_text": "MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "COM",
+    "number": "101",
+    "title": "Oral Communications",
+    "credits": 3,
+    "description": "Introduction to the principles and practices of public speaking.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "211",
+    "title": "Second Year Spanish I",
+    "credits": 3,
+    "description": "Prerequisites: SPAN112 or equivalent Considers structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_text": "SPAN112 or equivalent Considers structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_courses": [
+      "SPAN 112"
+    ]
+  },
+  {
+    "prefix": "ELM",
+    "number": "110",
+    "title": "Basic Electricity",
+    "credits": 3,
+    "description": "Prerequisite(s): NoneThis course covers basic AC/DC circuit principles and practices. Students will explore areas of electrical and electronic circuits including: circuit theory, components, circuit construction and analysis, proper test equipment usage, troubleshooting methodology, and applications in various technical fields.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "232",
+    "title": "Welding III Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 231Focuses on GMAW, GTAW, and FCAW which will train the student to perform production and certification performance welding on ferrous and non-ferrous metals.",
+    "prerequisite_text": "WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 231Focuses on GMAW, GTAW, and FCAW which will train the student to perform production and certification performance welding on ferrous and non-ferrous metals.",
+    "prerequisite_courses": [
+      "WELD 221",
+      "WELD 222"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "151",
+    "title": "Fingerspelling I",
+    "credits": 1,
+    "description": "Develops basic skills in receptive and expressive fingerspelling.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTP",
+    "number": "108",
+    "title": "Bt Plumbing Level VIII",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "115",
+    "title": "Scaffold Builder",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CSCO",
+    "number": "221",
+    "title": "Ccna Wan Fundamentals",
+    "credits": 4,
+    "description": "Prerequisites: CSCO121 & CSCO220 Explains the principles of traffic control and access control lists (ACLs) and provides an overview of the services and protocols at the data link layer for wide-area access. Students learn how to implement and configure Point-to-Point Protocol (PPP), Point-to-Point Protocol over Ethernet (PPPoE), DSL, and Frame Relay. WAN security concepts, tunneling, and VPN basics are also introduced.",
+    "prerequisite_text": "CSCO121 & CSCO220 Explains the principles of traffic control and access control lists (ACLs) and provides an overview of the services and protocols at the data link layer for wide-area access. Students learn how to implement and configure Point-to-Point Protocol (PPP), Point-to-Point Protocol over Ethernet (PPPoE), DSL, and Frame Relay. WAN security concepts, tunneling, and VPN basics are also in",
+    "prerequisite_courses": [
+      "CSCO 121",
+      "CSCO 220"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "215",
+    "title": "Conversational ASL",
+    "credits": 4,
+    "description": "Prerequisites: AM147 Focuses on the natural use of American Sign Language. Appropriate use of ASL grammar and vocabulary in conversational situations is stressed. Students master appropriate pragmatics, use of facial expressions, space, fingerspelling and classifiers, simultaneously for conversational fluency.",
+    "prerequisite_text": "AM147 Focuses on the natural use of American Sign Language. Appropriate use of ASL grammar and vocabulary in conversational situations is stressed. Students master appropriate pragmatics, use of facial expressions, space, fingerspelling and classifiers, simultaneously for conversational fluency.",
+    "prerequisite_courses": [
+      "AM 147"
+    ]
+  },
+  {
+    "prefix": "SUR",
+    "number": "161",
+    "title": "Elementary Surveying",
+    "credits": 4,
+    "description": "Prerequisites: MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "prerequisite_text": "MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "prerequisite_courses": [
+      "MATH 127"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "126",
+    "title": "Precalculus Mathematics I",
+    "credits": 3,
+    "description": "Prerequisite: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Provides a third course in algebra. Topics include: polynomial, rational and radical equations; absolute value and quadratic inequalities; relations and functions; linear, quadratic, polynomial exponential and logarithmic functions, their graphs and applications; and systems of equations.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Provides a third course in algebra. Topics include: polynomial, rational and radical equations; absolute value and quadratic inequalities; r",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "101",
+    "title": "Intro to General Mech",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automobiles. Includes safety, use of manuals, selection and use of hand tools, and hand-held test instruments. Introduces general maintenance of various systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "156",
+    "title": "Foundations Pharmacology III",
+    "credits": 1,
+    "description": "Prerequisite: admission to the nursing program and NURS 153Provides a continuation of study of pharmacological principles and practices through in-depth application of principles of pharmacology, pharmacokinetics and pharmacodynamics. Designed to expand the nursing student's knowledge of pharmacotherapeutics, which includes the cellular response level, for the clinical application within the context of the nursing process and prioritization of needs for patients across the lifespan. Selected drug classifications of pharmacological agents are examined and applied through case study application and analysis providing opportunity for development of the nursing competencies of clinical judgement, professional identity, use of evidence-based practice, and the facilitation of a spirit of inquiry.",
+    "prerequisite_text": "admission to the nursing program and NURS 153Provides a continuation of study of pharmacological principles and practices through in-depth application of principles of pharmacology, pharmacokinetics and pharmacodynamics. Designed to expand the nursing student's knowledge of pharmacotherapeutics, which includes the cellular response level, for the clinical application within the context of the nurs",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "153",
+    "title": "Foundtns Pharmacology II",
+    "credits": 1,
+    "description": "Prerequisites: Successful completion of the first semester of the nursing program. Provides a continuation of study of pharmacological principles and practices to achieve safe administration of medications. Selected drug classifications are presented, with an emphasis on understanding intended and unintended effects of drugs on body systems. Provides an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs.",
+    "prerequisite_text": "Successful completion of the first semester of the nursing program. Provides a continuation of study of pharmacological principles and practices to achieve safe administration of medications. Selected drug classifications are presented, with an emphasis on understanding intended and unintended effects of drugs on body systems. Provides an overview of pharmacology with an emphasis on clinical appli",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IS",
+    "number": "201",
+    "title": "Computer Applications",
+    "credits": 3,
+    "description": "Prerequisites: IS101 or experience in office software. Develops the student's knowledge in integrated office productivity software. Topics will cover word processing, database, spreadsheets and working with macro programming. Coursework or experience using office software is essential for successful completion and gives students the foundation to pass expert level certification tests.",
+    "prerequisite_text": "IS101 or experience in office software. Develops the student's knowledge in integrated office productivity software. Topics will cover word processing, database, spreadsheets and working with macro programming. Coursework or experience using office software is essential for successful completion and gives students the foundation to pass expert level certification tests.",
+    "prerequisite_courses": [
+      "IS 101"
+    ]
+  },
+  {
+    "prefix": "BTP",
+    "number": "104",
+    "title": "Bt Plumbing Level IV",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program. Covers building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 4 of the Plumbing Apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program. Covers building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 4 of the Plumbing Apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MT",
+    "number": "130",
+    "title": "Intro to the Nat Gas Industry",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduces the natural gas industry. Includes history of the gas industry, safety issues, and field operations",
+    "prerequisite_text": "NoneIntroduces the natural gas industry. Includes history of the gas industry, safety issues, and field operations",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "210",
+    "title": "Auto Trans & Transaxles I",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automatic transmissions used in today's automobiles. Includes safety, use of manuals, selection and use of hand tools, and appropriate transmission test instruments. Introduces maintenance of a variety of different automatic transmissions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "96D",
+    "title": "Alegbra Review for Math 126",
+    "credits": 2,
+    "description": "Corequisite: Math 126Offers a second course in algebra. Includes multiplying, dividing, and factoring polynomial expressions, solving polynomial and rational equations, algebraic techniques involving exponents and radicals, and systems of linear equations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "226",
+    "title": "Pop Culture Hist: Org Crime",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101Topical survey of popular culture and history, focusing on historical background and utilizing diverse primary and secondary sources. Emphasis on organized crime, predominantly in the 20th & 21st centuries across the globe. Repeatable up to a maximum of 9 credits.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101Topical survey of popular culture and history, focusing on historical background and utilizing diverse primary and secondary sources. Emphasis on organized crime, predominantly in the 20th & 21st centuries across the globe. Repeatable up to a maximum of 9 credits.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "CH",
+    "number": "202",
+    "title": "The Modern World",
+    "credits": 3,
+    "description": "Prerequisites: ENG101Explores the intellectual, literary and political history of Europe from the Renaissance to the present.",
+    "prerequisite_text": "ENG101Explores the intellectual, literary and political history of Europe from the Renaissance to the present.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "211",
+    "title": "Ceramics I",
+    "credits": 3,
+    "description": "Offers a beginning studio course in ceramic construction and decoration. Lecture and laboratory methods are used to give special attention to the development of individual student's skills. Uses potter's wheels. One hour lecture and four hours studio per week.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INF",
+    "number": "100",
+    "title": "Intro to Informatics I - Basic",
+    "credits": 3,
+    "description": "Deals with the nature of Informatics withing the information technology space. Addresses the core concept of integration of people, technology and information. Emphasizes the practical dimension of Informatics, real problems, and the socio-economic situations in which they arise. Presents a variety of Informatics tools from a variety of domains, and their implications for science, engineering, art, the humanities and society.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "101",
+    "title": "Building Trades Carpentry I",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 1 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 1 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "295",
+    "title": "Wk Exp - Corrections",
+    "credits": 6,
+    "description": "Prerequisites: CRJ 104 or consent of instructorProvides the student with on-the job, supervised and educationally directed work experience.",
+    "prerequisite_text": "CRJ 104 or consent of instructorProvides the student with on-the job, supervised and educationally directed work experience.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "SPAN",
+    "number": "102",
+    "title": "Conversational Spanish II",
+    "credits": 3,
+    "description": "Prerequisites: SPAN101B or consent of instructor Offers a second semester of Conversational Spanish designed to continue and improve the skills learned in the first semester.",
+    "prerequisite_text": "SPAN101B or consent of instructor Offers a second semester of Conversational Spanish designed to continue and improve the skills learned in the first semester.",
+    "prerequisite_courses": [
+      "SPAN 101B"
+    ]
+  },
+  {
+    "prefix": "PHYS",
+    "number": "182",
+    "title": "Physics Science/Eng III",
+    "credits": 3,
+    "description": "Prerequisite: PHYS 181. Corequisite: PHYS 182L.Explores light, optical systems, relativity, wave aspects of particles, quantum mechanics, statistical mechanics, semiconductors, radioactivity, nuclear physics and particles. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_text": "PHYS 181. Corequisite: PHYS 182L.Explores light, optical systems, relativity, wave aspects of particles, quantum mechanics, statistical mechanics, semiconductors, radioactivity, nuclear physics and particles. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_courses": [
+      "PHYS 181",
+      "PHYS 182L"
+    ]
+  },
+  {
+    "prefix": "GEOL",
+    "number": "102",
+    "title": "Earth & Life Through Time",
+    "credits": 4,
+    "description": "Prerequisites: GEOL101 3 hours lecture and 3 hours lab.Studies the history of the earth and the origins of its landforms, including dating, evolution of organisms, times of extinction, mountain building episodes, and periods of glaciation.",
+    "prerequisite_text": "GEOL101 3 hours lecture and 3 hours lab.Studies the history of the earth and the origins of its landforms, including dating, evolution of organisms, times of extinction, mountain building episodes, and periods of glaciation.",
+    "prerequisite_courses": [
+      "GEOL 101"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "166",
+    "title": "Med Surgical Nurs I Lab",
+    "credits": 1,
+    "description": "Successful completion of the first semester of the nursing program. Corequisites: NURS165 & NURS167 Prepares students to safely perform intermediate nursing skills (therapeutic procedures) that are encountered in the care of hospitalized adult patients with common alterations in body systems. Emphasizes the critical elements of nursing procedures and the scientific rationale for performing the procedures safely.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CH",
+    "number": "203",
+    "title": "Amer Exp & Constitution Change",
+    "credits": 3,
+    "description": "Prerequisites: ENG101Emphasizes the origins of the U.S. and Nevada constitutions and issues such as equality and civil rights, individualism and civil liberties, federalism, environmentalism, urbanization and industrialization, as well as religious and cultural diversity. Satisfies the United States and Nevada Constitutions requirements.",
+    "prerequisite_text": "ENG101Emphasizes the origins of the U.S. and Nevada constitutions and issues such as equality and civil rights, individualism and civil liberties, federalism, environmentalism, urbanization and industrialization, as well as religious and cultural diversity. Satisfies the United States and Nevada Constitutions requirements.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "101",
+    "title": "General Psychology",
+    "credits": 3,
+    "description": "Introduces the field of psychology. Covers major principles and their application to the study of human behavior.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PBH",
+    "number": "120",
+    "title": "Health and Wellness",
+    "credits": 3,
+    "description": "Covers the components and wellness and of lifelong tools that will help enhance wellness. health values, attitudes and behaviors of self and others. Students will be active in design and execution of personal fitness and wellness plans.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "101",
+    "title": "CTE Teaching Foundations I",
+    "credits": 3,
+    "description": "Prerequisites: NoneIn this course, students will learn about the educational framework and classroom practices that will prepare them for employment as a secondary career and technical education (CTE) teacher and/or post-secondary opportunities in a CTE field. Topics include the general knowledge CTE teachers need in order to develop professionally and experience success in their first years of teaching and develop as a professional CTE educator; foundations of learning and education; educational jargon, terms and acronyms related to education and CTE; school operations and teacher requirements; instructional standards, lesson planning, assessment and grading; creating and managing an effective learning environment; CTE funding; and career and technical student organizations (CTSOs).",
+    "prerequisite_text": "NoneIn this course, students will learn about the educational framework and classroom practices that will prepare them for employment as a secondary career and technical education (CTE) teacher and/or post-secondary opportunities in a CTE field. Topics include the general knowledge CTE teachers need in order to develop professionally and experience success in their first years of teaching and deve",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "152",
+    "title": "Web Script Language Prog",
+    "credits": 3,
+    "description": "Prerequisites: CIT 151 Programming class providing instruction in the creation of interactive web pages using technologies such as Javascript, SQL, CSS and HTML; investigates client- and server- side programming techniques.",
+    "prerequisite_text": "CIT 151 Programming class providing instruction in the creation of interactive web pages using technologies such as Javascript, SQL, CSS and HTML; investigates client- and server- side programming techniques.",
+    "prerequisite_courses": [
+      "CIT 151"
+    ]
+  },
+  {
+    "prefix": "COM",
+    "number": "215",
+    "title": "Intro Group Communication",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduces communication as it functions within small task groups. Emphasizes observation and analysis of actual small group behavior and on improvement of communication skills within the small group setting. Topics to include leadership, conflict, norms, role structure, cohesiveness and decision making. Course stresses student involvement in exercises, discussions and group projects.",
+    "prerequisite_text": "NoneIntroduces communication as it functions within small task groups. Emphasizes observation and analysis of actual small group behavior and on improvement of communication skills within the small group setting. Topics to include leadership, conflict, norms, role structure, cohesiveness and decision making. Course stresses student involvement in exercises, discussions and group projects.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "106",
+    "title": "Building Trades Carpentry VI",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 6 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 6 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "222",
+    "title": "Welding II Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 211 and WELD 212, or consent of instructor; Corequisite: WELD 221Continues MTL 212 with emphasis on developing welding skills for SMAW, GMAW, and GTAW production in overhead, flat, horizontal, and vertical positions.",
+    "prerequisite_text": "WELD 211 and WELD 212, or consent of instructor; Corequisite: WELD 221Continues MTL 212 with emphasis on developing welding skills for SMAW, GMAW, and GTAW production in overhead, flat, horizontal, and vertical positions.",
+    "prerequisite_courses": [
+      "WELD 211",
+      "WELD 212",
+      "MTL 212"
+    ]
+  },
+  {
+    "prefix": "PEX",
+    "number": "159",
+    "title": "Horsemanship",
+    "credits": 2,
+    "description": "Helps students understand the principles of dressage and show jumping and to improve their skills in both sports. may be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "100",
+    "title": "Introductory Physics",
+    "credits": 3,
+    "description": "Prerequisites: MATH120,MATH126 or higher Introduces students to a broad range of concepts in physics from basic classical mechanics to modern physics. Students will conduct at least four experiments with many demonstrations performed throughout the course.",
+    "prerequisite_text": "MATH120,MATH126 or higher Introduces students to a broad range of concepts in physics from basic classical mechanics to modern physics. Students will conduct at least four experiments with many demonstrations performed throughout the course.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "SPAN",
+    "number": "212",
+    "title": "Second Year Spanish II",
+    "credits": 3,
+    "description": "Prerequisites: SPAN211 Continues structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_text": "SPAN211 Continues structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_courses": [
+      "SPAN 211"
+    ]
+  },
+  {
+    "prefix": "ELM",
+    "number": "198",
+    "title": "SPECIAL TOPICS IN ELECTRICAL",
+    "credits": 4,
+    "description": "Prerequisite(s): Must be admitted to an approved apprenticeship program.Basic understanding and hands-on experience of current theories in electrical and mechanical technologies as well as advanced technologies utilized in industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "293",
+    "title": "Directed Study",
+    "credits": 3,
+    "description": "Prerequisites: PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "prerequisite_text": "PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "prerequisite_courses": [
+      "PHYS 151",
+      "PHYS 180"
+    ]
+  },
+  {
+    "prefix": "CIT",
+    "number": "180",
+    "title": "Database Concepts and Sql",
+    "credits": 3,
+    "description": "Prerequisites: CIT129 or equivalent programming experience or consent of instructor Teaches basic principles of data modeling and relational database design. Class is targeted for people with little or no SQL knowledge. Provides a comprehensive overview of query writing, focusing on practical techniques for the IT professional new to relational databases. Course accents hands-on learning in a Structured Query Language (SQL) and SQL procedures.",
+    "prerequisite_text": "CIT129 or equivalent programming experience or consent of instructor Teaches basic principles of data modeling and relational database design. Class is targeted for people with little or no SQL knowledge. Provides a comprehensive overview of query writing, focusing on practical techniques for the IT professional new to relational databases. Course accents hands-on learning in a Structured Query La",
+    "prerequisite_courses": [
+      "CIT 129"
+    ]
+  },
+  {
+    "prefix": "PHYS",
+    "number": "152",
+    "title": "General Physics II",
+    "credits": 4,
+    "description": "Prerequisites: PHYS151. For non-physical science majors. Topics include electricity, magnetism, electromagnetic waves, optics, relativity, introductory quantum physics, atomic physics, and nuclear physics. Laboratory experiments illustrate many of these fundamental principles.¿",
+    "prerequisite_text": "PHYS151. For non-physical science majors. Topics include electricity, magnetism, electromagnetic waves, optics, relativity, introductory quantum physics, atomic physics, and nuclear physics. Laboratory experiments illustrate many of these fundamental principles.¿",
+    "prerequisite_courses": [
+      "PHYS 151"
+    ]
+  },
+  {
+    "prefix": "BTS",
+    "number": "102",
+    "title": "BT Construction Sheet Metal II",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 2 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 2 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "214",
+    "title": "Sp Populations in Paramedicine",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine ProgramPrepares the Paramedic student to identify, assess, manage, and treat age related emergencies, and other special challenges. Topics include obstetrics, neonatology, pediatrics, geriatrics, abuse and assault, and patients with special challenges.",
+    "prerequisite_text": "Admission to the Paramedicine ProgramPrepares the Paramedic student to identify, assess, manage, and treat age related emergencies, and other special challenges. Topics include obstetrics, neonatology, pediatrics, geriatrics, abuse and assault, and patients with special challenges.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "JPN",
+    "number": "111",
+    "title": "First Year Japanese I",
+    "credits": 4,
+    "description": "Prerequisites: NoneIntroduces the language through structural analysis and the writing system. Includes some conversation and an introduction to Japanese culture.",
+    "prerequisite_text": "NoneIntroduces the language through structural analysis and the writing system. Includes some conversation and an introduction to Japanese culture.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "206",
+    "title": "Class Learn Env",
+    "credits": 3,
+    "description": "Prerequisites: EDU201 Presents the function and analysis of elementary school classrooms, daily activities, and methods of behavior management. Includes field experience. A background check may be required for field experience.",
+    "prerequisite_text": "EDU201 Presents the function and analysis of elementary school classrooms, daily activities, and methods of behavior management. Includes field experience. A background check may be required for field experience.",
+    "prerequisite_courses": [
+      "EDU 201"
+    ]
+  },
+  {
+    "prefix": "RE",
+    "number": "101",
+    "title": "Real Estate Principles",
+    "credits": 4,
+    "description": "Prepares students for careers in the real estate profession. Includes law of agency, listing agreements, encumbrances, legal descriptions, taxes, contracts and escrow. This course, along with RE 103, satisfies requirements of the Real Estate Division and Commission for taking the salesperson exam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "291",
+    "title": "Cnc Practice",
+    "credits": 3,
+    "description": "Develops computer aided manufacturing skills with hands on instruction on how to design and prepare manufacture parts using state of the art CAD/CAM software. Safety and clean up are stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "118",
+    "title": "OSHA 30",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers workplace safety and health hazards and the regulations that protect employee on the jobsite. Many construction contractors are requiring employees to have an OSHA 30 card.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers workplace safety and health hazards and the regulations that protect employee on the jobsite. Many construction contractors are requiring employees to have an OSHA 30 card.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "285",
+    "title": "History of Witchcraft",
+    "credits": 3,
+    "description": "Prerequisites: None. Recommended: ENG 101Addresses the changing definitions of magic, science, religion and law as they pertain to the supernatural from the beginnings of ancient civilizations through the modern era. Topics will include pagan religions, heresy, possession and exorcism, demons, artistic representations, and gender.",
+    "prerequisite_text": "None. Recommended: ENG 101Addresses the changing definitions of magic, science, religion and law as they pertain to the supernatural from the beginnings of ancient civilizations through the modern era. Topics will include pagan religions, heresy, possession and exorcism, demons, artistic representations, and gender.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "140",
+    "title": "Battery Basics",
+    "credits": 1,
+    "description": "Prerequisites: ELM 110; This course provides comprehensive training on the safe disassembly of rechargeable batteries, with a focus on electric vehicle (EV) battery packs. Students will learn to identify hazards, implement safety protocols, and utilize appropriate tools and personal protective equipment (PPE). The course covers key topics, including battery construction, electrical safety, discharge methods, and recycling practices. Designed for professionals in battery recycling and manufacturing, this training emphasizes safety, efficiency, and environmental sustainability.",
+    "prerequisite_text": "ELM 110; This course provides comprehensive training on the safe disassembly of rechargeable batteries, with a focus on electric vehicle (EV) battery packs. Students will learn to identify hazards, implement safety protocols, and utilize appropriate tools and personal protective equipment (PPE). The course covers key topics, including battery construction, electrical safety, discharge methods,",
+    "prerequisite_courses": [
+      "ELM 110"
+    ]
+  },
+  {
+    "prefix": "PHIL",
+    "number": "102",
+    "title": "Critical Think & Reason",
+    "credits": 3,
+    "description": "Covers nonsymbolic introduction to logical thinking in everyday life, law, politics, science, advertising; common fallacies; and the uses of language, including techniques of persuasion.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOG",
+    "number": "103",
+    "title": "Physical Geography",
+    "credits": 3,
+    "description": "Prerequisites: MATH120,MATH126 or higher or consent of instructor Teaches the physical processes of geography, including maps, seasons, weather and climate. Includes at least four lab experiences.",
+    "prerequisite_text": "MATH120,MATH126 or higher or consent of instructor Teaches the physical processes of geography, including maps, seasons, weather and climate. Includes at least four lab experiences.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "121",
+    "title": "Electrical Control Systems",
+    "credits": 3,
+    "description": "Prerequisite: AIT 101Covers the function and operation of logic control circuits used in industrial, commercial and residential applications. Relays, limit switches and time-delays are introduced for a variety of uses. Automation with electrical control is common in many settings, using components wired together in specific configurations that form the logic needed to determine the sequences of machine operations.",
+    "prerequisite_text": "AIT 101Covers the function and operation of logic control circuits used in industrial, commercial and residential applications. Relays, limit switches and time-delays are introduced for a variety of uses. Automation with electrical control is common in many settings, using components wired together in specific configurations that form the logic needed to determine the sequences of machine operat",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "105",
+    "title": "Scuba",
+    "credits": 1,
+    "description": "Features PADI Open Water Dive and teaches foundational knowledge and skills needed to dive with a buddy, independent of supervision. Open Water Divers are qualified to obtain air fills, equipment, and services, and may plan, conduct, and log no stop dives in conditions with which they have training and experience.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "101",
+    "title": "Intro to Philosophy",
+    "credits": 3,
+    "description": "Prerequisites: ENG 101 recommendedStudies basic problems in different areas of philosophy such as ethics, political theory, metaphysics, and epistemology.",
+    "prerequisite_text": "ENG 101 recommendedStudies basic problems in different areas of philosophy such as ethics, political theory, metaphysics, and epistemology.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "CRJ",
+    "number": "215",
+    "title": "Probation & Parole I",
+    "credits": 3,
+    "description": "Surveys the probation and parole system of the U.S. through its evolution to the present. Shows different systems within the U.S. and focuses on executive clemency, parole, rights of prisoners, probationers and parolees, and strategies for treatment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "496",
+    "title": "Strategic Mgmt and Policy",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organization and Project Management Program, FIN 310, MGT 310Emphasis on the application of knowledge from all functional areas of business to organizational problems and the formulation and implementation of organizational strategies.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management Program, FIN 310, MGT 310Emphasis on the application of knowledge from all functional areas of business to organizational problems and the formulation and implementation of organizational strategies.",
+    "prerequisite_courses": [
+      "FIN 310"
+    ]
+  },
+  {
+    "prefix": "BTT",
+    "number": "106",
+    "title": "BT Telecomm Tech Level VI",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 6 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 6 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "108",
+    "title": "Bus Letter & Reports",
+    "credits": 3,
+    "description": "Prerequisite: ENG 95, 98, 99, or equivalent writing course or appropriate score on WNC placement or equivalent exam. Students should meet with a WNC Counselor to determine readiness based on placement based on readiness exams, high school coursework, or other factors.Develops letter and report writing skills including proper word choice, letter tone, and structure. Demonstrates how these skills are best used in business letters, memoranda, reports and other business documents.",
+    "prerequisite_text": "ENG 95, 98, 99, or equivalent writing course or appropriate score on WNC placement or equivalent exam. Students should meet with a WNC Counselor to determine readiness based on placement based on readiness exams, high school coursework, or other factors.Develops letter and report writing skills including proper word choice, letter tone, and structure. Demonstrates how these skills are best used in",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "226",
+    "title": "Span for Heritage Speakers I",
+    "credits": 3,
+    "description": "Prerequisite: None; students should have some bilingual communications skills.Designed for native Spanish speaking students who want to improve their literacy in the language. Students will study and practice basic Spanish grammar for improving and developing written and oral communications and reading skills while exploring some of the most interesting and important aspects of their own history and culture.",
+    "prerequisite_text": "None; students should have some bilingual communications skills.Designed for native Spanish speaking students who want to improve their literacy in the language. Students will study and practice basic Spanish grammar for improving and developing written and oral communications and reading skills while exploring some of the most interesting and important aspects of their own history and culture.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "290",
+    "title": "Internship in Construction",
+    "credits": 3,
+    "description": "Prerequisites: NoneStudies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_text": "NoneStudies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MT",
+    "number": "132",
+    "title": "Natural Gas Pipe Joining",
+    "credits": 3,
+    "description": "Prerequisite: MT 130Introduces the concepts of natural gas pipe joining. Includes plastic pipe and metal pipe joining. Covers types of joining: plastic solvent, compression coupling, heat fusion, welded and bolted.",
+    "prerequisite_text": "MT 130Introduces the concepts of natural gas pipe joining. Includes plastic pipe and metal pipe joining. Covers types of joining: plastic solvent, compression coupling, heat fusion, welded and bolted.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "260",
+    "title": "911 Dispatch Academy",
+    "credits": 12,
+    "description": "Prerequisites: 4 hour sit-in in Dispatch Center (prior to class start date) Focuses on the skills needed to become a dispatcher with law enforcement agencies, fire centers, trucking firms, taxicab companies, etc. During the 12-credit semester-long course, students will be required to spend 44 hours job shadowing dispatchers, fire fighters and law enforcement officers. They will attend law classes, build their communication and typing skills, and participate in practical scenarios.",
+    "prerequisite_text": "4 hour sit-in in Dispatch Center (prior to class start date) Focuses on the skills needed to become a dispatcher with law enforcement agencies, fire centers, trucking firms, taxicab companies, etc. During the 12-credit semester-long course, students will be required to spend 44 hours job shadowing dispatchers, fire fighters and law enforcement officers. They will attend law classes, build their co",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GRC",
+    "number": "210",
+    "title": "Typography I",
+    "credits": 3,
+    "description": "Prerequisites: GRC 116Introduces students to designing with type for graphic design. Offers readings that outline the historical context of letter forms, while studio-based projects focus on practical analysis, visual and conceptual interaction of type and image, and the creative exploration of type as a formal element.",
+    "prerequisite_text": "GRC 116Introduces students to designing with type for graphic design. Offers readings that outline the historical context of letter forms, while studio-based projects focus on practical analysis, visual and conceptual interaction of type and image, and the creative exploration of type as a formal element.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "250",
+    "title": "Mechatronics: Electrical",
+    "credits": 3,
+    "description": "3 units Prerequisite or Corequisite: AIT 101Covers the basics of electrical components in a complex mechatronic system. Students will learn the basic functions and physical properties of electrical components, and the roles they play within the system. Technical documentation such as data sheets, schematics, and timing diagrams will be covered while exploring troubleshooting strategies and preventive maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "107",
+    "title": "Guitar Class I",
+    "credits": 3,
+    "description": "Studies basic guitar technique, bluegrass, classical and rock styles. No previous musical training required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTO",
+    "number": "104",
+    "title": "BT Heavy Equipment Operator IV",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 4 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 4 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "123",
+    "title": "Health & Nutri for Child",
+    "credits": 1,
+    "description": "Examines the health and nutritional needs of young children. Develops skills in menu planning, selecting safe equipment and toys, routines to ensure good health and policies on illness.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "100",
+    "title": "Composition - Enhanced",
+    "credits": 5,
+    "description": "Prerequisite: ENG 95 or equivalent writing course or appropriate scored on WNC placement or equivalent exam. Students should meet with a WNC Counselor to determine readiness based on placement based on readiness exams, high school coursework, or other factors.Intensive reading and writing course focusing on writing the expository and argumentative essay. Emphasis on revising and editing essays for development, coherence, style, and correctness as well as on investigative, reasoning, and organizational skills necessary to create successful research papers. Provides extra assistance in English writing skills, grammar, sentence structure, usage, and punctuation.Includes objectives covered in ENG 101; satisfies the ENG 101 writing requirement for all degrees and certificates of achievement.",
+    "prerequisite_text": "ENG 95 or equivalent writing course or appropriate scored on WNC placement or equivalent exam. Students should meet with a WNC Counselor to determine readiness based on placement based on readiness exams, high school coursework, or other factors.Intensive reading and writing course focusing on writing the expository and argumentative essay. Emphasis on revising and editing essays for development,",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "207",
+    "title": "Discover Nevada",
+    "credits": 3,
+    "description": "Explores the many historic sites and scenic areas of Nevada, utilizing lecture discussions, slide presentations, readings and videos.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "201",
+    "title": "Geology of Nevada",
+    "credits": 3,
+    "description": "Prerequisites: GEOL101 or consent of instructor Studies how Nevada¿s geology has changed through time. Includes Nevada¿s fossils, rocks and minerals, earthquakes and geothermal resources. Includes at least four lab experiences.",
+    "prerequisite_text": "GEOL101 or consent of instructor Studies how Nevada¿s geology has changed through time. Includes Nevada¿s fossils, rocks and minerals, earthquakes and geothermal resources. Includes at least four lab experiences.",
+    "prerequisite_courses": [
+      "GEOL 101"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "282",
+    "title": "Intro Lang/Lit Expression",
+    "credits": 3,
+    "description": "Explores the forms and function of language with special application to literary study.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENV",
+    "number": "100",
+    "title": "Humans and Environment",
+    "credits": 3,
+    "description": "Prerequisites: MATH120 or consent of instructor Provides an interdisciplinary introductory survey of the ecology of natural systems with emphasis on the relationship of humans to the environment. Includes four laboratory experiences.",
+    "prerequisite_text": "MATH120 or consent of instructor Provides an interdisciplinary introductory survey of the ecology of natural systems with emphasis on the relationship of humans to the environment. Includes four laboratory experiences.",
+    "prerequisite_courses": [
+      "MATH 120"
+    ]
+  },
+  {
+    "prefix": "PEX",
+    "number": "122",
+    "title": "Raquetball",
+    "credits": 2,
+    "description": "Covers the fundamentals of racquetball.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPD",
+    "number": "163",
+    "title": "PPST/Praxis I Writing Review",
+    "credits": 1,
+    "description": "Prerequisites: NoneReview of writing skills and test-taking strategies in preparation for taking the PPST/Praxis I Writing Exam. This course is graded as Pass/Fail.",
+    "prerequisite_text": "NoneReview of writing skills and test-taking strategies in preparation for taking the PPST/Praxis I Writing Exam. This course is graded as Pass/Fail.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AV",
+    "number": "210",
+    "title": "Instrument Ground School",
+    "credits": 4,
+    "description": "Prerequisite: None. Recommend AV 110This course provides in-depth study of the purpose, use and operation of flight instruments in airport departures, en route navigation, approaches and other aspects of instrument flight.",
+    "prerequisite_text": "None. Recommend AV 110This course provides in-depth study of the purpose, use and operation of flight instruments in airport departures, en route navigation, approaches and other aspects of instrument flight.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "168",
+    "title": "Infect Diseases & 1st Aid",
+    "credits": 1,
+    "description": "Provides information about infectious diseases and first aid measures in the child care setting. Course content will include recognizing communicable and acute illnesses, management of accidents and injuries, preventive measures, health education, current research, and community resources.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "124",
+    "title": "College Algebra",
+    "credits": 3,
+    "description": "Prerequisites: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a WNC Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors. Covers equations and inequalities; relations and functions; linear, quadratic, polynomial, exponential, and logarithmic functions; systems of linear equations.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a WNC Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors. Covers equations and inequalities; relations and functions; linear, quadratic, polynomial, exponential, and logarithmic functions; syste",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "105",
+    "title": "Introduction to Neuroscience",
+    "credits": 3,
+    "description": "Presents basic principles in biological science, including neural function and cognition. Topics will range from the electrical basis of brain function to higher-order cognitive processes and neurodegenerative diseases. Applications will also be introduced, from the treatment and impact of neurological diseases on society, to how we can use computational models of the brain. Same as PSY 105 and NS 105.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "299",
+    "title": "Business Capstone",
+    "credits": 3,
+    "description": "Prerequisite: Completion of a minimum of 45 units of requirements for an AAS degree in business or consent of instructor.Concludes various business concepts introduced throughout the business program by merging acquired skills and concepts through the business plan with additional emphasis on job preparation and business ethics.",
+    "prerequisite_text": "Completion of a minimum of 45 units of requirements for an AAS degree in business or consent of instructor.Concludes various business concepts introduced throughout the business program by merging acquired skills and concepts through the business plan with additional emphasis on job preparation and business ethics.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AST",
+    "number": "120",
+    "title": "Intro to Astrobiology",
+    "credits": 3,
+    "description": "Study of the origin, evolution and distribution of life in the geology, planetary science, atmospheric science, oceanography, and other sciences. Will explore the scientific reasons behind why the Solar System harbors a living planet. Covers the factors that allow the Earth to support life and the potential for life on other planets within the universe.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DAN",
+    "number": "244",
+    "title": "Tap Dance (Intermediate)",
+    "credits": 1,
+    "description": "Prerequisites: DAN144 or consent of instructor Emphasizes intermediate techniques of tap dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": "DAN144 or consent of instructor Emphasizes intermediate techniques of tap dance. May be repeated for up to 4 credits.",
+    "prerequisite_courses": [
+      "DAN 144"
+    ]
+  },
+  {
+    "prefix": "BTE",
+    "number": "102",
+    "title": "Bt Electrical Level II",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FIN",
+    "number": "310",
+    "title": "Applied Accounting and Finance",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organization and Project Management ProgramDesigned to provide the keys, concepts and tools used in understanding the financial functions of a business enterprise. Introduces the essential concepts necessary in understanding formal financial statements from the user's perspective.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management ProgramDesigned to provide the keys, concepts and tools used in understanding the financial functions of a business enterprise. Introduces the essential concepts necessary in understanding formal financial statements from the user's perspective.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "99",
+    "title": "Basic Writing Strategies",
+    "credits": 4,
+    "description": "Provides instruction in basic English skills including sentence patterns and basic paragraph development. Provides review of grammar, mechanics, punctuation, spelling, and work usage. Offers practice in sentence, paragraph, and short essay writing with attention to grammar, sentence structure, and punctuation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "103",
+    "title": "Bt Electrical Level III",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "103",
+    "title": "Building Trades Carpentry III",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 3 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 3 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AC",
+    "number": "106",
+    "title": "Residential Gas Heating",
+    "credits": 6,
+    "description": "Prerequisites: AC 102, AC 107Application of principles and skills in the troubleshooting, repair and maintenance of air conditioning, heating and ventilation equipment. Topics covered are the refrigeration cycle, gas furnace, oil furnace, heat pump, chilled water systems, hot water systems and cooling.",
+    "prerequisite_text": "AC 102, AC 107Application of principles and skills in the troubleshooting, repair and maintenance of air conditioning, heating and ventilation equipment. Topics covered are the refrigeration cycle, gas furnace, oil furnace, heat pump, chilled water systems, hot water systems and cooling.",
+    "prerequisite_courses": [
+      "AC 102"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "145",
+    "title": "Voice-Lower Division",
+    "credits": 2,
+    "description": "Introduces the correct and pleasing use of the singing voice through a well balanced and coordinated study of vocal literature and exercises. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "167",
+    "title": "Home Energy Audit Quality Cont",
+    "credits": 1,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this concurrently with the prerequisites with instructor approval.This course prepares students to become a quality control inspector with the skills to ensure the completion, appropriateness and quality of residential home energy upgrade work through use of methodological inspection of the building including performing safety and diagnostic tests and observing work performed. The course also prepares students for success on the BPI Home Energy Auditor Quality Control Inspection Certification examination.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this concurrently with the prerequisites with instructor approval.This course prepares students to become a quality control inspector with the skills to en",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  {
+    "prefix": "CIT",
+    "number": "263",
+    "title": "It Project Management",
+    "credits": 3,
+    "description": "Introduces students to the concepts of project management as used within the information technology fields of study.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "122",
+    "title": "Intercollegiate Rodeo",
+    "credits": 2,
+    "description": "Prerequisite: NoneDesigned for men and women interested in rodeo as a knowledgeable spectator, producer, or participant. Covers rodeo history, current rules, equipment use, and physical and mental conditioning.",
+    "prerequisite_text": "NoneDesigned for men and women interested in rodeo as a knowledgeable spectator, producer, or participant. Covers rodeo history, current rules, equipment use, and physical and mental conditioning.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "214",
+    "title": "Microsoft Azure Administration",
+    "credits": 5,
+    "description": "Prerequisites: CIT213 or consent of instructor Through lectures, discussions, demonstrations, textbook study, and hands-on lab exercises, teaches the basic skills and knowledge necessary to implement, administer and maintain a Microsoft Directory Services environment.",
+    "prerequisite_text": "CIT213 or consent of instructor Through lectures, discussions, demonstrations, textbook study, and hands-on lab exercises, teaches the basic skills and knowledge necessary to implement, administer and maintain a Microsoft Directory Services environment.",
+    "prerequisite_courses": [
+      "CIT 213"
+    ]
+  },
+  {
+    "prefix": "ECE",
+    "number": "200",
+    "title": "The Exceptional Child",
+    "credits": 3,
+    "description": "Surveys the characteristics and specific needs of special children. Emphasizes teaching and behavioral management as well as available support services.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DAN",
+    "number": "135",
+    "title": "Beginning Ballet",
+    "credits": 1,
+    "description": "Introduces beginning techniques of ballet. May be repeated for up to four credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "283",
+    "title": "Calculus III",
+    "credits": 4,
+    "description": "Prerequisites: MATH182 or equivalent or consent of instructor Covers infinite series, vectors, differential and integral calculus of functions of several variables, and introduction to vector analysis.",
+    "prerequisite_text": "MATH182 or equivalent or consent of instructor Covers infinite series, vectors, differential and integral calculus of functions of several variables, and introduction to vector analysis.",
+    "prerequisite_courses": [
+      "MATH 182"
+    ]
+  },
+  {
+    "prefix": "GRC",
+    "number": "282",
+    "title": "Motion Graphics for Video",
+    "credits": 3,
+    "description": "Prerequisites: NoneOffers principles of visual design and color, animation and sound design applied to motion graphic design. Emphasis on designing projects that combine text, graphics, animation, audio and video. Hands-on projects using multimedia authoring software.",
+    "prerequisite_text": "NoneOffers principles of visual design and color, animation and sound design applied to motion graphic design. Emphasis on designing projects that combine text, graphics, animation, audio and video. Hands-on projects using multimedia authoring software.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "107",
+    "title": "Technical Communications I",
+    "credits": 3,
+    "description": "Prerequisites: English 99 with a grade of C- or higher or appropriate score on WNC placement examination or equivalent examination. Introduction to expository methods with concentration on specific vocational writing forms including memorandums, formal reports, manuals and proposals. Students will learn how adapt correct paragraph construction to suit the expectations of an occupational audience, in order to communicate clearly and effectively.",
+    "prerequisite_text": "English 99 with a grade of C- or higher or appropriate score on WNC placement examination or equivalent examination. Introduction to expository methods with concentration on specific vocational writing forms including memorandums, formal reports, manuals and proposals. Students will learn how adapt correct paragraph construction to suit the expectations of an occupational aud",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "103",
+    "title": "Conversationl Spanish III",
+    "credits": 3,
+    "description": "Prerequisites: SPAN102B or consent of instructor Further develops skills learned in previous semesters.",
+    "prerequisite_text": "SPAN102B or consent of instructor Further develops skills learned in previous semesters.",
+    "prerequisite_courses": [
+      "SPAN 102B"
+    ]
+  },
+  {
+    "prefix": "DAN",
+    "number": "232",
+    "title": "Jazz Dance (Intermediate)",
+    "credits": 1,
+    "description": "Prerequisites: DAN132 Emphasizes intermediate techniques of jazz dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": "DAN132 Emphasizes intermediate techniques of jazz dance. May be repeated for up to 4 credits.",
+    "prerequisite_courses": [
+      "DAN 132"
+    ]
+  },
+  {
+    "prefix": "FREN",
+    "number": "112",
+    "title": "First Year French II",
+    "credits": 4,
+    "description": "Prerequisites: FREN111 or equivalent or consent of instructor Continues with the second semester of the course to build on speaking, writing and reading skills in the French language.",
+    "prerequisite_text": "FREN111 or equivalent or consent of instructor Continues with the second semester of the course to build on speaking, writing and reading skills in the French language.",
+    "prerequisite_courses": [
+      "FREN 111"
+    ]
+  },
+  {
+    "prefix": "EDU",
+    "number": "207",
+    "title": "Explor. Child Literature",
+    "credits": 3,
+    "description": "Surveys children's literature: issues, genre, censorship, historical background, book evaluation and selection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "270",
+    "title": "Construction Management",
+    "credits": 1,
+    "description": "Prerequisites: CONS 260 or Consent of InstructorProvides the necessary lecture and laboratory experience to satisfy the state regulations concerning the General Level Inspection Regulation NAC 645D.120. Course number or instructor approval needed.",
+    "prerequisite_text": "CONS 260 or Consent of InstructorProvides the necessary lecture and laboratory experience to satisfy the state regulations concerning the General Level Inspection Regulation NAC 645D.120. Course number or instructor approval needed.",
+    "prerequisite_courses": [
+      "CONS 260",
+      "NAC 645D"
+    ]
+  },
+  {
+    "prefix": "CPD",
+    "number": "116",
+    "title": "Substance Abuse",
+    "credits": 3,
+    "description": "Covers topics related to substance abuse in society: identification of substance, reasons for abuse of alcohol and of drugs, signs and symptoms of substance abuse, and approaches and techniques recognized as effective in substance abuse counseling.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "123",
+    "title": "Oboe - Lower Division",
+    "credits": 1,
+    "description": "Provides personal introduction to the study and performance of music for horn. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DAN",
+    "number": "260",
+    "title": "Interm. Hip-Hop Dance",
+    "credits": 1,
+    "description": "Prerequisites: DAN160B Teaches intermediate techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": "DAN160B Teaches intermediate techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_courses": [
+      "DAN 160B"
+    ]
+  },
+  {
+    "prefix": "PHYS",
+    "number": "151A",
+    "title": "General Physics I - Lecture",
+    "credits": 3,
+    "description": "Prerequisites: MATH126 & MATH127,or MATH128 or equivalent. For non-physical science majors. Topics include kinematics, Newton's laws of motion, energy and momentum conservation, rotational dynamics, thermodynamics, fluids, harmonic motion, and sound.",
+    "prerequisite_text": "MATH126 & MATH127,or MATH128 or equivalent. For non-physical science majors. Topics include kinematics, Newton's laws of motion, energy and momentum conservation, rotational dynamics, thermodynamics, fluids, harmonic motion, and sound.",
+    "prerequisite_courses": [
+      "MATH 126",
+      "MATH 127",
+      "MATH 128"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "299",
+    "title": "Special Topics in English",
+    "credits": 3,
+    "description": "Includes short courses and experimental classes covering a variety of subjects. May be repeated for up to three credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "299",
+    "title": "Spec Topics in Studio Art",
+    "credits": 3,
+    "description": "Applies to assorted short courses and workshops covering a variety of subjects. May be repeated for up to six credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTP",
+    "number": "103",
+    "title": "Bt Plumbing Level III",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AV",
+    "number": "111",
+    "title": "Private Pilot Lab",
+    "credits": 3,
+    "description": "Co-requisites: AV 110Students will begin their flight training with an FAA Certificated Flight Instructor, covering all skills necessary to pass the FAA Private Pilot Airplane Certificate Practical Exam. To qualify for the FAA Private Pilot Certificate, students must meet the following requirements: be at least 17 years old, be able to read, speak, write, and understand English, hold at least a third-class medical certificate, and complete both ground and flight training, including a minimum of 40 flight hours with specific time requirements for solo and dual instruction.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "295",
+    "title": "CTE Teaching Internship",
+    "credits": 6,
+    "description": "Observation and teaching under supervision in a secondary school, community or technical college, or business and industry training environment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "298",
+    "title": "Wk Exp - Probation/Parole",
+    "credits": 6,
+    "description": "Prerequisites: CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_text": "CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "203",
+    "title": "Interpreting Sign Lng III",
+    "credits": 3,
+    "description": "Prerequisites: AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "prerequisite_text": "AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "prerequisite_courses": [
+      "AM 202"
+    ]
+  },
+  {
+    "prefix": "AST",
+    "number": "109",
+    "title": "Planetary Astronomy",
+    "credits": 3,
+    "description": "Prerequisites: MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to current concepts of the solar system, modern observational techniques, and their results. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "prerequisite_text": "MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to current concepts of the solar system, modern observational techniques, and their results. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "BTL",
+    "number": "108",
+    "title": "Permit Required Confined Space",
+    "credits": 1,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers the hazards associated with working in confined spaces and safety precautions that must be taken during this work. Hands-on activities include preparing for and entering a mock confined space.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers the hazards associated with working in confined spaces and safety precautions that must be taken during this work. Hands-on activities include preparing for and entering a mock confined space.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "181",
+    "title": "Physics Science/Eng II",
+    "credits": 3,
+    "description": "Prerequisites: MATH 182 AND PHYS 180. Corequisite: PHYS 181L. Explores electric fields, potential, current, dielectrics, circuits, magnetic fields, electromagnetic oscillations, thermodynamics and kinetic theory of gases. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_text": "MATH 182 AND PHYS 180. Corequisite: PHYS 181L. Explores electric fields, potential, current, dielectrics, circuits, magnetic fields, electromagnetic oscillations, thermodynamics and kinetic theory of gases. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_courses": [
+      "MATH 182",
+      "PHYS 180",
+      "PHYS 181L"
+    ]
+  },
+  {
+    "prefix": "CIT",
+    "number": "230",
+    "title": "Advanced Java",
+    "credits": 3,
+    "description": "Prerequisites: CIT130 Builds upon the foundation constructed in Beginning Java. Since Java works behind the scenes to power Internet applications, this class will focus more heavily upon application development with an emphasis on client-side and server-side techniques. Topics include, but not limited to, inheritance, interfaces, exception handling, javafx, input and ouput to files and databases, data structures, generics, and searching and sort algorithms.",
+    "prerequisite_text": "CIT130 Builds upon the foundation constructed in Beginning Java. Since Java works behind the scenes to power Internet applications, this class will focus more heavily upon application development with an emphasis on client-side and server-side techniques. Topics include, but not limited to, inheritance, interfaces, exception handling, javafx, input and ouput to files and databases, data structure",
+    "prerequisite_courses": [
+      "CIT 130"
+    ]
+  },
+  {
+    "prefix": "PEX",
+    "number": "136",
+    "title": "Snow Boarding",
+    "credits": 1,
+    "description": "Prerequisites: intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the ski area.",
+    "prerequisite_text": "intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the s",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ITAL",
+    "number": "111",
+    "title": "First Year Italian I",
+    "credits": 4,
+    "description": "Prerequisites: NoneIntroduces the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "prerequisite_text": "NoneIntroduces the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "162",
+    "title": "Building Analyst Professional",
+    "credits": 1,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent) and ENRG 161 or BPI BA-T certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to use energy modeling software to model the energy upgrade potential of a home, develop a scope of work and for success on the nationally recognized BPI BA-P Certification examination.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent) and ENRG 161 or BPI BA-T certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to use energy modeling software to model the energy upgrade potential of a home, develop a scope of work and for succes",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161"
+    ]
+  },
+  {
+    "prefix": "MUS",
+    "number": "104",
+    "title": "Voice Class II",
+    "credits": 3,
+    "description": "Prerequisites: MUS103 Continues the skills learned in MUS 103.",
+    "prerequisite_text": "MUS103 Continues the skills learned in MUS 103.",
+    "prerequisite_courses": [
+      "MUS 103"
+    ]
+  },
+  {
+    "prefix": "EMS",
+    "number": "203",
+    "title": "Paramedic Skills",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Familiarizes the Paramedic student with nationally recognized testing. Provides skill-based practice and assessments in a laboratory environment.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Familiarizes the Paramedic student with nationally recognized testing. Provides skill-based practice and assessments in a laboratory environment.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "121",
+    "title": "Principle Cons Estimating",
+    "credits": 3,
+    "description": "Prerequisite: CONS 120 and CONS 216Presents basic criteria and procedure for estimating labor and material in residential and commercial applications.",
+    "prerequisite_text": "CONS 120 and CONS 216Presents basic criteria and procedure for estimating labor and material in residential and commercial applications.",
+    "prerequisite_courses": [
+      "CONS 120"
+    ]
+  },
+  {
+    "prefix": "BUS",
+    "number": "271",
+    "title": "Introduction to Employment Law",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101. Recommend MGT 283Provides a framework to develop productive and effective employers and employees in the workplace. Topics include federal and state labor and employment laws and how they impact employers, employees and the workforce environment.",
+    "prerequisite_text": "BUS 101. Recommend MGT 283Provides a framework to develop productive and effective employers and employees in the workplace. Topics include federal and state labor and employment laws and how they impact employers, employees and the workforce environment.",
+    "prerequisite_courses": [
+      "BUS 101"
+    ]
+  },
+  {
+    "prefix": "GRC",
+    "number": "220",
+    "title": "Graphic Design I",
+    "credits": 3,
+    "description": "Prerequisites: GRC 116, GRC 200, GRC 210Emphasizes principles and language of graphic design. Provides further development of an understanding of visual communications theories, processes and methods using current industry technologies. Focuses on advancing student's ability, using research and thumbnails, to devise and produce wide varieties of solutions to visual problems through assigned graphic design projects.",
+    "prerequisite_text": "GRC 116, GRC 200, GRC 210Emphasizes principles and language of graphic design. Provides further development of an understanding of visual communications theories, processes and methods using current industry technologies. Focuses on advancing student's ability, using research and thumbnails, to devise and produce wide varieties of solutions to visual problems through assigned graphic design projec",
+    "prerequisite_courses": [
+      "GRC 116",
+      "GRC 200"
+    ]
+  },
+  {
+    "prefix": "ANTH",
+    "number": "443",
+    "title": "Environmental Archaeology",
+    "credits": 3,
+    "description": "Topics selected from paleoecology, taphonomy, geoarchaeology, and dating methods. Lectures, readings, and field trips cover advanced principles, method and theory, and practical applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "245",
+    "title": "Foundations of Elem Literacy",
+    "credits": 3,
+    "description": "This course is designed to teach paraprofessionals, substitute teachers, and other support staff current research, theory, methods, and instructional strategies related to the science of reading. The curriculum will focus on the 5 pillars of literacy instruction. Effective literacy assessments, intervention strategies, and differentiation techniques will also be explored.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "100",
+    "title": "Healthcare Provider CPR",
+    "credits": 0.5,
+    "description": "Provides instruction of Basic Cardiac Life Support/ Cardiopulmonary Resuscitation for the Healthcare Provider which includes: one and two person rescuer for CPR and management of foreign body obstruction of the airway in adults, children and infants. Instruction also provides for recognition of signs and symptoms requiring AED intervention, safe administration of AED, and common actions that can be utilized for survival, and prevention of risk factors for heart attack and stroke. Certification according to the standards of the American Heart Association (AHA) is issued upon successful completion of course which requires passing of a written examination and practical demonstration. The course satisfies the CPR requirement for students admitted to the nursing and surgical technology programs, nursing assistant and EMS courses. May be repeated for up to one credit.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "275",
+    "title": "Mechatronics 2: Mfg Processes",
+    "credits": 3,
+    "description": "Prerequisites: AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Course is divided into two main sections: process management, and function and importance of a hands-on design project. Lessons and labs explore engineering technology in ways that ensure students have an awareness of what it is like to work with customers, timelines, budgetary restrictions, and in general to include some basic business sense in the spirit of their work. The simulations and exercises in this course emphasize business-related factors that further develop well-rounded mechatronics technicians.",
+    "prerequisite_text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Course is divided into two main sections: process management, and function and importance of a hands-on design project. Lessons and labs explore engineering technology in w",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACC",
+    "number": "180",
+    "title": "Payroll/Empl Benefit Acct",
+    "credits": 3,
+    "description": "Prerequisites: ACC135,ACC201 or equivalent work experience Introduces payroll and employee benefit reporting to federal state, and local government agencies. Includes an overview of federal and state labor laws and specialized reporting requirements including both manual and computerized payroll accounting systems.",
+    "prerequisite_text": "ACC135,ACC201 or equivalent work experience Introduces payroll and employee benefit reporting to federal state, and local government agencies. Includes an overview of federal and state labor laws and specialized reporting requirements including both manual and computerized payroll accounting systems.",
+    "prerequisite_courses": [
+      "ACC 135",
+      "ACC 201"
+    ]
+  },
+  {
+    "prefix": "BIOL",
+    "number": "190",
+    "title": "Intro to Cell & Molec Bio",
+    "credits": 4,
+    "description": "Prerequisite: Math 124 or higher with a grade of C- or higher; or, placementinto a MATH course numbered 127 or higher; or, ACT MATH score of 25 orhigher or SAT MATH score of 560 or higher; or, a grade of B- or better in highschool precalculus.Covers the structure and functions of cells. Includes the major molecules of life, composition and physiology of cellular organelles, cellular metabolism, reproduction, motility, gene function and related topics. Meets for a total of 45 lab hours and 45 lecture hours. Note: BIOL 190 plus BIOL 191 transfer to UNR as fulfilling BIOL 190, 191 and 192 requirements.",
+    "prerequisite_text": "Math 124 or higher with a grade of C- or higher; or, placementinto a MATH course numbered 127 or higher; or, ACT MATH score of 25 orhigher or SAT MATH score of 560 or higher; or, a grade of B- or better in highschool precalculus.Covers the structure and functions of cells. Includes the major molecules of life, composition and physiology of cellular organelles, cellular metabolism, reproduction, mo",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSC",
+    "number": "210",
+    "title": "American Public Policy",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended prerequisite or corequisite: ENG 101, or eligibility to enroll in ENG 101.Explores an analysis of the interplay of forces involved in policy-making at all levels of American government. Studies the impact of policy on individuals and institutions.",
+    "prerequisite_text": "None. Recommended prerequisite or corequisite: ENG 101, or eligibility to enroll in ENG 101.Explores an analysis of the interplay of forces involved in policy-making at all levels of American government. Studies the impact of policy on individuals and institutions.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "PHYS",
+    "number": "180L",
+    "title": "Physics Science/Eng Lab I",
+    "credits": 1,
+    "description": "Prerequisites: MATH181 ; Corequisites: PHYS180 Explores vectors, rectilinear motion, particle dynamics, work and energy, momentum, rotational mechanics, oscillations, gravitation, fluids, wave properties and sound. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_text": "MATH181 ; Corequisites: PHYS180 Explores vectors, rectilinear motion, particle dynamics, work and energy, momentum, rotational mechanics, oscillations, gravitation, fluids, wave properties and sound. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_courses": [
+      "MATH 181",
+      "PHYS 180"
+    ]
+  },
+  {
+    "prefix": "BUS",
+    "number": "101",
+    "title": "Intro to Business",
+    "credits": 3,
+    "description": "Provides the student a broad background about the modern business world. An important course for students who are considering choosing a business major.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTS",
+    "number": "105",
+    "title": "BT Construction Sheet Metal V",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 5 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 5 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "180",
+    "title": "Strength Training",
+    "credits": 2,
+    "description": "Introduces resistance training and proper lifting techniques to strength (weight)training students. Safety rules, proper use of equipment and concepts of lifting will be emphasized.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ITAL",
+    "number": "112",
+    "title": "First Year Italian II",
+    "credits": 4,
+    "description": "Prerequisites: ITAL111 or consent of instructorContinues study of the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "prerequisite_text": "ITAL111 or consent of instructorContinues study of the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "prerequisite_courses": [
+      "ITAL 111"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "129",
+    "title": "Level I Basic Nursing Skills",
+    "credits": 2,
+    "description": "Prepares students to provide holistic basic nursing care within the lab simulation environment. Students provide total patient care and comfort measures at the level of a nursing assistant while incorporating basic principles of safety and infection control for self and others. This is an alternative prerequisite (in lieu of the Certified Nursing Assistant class) for the WNC nursing program. Note: This class does NOT prepare students to sit for the Nevada State Board of Nursing Certified Nursing Assistant Examination.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSE",
+    "number": "101",
+    "title": "Concert Choir",
+    "credits": 1,
+    "description": "Teaches representative choral music of all periods. Choir is featured in concerts throughout the WNC service area. May be repeated for a total of four credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "152",
+    "title": "Fingerspelling II",
+    "credits": 1,
+    "description": "Prerequisites: AM151 or current enrollment in AM 151 Improves receptive and expressive fingerspelling skills to intermediate/advanced levels.",
+    "prerequisite_text": "AM151 or current enrollment in AM 151 Improves receptive and expressive fingerspelling skills to intermediate/advanced levels.",
+    "prerequisite_courses": [
+      "AM 151"
+    ]
+  },
+  {
+    "prefix": "CEM",
+    "number": "453",
+    "title": "Construction Scheduling",
+    "credits": 3,
+    "description": "Additional Prerequisites: CONS 109, 281, and MATH 126Provides an overview of scheduling and resource optimization. Includes short-interval scheduling, Gantt charts, linear, and matrix scheduling formats. Covers network techniques including CPM and PERT concepts and calculations and computer applications using Microsoft Project.",
+    "prerequisite_text": "CONS 109, 281, and MATH 126Provides an overview of scheduling and resource optimization. Includes short-interval scheduling, Gantt charts, linear, and matrix scheduling formats. Covers network techniques including CPM and PERT concepts and calculations and computer applications using Microsoft Project.",
+    "prerequisite_courses": [
+      "CONS 109"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "148",
+    "title": "Health Assessment Lab",
+    "credits": 1,
+    "description": "Prerequisites: admission to the nursing program. Incorporates knowledge from NURS 147 to provide students with learning opportunities to collect, organize, analyze and synthesize health assessment data for adult and elder patients in a laboratory setting using simulated and peer assessment models.",
+    "prerequisite_text": "admission to the nursing program. Incorporates knowledge from NURS 147 to provide students with learning opportunities to collect, organize, analyze and synthesize health assessment data for adult and elder patients in a laboratory setting using simulated and peer assessment models.",
+    "prerequisite_courses": [
+      "NURS 147"
+    ]
+  },
+  {
+    "prefix": "CHEM",
+    "number": "110",
+    "title": "Chemistry for Health Sci.",
+    "credits": 4,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "JPN",
+    "number": "112",
+    "title": "First Year Japanese II",
+    "credits": 4,
+    "description": "Prerequisites: JPN 111Continues study of the language through structural analysis and the writing system. Includes some conversation and an introduction to Japanese culture.",
+    "prerequisite_text": "JPN 111Continues study of the language through structural analysis and the writing system. Includes some conversation and an introduction to Japanese culture.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AV",
+    "number": "110",
+    "title": "Private Pilot Ground School",
+    "credits": 4,
+    "description": "Prerequisite: NoneA study of aviation fundamentals including principles of flight, aircraft and engine operations, weather, navigation, and radio communications as required by the Federal Aviation Administration (FAA) regulations. Topics will include general service, maintenance, and safety practices.",
+    "prerequisite_text": "NoneA study of aviation fundamentals including principles of flight, aircraft and engine operations, weather, navigation, and radio communications as required by the Federal Aviation Administration (FAA) regulations. Topics will include general service, maintenance, and safety practices.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "130",
+    "title": "Nursing Assistant",
+    "credits": 6,
+    "description": "Prerequisites: basic Life Support/Healthcare Provider CPR certification. See Nursing and Allied Health website for additional information. Prepares students to function as nursing assistant trainees (NAT) who assist licensed nurses to provide direct care to health care consumers across the lifespan in a variety of heath care settings. The 150-hour competency based course is designed to prepare students to achieve certification as a nurse assistant in the State of Nevada. The course is approved by the Nevada State Board of Nursing and is in accordance with the Omnibus Budget Reconciliation Act (OBRA) and Occupational Safety and Health Agency (OSHA) regulations.",
+    "prerequisite_text": "basic Life Support/Healthcare Provider CPR certification. See Nursing and Allied Health website for additional information. Prepares students to function as nursing assistant trainees (NAT) who assist licensed nurses to provide direct care to health care consumers across the lifespan in a variety of heath care settings. The 150-hour competency based course is designed to prepare students to achiev",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "215",
+    "title": "Technique of Songwriting",
+    "credits": 3,
+    "description": "Offers a practical course in composing pop music. Analysis of hit songs and discussion of songs written by the class. Each student will compose melodies and lyrics, helping the poet with music and the musician with poetry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "270",
+    "title": "Network Tools",
+    "credits": 4,
+    "description": "Prerequisites: CIT 112 or Consent of InstructorIntroduces current needed tools and techniques to effectively enumerate, map, document, investigate, and configure within current network architectures and environments. Focuses on tools and methods needed in computer and network technician, and cybersecurity roles.",
+    "prerequisite_text": "CIT 112 or Consent of InstructorIntroduces current needed tools and techniques to effectively enumerate, map, document, investigate, and configure within current network architectures and environments. Focuses on tools and methods needed in computer and network technician, and cybersecurity roles.",
+    "prerequisite_courses": [
+      "CIT 112"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "110",
+    "title": "Basic Wildland Firefighting",
+    "credits": 3,
+    "description": "Prerequisites: NoneAddresses the basic elements of wildland fire protection, fire behavior, department organization, apparatus and equipment, fire safety and incident command organization.",
+    "prerequisite_text": "NoneAddresses the basic elements of wildland fire protection, fire behavior, department organization, apparatus and equipment, fire safety and incident command organization.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FT",
+    "number": "154",
+    "title": "Prin Fire Emg Svcs Safety Surv",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduces the basic principles and history related to the national firefighter life safety initiatives, focusing on the need for cultural and behavior change throughout the emergency services. FESHE Core Course.",
+    "prerequisite_text": "NoneIntroduces the basic principles and history related to the national firefighter life safety initiatives, focusing on the need for cultural and behavior change throughout the emergency services. FESHE Core Course.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "109",
+    "title": "Drum Set",
+    "credits": 1,
+    "description": "Provides individual instruction in the technique and repertoire of drum set. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "274",
+    "title": "Ethical Hacking",
+    "credits": 3,
+    "description": "Prerequisites: Instructor ConsentExplains basic IT security concepts and models. Introduces concepts of penetration testing to validate security measures and identify vulnerabilities; formulate a basic security policy; demonstrate basic penetration attacks; assess risks and countermeasures; explain legal and ethical concerns as they apply to penetration testing; explores methods to gain access to computer resources and methods to prevent/reduce vulnerabilities.",
+    "prerequisite_text": "Instructor ConsentExplains basic IT security concepts and models. Introduces concepts of penetration testing to validate security measures and identify vulnerabilities; formulate a basic security policy; demonstrate basic penetration attacks; assess risks and countermeasures; explain legal and ethical concerns as they apply to penetration testing; explores methods to gain access to computer resour",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "247",
+    "title": "Intro. to Hist. of Mexico",
+    "credits": 3,
+    "description": "Introduces pre-Columbian Mexico, Colonial New Spain and Mexican national history to the present.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "111",
+    "title": "First Year French I",
+    "credits": 4,
+    "description": "Develops language skills through practice in listening, speaking, reading, writing and structural analysis. Includes an introduction to French culture.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SUR",
+    "number": "119",
+    "title": "Construction Surveying",
+    "credits": 3,
+    "description": "Prerequisites: CONS108 or consent of instructor Presents care and use of surveying equipment. Profile elevation and closed traverse projects will provide hands-on experience. Construction staking will be explained in detail.",
+    "prerequisite_text": "CONS108 or consent of instructor Presents care and use of surveying equipment. Profile elevation and closed traverse projects will provide hands-on experience. Construction staking will be explained in detail.",
+    "prerequisite_courses": [
+      "CONS 108"
+    ]
+  },
+  {
+    "prefix": "ET",
+    "number": "131",
+    "title": "Dc for Electronics",
+    "credits": 6,
+    "description": "Familiarizes students with fundamentals of electronics including how to read resistor color codes, decipher capacitor values, and use electronic schematics to build simple electronic devices. Students conduct laboratory experiments to apply theoretical concepts and will use standard or simulated laboratory instruments such as multimeters. Covers Ohm's Law and Kirchhoff's Laws of voltage and current, and simple series and parallel circuits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "145",
+    "title": "American Sign Lang I",
+    "credits": 4,
+    "description": "Introduces ASL and focuses on the development of basic conversational skills, emphasizing receptive abilities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CSCO",
+    "number": "120",
+    "title": "Ccna Internetworking Fund",
+    "credits": 4,
+    "description": "Introduces the architecture, structure, functions, components, and models of the Internet and other computer networks. Uses the OSI and TCP layered models to examine the nature and roles of protocols and services at the application, network, data link, and physical layers. Principles and structure of IP addressing and the fundamentals of Ethernet concepts, media, and operations are introduced.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "218",
+    "title": "The Artist's Book",
+    "credits": 3,
+    "description": "Prerequisite: ART 214 or instructor permissionProvides the opportunity for students to create a limited-edition, letterpress-printed artist's book edition of 12-15 copies. Students will write original text, generate imagery using traditional and alternative printing techniques, hand set type, letterpress print on antique printing pressed, and hand-bind each copy of their artist's book.",
+    "prerequisite_text": "ART 214 or instructor permissionProvides the opportunity for students to create a limited-edition, letterpress-printed artist's book edition of 12-15 copies. Students will write original text, generate imagery using traditional and alternative printing techniques, hand set type, letterpress print on antique printing pressed, and hand-bind each copy of their artist's book.",
+    "prerequisite_courses": [
+      "ART 214"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "106",
+    "title": "Firefighter Academy I",
+    "credits": 12,
+    "description": "Prerequisites: EMS 108 or current State of Nevada EMT certification FT 101, and FT 109 OR EMS 108 or current State of Nevada EMT certification and six months of firefighting experience and Candidate Physical Abilities Test (CPAT) certification within 12 months of the course start date. Corequisite: FT 131This course combines lecture with hands on firefighting skills to meet the requirements of the Nevada State Fire Training Firefighter I and the National Fire Protection Association (NFPA). Topics include fire service organization, fire safety, tools and equipment, fire prevention, incident management systems, wildland fire fighting and fire suppression techniques. Students who successfully complete the Academy are eligible for Nevada State Fire Marshal certification as a Firefighter I and National Wildfire Coordinating Group (NWCG) certificates S-110, S-130 and S-190)",
+    "prerequisite_text": "EMS 108 or current State of Nevada EMT certification FT 101, and FT 109 OR EMS 108 or current State of Nevada EMT certification and six months of firefighting experience and Candidate Physical Abilities Test (CPAT) certification within 12 months of the course start date. Corequisite: FT 131This course combines lecture with hands on firefighting skills to meet the requirements of the Nevada State",
+    "prerequisite_courses": [
+      "EMS 108",
+      "FT 101",
+      "FT 109"
+    ]
+  },
+  {
+    "prefix": "ENRG",
+    "number": "165",
+    "title": "Professional Home Energy Audit",
+    "credits": 3,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to learn the most advanced methods for testing buildings and be prepared for success on the HEP Energy Auditor certification.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to learn the most advanced methods for testing build",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  {
+    "prefix": "ENRG",
+    "number": "160",
+    "title": "Building Science Principles",
+    "credits": 1,
+    "description": "This introductory course prepares students to develop a comprehensive view of the importance of energy auditing and retrofit work in improving home energy efficiency as well as understanding how all of the systems (e.g. HVAC, insulation, appliances) affect the comfort, health, and safety of occupants and durability of the home. This course prepares students for success on the BPI Building Science Principles Certificate of Knowledge examination.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "141",
+    "title": "Viola-Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for viola. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "125",
+    "title": "Softball",
+    "credits": 1,
+    "description": "Focuses on advanced softball skill development, competition techniques and strategy for highly skilled participants in competitive softball. May be repeated for up to six credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "120",
+    "title": "Psych of Hum Performance",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Surveys the psychology of human performance. Explores the psychological, emotional, and strategic dimensions of human performance. Emphasis will be to provide students with a comprehensive background that they can apply to their own performance areas.",
+    "prerequisite_text": "PSY101 or consent of instructor Surveys the psychology of human performance. Explores the psychological, emotional, and strategic dimensions of human performance. Emphasis will be to provide students with a comprehensive background that they can apply to their own performance areas.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "MPT",
+    "number": "114",
+    "title": "Manufacturing & Automation III",
+    "credits": 3,
+    "description": "Prerequisite(s): MPT 112 or concurrent enrollmentA continuation of MPT 112. Production and automation systems management and control are further developed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "217",
+    "title": "Lang/Litrcy For Deaf Children",
+    "credits": 3,
+    "description": "Teaches the process of language acquisition and literacy development for children who are deaf or have a hearing loss. Includes comparison to the natural acquisition of language for all children and adults. Includes clinical, cultural, historical and audiological descriptions of deafness; the unique linguistic aspects of language and literacy acquisition and most importantly, practical application and activities that can be utilized with deaf/hard of hearing children. Geared to all persons wishing to learn about language and literacy acquisition, but especially geared to parents, educational interpreters, speech and language pathologists, audiologist, and teacher of dear and hard of hearing children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "105",
+    "title": "Building Trades Carpentry V",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 5 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 5 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DAN",
+    "number": "144",
+    "title": "Beginning Tap Dancing",
+    "credits": 1,
+    "description": "Introduces beginning techniques of tap dance. May be repeated for up to four credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ANTH",
+    "number": "198",
+    "title": "Special Topics: Anthropology",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "198",
+    "title": "Special Topics in AIT",
+    "credits": 6,
+    "description": "Explores various topics of current interest/demand in Applied Industrial Technology areas of study. Applies to a variety of current topics in the field of industrial technology, covering subjects such as new approaches and techniques, equipment configuration, upgrades, preventive maintenance, etc.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "260",
+    "title": "Cert Insp-Residential",
+    "credits": 3,
+    "description": "Provides prescribed course of instruction for Certified Inspector of Structures as per the state of Nevada.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "121",
+    "title": "Horn - Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for horn. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACC",
+    "number": "202",
+    "title": "Managerial Accounting",
+    "credits": 3,
+    "description": "Prerequisites: ACC 201 with a grade of C or betterIntroduces the basic principles of management accounting including manufacturing and cost accounting, budgeting, accounting for management decision-making, and financial statement analysis.",
+    "prerequisite_text": "ACC 201 with a grade of C or betterIntroduces the basic principles of management accounting including manufacturing and cost accounting, budgeting, accounting for management decision-making, and financial statement analysis.",
+    "prerequisite_courses": [
+      "ACC 201"
+    ]
+  },
+  {
+    "prefix": "BIOL",
+    "number": "113",
+    "title": "Life in the Oceans",
+    "credits": 3,
+    "description": "Introduces the plants, animals and microorganisms of the oceans with an emphasis on important marine ecosystems such as intertidal zones, estuaries and coral reefs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LTE",
+    "number": "102",
+    "title": "Applied Phlebotomy",
+    "credits": 3.5,
+    "description": "Prerequisites: LTE 101 with C or better. Vaccinations and major medical insurance. See Nursing and Allied Health Division student requirements for LTE.Provides 100 hours of clinical phlebotomy experience (of clinical phlebotomy to apply knowledge and skills learned in LTE 101. Under the guidance of a laboratory technician preceptor, students will perform a minimum of 100 successful, documented blood draws with patients across the lifespan (except infants and toddlers). Upon successful completion with a grade of C or better, students are eligible to sit for a national certification examination offered through a variety of certifying organizations, including the American Society for Clinical Pathology (ASCP).",
+    "prerequisite_text": "LTE 101 with C or better. Vaccinations and major medical insurance. See Nursing and Allied Health Division student requirements for LTE.Provides 100 hours of clinical phlebotomy experience (of clinical phlebotomy to apply knowledge and skills learned in LTE 101. Under the guidance of a laboratory technician preceptor, students will perform a minimum of 100 successful, documented blood draws with",
+    "prerequisite_courses": [
+      "LTE 101"
+    ]
+  },
+  {
+    "prefix": "FIN",
+    "number": "101",
+    "title": "Personal Finance",
+    "credits": 3,
+    "description": "Introduces personal financial planning. Emphasizes budgeting, obtaining credit, buying decisions for a home, auto or other large purchases, investment decisions, and retirement planning.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "216",
+    "title": "Receptive ASL",
+    "credits": 4,
+    "description": "Prerequisites: AM147 Provides opportunities for students to develop receptive skills with a wide variety of signers. Receptive language of children, teens, adults with various socio-economic levels, and senior signers will be developed. Acquisition and comprehension of regional signs, \"slang\" signs, and generational signs will also be emphasized.",
+    "prerequisite_text": "AM147 Provides opportunities for students to develop receptive skills with a wide variety of signers. Receptive language of children, teens, adults with various socio-economic levels, and senior signers will be developed. Acquisition and comprehension of regional signs, \"slang\" signs, and generational signs will also be emphasized.",
+    "prerequisite_courses": [
+      "AM 147"
+    ]
+  },
+  {
+    "prefix": "EPD",
+    "number": "276",
+    "title": "Mgmt Mthds for Subs",
+    "credits": 3,
+    "description": "Offers practical methods and ready-to-use ideas for K-12 substitutes, including models of discipline, attentions signals, active participation, instant ideas, transition activities, methods for dealing with problem behavior, and inclusion strategies.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELM",
+    "number": "131",
+    "title": "National Electric Code",
+    "credits": 3,
+    "description": "Prerequisite(s): Must be admitted to an approved apprenticeship program.Survey of the National Electric Code (NEC) and its application to the safe installation of electrical conductors and equipment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "454",
+    "title": "Heavy Cons Methods/Equipment",
+    "credits": 3,
+    "description": "Additional prerequisites: CEM 330 and MATH 126Covers characteristics, capabilities, limitations, uses, and selection techniques for heavy construction methods and equipment process planning, simulation, fleet operations, and maintenance programs",
+    "prerequisite_text": "CEM 330 and MATH 126Covers characteristics, capabilities, limitations, uses, and selection techniques for heavy construction methods and equipment process planning, simulation, fleet operations, and maintenance programs",
+    "prerequisite_courses": [
+      "CEM 330"
+    ]
+  },
+  {
+    "prefix": "EMS",
+    "number": "209",
+    "title": "Patient Assessment",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Introduces the Paramedic student to a comprehensive physical examination and assessment, which includes history taking, clinical decision making, communications, and documentation.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Introduces the Paramedic student to a comprehensive physical examination and assessment, which includes history taking, clinical decision making, communications, and documentation.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "209",
+    "title": "World History II",
+    "credits": 3,
+    "description": "Prerequisites: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll ENG 101A review of the principal developments in world history since 1600, including scientific and technological revolutions, social revolutions, nationalism, immigration, colonialism, world wars, decolonization, modernization, democracy, and dictatorships.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll ENG 101A review of the principal developments in world history since 1600, including scientific and technological revolutions, social revolutions, nationalism, immigration, colonialism, world wars, decolonization, modernization, democracy, and dictatorships.",
+    "prerequisite_courses": [
+      "ENG 101",
+      "ENG 101A"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "273",
+    "title": "Mechatronics 2: Motor Control",
+    "credits": 3,
+    "description": "Prerequisites: AIT 253Covers general machine operation, different types of braking and loads on a motor, and motor efficiency and power. Different control techniques are introduced, including different methods of starting a motor, controlling voltage and frequency, and the role of different sensors in relation to motor operation. Troubleshooting techniques and an examination of the various causes of motor failure are explored; preventive measures to protect motors are also introduced.",
+    "prerequisite_text": "AIT 253Covers general machine operation, different types of braking and loads on a motor, and motor efficiency and power. Different control techniques are introduced, including different methods of starting a motor, controlling voltage and frequency, and the role of different sensors in relation to motor operation. Troubleshooting techniques and an examination of the various causes of motor failur",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "131",
+    "title": "Saxophone-Lower Division",
+    "credits": 2,
+    "description": "Introduces students to the study and performance of music for saxophone. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "280",
+    "title": "Intro to Blockchain Concepts",
+    "credits": 3,
+    "description": "Prerequisites: MATH 124 or higherIntroduction to Blockchain technology; a type of distributed ledger technology. Covers what blockchain is, how blockchain was developed, how blockchain works, and the primary issues, challenges and opportunities blockchain faces. Engages students in hands-on contextualized code exercises, to lay a strong foundation for blockchain development.",
+    "prerequisite_text": "MATH 124 or higherIntroduction to Blockchain technology; a type of distributed ledger technology. Covers what blockchain is, how blockchain was developed, how blockchain works, and the primary issues, challenges and opportunities blockchain faces. Engages students in hands-on contextualized code exercises, to lay a strong foundation for blockchain development.",
+    "prerequisite_courses": [
+      "MATH 124"
+    ]
+  },
+  {
+    "prefix": "BTT",
+    "number": "101",
+    "title": "BT Telecomm Technician Level I",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 1 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 1 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "114",
+    "title": "Asphalt Worker",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroduces students to working with asphalt. Hands-on activities include: asphalt placement, raking, patching and repairing.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroduces students to working with asphalt. Hands-on activities include: asphalt placement, raking, patching and repairing.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "114",
+    "title": "IT Essentials",
+    "credits": 4,
+    "description": "Provides a comprehensive overview of the primary operating systems and the support of hardware devices. Demonstrates the integration between hardware and software. Emphasis is on installing, configuring, troubleshooting and upgrading a PC and working with computer users as an IT technician.Non-transferable/non-applicable towards an AA or AS degree",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "276",
+    "title": "Adv M/S Nsg. II Theory",
+    "credits": 3,
+    "description": "Prerequisites: successful completion of the third semester of the nursing program. ; Corequisites: NURS277 Assists students to gain knowledge of nursing care for the patient experiencing primary threats to physiological integrity due to complex multisystem disruption in cardiovascular, respiratory, neurological, integumentary, elimination, and digestive systems. Students apply the nursing process to address needs in the psycho/social/cultural and spiritual domains which emerge when there are primary threats to physiological integrity. Related legal, ethical, teaching/learning and communication/documentation issues are also explored.",
+    "prerequisite_text": "successful completion of the third semester of the nursing program. ; Corequisites: NURS277 Assists students to gain knowledge of nursing care for the patient experiencing primary threats to physiological integrity due to complex multisystem disruption in cardiovascular, respiratory, neurological, integumentary, elimination, and digestive systems. Students apply the nursing process to address need",
+    "prerequisite_courses": [
+      "NURS 277"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "146",
+    "title": "Voice II",
+    "credits": 2,
+    "description": "Continues development of correct and pleasing use of the voice for singers through study of vocal literature and exercises.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "102",
+    "title": "Agriculture Comm & Organiz",
+    "credits": 3,
+    "description": "Prerequisite: NoneDesigned for students interested in pursuing an agricultural career. Provides students with an in depth investigation into personal and interpersonal leadership. Teaches students to strengthen their leadership influence through a personal application of leadership skills, attitudes and dispositions.",
+    "prerequisite_text": "NoneDesigned for students interested in pursuing an agricultural career. Provides students with an in depth investigation into personal and interpersonal leadership. Teaches students to strengthen their leadership influence through a personal application of leadership skills, attitudes and dispositions.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "112",
+    "title": "Education Internship",
+    "credits": 3,
+    "description": "Prerequisites: EDU 110 or Instructor ConsentSupervised work and learning experience in research, public, education, business or government organizations related to Elementary or Secondary Education.",
+    "prerequisite_text": "EDU 110 or Instructor ConsentSupervised work and learning experience in research, public, education, business or government organizations related to Elementary or Secondary Education.",
+    "prerequisite_courses": [
+      "EDU 110"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "205",
+    "title": "Intro to Creative Writing",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Offers a beginning writers' workshop in poetry, fiction, and creative non-fiction.",
+    "prerequisite_text": "ENG102 or consent of instructor Offers a beginning writers' workshop in poetry, fiction, and creative non-fiction.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "270",
+    "title": "Mechatronics 2: PCT",
+    "credits": 3,
+    "description": "Prerequisites: AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Topics include closed loop and other technologies used in process control in the context of a complex mechatronic system are included. Students will understand and establish operating parameters as PID controllers are introduced and explored, along with strategies for optimizing them. Troubleshooting strategies for a variety of industry controllers and their applications are embedded throughout the course.",
+    "prerequisite_text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Topics include closed loop and other technologies used in process control in the context of a complex mechatronic system are included. Students will understand and establis",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "92",
+    "title": "Algebra Review",
+    "credits": 1,
+    "description": "Prerequisite: Previous success in Intermediate Algebra or Algebra II or higher algebra course. Provides a review of algebra that will refresh previously taught concepts. Designed for students who have successfully completed Algebra II or Intermediate Algebra or similar course sometime in the past. Provides a condensed review of topics from Intermediate Algebra intended to help students place into the appropriate course via Accuplacer Exam.",
+    "prerequisite_text": "Previous success in Intermediate Algebra or Algebra II or higher algebra course. Provides a review of algebra that will refresh previously taught concepts. Designed for students who have successfully completed Algebra II or Intermediate Algebra or similar course sometime in the past. Provides a condensed review of topics from Intermediate Algebra intended to help students place into the appropriat",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "125",
+    "title": "Organ-Lower Division",
+    "credits": 1,
+    "description": "Provides individual instruction in the technique and repertoire of the organ.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "125",
+    "title": "Industrial Robotics",
+    "credits": 6,
+    "description": "Prerequisites: AIT 101Covers the fundamentals of industrial robotics found in modern manufacturing, logistics and distribution environments. Covers servo robot system components, prepares students to perform robotic movement using articular and/or Cartesian coordinates, ensures exposure to the design of programs for point-to-point and task activities, includes analysis of industrial robotic integration to standardize production line systems, and integrates basic troubleshooting techniques into robot theory and operation.",
+    "prerequisite_text": "AIT 101Covers the fundamentals of industrial robotics found in modern manufacturing, logistics and distribution environments. Covers servo robot system components, prepares students to perform robotic movement using articular and/or Cartesian coordinates, ensures exposure to the design of programs for point-to-point and task activities, includes analysis of industrial robotic integration to standa",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "295",
+    "title": "Work Experience I",
+    "credits": 6,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "91",
+    "title": "Basic Mathematics",
+    "credits": 3,
+    "description": "Provides the fundamental operation of whole numbers, fractions and mixed numbers, decimals, percentage, measurement and geometry. The course is intended to provide a thorough review of basics needed in future mathematics courses and in applied fields.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "209",
+    "title": "Theatre Practicum",
+    "credits": 6,
+    "description": "Offers practical experience in stage productions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "257",
+    "title": "Intro to Positive Psychology",
+    "credits": 3,
+    "description": "Prerequisites: PSY101. Recommended: COM102 and SOC 101.Explores the scope of this new branch of Psychology. Key topics include: the history of Positive Psychology, positivity, learned optimism, purpose, handling adversity and resilience, happiness and well-being, personality development and integration, and positive relationships.",
+    "prerequisite_text": "PSY101. Recommended: COM102 and SOC 101.Explores the scope of this new branch of Psychology. Key topics include: the history of Positive Psychology, positivity, learned optimism, purpose, handling adversity and resilience, happiness and well-being, personality development and integration, and positive relationships.",
+    "prerequisite_courses": [
+      "PSY 101",
+      "COM 102",
+      "SOC 101"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "285",
+    "title": "AIT Certification/Exam Prep",
+    "credits": 3,
+    "description": "Reviews industrial technology theory and practice including devices and circuits, wiring techniques, controls, operation of test instruments, measurement methods, and troubleshooting of industrial systems. Manufacturing, distribution, and logistics practices and tasks will be covered as applicable. Prepares students for current industrial certification and employment tests through practice questions, example scenarios, and review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CADD",
+    "number": "120",
+    "title": "Architect Drafting I",
+    "credits": 3,
+    "description": "Prerequisites: CADD100 or equivalent experience Stresses blueprint reading skills. Introduces residential working drawing concepts leading to a full set of professional level working drawings.",
+    "prerequisite_text": "CADD100 or equivalent experience Stresses blueprint reading skills. Introduces residential working drawing concepts leading to a full set of professional level working drawings.",
+    "prerequisite_courses": [
+      "CADD 100"
+    ]
+  },
+  {
+    "prefix": "ELM",
+    "number": "134",
+    "title": "Programmable Logic Controllers",
+    "credits": 3,
+    "description": "Prerequisite(s): ELM 127Covers the fundamentals of digital logic and an introduction to programmable logic controllers (PLCs) in a complex mechatronic system. Students will learn the role PLCs play within a mechatronic system or subsystem; will explore basic elements of PLC functions by writing and testing programs to control them; identify malfunctioning PLCs, applying troubleshooting strategies to identify and localize problems caused by PLC hardware.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "276",
+    "title": "Musical Theatre Practicum II",
+    "credits": 3,
+    "description": "Prerequisite: Six units of MUS 176.Continues skills learned in MUS 176.Repeatable up to 9 units.",
+    "prerequisite_text": "Six units of MUS 176.Continues skills learned in MUS 176.Repeatable up to 9 units.",
+    "prerequisite_courses": [
+      "MUS 176"
+    ]
+  },
+  {
+    "prefix": "CRJ",
+    "number": "115",
+    "title": "Cultural Recog Hist Patrol Aca",
+    "credits": 3,
+    "description": "Prerequisite: Acceptance to the Police Officers Standards and Training AcademyProvides necessary training to recognize cultural awareness and bias recognition in the practice of patrol for law enforcement. Includes proper training and history of patrol basics with the integration of communication of various types, such as interpersonal, and cultural diversity.",
+    "prerequisite_text": "Acceptance to the Police Officers Standards and Training AcademyProvides necessary training to recognize cultural awareness and bias recognition in the practice of patrol for law enforcement. Includes proper training and history of patrol basics with the integration of communication of various types, such as interpersonal, and cultural diversity.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AV",
+    "number": "250",
+    "title": "Commrcl Aviation Ground School",
+    "credits": 4,
+    "description": "Provides aspiring pilots with the necessary knowledge and skills to pursue a career in commercial aviation. Essential topics related to commercial pilot operations, regulations, advanced navigation, meteorology, aerodynamics, and more will be covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IS",
+    "number": "101",
+    "title": "Intro to Information Sys",
+    "credits": 3,
+    "description": "Introduces the student to the role of computers in today's technology-driven environment, allowing for hands on lab experience. Students will be introduced to the Internet, distance education, and the World Wide Web for research, along with operating systems, word processing, spreadsheets, database and basic multi-media. Upon successful completion of this course, the student will be able to demonstrate basic computer survival skills, understand computer terminology, and create data using a variety of software.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "93",
+    "title": "Pre Algebra",
+    "credits": 3,
+    "description": "Prerequisites: MATH91 or equivalent or consent of instructor Prepares students for MATH 95. Helps students who have experienced difficulties with math to get an introduction to the language and concepts of algebra. Provides a transition from self-paced, basic math to the quick pace required in MATH 95.",
+    "prerequisite_text": "MATH91 or equivalent or consent of instructor Prepares students for MATH 95. Helps students who have experienced difficulties with math to get an introduction to the language and concepts of algebra. Provides a transition from self-paced, basic math to the quick pace required in MATH 95.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "206",
+    "title": "Fund of Animal Nutrition",
+    "credits": 3,
+    "description": "Prerequisite: AGSC 100 or 105Provides an overview of animal nutrition as the basis for livestock feeding and nutrition. Discusses the fundamentals of digestion and absorption in both ruminants and non-ruminants. Emphasizes the nutritive value of feeds as they relate to the formulation of livestock rations, including by-product feeding.",
+    "prerequisite_text": "AGSC 100 or 105Provides an overview of animal nutrition as the basis for livestock feeding and nutrition. Discusses the fundamentals of digestion and absorption in both ruminants and non-ruminants. Emphasizes the nutritive value of feeds as they relate to the formulation of livestock rations, including by-product feeding.",
+    "prerequisite_courses": [
+      "AGSC 100"
+    ]
+  },
+  {
+    "prefix": "ENV",
+    "number": "101",
+    "title": "Intro to Environmental Scienc",
+    "credits": 3,
+    "description": "Prerequisite: Math 120 or consent of instructor.Explores the fundamental components and interactions of earth's natural systems, the relationships between humans and environment, and solutions to current and potential environmental problems.",
+    "prerequisite_text": "Math 120 or consent of instructor.Explores the fundamental components and interactions of earth's natural systems, the relationships between humans and environment, and solutions to current and potential environmental problems.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTS",
+    "number": "104",
+    "title": "BT Construction Sheet Metal IV",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 4 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 4 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "271",
+    "title": "Intro to Shakespeare",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Examines Shakespeare's principal plays read for their social interest and their literary excellence.",
+    "prerequisite_text": "ENG102 or consent of instructor Examines Shakespeare's principal plays read for their social interest and their literary excellence.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "ANTH",
+    "number": "102",
+    "title": "Intro Biological Anth",
+    "credits": 5,
+    "description": "Recommended corequisite: ANTH 110LExplores the biological and evolutionary origins of humans through the examination of the fossil record, the study of primates, and the study of human biology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "298",
+    "title": "Special Topics in CTE Educatio",
+    "credits": 6,
+    "description": "Prerequisites: NoneVarious short courses and experimental classes covering a variety of subjects. The class will be a variable credit of one-half to six credits depending upon class content and number of hours required. The course may be repeated for up to six credits.",
+    "prerequisite_text": "NoneVarious short courses and experimental classes covering a variety of subjects. The class will be a variable credit of one-half to six credits depending upon class content and number of hours required. The course may be repeated for up to six credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "242L",
+    "title": "Organic Chem Lab II",
+    "credits": 1,
+    "description": "Prerequisites: CHEM241 & CHEM241L; Corequisite: CHEM242 Provides an emphasis on functional groups, fundamental reaction mechanisms, and biomoleculaes. For life science and sciences majors. Three hours laboratory.",
+    "prerequisite_text": "CHEM241 & CHEM241L; Corequisite: CHEM242 Provides an emphasis on functional groups, fundamental reaction mechanisms, and biomoleculaes. For life science and sciences majors. Three hours laboratory.",
+    "prerequisite_courses": [
+      "CHEM 241",
+      "CHEM 241L",
+      "CHEM 242"
+    ]
+  },
+  {
+    "prefix": "PEX",
+    "number": "143",
+    "title": "Karate",
+    "credits": 2,
+    "description": "Covers the basic history, philosophy and origins of Karate systems. Students are provided with demonstrations of the basic moves and are allowed to practice the moves with feedback. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "275",
+    "title": "Undergraduate Research",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 & PSY210&PSY240 Requires independent or collaborative research.",
+    "prerequisite_text": "PSY101 & PSY210&PSY240 Requires independent or collaborative research.",
+    "prerequisite_courses": [
+      "PSY 101",
+      "PSY 210",
+      "PSY 240"
+    ]
+  },
+  {
+    "prefix": "CRJ",
+    "number": "296",
+    "title": "Wk Exp - Juvenile Just",
+    "credits": 6,
+    "description": "Prerequisites: CRJ 104 or consent of instructor Provides the student with on-the job, supervised and educationally directed work experience.",
+    "prerequisite_text": "CRJ 104 or consent of instructor Provides the student with on-the job, supervised and educationally directed work experience.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "ACC",
+    "number": "105",
+    "title": "Taxation for Individuals",
+    "credits": 3,
+    "description": "Covers income, expenses, exclusions, deductions, and credits. Emphasizes the preparation of individual income tax.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SW",
+    "number": "230",
+    "title": "Crisis Intervention",
+    "credits": 3,
+    "description": "Analyzes types of crisis theory, effects of crisis on the individual, family and community. Looks at methods and resources for crisis intervention.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "260",
+    "title": "Machine Shop IV",
+    "credits": 3,
+    "description": "Prerequisites: MTT 250 or consent of instructor Concentrates on areas of interest leading to design of an advanced project emphasizing skills learned in MTT 105, MTT 110 and MTT 250.",
+    "prerequisite_text": "MTT 250 or consent of instructor Concentrates on areas of interest leading to design of an advanced project emphasizing skills learned in MTT 105, MTT 110 and MTT 250.",
+    "prerequisite_courses": [
+      "MTT 250",
+      "MTT 105",
+      "MTT 110"
+    ]
+  },
+  {
+    "prefix": "ENRG",
+    "number": "110",
+    "title": "Intro to Alternative Energy",
+    "credits": 3,
+    "description": "Introduces alternative and sustainable energy sources and systems, including renewable approaches such as solar and wind.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "205",
+    "title": "Manual Drivetrain and Axles",
+    "credits": 3,
+    "description": "Prerequisite(s): AUTO 101Covers theory and operation of the automotive and light truck manual drive trains and axles. Emphasis is placed on operation, maintenance, diagnosis, repair, clutch assemblies, differentials, drivelines, axles and manual transaxles. Components will be inspected for wear and failure. Drive train components will be reassembled to manufactures specifications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "262",
+    "title": "Prin of Statistics II",
+    "credits": 3,
+    "description": "Prerequisites: ECON261 Offers statistical inference; estimation hypothesis testing, simple linear regression and correlation, and analysis of variance.",
+    "prerequisite_text": "ECON261 Offers statistical inference; estimation hypothesis testing, simple linear regression and correlation, and analysis of variance.",
+    "prerequisite_courses": [
+      "ECON 261"
+    ]
+  },
+  {
+    "prefix": "ACC",
+    "number": "290",
+    "title": "Cert Bookkeeper Course",
+    "credits": 6,
+    "description": "Prerequisites: ACC201 with a grade of C or better, or by demonstrating a thorough knowledge of double-entry accounting Offers skills for working professionals and students who wish to advance their career in the bookkeeping profession. Upon successful completion, students will be able to sit for a national exam administered by the American Institute of Professional Bookkeepers (AIPB). Upon passing this exam and completing two years of bookkeeping experience, individuals earn the right to call themselves \"Certified Bookkeepers.\"",
+    "prerequisite_text": "ACC201 with a grade of C or better, or by demonstrating a thorough knowledge of double-entry accounting Offers skills for working professionals and students who wish to advance their career in the bookkeeping profession. Upon successful completion, students will be able to sit for a national exam administered by the American Institute of Professional Bookkeepers (AIPB). Upon passing this exam and",
+    "prerequisite_courses": [
+      "ACC 201"
+    ]
+  },
+  {
+    "prefix": "ECON",
+    "number": "102",
+    "title": "Prin of Microeconomics",
+    "credits": 3,
+    "description": "Recommended prerequisite: MATH 95 or higher.Covers supply and demand, the four types of markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, and price determination.",
+    "prerequisite_text": "MATH 95 or higher.Covers supply and demand, the four types of markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, and price determination.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "137",
+    "title": "Trumpet-Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for trumpet. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MT",
+    "number": "115",
+    "title": "Industrial Material Automation",
+    "credits": 3,
+    "description": "Prerequisite: AIT 101Introduces the concepts of Programmable Logic Controllers (PLC) and computerized control operations. Covers basic PLC programming by describing numbering systems, PLC memory organization, PLC programming software and PLC program logic elements.",
+    "prerequisite_text": "AIT 101Introduces the concepts of Programmable Logic Controllers (PLC) and computerized control operations. Covers basic PLC programming by describing numbering systems, PLC memory organization, PLC programming software and PLC program logic elements.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "127",
+    "title": "Percussion-Lower Division",
+    "credits": 2,
+    "description": "Offers private instruction in the study and performance of percussion instruments. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "108",
+    "title": "Building Trades Carpentry VIII",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 8 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 8 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "124",
+    "title": "Beginning Printmaking",
+    "credits": 3,
+    "description": "Introduces printmaking processes emphasizing relief, intaglio, lithographic, and screen processes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPD",
+    "number": "400",
+    "title": "Curriculum/Instruction for EDU",
+    "credits": 3,
+    "description": "Prerequisite: Educator within the Nevada Department of Education System or permission of instructor.Offers insight and methods for improving curriculum design and delivery. Provides students opportunities to design and refine assessment projects for PreK-12 curriculum. Project-based course.May be repeated up to three units.",
+    "prerequisite_text": "Educator within the Nevada Department of Education System or permission of instructor.Offers insight and methods for improving curriculum design and delivery. Provides students opportunities to design and refine assessment projects for PreK-12 curriculum. Project-based course.May be repeated up to three units.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "266",
+    "title": "Popular Literature",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Studies various forms of popular writing, e.g., best-sellers, the western, science fiction, fantasy, the detective story.",
+    "prerequisite_text": "ENG102 or consent of instructor Studies various forms of popular writing, e.g., best-sellers, the western, science fiction, fantasy, the detective story.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "DAN",
+    "number": "260",
+    "title": "Interm. Hip-Hop Dance",
+    "credits": 1,
+    "description": "Prerequisites: DAN160B Teaches intermediate techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": "DAN160B Teaches intermediate techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_courses": [
+      "DAN 160B"
+    ]
+  },
+  {
+    "prefix": "BTL",
+    "number": "106",
+    "title": "Pipelaying Part I",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers gravity flow pipe systems, the math used during layout and installation, and the tools, PPE, and equipment to perform the work. Trench and excavation safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers gravity flow pipe systems, the math used during layout and installation, and the tools, PPE, and equipment to perform the work. Trench and excavation safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSC",
+    "number": "231",
+    "title": "Intro International Relations",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Explores policy making institutions, foreign policies and politics of various nations.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Explores policy making institutions, foreign policies and politics of various nations.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "101",
+    "title": "Fund of Industrial Tech",
+    "credits": 4,
+    "description": "Explains the fundamental concepts of electricity used in many applications, especially control systems. Ohm's Law and Kirchhoff's voltage and current laws will be applied both in theory and through lab experiments. Mechanical concepts of basic levers and forces, friction and pulleys and gears are introduced, as well as their effects on a system. Covers fundamental operation of electric relay controls and explains basic logic circuits which are used to provide automated control of many types of machines. Simulated tools and test equipment are utilized.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "122",
+    "title": "Observation Skills",
+    "credits": 1,
+    "description": "Provides parents and teachers various formal and informal methods to enhance their observation and assessment skills. Discussion includes methods for use with developmentally delayed children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "107",
+    "title": "Business Speech Comm",
+    "credits": 3,
+    "description": "Focuses on speech communication skills. Includes effective listening and feedback methods, voice improvement, group and team interaction, developing messages for positive and negative audiences, preparation and presentation of an oral report.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "202",
+    "title": "Intro to Secondary Ed",
+    "credits": 3,
+    "description": "Introduces the prospective middle/secondary school teacher to the role of thinker/reflective practitioner. Creates awareness of the historical, social, political and economic forces influencing schooling in the United States.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "107",
+    "title": "Swimming",
+    "credits": 1,
+    "description": "Covers water safety, floating, the backstroke, Austrian crawl and other strokes. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "111",
+    "title": "Bt Elec Resi Level III",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "235",
+    "title": "Organizational Behavior",
+    "credits": 3,
+    "description": "Prerequisites:BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and control systems on human behavior.",
+    "prerequisite_text": "BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and contro",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MGT 201"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "146",
+    "title": "Amer Sign Lang II",
+    "credits": 4,
+    "description": "Prerequisites: AM145 Continues to stress the development of basic conversational skills with emphasis on expanding vocabulary and expressive skills.",
+    "prerequisite_text": "AM145 Continues to stress the development of basic conversational skills with emphasis on expanding vocabulary and expressive skills.",
+    "prerequisite_courses": [
+      "AM 145"
+    ]
+  },
+  {
+    "prefix": "MPT",
+    "number": "160",
+    "title": "Mechanical Drive Systems I",
+    "credits": 3,
+    "description": "Prerequisite(s): Recommend ELM 110 or ELM 112Covers the basics of mechanical components and systems, chain and belt drives in a complex mechatronic system. Teaches the functions and properties of mechanical components and control elements based upon physical principles, and the roles they play within the system. Covers technical documentation such as data sheets, circuit diagrams, displacement step diagrams and function charts while exploring installation, troubleshooting strategies and preventive maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SW",
+    "number": "311",
+    "title": "Perspectives On Human Behavior",
+    "credits": 3,
+    "description": "Prerequisites: SW 310Second course in two-course sequence that promotes a multidimensional understanding of human functioning and behavior across systems and the life course. Specifically examines human behavior and functioning among individuals and families. Emphasizes an evidence-informed approach to assessing human functioning. Advances student ability to critically apply a range of theories and research to better understand and assess human behavior and development.",
+    "prerequisite_text": "SW 310Second course in two-course sequence that promotes a multidimensional understanding of human functioning and behavior across systems and the life course. Specifically examines human behavior and functioning among individuals and families. Emphasizes an evidence-informed approach to assessing human functioning. Advances student ability to critically apply a range of theories and research to b",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "155",
+    "title": "Juvenile Justice System",
+    "credits": 3,
+    "description": "Introduces the field of police work with juveniles. Focuses on juvenile crime problems and their causes, detention and processing of the juvenile offender, practices of the juvenile court, and case disposition.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "151",
+    "title": "Intro Time Based Media/Video",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduces Time-Based Media/Videography using still and moving images. Lecture and studio study using broadcast video as a means of personal expression. Discussion of technical and theoretical themes; production by students of short videos that demonstrate understanding of these concepts.",
+    "prerequisite_text": "NoneIntroduces Time-Based Media/Videography using still and moving images. Lecture and studio study using broadcast video as a means of personal expression. Discussion of technical and theoretical themes; production by students of short videos that demonstrate understanding of these concepts.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "275",
+    "title": "Hacking Forensics Investgn",
+    "credits": 3,
+    "description": "Prerequisites: Instructor ConsentProvides key baseline knowledge and practices in the digital forensic domains including file systems, operating systems, network and database systems, websites and email.",
+    "prerequisite_text": "Instructor ConsentProvides key baseline knowledge and practices in the digital forensic domains including file systems, operating systems, network and database systems, websites and email.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "111",
+    "title": "Concrete Worker Part I",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroduces concrete work; increases knowledge and practical experience in the placement and finishing of concrete.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroduces concrete work; increases knowledge and practical experience in the placement and finishing of concrete.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "167",
+    "title": "Med Surg Nurs 1 Clinical",
+    "credits": 2,
+    "description": "Prerequisites: successful completion of the first semester of the nursing program. Corequisites: NURS165 & NURS166 Provides opportunities for students to utilize knowledge from the bio/psycho/social sciences, humanities, nursing and current literature to provide safe, competent care of adult patients experiencing common alterations in body systems. Organized by the nursing process to achieve best practice outcomes in a medical/surgical setting. Particular emphasis is placed on concepts of holistic care, holistic care, patient education.",
+    "prerequisite_text": "successful completion of the first semester of the nursing program. Corequisites: NURS165 & NURS166 Provides opportunities for students to utilize knowledge from the bio/psycho/social sciences, humanities, nursing and current literature to provide safe, competent care of adult patients experiencing common alterations in body systems. Organized by the nursing process to achieve best practice outcom",
+    "prerequisite_courses": [
+      "NURS 165",
+      "NURS 166"
+    ]
+  },
+  {
+    "prefix": "CHEM",
+    "number": "121",
+    "title": "General Chemistry I",
+    "credits": 4,
+    "description": "Prerequisite: MATH 126 with a grade of C- or higher; or, placement into higher MATH course (excluding MATH 176); or, ACT MATH score of 25 or higher or SAT MATH score of 560 or higher; or, a grade of B- or better in high school precalculus.Provides fundamentals of chemistry including reaction stoichiometry, atomic structure, chemical bonding, molecular structure, states of matter and thermochemistry. Three hours lecture/three hours laboratory.",
+    "prerequisite_text": "MATH 126 with a grade of C- or higher; or, placement into higher MATH course (excluding MATH 176); or, ACT MATH score of 25 or higher or SAT MATH score of 560 or higher; or, a grade of B- or better in high school precalculus.Provides fundamentals of chemistry including reaction stoichiometry, atomic structure, chemical bonding, molecular structure, states of matter and thermochemistry. Three hours",
+    "prerequisite_courses": [
+      "MATH 126",
+      "MATH 176"
+    ]
+  },
+  {
+    "prefix": "AUTO",
+    "number": "227",
+    "title": "Eng Performance II",
+    "credits": 4,
+    "description": "Prerequisites: AUTO225Automotive emission control systems. Preparation on current gas analyzers for the purpose of diagnosis and repair of specific emission devices. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO225Automotive emission control systems. Preparation on current gas analyzers for the purpose of diagnosis and repair of specific emission devices. Prepares students for ASE certification.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "134",
+    "title": "Jazz Appreciation",
+    "credits": 3,
+    "description": "Covers how Jazz music's evolution as an art form unique to the United States has both shaped and reflected the construction of our national identity. Teaches how social and cultural events led to the development of jazz music from 1890 through the 1960's. Prominent players and groups of each era will be covered, as well as sociological, economic and cultural factors that shaped the many styles of American Jazz as evolved.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "102",
+    "title": "U.S. History Since 1877",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101. Covers American history and civilization since the end of the American Civil War and Reconstruction Era. Satisfies the Nevada Constitution requirement.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101. Covers American history and civilization since the end of the American Civil War and Reconstruction Era. Satisfies the Nevada Constitution requirement.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "CADD",
+    "number": "105",
+    "title": "Inter Computer-Aided Dft",
+    "credits": 3,
+    "description": "Prerequisites: CADD100 or consent of instructor Provides instruction and training in advanced two-dimension AutoCAD commands. Covers the use of symbols and symbol libraries. Introduces three-dimensional drawing.",
+    "prerequisite_text": "CADD100 or consent of instructor Provides instruction and training in advanced two-dimension AutoCAD commands. Covers the use of symbols and symbol libraries. Introduces three-dimensional drawing.",
+    "prerequisite_courses": [
+      "CADD 100"
+    ]
+  },
+  {
+    "prefix": "DAN",
+    "number": "160",
+    "title": "Hip-Hop Dance",
+    "credits": 1,
+    "description": "Teaches beginning techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "148",
+    "title": "American Sign Language IV",
+    "credits": 4,
+    "description": "Prerequisites: AM147 Encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_text": "AM147 Encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_courses": [
+      "AM 147"
+    ]
+  },
+  {
+    "prefix": "GRC",
+    "number": "200",
+    "title": "Design Thinking Methodologies",
+    "credits": 3,
+    "description": "Prerequisites: GRC 116Builds upon the skills and processes learned in GRC 116. Further investigation and advanced techniques of Adobe Creative Cloud Software (Illustrator, InDesign, Photoshop and Acrobat). Course broadens techniques for design ideation, process, and effective design thinking and analysis. Class will present projects and design exercises that will increase student's technical fluency in industry-standards for Graphic Design software applications. Designed to increase conceptual thinking and improve technical skillsets.",
+    "prerequisite_text": "GRC 116Builds upon the skills and processes learned in GRC 116. Further investigation and advanced techniques of Adobe Creative Cloud Software (Illustrator, InDesign, Photoshop and Acrobat). Course broadens techniques for design ideation, process, and effective design thinking and analysis. Class will present projects and design exercises that will increase student's technical fluency in industry-",
+    "prerequisite_courses": [
+      "GRC 116"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "261",
+    "title": "Introduction to Poetry",
+    "credits": 3,
+    "description": "Prerequisites: ENG101Reading and discussion of selected British and American poems with attention to form and content.",
+    "prerequisite_text": "ENG101Reading and discussion of selected British and American poems with attention to form and content.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CS",
+    "number": "135",
+    "title": "Computer Science I",
+    "credits": 3,
+    "description": "Prerequisites: MATH128 or higher or satisfactory score on a placement exam Introduces modern problem solving and programming methods. Emphasis is placed on algorithm development, data abstraction, procedural and object-oriented design, implementation, testing, and documentation of computer programs. Students will write several computer programs.",
+    "prerequisite_text": "MATH128 or higher or satisfactory score on a placement exam Introduces modern problem solving and programming methods. Emphasis is placed on algorithm development, data abstraction, procedural and object-oriented design, implementation, testing, and documentation of computer programs. Students will write several computer programs.",
+    "prerequisite_courses": [
+      "MATH 128"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "299",
+    "title": "Directed Study",
+    "credits": 3,
+    "description": "Prerequisite: Consent of instructor.Provides individual study conducted under the direction of a faculty member.",
+    "prerequisite_text": "Consent of instructor.Provides individual study conducted under the direction of a faculty member.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "109",
+    "title": "Bt Elect Resident Level I",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "297",
+    "title": "Wk Exp - Law Enforcement",
+    "credits": 6,
+    "description": "Prerequisites: CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_text": "CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "READ",
+    "number": "135",
+    "title": "College Read Strategies",
+    "credits": 3,
+    "description": "Prerequisites: READ093 with a C or better, reading placement exam, or consent of instructor Helps the average reader improve reading efficiency through practice with advanced comprehension skills. Reading rate is thereby improved indirectly. Students with heavy academic or on-the-job reading will benefit. Attention is also given to expanding reading vocabularies.",
+    "prerequisite_text": "READ093 with a C or better, reading placement exam, or consent of instructor Helps the average reader improve reading efficiency through practice with advanced comprehension skills. Reading rate is thereby improved indirectly. Students with heavy academic or on-the-job reading will benefit. Attention is also given to expanding reading vocabularies.",
+    "prerequisite_courses": [
+      "READ 093"
+    ]
+  },
+  {
+    "prefix": "GEOG",
+    "number": "200",
+    "title": "World Regional Geography",
+    "credits": 3,
+    "description": "Introduces the world's regions with concentration on parts of the world with which we may be less familiar - many of which are experiencing great changes and have a major impact on our lives in the United States. Specific areas that will be covered include Africa, Asia, and Latin America.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "198",
+    "title": "Special Topics in Theater",
+    "credits": 6,
+    "description": "Focuses in depth on a special topic in theater.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSC",
+    "number": "100",
+    "title": "Nevada Constitution",
+    "credits": 1,
+    "description": "Prerequisite: None. An introduction to the political system of Nevada through an examination of the state¿s constitution. PSC 100 satisfies the Nevada Constitution requirement.",
+    "prerequisite_text": "None. An introduction to the political system of Nevada through an examination of the state¿s constitution. PSC 100 satisfies the Nevada Constitution requirement.",
+    "prerequisite_courses": [
+      "PSC 100"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "221",
+    "title": "Writing Fiction",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Teaches fiction writing in a workshop setting. Includes lectures and discussion of plot, character, style, and elements of fiction. Students are required to produce several works of short fiction.",
+    "prerequisite_text": "ENG102 or consent of instructor Teaches fiction writing in a workshop setting. Includes lectures and discussion of plot, character, style, and elements of fiction. Students are required to produce several works of short fiction.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "PSY",
+    "number": "230",
+    "title": "Intro Personality Psych",
+    "credits": 3,
+    "description": "Introduces students to personality testing and the major approaches to the study of personality, including the influence of heredity, learning, the unconscious, etc.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GRC",
+    "number": "294",
+    "title": "Professional Portfolio",
+    "credits": 3,
+    "description": "Prerequisites: minimum of 21 credits of GRC design/production classes or consent of instructor Focuses on the development of a portfolio for employment in the graphics communications field. Professional and legal requirements will be explored.",
+    "prerequisite_text": "minimum of 21 credits of GRC design/production classes or consent of instructor Focuses on the development of a portfolio for employment in the graphics communications field. Professional and legal requirements will be explored.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "20",
+    "title": "Learning Support for MATH 120",
+    "credits": 3,
+    "description": "Prerequisites: None. Corequisite: Enrollment in designated section of Math 120. Provides foundational material to support students in Math 120, Fundamentals of College Mathematics.",
+    "prerequisite_text": "None. Corequisite: Enrollment in designated section of Math 120. Provides foundational material to support students in Math 120, Fundamentals of College Mathematics.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "248",
+    "title": "Advanced Python Programming",
+    "credits": 3,
+    "description": "Prerequisite: CIT 148Focus on Python as an object-oriented language and introduction to Python collections, modules and packages. Techniques for accessing data in relational databases and testing methodologies are included as part of development of larger programs.",
+    "prerequisite_text": "CIT 148Focus on Python as an object-oriented language and introduction to Python collections, modules and packages. Techniques for accessing data in relational databases and testing methodologies are included as part of development of larger programs.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "112",
+    "title": "Network +",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduction to the concepts and practices needed to function in an entry level network technician capacity. Course content is mapped to current domains within the Comp/TIA Network+ Certification",
+    "prerequisite_text": "NoneIntroduction to the concepts and practices needed to function in an entry level network technician capacity. Course content is mapped to current domains within the Comp/TIA Network+ Certification",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "212",
+    "title": "Engmnt & Advocacy CTE Teachers",
+    "credits": 3,
+    "description": "Introduces CTE teachers to the elements, goals, and strategies for engaging families and the community, with emphasis on relationship building, outreach, developing strong partnerships, and engaging diverse stakeholders in the classroom. Topics include research supporting family and community engagement, national and state standards for family-school-community engagement and partnerships, and quality collaboration methods to enhance learning and support student success.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CH",
+    "number": "212",
+    "title": "Science,Tech & Society Mod Era",
+    "credits": 3,
+    "description": "Prerequisite: Eng 101Analyzes history and culture of the modern world, exploration of scientific revolutions and methods, rise and global spread of science-based technologies, and their impact on nature, the human body, society and the world.",
+    "prerequisite_text": "Eng 101Analyzes history and culture of the modern world, exploration of scientific revolutions and methods, rise and global spread of science-based technologies, and their impact on nature, the human body, society and the world.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "117",
+    "title": "Adv Auto Elect",
+    "credits": 4,
+    "description": "Prerequisites: AUTO115 Advanced AC and DC automotive electronic circuits. Troubleshooting electronically controlled components including supplemental restraint systems and convenience accessories. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO115 Advanced AC and DC automotive electronic circuits. Troubleshooting electronically controlled components including supplemental restraint systems and convenience accessories. Prepares students for ASE certification.",
+    "prerequisite_courses": [
+      "AUTO 115"
+    ]
+  },
+  {
+    "prefix": "GEOL",
+    "number": "105",
+    "title": "Intro Geology of Natl Parks",
+    "credits": 3,
+    "description": "Studies geologic processes through the lens of the national park system. Concepts of geologic time, plate tectonics, and the rock cycle will be explored by studying national parks and monuments that highlight geologic examples of the material presented.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "141",
+    "title": "Foundations of Nursing Clnical",
+    "credits": 2,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS136 & NURS137 Provides opportunities for students to utilize knowledge, concepts and skills learned in first semester nursing courses to meet the bio/psycho/social needs of patients in a long term acute care facility. Students use the nursing process and Maslow's Hierarchy of Needs at a beginning level to assess, plan, implement and evaluate nursing care.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS136 & NURS137 Provides opportunities for students to utilize knowledge, concepts and skills learned in first semester nursing courses to meet the bio/psycho/social needs of patients in a long term acute care facility. Students use the nursing process and Maslow's Hierarchy of Needs at a beginning level to assess, plan, implement and evaluate nurs",
+    "prerequisite_courses": [
+      "NURS 136",
+      "NURS 137"
+    ]
+  },
+  {
+    "prefix": "CEM",
+    "number": "452",
+    "title": "Construction Cost Control",
+    "credits": 3,
+    "description": "Additional prerequisites: ACC 201 and MATH 126Covers construction cost management including productivity and cost reporting/analysis concepts. Includes financial/cost issues/cash flow for the construction firm including reporting methods and percentage of completion techniques. Covers performance/profitability enhancement, earned value management, construction bonding and insurance issues, and firm and job-site analysis.",
+    "prerequisite_text": "ACC 201 and MATH 126Covers construction cost management including productivity and cost reporting/analysis concepts. Includes financial/cost issues/cash flow for the construction firm including reporting methods and percentage of completion techniques. Covers performance/profitability enhancement, earned value management, construction bonding and insurance issues, and firm and job-site analysis.",
+    "prerequisite_courses": [
+      "ACC 201"
+    ]
+  },
+  {
+    "prefix": "CONS",
+    "number": "451",
+    "title": "Adv Internship in Const",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 281 and consent of instructor.Studies advanced project management techniques on-site under the supervision of a project manager or superintendent and instructor. In consultation with the student, based on the specific internship, instructor determines additional learning objectives in addition to standard course learning objectives. Includes interaction with the instructor on a weekly basis. Assignments are required.",
+    "prerequisite_text": "CONS 281 and consent of instructor.Studies advanced project management techniques on-site under the supervision of a project manager or superintendent and instructor. In consultation with the student, based on the specific internship, instructor determines additional learning objectives in addition to standard course learning objectives. Includes interaction with the instructor on a weekly basis.",
+    "prerequisite_courses": [
+      "CONS 281"
+    ]
+  },
+  {
+    "prefix": "BTL",
+    "number": "107",
+    "title": "Pipelaying Part 2",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCourse covers polyethylene pipe fusion, utility locating programs, tapping, pressure pipe techniques and the tools, PPE, and equipment to perform the work. Safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCourse covers polyethylene pipe fusion, utility locating programs, tapping, pressure pipe techniques and the tools, PPE, and equipment to perform the work. Safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "90",
+    "title": "Elementary Arithmetic",
+    "credits": 3,
+    "description": "Provides individualized instruction in basic math skills including addition, subtraction, multiplication, and division of whole numbers, fractions, and decimals. Intended for students who need a review of whole numbers before studying fractions. Instruction is tailored specifically to each student's needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "235",
+    "title": "Photography II",
+    "credits": 3,
+    "description": "Prerequisites: ART135 or 141 Covers artificial lighting techniques and theory; strobe equipment, hotlights andelectronic flashes. Students produce a portfolio of work demonstratingknowledge of these techniques.",
+    "prerequisite_text": "ART135 or 141 Covers artificial lighting techniques and theory; strobe equipment, hotlights andelectronic flashes. Students produce a portfolio of work demonstratingknowledge of these techniques.",
+    "prerequisite_courses": [
+      "ART 135"
+    ]
+  },
+  {
+    "prefix": "COM",
+    "number": "299",
+    "title": "Special Topics in Comm",
+    "credits": 3,
+    "description": "Investigates a special topic or technique of speech communication.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "230",
+    "title": "Comp Numerical Control",
+    "credits": 4,
+    "description": "Prerequisite: None. Offers an introductory class to provide a basic understanding of computer numerical control. The student is introduced to the axis systems, absolute and incremental programming, tool offsets, controller operation, and fixture offsets. To better understand CNC programming process, CNC II is recommended as a follow-up. Includes three hours lecture, three hours lab per week.",
+    "prerequisite_text": "None. Offers an introductory class to provide a basic understanding of computer numerical control. The student is introduced to the axis systems, absolute and incremental programming, tool offsets, controller operation, and fixture offsets. To better understand CNC programming process, CNC II is recommended as a follow-up. Includes three hours lecture, three hours lab per week.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ATMS",
+    "number": "117",
+    "title": "Meteorology",
+    "credits": 3,
+    "description": "Covers the elements that make up meteorology, potential climate change, severe weather, and weather forecasting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSE",
+    "number": "135",
+    "title": "Jazz Vocal Ensemble",
+    "credits": 1,
+    "description": "Prerequisites: instrumentalists should be of intermediate level proficiency. No prerequisites for vocalists Explores a variety of musical styles, including pop, rock and jazz. Class may be repeated for a total of eight credits.",
+    "prerequisite_text": "instrumentalists should be of intermediate level proficiency. No prerequisites for vocalists Explores a variety of musical styles, including pop, rock and jazz. Class may be repeated for a total of eight credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "181L",
+    "title": "Physics Science/Eng Lab II",
+    "credits": 1,
+    "description": "Prerequisites: MATH182 & PHYS180 ; Corequisites: PHYS181 Explores electric fields, potential, current, dielectrics, circuits, magnetic fields, electromagnetic oscillations, thermodynamics and kinetic theory of gases. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_text": "MATH182 & PHYS180 ; Corequisites: PHYS181 Explores electric fields, potential, current, dielectrics, circuits, magnetic fields, electromagnetic oscillations, thermodynamics and kinetic theory of gases. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_courses": [
+      "MATH 182",
+      "PHYS 180",
+      "PHYS 181"
+    ]
+  },
+  {
+    "prefix": "CEM",
+    "number": "432",
+    "title": "Temp Construction Structures",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 109 and MATH 126.Introduces the analysis, design, and construction of temporary structures including formwork, false work, shoring, rigging, and access units. Addresses cost analysis, load and pressure calculations and safety considerations and requirements.",
+    "prerequisite_text": "CONS 109 and MATH 126.Introduces the analysis, design, and construction of temporary structures including formwork, false work, shoring, rigging, and access units. Addresses cost analysis, load and pressure calculations and safety considerations and requirements.",
+    "prerequisite_courses": [
+      "CONS 109",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "CSCO",
+    "number": "121",
+    "title": "Ccna Routing Protocols",
+    "credits": 4,
+    "description": "Prerequisites: CSCO120 or consent of instructor Covers the architecture, components, and operation of routers, and explains the principles of routing and routing protocols. Students analyze, configure, verify, and troubleshoot the primary routing protocols RIPv1, RIPv2, EIGRP, and OSPF.",
+    "prerequisite_text": "CSCO120 or consent of instructor Covers the architecture, components, and operation of routers, and explains the principles of routing and routing protocols. Students analyze, configure, verify, and troubleshoot the primary routing protocols RIPv1, RIPv2, EIGRP, and OSPF.",
+    "prerequisite_courses": [
+      "CSCO 120"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "241",
+    "title": "Welding IV",
+    "credits": 3,
+    "description": "Prerequisites: WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 242Covers shielded metal-arc welding of pipe, flux core arc welding of pipe and introduction to A.P.I., A.S.M.E., and A.W.S. code certification. Welding of pipe provides training to develop welding skills necessary to produce high quality multipass welds on 6-inch schedule, 80 mild steel pipe in the 6 G positions, using advanced welding processes.",
+    "prerequisite_text": "WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 242Covers shielded metal-arc welding of pipe, flux core arc welding of pipe and introduction to A.P.I., A.S.M.E., and A.W.S. code certification. Welding of pipe provides training to develop welding skills necessary to produce high quality multipass welds on 6-inch schedule, 80 mild steel pipe in the 6 G positions, using advanced we",
+    "prerequisite_courses": [
+      "WELD 231",
+      "WELD 232"
+    ]
+  },
+  {
+    "prefix": "AGSC",
+    "number": "211",
+    "title": "Agribusiness Management",
+    "credits": 3,
+    "description": "Applies business management principles to the operation of commercial farms/ranches and food processing/manufacturing firms.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "212",
+    "title": "Ceramics II",
+    "credits": 3,
+    "description": "Prerequisites: ART211 Continues ART 211 but with increased attention given to further refinement of skills. One hour lecture/four hours studio per week.",
+    "prerequisite_text": "ART211 Continues ART 211 but with increased attention given to further refinement of skills. One hour lecture/four hours studio per week.",
+    "prerequisite_courses": [
+      "ART 211"
+    ]
+  },
+  {
+    "prefix": "EDU",
+    "number": "201",
+    "title": "Intro to Elementary Educ",
+    "credits": 3,
+    "description": "Introduces the foundations of elementary education, current trends and issues in curriculum and instruction, the roles of teachers and issues of diversity. Includes field experience. A background check may be required for field experience.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "164",
+    "title": "Prin of Investigation",
+    "credits": 3,
+    "description": "Prerequisites: CRJ 104 or consent of instructorExamines the fundamentals of investigation: crime scene search and recording of information, collection and presentation of physical evidence, sources of information, scientific aids, case preparation, and interviews and interrogation procedures.",
+    "prerequisite_text": "CRJ 104 or consent of instructorExamines the fundamentals of investigation: crime scene search and recording of information, collection and presentation of physical evidence, sources of information, scientific aids, case preparation, and interviews and interrogation procedures.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "ECE",
+    "number": "204",
+    "title": "Prin Child Guidance",
+    "credits": 3,
+    "description": "Studies effective communication with children in guiding behavior. Emphasis will be placed on techniques which help children build positive self-concepts and individual strengths within the context of appropriate limits and discipline. The study includes uses of direct and indirect guidance techniques as well as introduction to guidance systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "114",
+    "title": "Bt Elec Resi Level Vi",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "299",
+    "title": "Special Topics in Geology",
+    "credits": 5,
+    "description": "Applies to assorted short courses and workshops covering a variety of subjects. May be repeated for up to six units.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "455",
+    "title": "Const Management Practice",
+    "credits": 3,
+    "description": "Additional prerequisites CEM 451, CEM 452, and CEM 453: Includes direction and operation of construction organizations with examination of general contracting, design-build, and construction management methods. Covers synthesis of project management concepts, applications, and limitations through case studies and semester projects.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "102",
+    "title": "Building Trades Carpentry II",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 2 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 2 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "233",
+    "title": "Recrding Technqs & Midi I",
+    "credits": 2,
+    "description": "Covers topics such as the job market, mics, consoles, tape recorders, and special effects. Teaches concepts including signal flow, multi-tracking, EQ, signal processing, MIDI, mixing and mastering. Students will learn to turn a Mac or PC into a multi-track studio.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "299",
+    "title": "Special Topics",
+    "credits": 3,
+    "description": "Explores special topics which vary across semesters. A maximum of three credits may be applied towards a WNC degree.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MKT",
+    "number": "127",
+    "title": "Intro to Retailing",
+    "credits": 3,
+    "description": "Studies an overview of retail merchandising, including buying, pricing, selling, advertising, sales promotion and display principles.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SOC",
+    "number": "102",
+    "title": "Contemp. Social Issues",
+    "credits": 3,
+    "description": "Prerequisites: SOC101 or consent of instructor Acquaints students with selected social problems, their causes and possible solutions.",
+    "prerequisite_text": "SOC101 or consent of instructor Acquaints students with selected social problems, their causes and possible solutions.",
+    "prerequisite_courses": [
+      "SOC 101"
+    ]
+  },
+  {
+    "prefix": "PSY",
+    "number": "234",
+    "title": "Psychology of Adolescence",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Examines psychological development during adolescence with emphasis on special problems in American society: drug abuse, pregnancy, and familial problems.",
+    "prerequisite_text": "PSY101 or consent of instructor Examines psychological development during adolescence with emphasis on special problems in American society: drug abuse, pregnancy, and familial problems.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "214",
+    "title": "Intro to Book Art",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduction to the book as a physical object. Course covers the field of artists' books as a form of artistic expression and inquiry as well as antiquarian books. Course introduces the mechanics of printing on cylinder and platen presses and several binding structures.",
+    "prerequisite_text": "NoneIntroduction to the book as a physical object. Course covers the field of artists' books as a form of artistic expression and inquiry as well as antiquarian books. Course introduces the mechanics of printing on cylinder and platen presses and several binding structures.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "113",
+    "title": "Flute-Lower Division",
+    "credits": 2,
+    "description": "Introduces students to the study and performance of music for flute. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "236",
+    "title": "Darkroom Photography II",
+    "credits": 3,
+    "description": "Prerequisites: ART 135Advanced darkroom photography course involving continued explorations of numerous photographic techniques, compositional styles, concepts and critical analysis of photography as a Fine Art.",
+    "prerequisite_text": "ART 135Advanced darkroom photography course involving continued explorations of numerous photographic techniques, compositional styles, concepts and critical analysis of photography as a Fine Art.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "104",
+    "title": "Blueprint Reading",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "104",
+    "title": "Building Trades Carpentry IV",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 4 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 4 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "153",
+    "title": "Foundtns Pharmacology II",
+    "credits": 1,
+    "description": "Prerequisites: Successful completion of the first semester of the nursing program. Provides a continuation of study of pharmacological principles and practices to achieve safe administration of medications. Selected drug classifications are presented, with an emphasis on understanding intended and unintended effects of drugs on body systems. Provides an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs.",
+    "prerequisite_text": "Successful completion of the first semester of the nursing program. Provides a continuation of study of pharmacological principles and practices to achieve safe administration of medications. Selected drug classifications are presented, with an emphasis on understanding intended and unintended effects of drugs on body systems. Provides an overview of pharmacology with an emphasis on clinical appli",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LTE",
+    "number": "102",
+    "title": "Applied Phlebotomy",
+    "credits": 3.5,
+    "description": "Prerequisites: LTE 101 with C or better. Vaccinations and major medical insurance. See Nursing and Allied Health Division student requirements for LTE.Provides 100 hours of clinical phlebotomy experience (of clinical phlebotomy to apply knowledge and skills learned in LTE 101. Under the guidance of a laboratory technician preceptor, students will perform a minimum of 100 successful, documented blood draws with patients across the lifespan (except infants and toddlers). Upon successful completion with a grade of C or better, students are eligible to sit for a national certification examination offered through a variety of certifying organizations, including the American Society for Clinical Pathology (ASCP).",
+    "prerequisite_text": "LTE 101 with C or better. Vaccinations and major medical insurance. See Nursing and Allied Health Division student requirements for LTE.Provides 100 hours of clinical phlebotomy experience (of clinical phlebotomy to apply knowledge and skills learned in LTE 101. Under the guidance of a laboratory technician preceptor, students will perform a minimum of 100 successful, documented blood draws with",
+    "prerequisite_courses": [
+      "LTE 101"
+    ]
+  },
+  {
+    "prefix": "COT",
+    "number": "262",
+    "title": "Interm Spreadsheets",
+    "credits": 3,
+    "description": "Prerequisites: IS101 or consent of instructor Studies the concepts and capabilities of computer spreadsheet systems. Teaches command and macro generation. Students gain experience generating spreadsheet templates, graphs and macros as business problem-solving tools. When offered for variable credit, content will be divided as follows: A) Concepts and capabilities of the computer spreadsheet with spreadsheet generation; B) Experience with the user-level menu access of the software, including graphing; C) More advanced capabilities of database and macro generation.",
+    "prerequisite_text": "IS101 or consent of instructor Studies the concepts and capabilities of computer spreadsheet systems. Teaches command and macro generation. Students gain experience generating spreadsheet templates, graphs and macros as business problem-solving tools. When offered for variable credit, content will be divided as follows: A) Concepts and capabilities of the computer spreadsheet with spreadsheet gene",
+    "prerequisite_courses": [
+      "IS 101"
+    ]
+  },
+  {
+    "prefix": "BTL",
+    "number": "114",
+    "title": "Asphalt Worker",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroduces students to working with asphalt. Hands-on activities include: asphalt placement, raking, patching and repairing.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroduces students to working with asphalt. Hands-on activities include: asphalt placement, raking, patching and repairing.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "115",
+    "title": "Adv Emergency Medical Tech",
+    "credits": 7.5,
+    "description": "Prerequisite: Certified as a Nationally Registered EMT within the last two years. CPR Certificate. Must be at least 18 year of age at the time of enrollment.Prepares students to incorporate knowledge of basic and advanced emergency medical care for critically ill and emergent patients to reduce the morbidity and mortally associated with acute out-of-hospital medical and traumatic emergencies. The A-EMT is educated to safely provide more advanced airway maintenance skills and the ability to recognize basic electrocardiography (ECG) arrhythmia's and utilize pharmacological interventions within the scope of practices. Other competencies include interventions such as suctioning, initiation of IV therapy, control of breathing and shock, and cardiopulmonary resuscitation. The A-EMT provides care based on site assessment data and works alongside other EMS and health care professionals as an integral part of the emergency care team.",
+    "prerequisite_text": "Certified as a Nationally Registered EMT within the last two years. CPR Certificate. Must be at least 18 year of age at the time of enrollment.Prepares students to incorporate knowledge of basic and advanced emergency medical care for critically ill and emergent patients to reduce the morbidity and mortally associated with acute out-of-hospital medical and traumatic emergencies. The A-EMT is educa",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "198",
+    "title": "Spec Topics in Automotive",
+    "credits": 6,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "105",
+    "title": "Bt Electrical Level V",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "100",
+    "title": "Gen Biol for Non-Majors",
+    "credits": 4,
+    "description": "Prerequisites: None. Recommended: MATH120, MATH126 or higher Covers fundamental concepts and theories of life science. Major topics include cellular/molecular biology, anatomy, physiology, genetics, evolutions and ecology. Includes four laboratory experiences.",
+    "prerequisite_text": "None. Recommended: MATH120, MATH126 or higher Covers fundamental concepts and theories of life science. Major topics include cellular/molecular biology, anatomy, physiology, genetics, evolutions and ecology. Includes four laboratory experiences.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "106",
+    "title": "Firefighter Academy I",
+    "credits": 12,
+    "description": "Prerequisites: EMS 108 or current State of Nevada EMT certification FT 101, and FT 109 OR EMS 108 or current State of Nevada EMT certification and six months of firefighting experience and Candidate Physical Abilities Test (CPAT) certification within 12 months of the course start date. Corequisite: FT 131This course combines lecture with hands on firefighting skills to meet the requirements of the Nevada State Fire Training Firefighter I and the National Fire Protection Association (NFPA). Topics include fire service organization, fire safety, tools and equipment, fire prevention, incident management systems, wildland fire fighting and fire suppression techniques. Students who successfully complete the Academy are eligible for Nevada State Fire Marshal certification as a Firefighter I and National Wildfire Coordinating Group (NWCG) certificates S-110, S-130 and S-190)",
+    "prerequisite_text": "EMS 108 or current State of Nevada EMT certification FT 101, and FT 109 OR EMS 108 or current State of Nevada EMT certification and six months of firefighting experience and Candidate Physical Abilities Test (CPAT) certification within 12 months of the course start date. Corequisite: FT 131This course combines lecture with hands on firefighting skills to meet the requirements of the Nevada State",
+    "prerequisite_courses": [
+      "EMS 108",
+      "FT 101",
+      "FT 109"
+    ]
+  },
+  {
+    "prefix": "GEOL",
+    "number": "102",
+    "title": "Earth & Life Through Time",
+    "credits": 4,
+    "description": "Prerequisites: GEOL101 3 hours lecture and 3 hours lab.Studies the history of the earth and the origins of its landforms, including dating, evolution of organisms, times of extinction, mountain building episodes, and periods of glaciation.",
+    "prerequisite_text": "GEOL101 3 hours lecture and 3 hours lab.Studies the history of the earth and the origins of its landforms, including dating, evolution of organisms, times of extinction, mountain building episodes, and periods of glaciation.",
+    "prerequisite_courses": [
+      "GEOL 101"
+    ]
+  },
+  {
+    "prefix": "EPY",
+    "number": "150",
+    "title": "Strategies Academ Success",
+    "credits": 3,
+    "description": "Helps students to develop effective and efficient study skills. Students will learn how to learn.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FT",
+    "number": "224",
+    "title": "Fire Protection Systems",
+    "credits": 3,
+    "description": "Prerequisites: NoneProvides information relating to the features of design and operation of fire alarm systems, water-based fire suppression systems, special hazard fire suppression systems, water supply for fire protection and portable fire extinguishers. FESHE Core Course.",
+    "prerequisite_text": "NoneProvides information relating to the features of design and operation of fire alarm systems, water-based fire suppression systems, special hazard fire suppression systems, water supply for fire protection and portable fire extinguishers. FESHE Core Course.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "284",
+    "title": "Role Adn Mgr of Care",
+    "credits": 2,
+    "description": "Prerequisites: successful completion of the third semester of the nursing program. Utilizes a capstone laboratory/clinical to facilitate the role transition from student to graduate nurse. Students integrate knowledge derived from the bio/psycho/social sciences, humanities and nursing to achieve best practice outcomes for multiple patients and their significant others in the acute care setting. Students apply advanced concepts of leadership and management while functioning in the legal, ethical and regulatory structures of the profession of nursing. In the clinical setting students will establish a therapeutic environment to meet the needs of multiple patients and their significant others by demonstrating the ability to meet the nursing program educational outcomes.",
+    "prerequisite_text": "successful completion of the third semester of the nursing program. Utilizes a capstone laboratory/clinical to facilitate the role transition from student to graduate nurse. Students integrate knowledge derived from the bio/psycho/social sciences, humanities and nursing to achieve best practice outcomes for multiple patients and their significant others in the acute care setting. Students apply a",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "258",
+    "title": "Theatre Exper and Travel",
+    "credits": 2,
+    "description": "Field study class in which students travel to an arranged destination for the purpose of play viewing, play study and possible workshop attendance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "107",
+    "title": "Bt Electrical Level VII",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTO",
+    "number": "103",
+    "title": "BT Heavy Equipmnt Operator III",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 3 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 3 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IS",
+    "number": "101",
+    "title": "Intro to Information Sys",
+    "credits": 3,
+    "description": "Introduces the student to the role of computers in today's technology-driven environment, allowing for hands on lab experience. Students will be introduced to the Internet, distance education, and the World Wide Web for research, along with operating systems, word processing, spreadsheets, database and basic multi-media. Upon successful completion of this course, the student will be able to demonstrate basic computer survival skills, understand computer terminology, and create data using a variety of software.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NUTR",
+    "number": "223",
+    "title": "Prin of Nutrition",
+    "credits": 3,
+    "description": "Prerequisites: BIOL 190 and 190L with a grade of C or better or CHEM 121 with a grade of C or better Studies nutrient functions and basis for nutrient requirements at the cellular level. Three hours lecture.",
+    "prerequisite_text": "BIOL 190 and 190L with a grade of C or better or CHEM 121 with a grade of C or better Studies nutrient functions and basis for nutrient requirements at the cellular level. Three hours lecture.",
+    "prerequisite_courses": [
+      "BIOL 190",
+      "CHEM 121"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "24",
+    "title": "Learning Support for MATH 124",
+    "credits": 3,
+    "description": "Prerequisites: None. Corequisite: Enrollment in designated section of Math 124.Provides foundational material to support students in Math 124, College Algebra.",
+    "prerequisite_text": "None. Corequisite: Enrollment in designated section of Math 124.Provides foundational material to support students in Math 124, College Algebra.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "121",
+    "title": "Principle Cons Estimating",
+    "credits": 3,
+    "description": "Prerequisite: CONS 120 and CONS 216Presents basic criteria and procedure for estimating labor and material in residential and commercial applications.",
+    "prerequisite_text": "CONS 120 and CONS 216Presents basic criteria and procedure for estimating labor and material in residential and commercial applications.",
+    "prerequisite_courses": [
+      "CONS 120"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "152",
+    "title": "Legal Aspects Emergency Svcs",
+    "credits": 3,
+    "description": "Prerequisites: FT 101 or Instructor ApprovalAddresses the Federal, State, and local laws that regulate emergency services and include a review of national standards, regulations and consensus standards. FESHE Non-Core Course.",
+    "prerequisite_text": "FT 101 or Instructor ApprovalAddresses the Federal, State, and local laws that regulate emergency services and include a review of national standards, regulations and consensus standards. FESHE Non-Core Course.",
+    "prerequisite_courses": [
+      "FT 101"
+    ]
+  },
+  {
+    "prefix": "GEOL",
+    "number": "113",
+    "title": "Geology Lassen Volc Natl Park",
+    "credits": 2,
+    "description": "Provides a general field experience in geology for students with little or no earth science background. Teaches the basics of volcanic rock identification, history of the Cascade Range, and the recognition of modern and ancient geologic events through field study of Lassen Volcanic National Park.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "229",
+    "title": "Defensive Tactics",
+    "credits": 3,
+    "description": "Prerequisites: NoneProvides police recruits with training in the areas of self-protection against armed persons armed with dangerous and/or deadly weapons. Training in the use of holds, come alongs, restraints, and baton use on uncooperative suspects, prisoners, or the mentally ill. This course is only offered as part of the POST Academy.",
+    "prerequisite_text": "NoneProvides police recruits with training in the areas of self-protection against armed persons armed with dangerous and/or deadly weapons. Training in the use of holds, come alongs, restraints, and baton use on uncooperative suspects, prisoners, or the mentally ill. This course is only offered as part of the POST Academy.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ET",
+    "number": "155",
+    "title": "Home Tech Convergence",
+    "credits": 4,
+    "description": "Introduction to the components and technologies that make up the \"Smart Home\". The convergence of home entertainment audio/visual equipment, surveillance and security systems, computer networks, and telecommunications will be taught in both theory and application. Students will build, configure and install cables, wallplates, jacks, control modules and equipment to bring alive the multiple technologies commonly used in a home or small office environment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "156",
+    "title": "Foundations Pharmacology III",
+    "credits": 1,
+    "description": "Prerequisite: admission to the nursing program and NURS 153Provides a continuation of study of pharmacological principles and practices through in-depth application of principles of pharmacology, pharmacokinetics and pharmacodynamics. Designed to expand the nursing student's knowledge of pharmacotherapeutics, which includes the cellular response level, for the clinical application within the context of the nursing process and prioritization of needs for patients across the lifespan. Selected drug classifications of pharmacological agents are examined and applied through case study application and analysis providing opportunity for development of the nursing competencies of clinical judgement, professional identity, use of evidence-based practice, and the facilitation of a spirit of inquiry.",
+    "prerequisite_text": "admission to the nursing program and NURS 153Provides a continuation of study of pharmacological principles and practices through in-depth application of principles of pharmacology, pharmacokinetics and pharmacodynamics. Designed to expand the nursing student's knowledge of pharmacotherapeutics, which includes the cellular response level, for the clinical application within the context of the nurs",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "96",
+    "title": "Intermediate Algebra",
+    "credits": 3,
+    "description": "Offers a second course in algebra. Studies polynomial, rational and radical expressions; linear, quadratic and polynomial equations; linear and absolute value inequalities; relations, functions and their graphs; systems of linear equations; and applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AV",
+    "number": "111",
+    "title": "Private Pilot Lab",
+    "credits": 3,
+    "description": "Co-requisites: AV 110Students will begin their flight training with an FAA Certificated Flight Instructor, covering all skills necessary to pass the FAA Private Pilot Airplane Certificate Practical Exam. To qualify for the FAA Private Pilot Certificate, students must meet the following requirements: be at least 17 years old, be able to read, speak, write, and understand English, hold at least a third-class medical certificate, and complete both ground and flight training, including a minimum of 40 flight hours with specific time requirements for solo and dual instruction.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FIN",
+    "number": "115",
+    "title": "Intro to Investments",
+    "credits": 3,
+    "description": "Helps students understand the theoretical concepts and analytical foundations necessary for further study in the field. It will provide an overall picture of securities markets, institutions, processes and mechanisms on how stocks and bonds are bought and sold.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ITAL",
+    "number": "112",
+    "title": "First Year Italian II",
+    "credits": 4,
+    "description": "Prerequisites: ITAL111 or consent of instructorContinues study of the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "prerequisite_text": "ITAL111 or consent of instructorContinues study of the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "prerequisite_courses": [
+      "ITAL 111"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "253",
+    "title": "Mechatronics: PLCs",
+    "credits": 3,
+    "description": "3 units Prerequisite or Corequisite: AIT 252Covers the fundamentals of digital logic and an introduction to programmable logic controllers (PLCs) in a complex mechatronic system. Students will learn the role PLCs play within a mechatronic system or subsystem; students will explore basic elements of PLC functions by writing and testing programs to control them. Course teaches students how to identify malfunctioning PLCs, as well as to apply troubleshooting strategies to identify and localize problems caused by PLC hardware.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "109",
+    "title": "MSHA New Miner Training",
+    "credits": 1,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers operations for new miners at Part 46 mining facilities and fulfills the MSHA training requirements to work for contractors at these facilities. Note: This training is not a substitute for site-specific training that your employer is required to provide.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers operations for new miners at Part 46 mining facilities and fulfills the MSHA training requirements to work for contractors at these facilities. Note: This training is not a substitute for site-specific training that your employer is required to provide.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "270",
+    "title": "Construction Management",
+    "credits": 1,
+    "description": "Prerequisites: CONS 260 or Consent of InstructorProvides the necessary lecture and laboratory experience to satisfy the state regulations concerning the General Level Inspection Regulation NAC 645D.120. Course number or instructor approval needed.",
+    "prerequisite_text": "CONS 260 or Consent of InstructorProvides the necessary lecture and laboratory experience to satisfy the state regulations concerning the General Level Inspection Regulation NAC 645D.120. Course number or instructor approval needed.",
+    "prerequisite_courses": [
+      "CONS 260",
+      "NAC 645D"
+    ]
+  },
+  {
+    "prefix": "CONS",
+    "number": "261",
+    "title": "Under-Flr Insp-Cert Insp",
+    "credits": 1,
+    "description": "Prerequisites: CONS260B Provides instruction on all of the under-floor components that the Certified Inspector of Structures must inspect to complete a certified inspection per 645D of the Nevada Administrative Code. Students will complete two supervised under-floor inspections and prepare extensive narrative inspection reports for evaluation. They will be required to sign \"hold harmless\" waivers when conducting inspections off state property. Students are strongly encouraged to have medical insurance that provides coverage in the event of a job-site injury.",
+    "prerequisite_text": "CONS260B Provides instruction on all of the under-floor components that the Certified Inspector of Structures must inspect to complete a certified inspection per 645D of the Nevada Administrative Code. Students will complete two supervised under-floor inspections and prepare extensive narrative inspection reports for evaluation. They will be required to sign \"hold harmless\" waivers when conductin",
+    "prerequisite_courses": [
+      "CONS 260B"
+    ]
+  },
+  {
+    "prefix": "ENG",
+    "number": "205",
+    "title": "Intro to Creative Writing",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Offers a beginning writers' workshop in poetry, fiction, and creative non-fiction.",
+    "prerequisite_text": "ENG102 or consent of instructor Offers a beginning writers' workshop in poetry, fiction, and creative non-fiction.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "ELM",
+    "number": "127",
+    "title": "Introduction to AC Controls",
+    "credits": 3,
+    "description": "Prerequisite(s): NoneFamiliarizes students with critical electronic components in an industrial control setting. Control of electric motors is explored through the use of schematic symbols, diagrams, relay logic and solderless circuit boards. Students conduct laboratory experiments, building control circuits and learn troubleshooting methodologies.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "271",
+    "title": "Intro to Workforce/CT Stu Orgs",
+    "credits": 3,
+    "description": "Introduces the concepts of economic and workforce development, as well as the role of career and technical education (CTE) nationally, regionally and locally. Familiarizes students with career and technical student organizations (CTSO) and how they are utilized to help CTE students master critical workplace readiness/employability skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACC",
+    "number": "295",
+    "title": "Work Experience I",
+    "credits": 6,
+    "description": "Prerequisites: consent of instructor Provides on-the-job supervised and educationally directed work experience.",
+    "prerequisite_text": "consent of instructor Provides on-the-job supervised and educationally directed work experience.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "129",
+    "title": "Intro to Programming",
+    "credits": 3,
+    "description": "Prerequisites: IS101 or consent of instructor Offers a language-independent, introductory course on computer program design and development. Emphasizes identification and solution of business problems through various design tools.",
+    "prerequisite_text": "IS101 or consent of instructor Offers a language-independent, introductory course on computer program design and development. Emphasizes identification and solution of business problems through various design tools.",
+    "prerequisite_courses": [
+      "IS 101"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "110",
+    "title": "Basic Wildland Firefighting",
+    "credits": 3,
+    "description": "Prerequisites: NoneAddresses the basic elements of wildland fire protection, fire behavior, department organization, apparatus and equipment, fire safety and incident command organization.",
+    "prerequisite_text": "NoneAddresses the basic elements of wildland fire protection, fire behavior, department organization, apparatus and equipment, fire safety and incident command organization.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "141",
+    "title": "Viola-Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for viola. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "261",
+    "title": "Survey of Art History II",
+    "credits": 3,
+    "description": "Surveys art of the western world from the Renaissance to the present.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "148",
+    "title": "Tai Chi",
+    "credits": 3,
+    "description": "Familiarizes students with the forms, sequence and movements of Tai Chi. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "101",
+    "title": "Drawing I",
+    "credits": 3,
+    "description": "Develops drawing skills through practice with a broad variety of drawing tools and techniques. 1 hour lecture/4 hours studio per week.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "110",
+    "title": "A+ Hardware",
+    "credits": 3,
+    "description": "Introduces the fundamentals of computer system repair. Students learn the hardware and software elements that define an operating computing system. Troubleshooting methods and the use of diagnostic tools are taught with reinforcement provided using hands-on exercises. Successful completion of this course will place a student in good standing to take the nationally recognized A+ certification exam created by the computing industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "226",
+    "title": "Memoir and Autobiography",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Offers a writing-intensive class which explores various approaches to writing memoirs, autobiography, family history, autobiography-based fiction, or other \"life stories,\" incorporating the classic elements of the personal essay.",
+    "prerequisite_text": "ENG102 or consent of instructor Offers a writing-intensive class which explores various approaches to writing memoirs, autobiography, family history, autobiography-based fiction, or other \"life stories,\" incorporating the classic elements of the personal essay.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "CIT",
+    "number": "230",
+    "title": "Advanced Java",
+    "credits": 3,
+    "description": "Prerequisites: CIT130 Builds upon the foundation constructed in Beginning Java. Since Java works behind the scenes to power Internet applications, this class will focus more heavily upon application development with an emphasis on client-side and server-side techniques. Topics include, but not limited to, inheritance, interfaces, exception handling, javafx, input and ouput to files and databases, data structures, generics, and searching and sort algorithms.",
+    "prerequisite_text": "CIT130 Builds upon the foundation constructed in Beginning Java. Since Java works behind the scenes to power Internet applications, this class will focus more heavily upon application development with an emphasis on client-side and server-side techniques. Topics include, but not limited to, inheritance, interfaces, exception handling, javafx, input and ouput to files and databases, data structure",
+    "prerequisite_courses": [
+      "CIT 130"
+    ]
+  },
+  {
+    "prefix": "ACC",
+    "number": "261",
+    "title": "Governmental Accounting",
+    "credits": 3,
+    "description": "Prerequisites: ACC201 Introduces accounting and reporting for government and non-profit entities. Includes study of fund and budget accounts of local governmental units, revenues, appropriations, disbursements and assessments.",
+    "prerequisite_text": "ACC201 Introduces accounting and reporting for government and non-profit entities. Includes study of fund and budget accounts of local governmental units, revenues, appropriations, disbursements and assessments.",
+    "prerequisite_courses": [
+      "ACC 201"
+    ]
+  },
+  {
+    "prefix": "EMS",
+    "number": "215",
+    "title": "EMS Incident Mgt and Op",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine ProgramPrepares the student to implement a plan for patients with common complaints. Prepares the Paramedic with the concepts of medical incident command, ambulance and rescue operations, hazardous materials, incident, and crime scene awareness.",
+    "prerequisite_text": "Admission to the Paramedicine ProgramPrepares the student to implement a plan for patients with common complaints. Prepares the Paramedic with the concepts of medical incident command, ambulance and rescue operations, hazardous materials, incident, and crime scene awareness.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "218",
+    "title": "The Artist's Book",
+    "credits": 3,
+    "description": "Prerequisite: ART 214 or instructor permissionProvides the opportunity for students to create a limited-edition, letterpress-printed artist's book edition of 12-15 copies. Students will write original text, generate imagery using traditional and alternative printing techniques, hand set type, letterpress print on antique printing pressed, and hand-bind each copy of their artist's book.",
+    "prerequisite_text": "ART 214 or instructor permissionProvides the opportunity for students to create a limited-edition, letterpress-printed artist's book edition of 12-15 copies. Students will write original text, generate imagery using traditional and alternative printing techniques, hand set type, letterpress print on antique printing pressed, and hand-bind each copy of their artist's book.",
+    "prerequisite_courses": [
+      "ART 214"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "182",
+    "title": "Calculus II",
+    "credits": 4,
+    "description": "Prerequisites: MATH181 or equivalent or consent of instructor. Teaches transcendental functions, methods of integration, conics, vectors.",
+    "prerequisite_text": "MATH181 or equivalent or consent of instructor. Teaches transcendental functions, methods of integration, conics, vectors.",
+    "prerequisite_courses": [
+      "MATH 181"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "203",
+    "title": "Interpreting Sign Lng III",
+    "credits": 3,
+    "description": "Prerequisites: AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "prerequisite_text": "AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "prerequisite_courses": [
+      "AM 202"
+    ]
+  },
+  {
+    "prefix": "BTP",
+    "number": "104",
+    "title": "Bt Plumbing Level IV",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program. Covers building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 4 of the Plumbing Apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program. Covers building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 4 of the Plumbing Apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "176",
+    "title": "Musical Theatre Practicum I",
+    "credits": 3,
+    "description": "Performance ensemble, centered on public performance of musical theatre literature. Repeatable up to 9 units.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "208",
+    "title": "World History I",
+    "credits": 3,
+    "description": "Prerequisites: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll ENG 101A survey of the societies and cultures of Asia, Africa, the Middle East, Europe, the Americas, and Oceania to 1600.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll ENG 101A survey of the societies and cultures of Asia, Africa, the Middle East, Europe, the Americas, and Oceania to 1600.",
+    "prerequisite_courses": [
+      "ENG 101",
+      "ENG 101A"
+    ]
+  },
+  {
+    "prefix": "CHEM",
+    "number": "121",
+    "title": "General Chemistry I",
+    "credits": 4,
+    "description": "Prerequisite: MATH 126 with a grade of C- or higher; or, placement into higher MATH course (excluding MATH 176); or, ACT MATH score of 25 or higher or SAT MATH score of 560 or higher; or, a grade of B- or better in high school precalculus.Provides fundamentals of chemistry including reaction stoichiometry, atomic structure, chemical bonding, molecular structure, states of matter and thermochemistry. Three hours lecture/three hours laboratory.",
+    "prerequisite_text": "MATH 126 with a grade of C- or higher; or, placement into higher MATH course (excluding MATH 176); or, ACT MATH score of 25 or higher or SAT MATH score of 560 or higher; or, a grade of B- or better in high school precalculus.Provides fundamentals of chemistry including reaction stoichiometry, atomic structure, chemical bonding, molecular structure, states of matter and thermochemistry. Three hours",
+    "prerequisite_courses": [
+      "MATH 126",
+      "MATH 176"
+    ]
+  },
+  {
+    "prefix": "CEM",
+    "number": "455",
+    "title": "Const Management Practice",
+    "credits": 3,
+    "description": "Additional prerequisites CEM 451, CEM 452, and CEM 453: Includes direction and operation of construction organizations with examination of general contracting, design-build, and construction management methods. Covers synthesis of project management concepts, applications, and limitations through case studies and semester projects.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "134",
+    "title": "Beginning C# Programming",
+    "credits": 3,
+    "description": "Prerequisite: CIT 128Introduction to the C# programming language. Uses C# programming language for solving problems. Covers C#'s control structures, Object Oriented Concepts, simple graphical displays, file input/output and error handling.",
+    "prerequisite_text": "CIT 128Introduction to the C# programming language. Uses C# programming language for solving problems. Covers C#'s control structures, Object Oriented Concepts, simple graphical displays, file input/output and error handling.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "115",
+    "title": "Scaffold Builder",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTP",
+    "number": "107",
+    "title": "Bt Plumbing Level VII",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program. Offers advanced building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 7 of the Plumbing Apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program. Offers advanced building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 7 of the Plumbing Apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "220",
+    "title": "Principles of Educational Psyc",
+    "credits": 3,
+    "description": "The psychology of learning, motivation, growth and development, personality, dynamics, and social adjustment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "120",
+    "title": "Blueprint Read/Spec",
+    "credits": 3,
+    "description": "Equips students with technical and practical interpretation of blueprints. Assignments are made in relation to complete sets of working drawings. Students study construction relationships between architectural, structural, electrical and mechanical drawings, bidding along with inspection procedure technique.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "263",
+    "title": "It Project Management",
+    "credits": 3,
+    "description": "Introduces students to the concepts of project management as used within the information technology fields of study.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PBH",
+    "number": "120",
+    "title": "Health and Wellness",
+    "credits": 3,
+    "description": "Covers the components and wellness and of lifelong tools that will help enhance wellness. health values, attitudes and behaviors of self and others. Students will be active in design and execution of personal fitness and wellness plans.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "140",
+    "title": "Auto Brake Systems",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automotive brake systems including antilock systems. Includes safety, use of manuals, selection and use of hand tools, power tools and hand-held test instruments. Introduces general maintenance of a variety of different systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "224",
+    "title": "Spec Studies in Music Lit",
+    "credits": 3,
+    "description": "Prerequisites: pianists should be of intermediate level proficiency Focuses in depth on a special topic in music literature. Topics might include Baroque, classical, romantic, or 20th century keyboard literature. Students will explore musical topics through both lecture and their own performance of representative works. Class may be repeated for up to six credits.",
+    "prerequisite_text": "pianists should be of intermediate level proficiency Focuses in depth on a special topic in music literature. Topics might include Baroque, classical, romantic, or 20th century keyboard literature. Students will explore musical topics through both lecture and their own performance of representative works. Class may be repeated for up to six credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "270",
+    "title": "Adv. Clin. Nurs I Theory",
+    "credits": 3,
+    "description": "Prerequisites: successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students will also apply concepts of community care, case management, health teaching and discharge planning.",
+    "prerequisite_text": "successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students",
+    "prerequisite_courses": [
+      "NURS 271"
+    ]
+  },
+  {
+    "prefix": "BIOL",
+    "number": "212",
+    "title": "Intro to Human Genetics Lab",
+    "credits": 1,
+    "description": "Corequisites: BIOL 208 Provides an opportunity to learn how to extract and amplify genomic DNA using the polymerase chain reaction; apply concepts of chemistry and evolutionary biology to study an organism they choose; identify a question involving their chosen organism and answer it using DNA technology; research and identify protocols and materials such as M-SAT primers specific to the organism they choose; subject data to statistical analysis and relate their findings to concepts of evolution. Three hours laboratory.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "193",
+    "title": "Intercollegiate Soccer",
+    "credits": 3,
+    "description": "Prerequisites: must be a member of the WNC soccer team Participation on the intercollegiate soccer team. May be repeated for up to 6 credits.",
+    "prerequisite_text": "must be a member of the WNC soccer team Participation on the intercollegiate soccer team. May be repeated for up to 6 credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "145",
+    "title": "Religion in Amer Life",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "208",
+    "title": "Observ/Pract in Interpreting",
+    "credits": 3,
+    "description": "Prerequisite: Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "prerequisite_text": "Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "225",
+    "title": "Intro to the Vietnam War",
+    "credits": 3,
+    "description": "Survey of U.S. involvement in Vietnam from 1954 to U.S. withdraws in 1975. Provides an overview of the land, history, and culture of Vietnam and the region. In-depth study of the U.S. involvement in Vietnam. Concludes with an overview of post U.S. involvement issues and the present day Vietnam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "231",
+    "title": "Welding III",
+    "credits": 3,
+    "description": "Prerequisites: WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 232Includes theory and practice in gas metal-arc welding and gas tungsten-arc welding.",
+    "prerequisite_text": "WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 232Includes theory and practice in gas metal-arc welding and gas tungsten-arc welding.",
+    "prerequisite_courses": [
+      "WELD 221",
+      "WELD 222"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "242",
+    "title": "Welding IV Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 241Introduces fundamental pipe welding techniques and develops basic skills for the service and transmission fields in the shielded metal-arc section. Trains welders for work in either the pressure pipe industry or transmission pipeline work using the micro-wire weld.",
+    "prerequisite_text": "WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 241Introduces fundamental pipe welding techniques and develops basic skills for the service and transmission fields in the shielded metal-arc section. Trains welders for work in either the pressure pipe industry or transmission pipeline work using the micro-wire weld.",
+    "prerequisite_courses": [
+      "WELD 231",
+      "WELD 232"
+    ]
+  },
+  {
+    "prefix": "FREN",
+    "number": "101",
+    "title": "Conversational French I",
+    "credits": 3,
+    "description": "Emphasizes spoken communication. Listening, reading and writing skills will be explored. A vocabulary of French-English words can be developed to suit student needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "JOUR",
+    "number": "201",
+    "title": "Media Writing",
+    "credits": 3,
+    "description": "Prerequisites: JOUR103. Teaches writing in journalistic and persuasive styles for mass media. Emphasis on analysis and organization of information, and clarity of expression.",
+    "prerequisite_text": "JOUR103. Teaches writing in journalistic and persuasive styles for mass media. Emphasis on analysis and organization of information, and clarity of expression.",
+    "prerequisite_courses": [
+      "JOUR 103"
+    ]
+  },
+  {
+    "prefix": "BIOL",
+    "number": "105",
+    "title": "Introduction to Neuroscience",
+    "credits": 3,
+    "description": "Presents basic principles in biological science, including neural function and cognition. Topics will range from the electrical basis of brain function to higher-order cognitive processes and neurodegenerative diseases. Applications will also be introduced, from the treatment and impact of neurological diseases on society, to how we can use computational models of the brain. Same as PSY 105 and NS 105.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "275",
+    "title": "Undergraduate Research",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 & PSY210&PSY240 Requires independent or collaborative research.",
+    "prerequisite_text": "PSY101 & PSY210&PSY240 Requires independent or collaborative research.",
+    "prerequisite_courses": [
+      "PSY 101",
+      "PSY 210",
+      "PSY 240"
+    ]
+  },
+  {
+    "prefix": "BTO",
+    "number": "106",
+    "title": "BT Heavy Equipment Operator VI",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 6 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 6 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "191",
+    "title": "Intro Organismal Biology",
+    "credits": 4,
+    "description": "Prerequisite: None.Combines the principles of botany and zoology into one course emphasizing levels of organization and life processes common to all organisms. Topics range from nutrient processing and homeostasis to reproduction. Meets for a total of 45 lecture hours and 45 lab hours. Note: BIOL 190 plus BIOL 191 transfer to UNR as fulfilling BIOL 190, 191 and 192 requirements.",
+    "prerequisite_text": "None.Combines the principles of botany and zoology into one course emphasizing levels of organization and life processes common to all organisms. Topics range from nutrient processing and homeostasis to reproduction. Meets for a total of 45 lecture hours and 45 lab hours. Note: BIOL 190 plus BIOL 191 transfer to UNR as fulfilling BIOL 190, 191 and 192 requirements.",
+    "prerequisite_courses": [
+      "BIOL 190",
+      "BIOL 191"
+    ]
+  },
+  {
+    "prefix": "CIT",
+    "number": "330",
+    "title": "Designing Virtualized Systems",
+    "credits": 4,
+    "description": "Prerequisites: CIT 112 and CIT 211Teaches students to install, configure, and manage vSphere; to install a complete virtual network on VMware Workstation consisting of ESXi hosts, a domain controller, a vCenter server, and an iScsi SAN. Course prepares students for VCA-DCV and VCP-DCV certifications.",
+    "prerequisite_text": "CIT 112 and CIT 211Teaches students to install, configure, and manage vSphere; to install a complete virtual network on VMware Workstation consisting of ESXi hosts, a domain controller, a vCenter server, and an iScsi SAN. Course prepares students for VCA-DCV and VCP-DCV certifications.",
+    "prerequisite_courses": [
+      "CIT 112"
+    ]
+  },
+  {
+    "prefix": "HDFS",
+    "number": "202",
+    "title": "Intro to Families",
+    "credits": 3,
+    "description": "Explores the dynamics of development, interaction, and intimacy of primary relationships in contextual and theoretical frameworks, societal issues and choices facing diverse family systems. This course is taught from a bio-psycho-social approach within the family ecological system context. It incorporates issues relevant to international families and diverse family arrangements within North America. Traditional issues of families are reframed, reconstructed, and questioned. Application of ideas to those working with families in a variety of settings including: physical health, mental health, economic and educational arenas.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "121",
+    "title": "Horn - Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for horn. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "220",
+    "title": "Prin of Educational Psych",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Introduces the application of psychology principles of learning and cognitive development.",
+    "prerequisite_text": "PSY101 or consent of instructor Introduces the application of psychology principles of learning and cognitive development.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "152",
+    "title": "Foundtns Pharmacology I",
+    "credits": 1,
+    "description": "Prerequisites: admission to the nursing program. Provides students with an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs; with special consideration given to the physiological and psycho/social needs of patients. Explores indications, modes of action, effects, contraindications and interactions for selected drugs. Specific nursing responsibilities related to drug administration are emphasized.",
+    "prerequisite_text": "admission to the nursing program. Provides students with an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs; with special consideration given to the physiological and psycho/social needs of patients. Explores indications, modes of action, effects, contraindications and interactions for selected drugs. Specific",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "115",
+    "title": "Guitar",
+    "credits": 4,
+    "description": "Provides individual instruction in the technique and repertoire of the guitar. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "199",
+    "title": "Independent Study",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "250",
+    "title": "Mechatronics: Electrical",
+    "credits": 3,
+    "description": "3 units Prerequisite or Corequisite: AIT 101Covers the basics of electrical components in a complex mechatronic system. Students will learn the basic functions and physical properties of electrical components, and the roles they play within the system. Technical documentation such as data sheets, schematics, and timing diagrams will be covered while exploring troubleshooting strategies and preventive maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "485",
+    "title": "Construction Law & Contracts",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 118Provides information on legal problems in the construction process. Covers stipulated sum, unit price, cost-plus contracts, construction lien rights and bond rights, scope of work issues, builders risk issues, risk-shifting, and case studies.",
+    "prerequisite_text": "CONS 118Provides information on legal problems in the construction process. Covers stipulated sum, unit price, cost-plus contracts, construction lien rights and bond rights, scope of work issues, builders risk issues, risk-shifting, and case studies.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "320",
+    "title": "Organization & Project Mgt",
+    "credits": 3,
+    "description": "Prerequisite: Admission to BAS Organization and Project Management ProgramFocuses on the key drivers of a successful organization. Emphasizes organization theories and models to analyze and improve performance in the organization. skills and Knowledge of project management and introduced and linked to organization performance.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management ProgramFocuses on the key drivers of a successful organization. Emphasizes organization theories and models to analyze and improve performance in the organization. skills and Knowledge of project management and introduced and linked to organization performance.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSC",
+    "number": "210",
+    "title": "American Public Policy",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended prerequisite or corequisite: ENG 101, or eligibility to enroll in ENG 101.Explores an analysis of the interplay of forces involved in policy-making at all levels of American government. Studies the impact of policy on individuals and institutions.",
+    "prerequisite_text": "None. Recommended prerequisite or corequisite: ENG 101, or eligibility to enroll in ENG 101.Explores an analysis of the interplay of forces involved in policy-making at all levels of American government. Studies the impact of policy on individuals and institutions.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "EMS",
+    "number": "210",
+    "title": "Principles of Cardiology",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Prepares the Paramedic student to identify single and multi-lead cardiac rhythms and treat those rhythms considered to be life-threatening with electrical therapy. Teaches skills including defibrillation, cardioversion, and cardiac rhythm interpretation. Prepares the student to assess, manage, and treat various cardiovascular emergencies that includes ventricular fibrillation, bradycardia, tachycardia, myocardial infarction, cardiogenic shock, pulmonary edema, angina pectoris, congestive heart failure, hypertension, PEA (pulseless electrical activity), and asystole.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Prepares the Paramedic student to identify single and multi-lead cardiac rhythms and treat those rhythms considered to be life-threatening with electrical therapy. Teaches skills including defibrillation, cardioversion, and cardiac rhythm interpretation. Prepares the student to assess, manage, and treat various cardiovascular emergencies that includes ventric",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "211",
+    "title": "Paramedic Care Med Emgs & ACLS",
+    "credits": 4,
+    "description": "Prerequisite: Admission to the Paramedicine ProgramPrepares the Paramedic to identify, assess, manage, and treat various medical emergencies. Topics include Neurology, Endocrinology, Allergies and Anaphylaxis, Gastroenterology, Urology, Toxicology, Infectious and Communicable Diseases, Behavioral and Psychiatric Disorders, and associated pharmacological interventions.",
+    "prerequisite_text": "Admission to the Paramedicine ProgramPrepares the Paramedic to identify, assess, manage, and treat various medical emergencies. Topics include Neurology, Endocrinology, Allergies and Anaphylaxis, Gastroenterology, Urology, Toxicology, Infectious and Communicable Diseases, Behavioral and Psychiatric Disorders, and associated pharmacological interventions.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "111",
+    "title": "Mach Shop Practice II",
+    "credits": 2,
+    "description": "Corequisites: MTT110 Further develops student's manual skills by putting into practice the theories and user skills introduced MTT 110. The emphasis will be a more practical, hands-on experience through the use of vertical mill work, layout techniques, vertical and horizontal band saws, measuring instruments and some lathes. Shop safety and cleanup are always stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "180",
+    "title": "Strength Training",
+    "credits": 2,
+    "description": "Introduces resistance training and proper lifting techniques to strength (weight)training students. Safety rules, proper use of equipment and concepts of lifting will be emphasized.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "271",
+    "title": "Intro to Shakespeare",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Examines Shakespeare's principal plays read for their social interest and their literary excellence.",
+    "prerequisite_text": "ENG102 or consent of instructor Examines Shakespeare's principal plays read for their social interest and their literary excellence.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "232",
+    "title": "Welding III Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 231Focuses on GMAW, GTAW, and FCAW which will train the student to perform production and certification performance welding on ferrous and non-ferrous metals.",
+    "prerequisite_text": "WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 231Focuses on GMAW, GTAW, and FCAW which will train the student to perform production and certification performance welding on ferrous and non-ferrous metals.",
+    "prerequisite_courses": [
+      "WELD 221",
+      "WELD 222"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "128",
+    "title": "Precalculus/Trigonometry",
+    "credits": 5,
+    "description": "Prerequisites: MATH 096 with a grade of C- or better or appropriate score on the WNC math placement or equivalent exam or three units of high school mathematics at the level of algebra and above with a grade of C- or better within the last three years.Studies relations, functions and their graphs; polynomial, rational, exponential, logarithm and trigonometric functions; analytic trigonometry; systems of equations and inequalities; conics; mathematical induction; sequences and series.",
+    "prerequisite_text": "MATH 096 with a grade of C- or better or appropriate score on the WNC math placement or equivalent exam or three units of high school mathematics at the level of algebra and above with a grade of C- or better within the last three years.Studies relations, functions and their graphs; polynomial, rational, exponential, logarithm and trigonometric functions; analytic trigonometry; systems of equation",
+    "prerequisite_courses": [
+      "MATH 096"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "212",
+    "title": "Welding I Practice",
+    "credits": 2,
+    "description": "Corequisites: WELD 211 Develops the student's manual skills necessary to produce high quality gas welds and flame cuts. The student learns to set up the equipment for all phases of oxy-acetylene welding and cutting. The shielded metal-arc welding section develops entry level skills for welders. This course specifically develops basic shielded metal arc welding skills such as striking the arc, maintaining proper arc length, adjusting equipment and manipulating the electrode.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "210",
+    "title": "Intro to Statistical Mthd",
+    "credits": 4,
+    "description": "Prerequisites: PSY101,SOC101 & MATH096 or consent of instructor Develops an understanding of statistical methods and training in the useful presentation and interpretation of behavioral science data, including elementary computer use. Same as SOC 210.",
+    "prerequisite_text": "PSY101,SOC101 & MATH096 or consent of instructor Develops an understanding of statistical methods and training in the useful presentation and interpretation of behavioral science data, including elementary computer use. Same as SOC 210.",
+    "prerequisite_courses": [
+      "PSY 101",
+      "SOC 101",
+      "MATH 096",
+      "SOC 210"
+    ]
+  },
+  {
+    "prefix": "NS",
+    "number": "105",
+    "title": "Introduction to Neuroscience",
+    "credits": 3,
+    "description": "Presents basic principles in biological science, including neural function and cognition. Topics will range from the electrical basis of brain function to higher-order cognitive processes and neurodegenerative diseases. Applications will also be introduced, from the treatment and impact of neurological diseases on society, to how we can use computational models of the brain. Same as BIOL 150 & PSY 105.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "293",
+    "title": "Directed Study",
+    "credits": 3,
+    "description": "Prerequisites: PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "prerequisite_text": "PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "prerequisite_courses": [
+      "PHYS 151",
+      "PHYS 180"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "90",
+    "title": "Elementary Arithmetic",
+    "credits": 3,
+    "description": "Provides individualized instruction in basic math skills including addition, subtraction, multiplication, and division of whole numbers, fractions, and decimals. Intended for students who need a review of whole numbers before studying fractions. Instruction is tailored specifically to each student's needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTT",
+    "number": "104",
+    "title": "BT Telecomm Tech Level IV",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 4 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 4 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "160",
+    "title": "Art Appreciation",
+    "credits": 3,
+    "description": "Studies art, artists and art media of various historical periods to develop the student's capacity to evaluate and appreciate them.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "143",
+    "title": "Karate",
+    "credits": 2,
+    "description": "Covers the basic history, philosophy and origins of Karate systems. Students are provided with demonstrations of the basic moves and are allowed to practice the moves with feedback. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTT",
+    "number": "106",
+    "title": "BT Telecomm Tech Level VI",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 6 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 6 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "112",
+    "title": "Bt Elec Resi Level IV",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "119",
+    "title": "Foreman Preparedness",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programPrepares laborers to become foremen. Topics include the foreman's role, assuring crew and job site safely, record-keeping and documentation, project planning and management, effective communication, and employee supervision.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programPrepares laborers to become foremen. Topics include the foreman's role, assuring crew and job site safely, record-keeping and documentation, project planning and management, effective communication, and employee supervision.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "198",
+    "title": "Special Topics in Agriculture",
+    "credits": 6,
+    "description": "Prerequisite: NoneSelected agricultural topics offered for general interest in the agricultural community. Repeatable to a maximum of six units.",
+    "prerequisite_text": "NoneSelected agricultural topics offered for general interest in the agricultural community. Repeatable to a maximum of six units.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELM",
+    "number": "121",
+    "title": "Circuit Design",
+    "credits": 3,
+    "description": "Prerequisite(s): Recommend ELM 110 or ELM 112 or concurrent enrollmentCovers the basics of circuit design for automated systems. Integrates the use of elementary electrical and electronic devices as switches, relays, resistors, capacitors, inductors as well as sensors and filters.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CSCO",
+    "number": "120",
+    "title": "Ccna Internetworking Fund",
+    "credits": 4,
+    "description": "Introduces the architecture, structure, functions, components, and models of the Internet and other computer networks. Uses the OSI and TCP layered models to examine the nature and roles of protocols and services at the application, network, data link, and physical layers. Principles and structure of IP addressing and the fundamentals of Ethernet concepts, media, and operations are introduced.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "204",
+    "title": "Info Technlgy in Teaching",
+    "credits": 3,
+    "description": "Studies the use of microcomputers in operations and word processing applicable to classroom for teachers to operate and utilize microcomputers in education. Special instruction fees.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "235",
+    "title": "Photography II",
+    "credits": 3,
+    "description": "Prerequisites: ART135 or 141 Covers artificial lighting techniques and theory; strobe equipment, hotlights andelectronic flashes. Students produce a portfolio of work demonstratingknowledge of these techniques.",
+    "prerequisite_text": "ART135 or 141 Covers artificial lighting techniques and theory; strobe equipment, hotlights andelectronic flashes. Students produce a portfolio of work demonstratingknowledge of these techniques.",
+    "prerequisite_courses": [
+      "ART 135"
+    ]
+  },
+  {
+    "prefix": "AV",
+    "number": "250",
+    "title": "Commrcl Aviation Ground School",
+    "credits": 4,
+    "description": "Provides aspiring pilots with the necessary knowledge and skills to pursue a career in commercial aviation. Essential topics related to commercial pilot operations, regulations, advanced navigation, meteorology, aerodynamics, and more will be covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "100",
+    "title": "Introduction to Economics",
+    "credits": 3,
+    "description": "Recommended prerequisite: MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "prerequisite_text": "MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENGR",
+    "number": "241",
+    "title": "Statics",
+    "credits": 3,
+    "description": "Prerequisites: PHYS 180 with a \"C\" or better and Corequisite: MATH 182Studies Static force systems. Topics include resolution and composition of forces, equilibrium of force systems, friction, centroids, moments of inertia, mass moments of inertia, cables, beams, fluid statics, and work. Same as ME 241.",
+    "prerequisite_text": "PHYS 180 with a \"C\" or better and Corequisite: MATH 182Studies Static force systems. Topics include resolution and composition of forces, equilibrium of force systems, friction, centroids, moments of inertia, mass moments of inertia, cables, beams, fluid statics, and work. Same as ME 241.",
+    "prerequisite_courses": [
+      "PHYS 180",
+      "ME 241"
+    ]
+  },
+  {
+    "prefix": "MKT",
+    "number": "262",
+    "title": "Intro to Advertising",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "prerequisite_text": "BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MKT 210"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "251",
+    "title": "Discrete Mathematics I",
+    "credits": 3,
+    "description": "Prerequisite: Math 182A first course in discrete mathematics that provides an introduction to logic, set theory, relations, functions, digraphs, and cardinality.",
+    "prerequisite_text": "Math 182A first course in discrete mathematics that provides an introduction to logic, set theory, relations, functions, digraphs, and cardinality.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AC",
+    "number": "113",
+    "title": "Schematic Reading for HVAC/R",
+    "credits": 3,
+    "description": "Prerequisites: NoneApplication of principles and skills in reading schematics seen in HVAC/R. Followed by the operation of air conditioning, heating and Refrigeration equipment. Topics covered are the cooling cycle, gas furnaces, Ice-Machines and Refrigeration systems both residential and commercial.",
+    "prerequisite_text": "NoneApplication of principles and skills in reading schematics seen in HVAC/R. Followed by the operation of air conditioning, heating and Refrigeration equipment. Topics covered are the cooling cycle, gas furnaces, Ice-Machines and Refrigeration systems both residential and commercial.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "199",
+    "title": "Special Topics",
+    "credits": 3,
+    "description": "Offers special topics which vary across semesters. A maximum of six credits may be applied towards a WNC degree.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "114",
+    "title": "Geol Lava Beds Natl Monmnt",
+    "credits": 1,
+    "description": "Provides a general field experience in geology for students with little or no earth science background. Teaches the basics of volcanic rock and landform identification, and the recognition of modern and ancient geologic events through field study of Lava Beds National Monument.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "113",
+    "title": "Rigging and Signaling",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers safety and the procedures for working safely around cranes. Hands-on activities include: calculate weights of loads, choose proper rigging hardware and rig the load properly, and signal the crane operator to pick and move the load.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers safety and the procedures for working safely around cranes. Hands-on activities include: calculate weights of loads, choose proper rigging hardware and rig the load properly, and signal the crane operator to pick and move the load.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "100",
+    "title": "Healthcare Provider CPR",
+    "credits": 0.5,
+    "description": "Provides instruction of Basic Cardiac Life Support/ Cardiopulmonary Resuscitation for the Healthcare Provider which includes: one and two person rescuer for CPR and management of foreign body obstruction of the airway in adults, children and infants. Instruction also provides for recognition of signs and symptoms requiring AED intervention, safe administration of AED, and common actions that can be utilized for survival, and prevention of risk factors for heart attack and stroke. Certification according to the standards of the American Heart Association (AHA) is issued upon successful completion of course which requires passing of a written examination and practical demonstration. The course satisfies the CPR requirement for students admitted to the nursing and surgical technology programs, nursing assistant and EMS courses. May be repeated for up to one credit.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "217",
+    "title": "Lang/Litrcy For Deaf Children",
+    "credits": 3,
+    "description": "Teaches the process of language acquisition and literacy development for children who are deaf or have a hearing loss. Includes comparison to the natural acquisition of language for all children and adults. Includes clinical, cultural, historical and audiological descriptions of deafness; the unique linguistic aspects of language and literacy acquisition and most importantly, practical application and activities that can be utilized with deaf/hard of hearing children. Geared to all persons wishing to learn about language and literacy acquisition, but especially geared to parents, educational interpreters, speech and language pathologists, audiologist, and teacher of dear and hard of hearing children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "180",
+    "title": "Physics Science/Eng I",
+    "credits": 3,
+    "description": "Prerequisite: MATH 181. Corequisite: PHYS 180L.Explores vectors, rectilinear motion, particle dynamics, work and energy, momentum, rotational mechanics, oscillations, gravitation, fluids, wave properties and sound. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_text": "MATH 181. Corequisite: PHYS 180L.Explores vectors, rectilinear motion, particle dynamics, work and energy, momentum, rotational mechanics, oscillations, gravitation, fluids, wave properties and sound. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_courses": [
+      "MATH 181",
+      "PHYS 180L"
+    ]
+  },
+  {
+    "prefix": "CHEM",
+    "number": "241",
+    "title": "Organic Chemistry I",
+    "credits": 3,
+    "description": "Prerequisites: CHEM122 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Credit allowed in only one of CHEM 220 or 241. Three hours lecture.",
+    "prerequisite_text": "CHEM122 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Credit allowed in only one of CHEM 220 or 241. Three hours lecture.",
+    "prerequisite_courses": [
+      "CHEM 122",
+      "CHEM 220"
+    ]
+  },
+  {
+    "prefix": "MUS",
+    "number": "103",
+    "title": "Voice Class I",
+    "credits": 3,
+    "description": "Teaches fundamentals of tone production, breath control and practical techniques involved in reading and interpreting songs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "111",
+    "title": "First Year Spanish I",
+    "credits": 4,
+    "description": "Develops language skills through practice in listening, speaking, reading, writing and structural analysis. Includes an introduction to Spanish culture.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "230",
+    "title": "Intro Personality Psych",
+    "credits": 3,
+    "description": "Introduces students to personality testing and the major approaches to the study of personality, including the influence of heredity, learning, the unconscious, etc.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CH",
+    "number": "202",
+    "title": "The Modern World",
+    "credits": 3,
+    "description": "Prerequisites: ENG101Explores the intellectual, literary and political history of Europe from the Renaissance to the present.",
+    "prerequisite_text": "ENG101Explores the intellectual, literary and political history of Europe from the Renaissance to the present.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "144",
+    "title": "Introduction to Data Analytics",
+    "credits": 3,
+    "description": "Prerequisites: CIT 128An introduction to data analysis that uses technologies and applications to analyze and clean up data; to classify, visualize, and summarize sets of sample data; and to determine if the sample data reflects characteristics of populations.",
+    "prerequisite_text": "CIT 128An introduction to data analysis that uses technologies and applications to analyze and clean up data; to classify, visualize, and summarize sets of sample data; and to determine if the sample data reflects characteristics of populations.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "204",
+    "title": "Intro Comtemporary Phil",
+    "credits": 3,
+    "description": "Reviews the late 19th century movements as basis for the study of 20th century developments in thought from Nietzsche through existentialism, neopositivism, and American naturalism.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "141",
+    "title": "Foundations of Nursing Clnical",
+    "credits": 2,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS136 & NURS137 Provides opportunities for students to utilize knowledge, concepts and skills learned in first semester nursing courses to meet the bio/psycho/social needs of patients in a long term acute care facility. Students use the nursing process and Maslow's Hierarchy of Needs at a beginning level to assess, plan, implement and evaluate nursing care.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS136 & NURS137 Provides opportunities for students to utilize knowledge, concepts and skills learned in first semester nursing courses to meet the bio/psycho/social needs of patients in a long term acute care facility. Students use the nursing process and Maslow's Hierarchy of Needs at a beginning level to assess, plan, implement and evaluate nurs",
+    "prerequisite_courses": [
+      "NURS 136",
+      "NURS 137"
+    ]
+  },
+  {
+    "prefix": "HIST",
+    "number": "217",
+    "title": "Nevada History",
+    "credits": 3,
+    "description": "Studies Nevada's history from prehistoric times to the present. Examines the early mining and cattle frontiers, the development of towns and the advent of industrialization as well as the 20th century problems of water, energy, and growth. Satisfies the Nevada Constitution requirement.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "100",
+    "title": "Fundamentals Construction Mgt",
+    "credits": 3,
+    "description": "Provides an overview of the construction industry roles, responsibilities, and risks from perspectives of owners, constructors, designers, financial institutions, and government agencies. Study of construction process techniques and applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "276",
+    "title": "Musical Theatre Wkshp II",
+    "credits": 3,
+    "description": "Prerequisites: MUS176,THTR176 Continues skills learned in THTR 176 or MUS 176. Offers a workshop in the techniques of musical theatre. May be repeated to a maximum of nine credits. Same as MUS 176.",
+    "prerequisite_text": "MUS176,THTR176 Continues skills learned in THTR 176 or MUS 176. Offers a workshop in the techniques of musical theatre. May be repeated to a maximum of nine credits. Same as MUS 176.",
+    "prerequisite_courses": [
+      "MUS 176",
+      "THTR 176"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "271",
+    "title": "Adv Clncl Nurs I Clinical",
+    "credits": 2,
+    "description": "Prerequisites: successful completion of the first year of the nursing program. Corequisites: NURS270 Requires students to use the nursing process to identify and prioritize health care needs in the provision of care for patients experiencing complex/acute alterations in health. Expands upon previous clinical learning to include the teaching/learning process and administration of intravenous fluids and medications in the acute care setting.",
+    "prerequisite_text": "successful completion of the first year of the nursing program. Corequisites: NURS270 Requires students to use the nursing process to identify and prioritize health care needs in the provision of care for patients experiencing complex/acute alterations in health. Expands upon previous clinical learning to include the teaching/learning process and administration of intravenous fluids and medication",
+    "prerequisite_courses": [
+      "NURS 270"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "131",
+    "title": "Introduction to Painting",
+    "credits": 3,
+    "description": "Introduces the basics of various traditional and contemporary painting media.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "114",
+    "title": "Bt Elec Resi Level Vi",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "100",
+    "title": "Math for Allied Health",
+    "credits": 1,
+    "description": "Prerequisites: NoneReviews basic mathematics with emphasis on those skills that apply to calculating drug dosages. Includes fractions, decimals, proportions, percents, English apothecary and metric systems of measurements.",
+    "prerequisite_text": "NoneReviews basic mathematics with emphasis on those skills that apply to calculating drug dosages. Includes fractions, decimals, proportions, percents, English apothecary and metric systems of measurements.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "219",
+    "title": "Projects in Tech Theater",
+    "credits": 3,
+    "description": "Offers an in-depth study of some technical aspect of theater. Through practical application students can explore lighting, set art, set construction, sound, set design or rigging.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "136",
+    "title": "Foundtns Nursing Theory",
+    "credits": 3,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS137 & NURS141 Introduces students to the role of the associate degree nurse in contemporary practice. Students are guided to utilize knowledge from the sciences, humanities and nursing to understand man as a bio/psycho being. Students are introduced to the nursing program organizing concepts and outcomes which include professional behaviors, communication, collaboration, nursing process, clinical decision making, management of care and teaching learning.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS137 & NURS141 Introduces students to the role of the associate degree nurse in contemporary practice. Students are guided to utilize knowledge from the sciences, humanities and nursing to understand man as a bio/psycho being. Students are introduced to the nursing program organizing concepts and outcomes which include professional behaviors, comm",
+    "prerequisite_courses": [
+      "NURS 137",
+      "NURS 141"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "124",
+    "title": "Beginning Printmaking",
+    "credits": 3,
+    "description": "Introduces printmaking processes emphasizing relief, intaglio, lithographic, and screen processes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "145",
+    "title": "American Sign Lang I",
+    "credits": 4,
+    "description": "Introduces ASL and focuses on the development of basic conversational skills, emphasizing receptive abilities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIT",
+    "number": "117",
+    "title": "Medical Terminology",
+    "credits": 1,
+    "description": "Studies word derivations and formation with emphasis upon understanding common usage in the field of health care.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AC",
+    "number": "198",
+    "title": "Special Topics in Hvac",
+    "credits": 6,
+    "description": "Various short courses and experimental classes covering a variety of subjects. Offered from one-half to six credits depending on the course content and number of hours required. May be repeated up to six credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "201",
+    "title": "Geology of Nevada",
+    "credits": 3,
+    "description": "Prerequisites: GEOL101 or consent of instructor Studies how Nevada¿s geology has changed through time. Includes Nevada¿s fossils, rocks and minerals, earthquakes and geothermal resources. Includes at least four lab experiences.",
+    "prerequisite_text": "GEOL101 or consent of instructor Studies how Nevada¿s geology has changed through time. Includes Nevada¿s fossils, rocks and minerals, earthquakes and geothermal resources. Includes at least four lab experiences.",
+    "prerequisite_courses": [
+      "GEOL 101"
+    ]
+  },
+  {
+    "prefix": "MTT",
+    "number": "262",
+    "title": "Mach Shop Practice IV",
+    "credits": 2,
+    "description": "Corequisites: MTT260Allows students additional time to concentrate on areas of interest leading to completion of an advanced project emphasizing skills introduced in MTT 260.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "95",
+    "title": "Elementary Algebra",
+    "credits": 3,
+    "description": "Offers a first course in algebra. Topics include operations with signed numbers; algebraic symbols; evaluating formulas; operations with polynominal, radical and rational expressions; solving equations and application problems using algebra; and elementary graphing. Provides a foundation for the math used in business, science, engineering and related fields.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "222",
+    "title": "Welding II Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 211 and WELD 212, or consent of instructor; Corequisite: WELD 221Continues MTL 212 with emphasis on developing welding skills for SMAW, GMAW, and GTAW production in overhead, flat, horizontal, and vertical positions.",
+    "prerequisite_text": "WELD 211 and WELD 212, or consent of instructor; Corequisite: WELD 221Continues MTL 212 with emphasis on developing welding skills for SMAW, GMAW, and GTAW production in overhead, flat, horizontal, and vertical positions.",
+    "prerequisite_courses": [
+      "WELD 211",
+      "WELD 212",
+      "MTL 212"
+    ]
+  },
+  {
+    "prefix": "MPT",
+    "number": "112",
+    "title": "Manufacturing & Automation II",
+    "credits": 3,
+    "description": "Prequisite(s): MPT 111 or concurrent enrollmentAllows students to practice the concepts of production and automation systems management and controls. Enables students to practice manufacturing skills, including robotic and conveyor systems as well as quality integration. Covers the underlying programming, fluid and mechanical transmission concepts of these systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CS",
+    "number": "135",
+    "title": "Computer Science I",
+    "credits": 3,
+    "description": "Prerequisites: MATH128 or higher or satisfactory score on a placement exam Introduces modern problem solving and programming methods. Emphasis is placed on algorithm development, data abstraction, procedural and object-oriented design, implementation, testing, and documentation of computer programs. Students will write several computer programs.",
+    "prerequisite_text": "MATH128 or higher or satisfactory score on a placement exam Introduces modern problem solving and programming methods. Emphasis is placed on algorithm development, data abstraction, procedural and object-oriented design, implementation, testing, and documentation of computer programs. Students will write several computer programs.",
+    "prerequisite_courses": [
+      "MATH 128"
+    ]
+  },
+  {
+    "prefix": "ITAL",
+    "number": "212",
+    "title": "Second Year Italian II",
+    "credits": 3,
+    "description": "Prerequisites: ITAL211Continues structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_text": "ITAL211Continues structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "247",
+    "title": "Intro to CTE Curriculum & Inst",
+    "credits": 3,
+    "description": "Provides the foundation for developing curriculum and assessments in Career and Technical Education (CTE). Students will learn concepts and practices for developing standards-based course maps, unit and lesson plans, learning outcomes and assessments that support competency-based student learning.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "207",
+    "title": "Airway Management/Ventilation",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Integrates complex knowledge of anatomy, physiology, and pathophysiology into the assessment to develop and implement a treatment plan with the goal of ensuring a patient airway, adequate mechanical ventilation, and respiration for patients of all ages.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Integrates complex knowledge of anatomy, physiology, and pathophysiology into the assessment to develop and implement a treatment plan with the goal of ensuring a patient airway, adequate mechanical ventilation, and respiration for patients of all ages.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MKT",
+    "number": "295",
+    "title": "Work Experience I",
+    "credits": 4,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "137",
+    "title": "Foundation Nursing Lab",
+    "credits": 1,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedures and the scientific rationale for performing the procedures correctly.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedure",
+    "prerequisite_courses": [
+      "NURS 136"
+    ]
+  },
+  {
+    "prefix": "COM",
+    "number": "113",
+    "title": "Fund of Speech Com",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduces principles and theories of speech communication. Includes participation in public speaking and interpersonal communication.",
+    "prerequisite_text": "NoneIntroduces principles and theories of speech communication. Includes participation in public speaking and interpersonal communication.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "101",
+    "title": "Intro to General Mech",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automobiles. Includes safety, use of manuals, selection and use of hand tools, and hand-held test instruments. Introduces general maintenance of various systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "154",
+    "title": "Lit for Pre-School",
+    "credits": 1,
+    "description": "Surveys books for use with preschool children. Includes techniques of storytelling and reading to children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SUR",
+    "number": "161",
+    "title": "Elementary Surveying",
+    "credits": 4,
+    "description": "Prerequisites: MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "prerequisite_text": "MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "prerequisite_courses": [
+      "MATH 127"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "137",
+    "title": "Trumpet-Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for trumpet. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "131",
+    "title": "Basic Industry 4.0 Cert",
+    "credits": 4,
+    "description": "Prerequisites: NoneSmart Automation Certification Alliance Industry 4.0 Associate - Basic Operations Certification prepares individuals to succeed in operations and assembly positions in modern production environments that use Industry 4.0 automation technologies. Class provides the knowledge and skills necessary to earn this nationally recognized certification and it is also ideal for individuals in related occupations who want to learn more about automated equipment and processes. Topics include: concepts & terminology of smart manufacturing, basic setup, adjustment & operation of automated machines, safety, hand tools, blueprint & schematic reading, precision measurement, basic electrical control, pneumatic & sensor systems operation, basic robot operation & terminology and production monitoring via HMI.",
+    "prerequisite_text": "NoneSmart Automation Certification Alliance Industry 4.0 Associate - Basic Operations Certification prepares individuals to succeed in operations and assembly positions in modern production environments that use Industry 4.0 automation technologies. Class provides the knowledge and skills necessary to earn this nationally recognized certification and it is also ideal for individuals in related occ",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LTE",
+    "number": "101",
+    "title": "Fundamental Phlebotomy",
+    "credits": 4,
+    "description": "Prerequisites: Vaccinations and major medical insurance required (see requirements for LTE under the Nursing and Allied Health division)Provides knowledge and skills necessary to perform basic collection, identification, and preservation of blood samples as applied to venipuncture techniques. Incorporates finger stick procedures and patient contact methodologies carried out within the ethical, legal and professional boundaries of the roles. Successful completion of LTE 102 is required to sit for national certification examinations offered through a variety of certifying organizations, including the American Society for Clinical Pathology (ASCP).",
+    "prerequisite_text": "Vaccinations and major medical insurance required (see requirements for LTE under the Nursing and Allied Health division)Provides knowledge and skills necessary to perform basic collection, identification, and preservation of blood samples as applied to venipuncture techniques. Incorporates finger stick procedures and patient contact methodologies carried out within the ethical, legal and professi",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FIN",
+    "number": "101",
+    "title": "Personal Finance",
+    "credits": 3,
+    "description": "Introduces personal financial planning. Emphasizes budgeting, obtaining credit, buying decisions for a home, auto or other large purchases, investment decisions, and retirement planning.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AST",
+    "number": "110",
+    "title": "Stellar Astronomy",
+    "credits": 3,
+    "description": "Prerequisites: MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to stellar and galactic systems, the life cycle of stars, theories of the universe and its formation. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "prerequisite_text": "MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to stellar and galactic systems, the life cycle of stars, theories of the universe and its formation. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "BTE",
+    "number": "113",
+    "title": "Bt Elec Resi Level V",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "20",
+    "title": "Learning Support for MATH 120",
+    "credits": 3,
+    "description": "Prerequisites: None. Corequisite: Enrollment in designated section of Math 120. Provides foundational material to support students in Math 120, Fundamentals of College Mathematics.",
+    "prerequisite_text": "None. Corequisite: Enrollment in designated section of Math 120. Provides foundational material to support students in Math 120, Fundamentals of College Mathematics.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "208",
+    "title": "Student Diverse Backgrnds",
+    "credits": 3,
+    "description": "Prerequisites: EDU 203 ; Corequisites: EDU 209 Focuses on students with learning disabilities, mental retardation, behavior disorders and language disorders, and their accommodation in general education environments.",
+    "prerequisite_text": "EDU 203 ; Corequisites: EDU 209 Focuses on students with learning disabilities, mental retardation, behavior disorders and language disorders, and their accommodation in general education environments.",
+    "prerequisite_courses": [
+      "EDU 203",
+      "EDU 209"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "232",
+    "title": "Painting II",
+    "credits": 3,
+    "description": "Prerequisites: ART231 Continues ART 231, with increased emphasis on refinement of basic painting skills. One hour lecture and four hours studio per week.",
+    "prerequisite_text": "ART231 Continues ART 231, with increased emphasis on refinement of basic painting skills. One hour lecture and four hours studio per week.",
+    "prerequisite_courses": [
+      "ART 231"
+    ]
+  },
+  {
+    "prefix": "MT",
+    "number": "115",
+    "title": "Industrial Material Automation",
+    "credits": 3,
+    "description": "Prerequisite: AIT 101Introduces the concepts of Programmable Logic Controllers (PLC) and computerized control operations. Covers basic PLC programming by describing numbering systems, PLC memory organization, PLC programming software and PLC program logic elements.",
+    "prerequisite_text": "AIT 101Introduces the concepts of Programmable Logic Controllers (PLC) and computerized control operations. Covers basic PLC programming by describing numbering systems, PLC memory organization, PLC programming software and PLC program logic elements.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "167",
+    "title": "Home Energy Audit Quality Cont",
+    "credits": 1,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this concurrently with the prerequisites with instructor approval.This course prepares students to become a quality control inspector with the skills to ensure the completion, appropriateness and quality of residential home energy upgrade work through use of methodological inspection of the building including performing safety and diagnostic tests and observing work performed. The course also prepares students for success on the BPI Home Energy Auditor Quality Control Inspection Certification examination.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this concurrently with the prerequisites with instructor approval.This course prepares students to become a quality control inspector with the skills to en",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  {
+    "prefix": "PSC",
+    "number": "231",
+    "title": "Intro International Relations",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Explores policy making institutions, foreign policies and politics of various nations.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Explores policy making institutions, foreign policies and politics of various nations.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "MUS",
+    "number": "124",
+    "title": "Hist Amer Musical Theatre",
+    "credits": 3,
+    "description": "Offers a cultural, musical and theatrical survey of musical theatre in the United States, from the mid-nineteenth century to the present.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "117",
+    "title": "Adv Auto Elect",
+    "credits": 4,
+    "description": "Prerequisites: AUTO115 Advanced AC and DC automotive electronic circuits. Troubleshooting electronically controlled components including supplemental restraint systems and convenience accessories. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO115 Advanced AC and DC automotive electronic circuits. Troubleshooting electronically controlled components including supplemental restraint systems and convenience accessories. Prepares students for ASE certification.",
+    "prerequisite_courses": [
+      "AUTO 115"
+    ]
+  },
+  {
+    "prefix": "EDCT",
+    "number": "295",
+    "title": "CTE Teaching Internship",
+    "credits": 6,
+    "description": "Observation and teaching under supervision in a secondary school, community or technical college, or business and industry training environment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "107",
+    "title": "Business Speech Comm",
+    "credits": 3,
+    "description": "Focuses on speech communication skills. Includes effective listening and feedback methods, voice improvement, group and team interaction, developing messages for positive and negative audiences, preparation and presentation of an oral report.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "99",
+    "title": "Basic Writing Strategies",
+    "credits": 4,
+    "description": "Provides instruction in basic English skills including sentence patterns and basic paragraph development. Provides review of grammar, mechanics, punctuation, spelling, and work usage. Offers practice in sentence, paragraph, and short essay writing with attention to grammar, sentence structure, and punctuation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "252",
+    "title": "Mechatronics: Pneumatic & Hydr",
+    "credits": 3,
+    "description": "3 units Prerequisite or Corequisite: AIT 251Covers the basics of pneumatic, electropneumatic and hydraulic control circuits in a complex mechatronic system. Students will learn the functions and properties of control elements based upon physical principles, and the roles they play within the system. Technical documentation such as data sheets, circuit diagrams, displacement step diagrams and function charts will be covered while exploring troubleshooting strategies and preventive maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "129",
+    "title": "Piano-Lower Division",
+    "credits": 2,
+    "description": "Considers performance and analysis of keyboard literature from various musical eras, instruction of keyboard technique and application of basic music theory to piano literature. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "242",
+    "title": "Organic Chemistry II",
+    "credits": 3,
+    "description": "Prerequisites: CHEM241 Provides an emphasis on functional groups, fundamental reaction mechanisms, and biomoleculaes. For life science and sciences majors. Continues CHEM 241. Three hours lecture.",
+    "prerequisite_text": "CHEM241 Provides an emphasis on functional groups, fundamental reaction mechanisms, and biomoleculaes. For life science and sciences majors. Continues CHEM 241. Three hours lecture.",
+    "prerequisite_courses": [
+      "CHEM 241"
+    ]
+  },
+  {
+    "prefix": "MTT",
+    "number": "296",
+    "title": "Comp Num Control Practice II",
+    "credits": 4,
+    "description": "Prerequisites: MTT 232This course allows for the further development of CNC skills with hands-on instruction related to the design and production of machined parts using CAD/CAM software, CNC milling machines, and CNC turning centers. Students will plan, program, set up, and produce a variety of precision-machined projects.",
+    "prerequisite_text": "MTT 232This course allows for the further development of CNC skills with hands-on instruction related to the design and production of machined parts using CAD/CAM software, CNC milling machines, and CNC turning centers. Students will plan, program, set up, and produce a variety of precision-machined projects.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "102",
+    "title": "Conversational French II",
+    "credits": 3,
+    "description": "Prerequisites: FREN101 or consent of instructor Offers a second semester of Conversational French designed to continue and improve the skills learned in the first semester.",
+    "prerequisite_text": "FREN101 or consent of instructor Offers a second semester of Conversational French designed to continue and improve the skills learned in the first semester.",
+    "prerequisite_courses": [
+      "FREN 101"
+    ]
+  },
+  {
+    "prefix": "DAN",
+    "number": "160",
+    "title": "Hip-Hop Dance",
+    "credits": 1,
+    "description": "Teaches beginning techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ANTH",
+    "number": "214",
+    "title": "Mesoamerican Arch",
+    "credits": 3,
+    "description": "Introduces students to the archaeology and prehistory of Mesoamerica. Includes the development of complex societies in Mexico and Central America.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "165",
+    "title": "Professional Home Energy Audit",
+    "credits": 3,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to learn the most advanced methods for testing buildings and be prepared for success on the HEP Energy Auditor certification.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to learn the most advanced methods for testing build",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "290",
+    "title": "AIT Internship",
+    "credits": 6,
+    "description": "Prerequisite: Consent of Instructor.Allows students to apply knowledge to real on-the-job situations in a program designed by a company official and faculty advisor to maximize learning experiences.",
+    "prerequisite_text": "Consent of Instructor.Allows students to apply knowledge to real on-the-job situations in a program designed by a company official and faculty advisor to maximize learning experiences.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "290",
+    "title": "Internship in Construction",
+    "credits": 3,
+    "description": "Prerequisites: NoneStudies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_text": "NoneStudies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "241L",
+    "title": "Organic Chem Lab I",
+    "credits": 1,
+    "description": "Prerequisites: CHEM122 ; Corequisites: CHEM241 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Three hours laboratory.",
+    "prerequisite_text": "CHEM122 ; Corequisites: CHEM241 Introduces the chemistry of carbon compounds; functional groups; relationships among molecular structure, properties and reactivity and biological relevance. For life and environmental sciences majors. Three hours laboratory.",
+    "prerequisite_courses": [
+      "CHEM 122",
+      "CHEM 241"
+    ]
+  },
+  {
+    "prefix": "EDU",
+    "number": "207",
+    "title": "Explor. Child Literature",
+    "credits": 3,
+    "description": "Surveys children's literature: issues, genre, censorship, historical background, book evaluation and selection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "117",
+    "title": "Crisis Inter De-escal Pol Acad",
+    "credits": 3,
+    "description": "Prerequisite: Acceptance to the Police Officers Standards and Training AcademyProvides crisis intervention training and de-escalation techniques for the peace officer standards and training academy. Teaches skills that will allow the peace officer to interact in a safer manner with possible threats they may encounter and to assist in the prevention of escalated force.",
+    "prerequisite_text": "Acceptance to the Police Officers Standards and Training AcademyProvides crisis intervention training and de-escalation techniques for the peace officer standards and training academy. Teaches skills that will allow the peace officer to interact in a safer manner with possible threats they may encounter and to assist in the prevention of escalated force.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "136",
+    "title": "Snow Boarding",
+    "credits": 1,
+    "description": "Prerequisites: intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the ski area.",
+    "prerequisite_text": "intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the s",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "299",
+    "title": "Spec Topics in Sign Lang",
+    "credits": 3,
+    "description": "Includes short courses and experimental classes covering a variety of subjects. May be repeated for up to six credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "235",
+    "title": "Organizational Behavior",
+    "credits": 3,
+    "description": "Prerequisites:BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and control systems on human behavior.",
+    "prerequisite_text": "BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and contro",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MGT 201"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "107",
+    "title": "Clarinet-Lower Division",
+    "credits": 2,
+    "description": "Introduces students to the study and performance of music for clarinet. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "211",
+    "title": "Microsoft Op System Mgt",
+    "credits": 3,
+    "description": "Through lectures, discussions, demonstrations, textbook exercises and classroom labs, teaches the basic skills and knowledge necessary to help prepare for the Microsoft Certified Professional (MCP) exam on the topic of a current Microsoft Workstation operating system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "235",
+    "title": "Eng Performance III",
+    "credits": 4,
+    "description": "Prerequisites: AUTO227 Computerized engine and fuel management control. Operational theory of automotive computers. Use of hand held diagnostic interfaces. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO227 Computerized engine and fuel management control. Operational theory of automotive computers. Use of hand held diagnostic interfaces. Prepares students for ASE certification.",
+    "prerequisite_courses": [
+      "AUTO 227"
+    ]
+  },
+  {
+    "prefix": "MTT",
+    "number": "291",
+    "title": "Cnc Practice",
+    "credits": 3,
+    "description": "Develops computer aided manufacturing skills with hands on instruction on how to design and prepare manufacture parts using state of the art CAD/CAM software. Safety and clean up are stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "127",
+    "title": "Watercolor I",
+    "credits": 3,
+    "description": "Offers a beginning course in watercolor painting with emphasis on materials and techniques which contribute to the production of quality works of art.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "145",
+    "title": "Voice-Lower Division",
+    "credits": 2,
+    "description": "Introduces the correct and pleasing use of the singing voice through a well balanced and coordinated study of vocal literature and exercises. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "113",
+    "title": "Life in the Oceans",
+    "credits": 3,
+    "description": "Introduces the plants, animals and microorganisms of the oceans with an emphasis on important marine ecosystems such as intertidal zones, estuaries and coral reefs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "141",
+    "title": "American Sign Language III&IV",
+    "credits": 6,
+    "description": "Prerequisites: AM 140 or AM 145 / AM 146American Sign Language III promotes the shift from comprehension to production of ASL to bring the students current ASL fluency to a point of self-generated ASL. American Sign Language IV encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_text": "AM 140 or AM 145 / AM 146American Sign Language III promotes the shift from comprehension to production of ASL to bring the students current ASL fluency to a point of self-generated ASL. American Sign Language IV encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_courses": [
+      "AM 140",
+      "AM 145"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "277",
+    "title": "Adv M/S Nsg. II Clinical",
+    "credits": 2.5,
+    "description": "Prerequisites: successful completion of the third semester of the nursing program. ; Corequisites: NURS276 Requires students to apply knowledge and skills to the care of adult patients in a simulated laboratory and acute care environments experiencing needs resulting from complex multisystem disruptions. Students apply the nursing process and utilize information literacy skills to achieve deliberative and competent decision-making that is grounded in evidence based practice to achieve best practice outcomes. Emphasis will be placed on prioritization of care through collaboration with other members of the health care team, patients and their families.",
+    "prerequisite_text": "successful completion of the third semester of the nursing program. ; Corequisites: NURS276 Requires students to apply knowledge and skills to the care of adult patients in a simulated laboratory and acute care environments experiencing needs resulting from complex multisystem disruptions. Students apply the nursing process and utilize information literacy skills to achieve deliberative and compet",
+    "prerequisite_courses": [
+      "NURS 276"
+    ]
+  },
+  {
+    "prefix": "CONS",
+    "number": "451",
+    "title": "Adv Internship in Const",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 281 and consent of instructor.Studies advanced project management techniques on-site under the supervision of a project manager or superintendent and instructor. In consultation with the student, based on the specific internship, instructor determines additional learning objectives in addition to standard course learning objectives. Includes interaction with the instructor on a weekly basis. Assignments are required.",
+    "prerequisite_text": "CONS 281 and consent of instructor.Studies advanced project management techniques on-site under the supervision of a project manager or superintendent and instructor. In consultation with the student, based on the specific internship, instructor determines additional learning objectives in addition to standard course learning objectives. Includes interaction with the instructor on a weekly basis.",
+    "prerequisite_courses": [
+      "CONS 281"
+    ]
+  },
+  {
+    "prefix": "BIOL",
+    "number": "299",
+    "title": "Special Topics in Biology",
+    "credits": 1,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MPT",
+    "number": "114",
+    "title": "Manufacturing & Automation III",
+    "credits": 3,
+    "description": "Prerequisite(s): MPT 112 or concurrent enrollmentA continuation of MPT 112. Production and automation systems management and control are further developed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "220",
+    "title": "Intro Organic Chemistry",
+    "credits": 4,
+    "description": "Prerequisites: CHEM121 Surveys the principles of carbon chemistry. Credit allowed in only one of CHEM 220 or 241. Three hours lecture/three hours laboratory.",
+    "prerequisite_text": "CHEM121 Surveys the principles of carbon chemistry. Credit allowed in only one of CHEM 220 or 241. Three hours lecture/three hours laboratory.",
+    "prerequisite_courses": [
+      "CHEM 121",
+      "CHEM 220"
+    ]
+  },
+  {
+    "prefix": "AIT",
+    "number": "201",
+    "title": "Pneumatic Power Tech",
+    "credits": 3,
+    "description": "Introduces the concepts of how to connect and operate basic pneumatic components and systems, read circuit diagrams, monitor system operation, and design circuits. Different types of actuators and values will be explained, and skills working with pneumatic schematics will be strengthened by using simulated tools and test equipment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "276",
+    "title": "Musical Theatre Practicum II",
+    "credits": 3,
+    "description": "Prerequisite: Six units of MUS 176.Continues skills learned in MUS 176.Repeatable up to 9 units.",
+    "prerequisite_text": "Six units of MUS 176.Continues skills learned in MUS 176.Repeatable up to 9 units.",
+    "prerequisite_courses": [
+      "MUS 176"
+    ]
+  },
+  {
+    "prefix": "GRC",
+    "number": "210",
+    "title": "Typography I",
+    "credits": 3,
+    "description": "Prerequisites: GRC 116Introduces students to designing with type for graphic design. Offers readings that outline the historical context of letter forms, while studio-based projects focus on practical analysis, visual and conceptual interaction of type and image, and the creative exploration of type as a formal element.",
+    "prerequisite_text": "GRC 116Introduces students to designing with type for graphic design. Offers readings that outline the historical context of letter forms, while studio-based projects focus on practical analysis, visual and conceptual interaction of type and image, and the creative exploration of type as a formal element.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "180",
+    "title": "Database Concepts and Sql",
+    "credits": 3,
+    "description": "Prerequisites: CIT129 or equivalent programming experience or consent of instructor Teaches basic principles of data modeling and relational database design. Class is targeted for people with little or no SQL knowledge. Provides a comprehensive overview of query writing, focusing on practical techniques for the IT professional new to relational databases. Course accents hands-on learning in a Structured Query Language (SQL) and SQL procedures.",
+    "prerequisite_text": "CIT129 or equivalent programming experience or consent of instructor Teaches basic principles of data modeling and relational database design. Class is targeted for people with little or no SQL knowledge. Provides a comprehensive overview of query writing, focusing on practical techniques for the IT professional new to relational databases. Course accents hands-on learning in a Structured Query La",
+    "prerequisite_courses": [
+      "CIT 129"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "299",
+    "title": "Spec Topics in Studio Art",
+    "credits": 3,
+    "description": "Applies to assorted short courses and workshops covering a variety of subjects. May be repeated for up to six credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "260",
+    "title": "Teach Read Write Math in CTE",
+    "credits": 3,
+    "description": "In this course, students will explore and apply effective strategies for integrating academic language, literacy, and numeracy (academic skills) instruction within a Career and Technical Education (CTE) context. Upon completion, students will have mastered foundational skills for teaching reading, writing and math. They will be able to effectively teach and reinforce core academic skills and develop lessons and assessments that support diverse learners in achieving career readiness and success.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "148",
+    "title": "American Sign Language IV",
+    "credits": 4,
+    "description": "Prerequisites: AM147 Encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_text": "AM147 Encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_courses": [
+      "AM 147"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "105",
+    "title": "Cello-Lower Division",
+    "credits": 2,
+    "description": "Provides a personal introduction to the study and performance of music for cello. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "116",
+    "title": "Musical Theatre Dance",
+    "credits": 1,
+    "description": "Introduces beginning techniques of tap dance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "451",
+    "title": "Construction Estimating",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 109 and MATH 126Covers principles and procedures used in estimating construction costs. Includes application of quality determination, estimate pricing, specifications, subcontractor and supplier solicitation, risk assessment and risk analysis, and final bidding preparation. Computer based estimating software used for semester project.",
+    "prerequisite_text": "CONS 109 and MATH 126Covers principles and procedures used in estimating construction costs. Includes application of quality determination, estimate pricing, specifications, subcontractor and supplier solicitation, risk assessment and risk analysis, and final bidding preparation. Computer based estimating software used for semester project.",
+    "prerequisite_courses": [
+      "CONS 109"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "290",
+    "title": "Internship in Welding",
+    "credits": 8,
+    "description": "Prerequisites: consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_text": "consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "209",
+    "title": "Theatre Practicum",
+    "credits": 6,
+    "description": "Offers practical experience in stage productions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "236",
+    "title": "Darkroom Photography II",
+    "credits": 3,
+    "description": "Prerequisites: ART 135Advanced darkroom photography course involving continued explorations of numerous photographic techniques, compositional styles, concepts and critical analysis of photography as a Fine Art.",
+    "prerequisite_text": "ART 135Advanced darkroom photography course involving continued explorations of numerous photographic techniques, compositional styles, concepts and critical analysis of photography as a Fine Art.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SW",
+    "number": "311",
+    "title": "Perspectives On Human Behavior",
+    "credits": 3,
+    "description": "Prerequisites: SW 310Second course in two-course sequence that promotes a multidimensional understanding of human functioning and behavior across systems and the life course. Specifically examines human behavior and functioning among individuals and families. Emphasizes an evidence-informed approach to assessing human functioning. Advances student ability to critically apply a range of theories and research to better understand and assess human behavior and development.",
+    "prerequisite_text": "SW 310Second course in two-course sequence that promotes a multidimensional understanding of human functioning and behavior across systems and the life course. Specifically examines human behavior and functioning among individuals and families. Emphasizes an evidence-informed approach to assessing human functioning. Advances student ability to critically apply a range of theories and research to b",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "497",
+    "title": "Business Plan Creation",
+    "credits": 3,
+    "description": "Prerequisite Admission to BAS Organization and Project Management Program and MGT 310 and FIN 310Teaches how to create investor quality business plans. Follows a step-by-step process to develop a business plan from an opening executive summary to a financial offering.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "198",
+    "title": "Special Topics in AIT",
+    "credits": 6,
+    "description": "Explores various topics of current interest/demand in Applied Industrial Technology areas of study. Applies to a variety of current topics in the field of industrial technology, covering subjects such as new approaches and techniques, equipment configuration, upgrades, preventive maintenance, etc.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "203",
+    "title": "Intro to Existentialism",
+    "credits": 3,
+    "description": "Reviews readings from Kierkegaard, Nietzsche, Jaspers, Sarte, Heidegger. An examination of the existentialist concepts: \"being\" and \"nonbeing,\" \"estrangement,\" \"dread,\" \"anxiety\" and \"freedom.\"",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "108",
+    "title": "Emergency Medical Technician",
+    "credits": 7.5,
+    "description": "Prerequisite: must be 18 years or older. Current CPR certification and required immunizations and tests, and health insurance. See Nursing and Allied Health web site for further information.Prepares individuals to provide basic emergency medical care, according to US Department of Transportation guidelines, to individuals experiencing sudden illness or injury. Course content includes appraisal of scene safety and scene management, assessment and treatment of common emergency patient conditions, including fractures, wounds and airway obstruction. Instruction includes use of emergency medications and automatic external defibrillation (AED) devices as well as components of continuing care during emergency ambulance transportation to the emergency department (ED). Clinical experience includes Emergency department hospital and ambulance rotations to meet a required minimum of 10 patient contacts. Upon successful conclusion of the course the student is eligible to sit for the National Registry Examination for EMT Basic.",
+    "prerequisite_text": "must be 18 years or older. Current CPR certification and required immunizations and tests, and health insurance. See Nursing and Allied Health web site for further information.Prepares individuals to provide basic emergency medical care, according to US Department of Transportation guidelines, to individuals experiencing sudden illness or injury. Course content includes appraisal of scene safety a",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPD",
+    "number": "410",
+    "title": "Contemporary Pedagogical Strat",
+    "credits": 3,
+    "description": "Prerequisite: Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
+    "prerequisite_text": "Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "251",
+    "title": "Mechatronics: Mechanical",
+    "credits": 3,
+    "description": "3 units Prerequisite or Corequisite: AIT 250Covers the basics of pneumatic, electropneumatic and hydraulic control circuits in a complex mechatronic system. Teaches the functions and properties of control elements based upon physical principles, and the roles they play within the system. Covers technical documentation such as data sheets, circuit diagrams, displacement step diagrams and function charts while exploring troubleshooting strategies and preventive maintenance. Covers the basics of mechanical components in a complex mechatronic system. Students will learn the basic functions and physical properties of mechanical components, and the roles they play within the system. Technical documentation such as data sheets, schematics, and timing diagrams will be covered while exploring troubleshooting strategies and preventive maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "212",
+    "title": "Microsoft Networking II",
+    "credits": 5,
+    "description": "Through lectures, discussions, demonstrations, textbook study and hands-on lab exercises, teaches the basic skills and knowledge necessary to implement, administer and maintain the current Microsoft Windows Server Operation System.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "133",
+    "title": "Beginning C++",
+    "credits": 3,
+    "description": "Prerequisites: CIT129 or consent of instructor Teaches the \"C++\" programming language. Object-oriented programming techniques and hands-on learning will be emphasized. Students will complete several computer programming projects.",
+    "prerequisite_text": "CIT129 or consent of instructor Teaches the \"C++\" programming language. Object-oriented programming techniques and hands-on learning will be emphasized. Students will complete several computer programming projects.",
+    "prerequisite_courses": [
+      "CIT 129"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "270",
+    "title": "Adv. Clin. Nurs I Theory",
+    "credits": 3,
+    "description": "Prerequisites: successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students will also apply concepts of community care, case management, health teaching and discharge planning.",
+    "prerequisite_text": "successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students",
+    "prerequisite_courses": [
+      "NURS 271"
+    ]
+  },
+  {
+    "prefix": "ELM",
+    "number": "136",
+    "title": "Prog Logic Controllers II",
+    "credits": 3,
+    "description": "Prerequisite(s): ELM 134A continuation of ELM 134. Provides intermediate level skills in Programmable Logic Control (PLC) programming instruction and control concepts. Explores the advanced elements of PLC functions by writing and testing programs to control them. Emphasis placed on programming structure, instructions, and execution. Utilize advanced simulation software to develop and execute various PLC programs. Apply troubleshooting strategies to identify and localize problems caused by PLC hardware.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "285",
+    "title": "Unity Programming II",
+    "credits": 3,
+    "description": "Prerequisites: CIT 284Teaches the ability to create VR experiences and programs within Unity software. The course objectives are aligned with current industry standards set by professionals and educators.",
+    "prerequisite_text": "CIT 284Teaches the ability to create VR experiences and programs within Unity software. The course objectives are aligned with current industry standards set by professionals and educators.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "207",
+    "title": "Discover Nevada",
+    "credits": 3,
+    "description": "Explores the many historic sites and scenic areas of Nevada, utilizing lecture discussions, slide presentations, readings and videos.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "140",
+    "title": "Auto Brake Systems",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automotive brake systems including antilock systems. Includes safety, use of manuals, selection and use of hand tools, power tools and hand-held test instruments. Introduces general maintenance of a variety of different systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "120",
+    "title": "Psych of Hum Performance",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Surveys the psychology of human performance. Explores the psychological, emotional, and strategic dimensions of human performance. Emphasis will be to provide students with a comprehensive background that they can apply to their own performance areas.",
+    "prerequisite_text": "PSY101 or consent of instructor Surveys the psychology of human performance. Explores the psychological, emotional, and strategic dimensions of human performance. Emphasis will be to provide students with a comprehensive background that they can apply to their own performance areas.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "BUS",
+    "number": "101",
+    "title": "Intro to Business",
+    "credits": 3,
+    "description": "Provides the student a broad background about the modern business world. An important course for students who are considering choosing a business major.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "20",
+    "title": "Learning Support for MATH 120",
+    "credits": 3,
+    "description": "Prerequisites: None. Corequisite: Enrollment in designated section of Math 120. Provides foundational material to support students in Math 120, Fundamentals of College Mathematics.",
+    "prerequisite_text": "None. Corequisite: Enrollment in designated section of Math 120. Provides foundational material to support students in Math 120, Fundamentals of College Mathematics.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "261",
+    "title": "Machine Projects",
+    "credits": 6,
+    "description": "Prerequisites: consent of instructor Permits students to work on special projects of their own choosing and/or explore areas of special interest under the direction of a college instructor.",
+    "prerequisite_text": "consent of instructor Permits students to work on special projects of their own choosing and/or explore areas of special interest under the direction of a college instructor.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "154",
+    "title": "Lit for Pre-School",
+    "credits": 1,
+    "description": "Surveys books for use with preschool children. Includes techniques of storytelling and reading to children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "290",
+    "title": "The Roaring 20s",
+    "credits": 3,
+    "description": "Prerequisites: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Study of American society and culture in the 1920s through the interrelated topics of consumerism, youth culture, the role of the U.S. in the world, post-war retrenchment, the Harlem Renaissance/Jazz Age, and shifting definitions of race and gender.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Study of American society and culture in the 1920s through the interrelated topics of consumerism, youth culture, the role of the U.S. in the world, post-war retrenchment, the Harlem Renaissance/Jazz Age, and shifting definitions of race and gender.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "AC",
+    "number": "102",
+    "title": "Refrigeration Theory",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduction to the fundamental principles of mechanical refrigeration. Designed for those pursuing a career in servicing, repairing and/or installing refrigeration and air conditioning equipment as well as building maintenance.",
+    "prerequisite_text": "NoneIntroduction to the fundamental principles of mechanical refrigeration. Designed for those pursuing a career in servicing, repairing and/or installing refrigeration and air conditioning equipment as well as building maintenance.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "225",
+    "title": "Eng Performance I",
+    "credits": 4,
+    "description": "Prerequisites: AUTO 101 A study of engine related subsystems which include ignition, fuel, cooling, starting, and charging systems. Theory and testing of computerized engine management systems. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO 101 A study of engine related subsystems which include ignition, fuel, cooling, starting, and charging systems. Theory and testing of computerized engine management systems. Prepares students for ASE certification.",
+    "prerequisite_courses": [
+      "AUTO 101"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "104",
+    "title": "Nevada Firefighter I",
+    "credits": 3,
+    "description": "Prerequisites: FT 101Designed to familiarize the student with the general rules and regulations of fire fighting, use and explanation of forcible entry, protective breathing apparatus, fire streams, first aid, ropes, salvage, fire hose, nozzles and apparatus, ladders, ventilation, inspection, rescue, sprinklers, fire alarms and communications, safety and fire behavior.",
+    "prerequisite_text": "FT 101Designed to familiarize the student with the general rules and regulations of fire fighting, use and explanation of forcible entry, protective breathing apparatus, fire streams, first aid, ropes, salvage, fire hose, nozzles and apparatus, ladders, ventilation, inspection, rescue, sprinklers, fire alarms and communications, safety and fire behavior.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "261",
+    "title": "Prin of Statistics I",
+    "credits": 3,
+    "description": "Prerequisites: MATH126 or equivalent Offers probability and major probability distributions, sampling theory, descriptive statistics, measure of central tendency and dispersion, index figures, and time series.",
+    "prerequisite_text": "MATH126 or equivalent Offers probability and major probability distributions, sampling theory, descriptive statistics, measure of central tendency and dispersion, index figures, and time series.",
+    "prerequisite_courses": [
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "111",
+    "title": "Euphonium - Lower Division",
+    "credits": 2,
+    "description": "Provides a personal introduction to the study and performance of music for euphonium. No previous musical training required. Class may be repeated for a total of 4 credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTB",
+    "number": "120",
+    "title": "Automotive Collision I",
+    "credits": 3,
+    "description": "Provides fundamental instruction of hands-on skill and knowledge in auto body construction, tools, and safety. Students will also work with metal, plastics, fiberglass and trim.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DAN",
+    "number": "160",
+    "title": "Hip-Hop Dance",
+    "credits": 1,
+    "description": "Teaches beginning techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "111",
+    "title": "Piano Class I",
+    "credits": 3,
+    "description": "Introduces the piano, including instruction in note reading, technique, theory and easy repertoire. Students work in a laboratory setting, each using their own electronic piano.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "160",
+    "title": "Art Appreciation",
+    "credits": 3,
+    "description": "Studies art, artists and art media of various historical periods to develop the student's capacity to evaluate and appreciate them.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "208",
+    "title": "Observ/Pract in Interpreting",
+    "credits": 3,
+    "description": "Prerequisite: Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "prerequisite_text": "Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "204",
+    "title": "Info Technlgy in Teaching",
+    "credits": 3,
+    "description": "Studies the use of microcomputers in operations and word processing applicable to classroom for teachers to operate and utilize microcomputers in education. Special instruction fees.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTC",
+    "number": "107",
+    "title": "Building Trades Carpentry VII",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 7 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 7 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTP",
+    "number": "106",
+    "title": "Bt Plumbing Level Vi",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "130",
+    "title": "Nursing Assistant",
+    "credits": 6,
+    "description": "Prerequisites: basic Life Support/Healthcare Provider CPR certification. See Nursing and Allied Health website for additional information. Prepares students to function as nursing assistant trainees (NAT) who assist licensed nurses to provide direct care to health care consumers across the lifespan in a variety of heath care settings. The 150-hour competency based course is designed to prepare students to achieve certification as a nurse assistant in the State of Nevada. The course is approved by the Nevada State Board of Nursing and is in accordance with the Omnibus Budget Reconciliation Act (OBRA) and Occupational Safety and Health Agency (OSHA) regulations.",
+    "prerequisite_text": "basic Life Support/Healthcare Provider CPR certification. See Nursing and Allied Health website for additional information. Prepares students to function as nursing assistant trainees (NAT) who assist licensed nurses to provide direct care to health care consumers across the lifespan in a variety of heath care settings. The 150-hour competency based course is designed to prepare students to achiev",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "211",
+    "title": "Microsoft Op System Mgt",
+    "credits": 3,
+    "description": "Through lectures, discussions, demonstrations, textbook exercises and classroom labs, teaches the basic skills and knowledge necessary to help prepare for the Microsoft Certified Professional (MCP) exam on the topic of a current Microsoft Workstation operating system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "143",
+    "title": "Violin-Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for violin. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HDFS",
+    "number": "202",
+    "title": "Intro to Families",
+    "credits": 3,
+    "description": "Explores the dynamics of development, interaction, and intimacy of primary relationships in contextual and theoretical frameworks, societal issues and choices facing diverse family systems. This course is taught from a bio-psycho-social approach within the family ecological system context. It incorporates issues relevant to international families and diverse family arrangements within North America. Traditional issues of families are reframed, reconstructed, and questioned. Application of ideas to those working with families in a variety of settings including: physical health, mental health, economic and educational arenas.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "210",
+    "title": "World Religions",
+    "credits": 3,
+    "description": "Prerequisites: ENG 101 recommendedExamines the main moral and religious views of world religions.",
+    "prerequisite_text": "ENG 101 recommendedExamines the main moral and religious views of world religions.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "MGT",
+    "number": "320",
+    "title": "Organization & Project Mgt",
+    "credits": 3,
+    "description": "Prerequisite: Admission to BAS Organization and Project Management ProgramFocuses on the key drivers of a successful organization. Emphasizes organization theories and models to analyze and improve performance in the organization. skills and Knowledge of project management and introduced and linked to organization performance.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management ProgramFocuses on the key drivers of a successful organization. Emphasizes organization theories and models to analyze and improve performance in the organization. skills and Knowledge of project management and introduced and linked to organization performance.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "295",
+    "title": "Directed Study in English",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 Allows students to pursue individual writing or research projects under the close supervision and guidance of the instructor.",
+    "prerequisite_text": "ENG102 Allows students to pursue individual writing or research projects under the close supervision and guidance of the instructor.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "WELD",
+    "number": "242",
+    "title": "Welding IV Practice",
+    "credits": 2,
+    "description": "Prerequisites: WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 241Introduces fundamental pipe welding techniques and develops basic skills for the service and transmission fields in the shielded metal-arc section. Trains welders for work in either the pressure pipe industry or transmission pipeline work using the micro-wire weld.",
+    "prerequisite_text": "WELD 231 and WELD 232, or consent of instructor; Corequisite: WELD 241Introduces fundamental pipe welding techniques and develops basic skills for the service and transmission fields in the shielded metal-arc section. Trains welders for work in either the pressure pipe industry or transmission pipeline work using the micro-wire weld.",
+    "prerequisite_courses": [
+      "WELD 231",
+      "WELD 232"
+    ]
+  },
+  {
+    "prefix": "EDU",
+    "number": "220",
+    "title": "Principles of Educational Psyc",
+    "credits": 3,
+    "description": "The psychology of learning, motivation, growth and development, personality, dynamics, and social adjustment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "173",
+    "title": "Introduction to Linux",
+    "credits": 3,
+    "description": "Prerequisites: Basic computer literacy skills. Provides an introduction to the Linux Operating System. Topics include Linux origins, file system, user commands and utilities, graphical user interfaces, editors, manual pages and shells.",
+    "prerequisite_text": "Basic computer literacy skills. Provides an introduction to the Linux Operating System. Topics include Linux origins, file system, user commands and utilities, graphical user interfaces, editors, manual pages and shells.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "147",
+    "title": "Amer Sign Lang III",
+    "credits": 4,
+    "description": "Prerequisites: AM146 Promotes the shifting from comprehension to production of ASL to bring one's current ASL fluency to a point of self generated ASL.",
+    "prerequisite_text": "AM146 Promotes the shifting from comprehension to production of ASL to bring one's current ASL fluency to a point of self generated ASL.",
+    "prerequisite_courses": [
+      "AM 146"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "96D",
+    "title": "Alegbra Review for Math 126",
+    "credits": 2,
+    "description": "Corequisite: Math 126Offers a second course in algebra. Includes multiplying, dividing, and factoring polynomial expressions, solving polynomial and rational equations, algebraic techniques involving exponents and radicals, and systems of linear equations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "455",
+    "title": "Const Management Practice",
+    "credits": 3,
+    "description": "Additional prerequisites CEM 451, CEM 452, and CEM 453: Includes direction and operation of construction organizations with examination of general contracting, design-build, and construction management methods. Covers synthesis of project management concepts, applications, and limitations through case studies and semester projects.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "COM",
+    "number": "412",
+    "title": "Intercultural Commnctn",
+    "credits": 3,
+    "description": "Factors important to meaningful communication across cultures with emphasis on intercultural differences in North America.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "108",
+    "title": "Permit Required Confined Space",
+    "credits": 1,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers the hazards associated with working in confined spaces and safety precautions that must be taken during this work. Hands-on activities include preparing for and entering a mock confined space.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers the hazards associated with working in confined spaces and safety precautions that must be taken during this work. Hands-on activities include preparing for and entering a mock confined space.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "199",
+    "title": "Special Topics",
+    "credits": 3,
+    "description": "Offers special topics which vary across semesters. A maximum of six credits may be applied towards a WNC degree.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "115",
+    "title": "Scaffold Builder",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ME",
+    "number": "198",
+    "title": "Cooperative Training Rprt",
+    "credits": 1,
+    "description": "Prerequisites: enrollment in engineering program Guides students in preparation of written reports based on cooperative program assignments.",
+    "prerequisite_text": "enrollment in engineering program Guides students in preparation of written reports based on cooperative program assignments.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "165",
+    "title": "Med Surg Nurs I Theory",
+    "credits": 3,
+    "description": "Prerequisites: successful completion of the first semester of the nursing program; Corequisites: NURS166 & NURS167 Assists students to integrate knowledge derived from the bio/psycho/social sciences, humanities, nursing and current literature to achieve safe, competent care of adult patients experiencing common alterations in body systems. Organized by the nursing process to achieve best practice outcomes in an acute care medical/surgical setting. Particular emphasis is placed on the concepts of holistic care, patient education, and discharge planning.",
+    "prerequisite_text": "successful completion of the first semester of the nursing program; Corequisites: NURS166 & NURS167 Assists students to integrate knowledge derived from the bio/psycho/social sciences, humanities, nursing and current literature to achieve safe, competent care of adult patients experiencing common alterations in body systems. Organized by the nursing process to achieve best practice outcomes in an",
+    "prerequisite_courses": [
+      "NURS 166",
+      "NURS 167"
+    ]
+  },
+  {
+    "prefix": "AST",
+    "number": "109",
+    "title": "Planetary Astronomy",
+    "credits": 3,
+    "description": "Prerequisites: MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to current concepts of the solar system, modern observational techniques, and their results. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "prerequisite_text": "MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to current concepts of the solar system, modern observational techniques, and their results. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "MTT",
+    "number": "250",
+    "title": "Machine Shop III",
+    "credits": 3,
+    "description": "Prerequisites: MTT110 and DFT110 or consent of instructor. Corequisite: MTT 251 or consent of instructor.Expands skills introduced in MTT 105 and MTT 110 to a more advanced level by developing projects that emphasize tolerances, plan of procedure and blueprint reading. Introduces further skills for surface grinding and tool and cutter grinding.",
+    "prerequisite_text": "MTT110 and DFT110 or consent of instructor. Corequisite: MTT 251 or consent of instructor.Expands skills introduced in MTT 105 and MTT 110 to a more advanced level by developing projects that emphasize tolerances, plan of procedure and blueprint reading. Introduces further skills for surface grinding and tool and cutter grinding.",
+    "prerequisite_courses": [
+      "MTT 110",
+      "DFT 110",
+      "MTT 251",
+      "MTT 105"
+    ]
+  },
+  {
+    "prefix": "BTS",
+    "number": "105",
+    "title": "BT Construction Sheet Metal V",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 5 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 5 of the Construction Sheet Metal Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "211",
+    "title": "Welding I",
+    "credits": 3,
+    "description": "Corequisite: WELD 212Introduces welding which includes welding safety, environmental awareness, oxy-acetylene welding, cutting, and brazing as well as shielded metal-arc.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECE",
+    "number": "155",
+    "title": "Literacy/the Young Child",
+    "credits": 1,
+    "description": "Emphasizes activities and materials for developing auditory and visual perception and other reading readiness skills in the preschool.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MT",
+    "number": "134",
+    "title": "Nat Gas Line Loc & Leak Survey",
+    "credits": 3,
+    "description": "Prerequisites: MT 130, MT 132 (May be co-enrolled in MT 132)Introduces natural gas pipe leak detection. Includes various pipeline leak configurations and subsystems. Key devices/tools used in the detection of leaks are evaluated. Demonstrates classification, grading and surveying of leaks.",
+    "prerequisite_text": "MT 130, MT 132 (May be co-enrolled in MT 132)Introduces natural gas pipe leak detection. Includes various pipeline leak configurations and subsystems. Key devices/tools used in the detection of leaks are evaluated. Demonstrates classification, grading and surveying of leaks.",
+    "prerequisite_courses": [
+      "MT 130",
+      "MT 132"
+    ]
+  },
+  {
+    "prefix": "CIT",
+    "number": "130",
+    "title": "Beginning Java",
+    "credits": 3,
+    "description": "Prerequisites: CIT129 or previous programming experience with consent of instructor Teaches Java, an object-oriented programming language used in general-purpose computing, Web development, client-server computing, n-tier e-commerce applications, and Web-based applets. Object-oriented programing techniques and hands-on learning will be emphasized. Students will complete several computer programming projects.",
+    "prerequisite_text": "CIT129 or previous programming experience with consent of instructor Teaches Java, an object-oriented programming language used in general-purpose computing, Web development, client-server computing, n-tier e-commerce applications, and Web-based applets. Object-oriented programing techniques and hands-on learning will be emphasized. Students will complete several computer programming projects.",
+    "prerequisite_courses": [
+      "CIT 129"
+    ]
+  },
+  {
+    "prefix": "FS",
+    "number": "107",
+    "title": "Fire Srvc Comm Skills",
+    "credits": 3,
+    "description": "Develops interpersonal communication skills of speaking and listening through preparing and presenting both oral and written reports. Studies government structure; covers verbal and non-verbal communication, encoding and decoding. Develops presentation methods and selection of delivery process. Studies how to communicate ideas effectively.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "283",
+    "title": "Intro/Hum Resources Mgt",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101 and MGT 201 or consent of instructor.Develops an understanding of the duties and responsibilities of personnel at the mid-management level.",
+    "prerequisite_text": "BUS 101 and MGT 201 or consent of instructor.Develops an understanding of the duties and responsibilities of personnel at the mid-management level.",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MGT 201"
+    ]
+  },
+  {
+    "prefix": "CRJ",
+    "number": "211",
+    "title": "Police in Amer: Intro",
+    "credits": 3,
+    "description": "Explores the historical development, roles, socialization, and problems of police work.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "233",
+    "title": "Recrding Technqs & Midi I",
+    "credits": 2,
+    "description": "Covers topics such as the job market, mics, consoles, tape recorders, and special effects. Teaches concepts including signal flow, multi-tracking, EQ, signal processing, MIDI, mixing and mastering. Students will learn to turn a Mac or PC into a multi-track studio.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "150",
+    "title": "American Sign Language VI",
+    "credits": 4,
+    "description": "Prerequisites: AM149 Final course in the American Sign Language series, covering a culmination of all signs, pragmatics, grammar and fingerspelling skills acquired throughout the series. Emphasis is on utilizing all ASL skills simultaneously and fluently.",
+    "prerequisite_text": "AM149 Final course in the American Sign Language series, covering a culmination of all signs, pragmatics, grammar and fingerspelling skills acquired throughout the series. Emphasis is on utilizing all ASL skills simultaneously and fluently.",
+    "prerequisite_courses": [
+      "AM 149"
+    ]
+  },
+  {
+    "prefix": "CEE",
+    "number": "495",
+    "title": "Special Topics",
+    "credits": 3,
+    "description": "Additional prerequisites or corequisites: CONS 108 and CONS 114 and CEM 456Study and/or experimentation in areas of special current and modern fields that concerns construction managers. Teaches students to research different possibilities and their implications on the modern construction industry. Repeatable up to six units.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "106",
+    "title": "Pipelaying Part I",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers gravity flow pipe systems, the math used during layout and installation, and the tools, PPE, and equipment to perform the work. Trench and excavation safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers gravity flow pipe systems, the math used during layout and installation, and the tools, PPE, and equipment to perform the work. Trench and excavation safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "297",
+    "title": "Wk Exp - Law Enforcement",
+    "credits": 6,
+    "description": "Prerequisites: CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_text": "CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "92",
+    "title": "Algebra Review",
+    "credits": 1,
+    "description": "Prerequisite: Previous success in Intermediate Algebra or Algebra II or higher algebra course. Provides a review of algebra that will refresh previously taught concepts. Designed for students who have successfully completed Algebra II or Intermediate Algebra or similar course sometime in the past. Provides a condensed review of topics from Intermediate Algebra intended to help students place into the appropriate course via Accuplacer Exam.",
+    "prerequisite_text": "Previous success in Intermediate Algebra or Algebra II or higher algebra course. Provides a review of algebra that will refresh previously taught concepts. Designed for students who have successfully completed Algebra II or Intermediate Algebra or similar course sometime in the past. Provides a condensed review of topics from Intermediate Algebra intended to help students place into the appropriat",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "113",
+    "title": "Comp I/Non-Native Eng Spk",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CEM",
+    "number": "485",
+    "title": "Construction Law & Contracts",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 118Provides information on legal problems in the construction process. Covers stipulated sum, unit price, cost-plus contracts, construction lien rights and bond rights, scope of work issues, builders risk issues, risk-shifting, and case studies.",
+    "prerequisite_text": "CONS 118Provides information on legal problems in the construction process. Covers stipulated sum, unit price, cost-plus contracts, construction lien rights and bond rights, scope of work issues, builders risk issues, risk-shifting, and case studies.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "211",
+    "title": "Second Year Spanish I",
+    "credits": 3,
+    "description": "Prerequisites: SPAN112 or equivalent Considers structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_text": "SPAN112 or equivalent Considers structural review, conversation and writing, and readings in modern literature.",
+    "prerequisite_courses": [
+      "SPAN 112"
+    ]
+  },
+  {
+    "prefix": "ECE",
+    "number": "122",
+    "title": "Observation Skills",
+    "credits": 1,
+    "description": "Provides parents and teachers various formal and informal methods to enhance their observation and assessment skills. Discussion includes methods for use with developmentally delayed children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOG",
+    "number": "103",
+    "title": "Physical Geography",
+    "credits": 3,
+    "description": "Prerequisites: MATH120,MATH126 or higher or consent of instructor Teaches the physical processes of geography, including maps, seasons, weather and climate. Includes at least four lab experiences.",
+    "prerequisite_text": "MATH120,MATH126 or higher or consent of instructor Teaches the physical processes of geography, including maps, seasons, weather and climate. Includes at least four lab experiences.",
+    "prerequisite_courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "PHYS",
+    "number": "293",
+    "title": "Directed Study",
+    "credits": 3,
+    "description": "Prerequisites: PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "prerequisite_text": "PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "prerequisite_courses": [
+      "PHYS 151",
+      "PHYS 180"
+    ]
+  },
+  {
+    "prefix": "SW",
+    "number": "250",
+    "title": "Social Welfare History/Policy",
+    "credits": 3,
+    "description": "Explores the historical development of the social work profession and current policies governing the social service delivery system within the United States. Presents social policy as a social construction influenced by a range of ideologies and interests. Special attention is paid to social welfare policy and programs relevant to the practice of social work, including poverty, child and family well-being, mental and physical disability, health, and racial, ethnic, and sexual minorities. Includes a focus on the role of policy in creating, maintaining or eradicating social inequities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOG",
+    "number": "104",
+    "title": "Physical Geography Lab",
+    "credits": 1,
+    "description": "Pre or Corequisite: GEOG103 or consent of instructor.Offers experimental and in-depth investigations designed to illustrate fundamental principles of physical geography..",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ANTH",
+    "number": "213",
+    "title": "Indigenous Peoples Great Basin",
+    "credits": 3,
+    "description": "Introduces the Indigenous Nations of the Great Basin summarizing ethnographic and contemporary issues of Indigenous Nations of the Great Basin and the indigenous groups that are geographically adjacent and have influenced Basin cultures. Examines the archaeological documentation of pre-contact conditions..",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "212",
+    "title": "Welding I Practice",
+    "credits": 2,
+    "description": "Corequisites: WELD 211 Develops the student's manual skills necessary to produce high quality gas welds and flame cuts. The student learns to set up the equipment for all phases of oxy-acetylene welding and cutting. The shielded metal-arc welding section develops entry level skills for welders. This course specifically develops basic shielded metal arc welding skills such as striking the arc, maintaining proper arc length, adjusting equipment and manipulating the electrode.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELM",
+    "number": "134",
+    "title": "Programmable Logic Controllers",
+    "credits": 3,
+    "description": "Prerequisite(s): ELM 127Covers the fundamentals of digital logic and an introduction to programmable logic controllers (PLCs) in a complex mechatronic system. Students will learn the role PLCs play within a mechatronic system or subsystem; will explore basic elements of PLC functions by writing and testing programs to control them; identify malfunctioning PLCs, applying troubleshooting strategies to identify and localize problems caused by PLC hardware.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "262",
+    "title": "Prin of Statistics II",
+    "credits": 3,
+    "description": "Prerequisites: ECON261 Offers statistical inference; estimation hypothesis testing, simple linear regression and correlation, and analysis of variance.",
+    "prerequisite_text": "ECON261 Offers statistical inference; estimation hypothesis testing, simple linear regression and correlation, and analysis of variance.",
+    "prerequisite_courses": [
+      "ECON 261"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "147",
+    "title": "Health Assessment Theory",
+    "credits": 2,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS148 Provides opportunities for students to gain knowledge necessary to holistically assess adult and elder patients. Students utilize concepts of previously learned content from pre-requisite and co-requisite nursing courses including the nursing process and methods of prioritizing to perform nursing assessment and nursing diagnosis. Students learn the difference among a comprehensive assessment, an ongoing/partial assessment, a focused, problem-oriented assessment and an emergency assessment of a patient.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS148 Provides opportunities for students to gain knowledge necessary to holistically assess adult and elder patients. Students utilize concepts of previously learned content from pre-requisite and co-requisite nursing courses including the nursing process and methods of prioritizing to perform nursing assessment and nursing diagnosis. Students lea",
+    "prerequisite_courses": [
+      "NURS 148"
+    ]
+  },
+  {
+    "prefix": "AC",
+    "number": "150",
+    "title": "Basic Refrigeration Servicing",
+    "credits": 6,
+    "description": "Prerequisites: AC 102, AC 107Designed for those interested in entering the refrigeration service, installation or building maintenance fields. Orientated toward development of basic skills required in troubleshooting, repair and maintenance of refrigeration systems. Topics covered are soldering, silver soldering, service and troubleshooting tools and systems construction.",
+    "prerequisite_text": "AC 102, AC 107Designed for those interested in entering the refrigeration service, installation or building maintenance fields. Orientated toward development of basic skills required in troubleshooting, repair and maintenance of refrigeration systems. Topics covered are soldering, silver soldering, service and troubleshooting tools and systems construction.",
+    "prerequisite_courses": [
+      "AC 102"
+    ]
+  },
+  {
+    "prefix": "STAT",
+    "number": "152",
+    "title": "Intro to Statistics",
+    "credits": 3,
+    "description": "Prerequisites: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors. Introduces statistics, probability models, statistical estimation and hypothesis testing, linear regression analysis, and special topics.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors. Introduces statistics, probability models, statistical estimation and hypothesis testing, linear regression analysis, and special topics.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FIN",
+    "number": "310",
+    "title": "Applied Accounting and Finance",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organization and Project Management ProgramDesigned to provide the keys, concepts and tools used in understanding the financial functions of a business enterprise. Introduces the essential concepts necessary in understanding formal financial statements from the user's perspective.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management ProgramDesigned to provide the keys, concepts and tools used in understanding the financial functions of a business enterprise. Introduces the essential concepts necessary in understanding formal financial statements from the user's perspective.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "124",
+    "title": "College Algebra",
+    "credits": 3,
+    "description": "Prerequisites: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a WNC Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors. Covers equations and inequalities; relations and functions; linear, quadratic, polynomial, exponential, and logarithmic functions; systems of linear equations.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a WNC Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors. Covers equations and inequalities; relations and functions; linear, quadratic, polynomial, exponential, and logarithmic functions; syste",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTO",
+    "number": "106",
+    "title": "BT Heavy Equipment Operator VI",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 6 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 6 of the Heavy Equipment Operator Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "COT",
+    "number": "262",
+    "title": "Interm Spreadsheets",
+    "credits": 3,
+    "description": "Prerequisites: IS101 or consent of instructor Studies the concepts and capabilities of computer spreadsheet systems. Teaches command and macro generation. Students gain experience generating spreadsheet templates, graphs and macros as business problem-solving tools. When offered for variable credit, content will be divided as follows: A) Concepts and capabilities of the computer spreadsheet with spreadsheet generation; B) Experience with the user-level menu access of the software, including graphing; C) More advanced capabilities of database and macro generation.",
+    "prerequisite_text": "IS101 or consent of instructor Studies the concepts and capabilities of computer spreadsheet systems. Teaches command and macro generation. Students gain experience generating spreadsheet templates, graphs and macros as business problem-solving tools. When offered for variable credit, content will be divided as follows: A) Concepts and capabilities of the computer spreadsheet with spreadsheet gene",
+    "prerequisite_courses": [
+      "IS 101"
+    ]
+  },
+  {
+    "prefix": "ECE",
+    "number": "204",
+    "title": "Prin Child Guidance",
+    "credits": 3,
+    "description": "Studies effective communication with children in guiding behavior. Emphasis will be placed on techniques which help children build positive self-concepts and individual strengths within the context of appropriate limits and discipline. The study includes uses of direct and indirect guidance techniques as well as introduction to guidance systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "105",
+    "title": "Bt Electrical Level V",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "210",
+    "title": "Auto Trans & Transaxles I",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automatic transmissions used in today's automobiles. Includes safety, use of manuals, selection and use of hand tools, and appropriate transmission test instruments. Introduces maintenance of a variety of different automatic transmissions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPY",
+    "number": "150",
+    "title": "Strategies Academ Success",
+    "credits": 3,
+    "description": "Helps students to develop effective and efficient study skills. Students will learn how to learn.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "274",
+    "title": "Ethical Hacking",
+    "credits": 3,
+    "description": "Prerequisites: Instructor ConsentExplains basic IT security concepts and models. Introduces concepts of penetration testing to validate security measures and identify vulnerabilities; formulate a basic security policy; demonstrate basic penetration attacks; assess risks and countermeasures; explain legal and ethical concerns as they apply to penetration testing; explores methods to gain access to computer resources and methods to prevent/reduce vulnerabilities.",
+    "prerequisite_text": "Instructor ConsentExplains basic IT security concepts and models. Introduces concepts of penetration testing to validate security measures and identify vulnerabilities; formulate a basic security policy; demonstrate basic penetration attacks; assess risks and countermeasures; explain legal and ethical concerns as they apply to penetration testing; explores methods to gain access to computer resour",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "104",
+    "title": "Blueprint Reading",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "199",
+    "title": "Independent Study",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "24",
+    "title": "Learning Support for MATH 124",
+    "credits": 3,
+    "description": "Prerequisites: None. Corequisite: Enrollment in designated section of Math 124.Provides foundational material to support students in Math 124, College Algebra.",
+    "prerequisite_text": "None. Corequisite: Enrollment in designated section of Math 124.Provides foundational material to support students in Math 124, College Algebra.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "200",
+    "title": "Elements of Anat/Physiol",
+    "credits": 3,
+    "description": "Provides students with an intense descriptive overview of anatomy and physiology with related, illustrative pathology and microbiology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "229",
+    "title": "Defensive Tactics",
+    "credits": 3,
+    "description": "Prerequisites: NoneProvides police recruits with training in the areas of self-protection against armed persons armed with dangerous and/or deadly weapons. Training in the use of holds, come alongs, restraints, and baton use on uncooperative suspects, prisoners, or the mentally ill. This course is only offered as part of the POST Academy.",
+    "prerequisite_text": "NoneProvides police recruits with training in the areas of self-protection against armed persons armed with dangerous and/or deadly weapons. Training in the use of holds, come alongs, restraints, and baton use on uncooperative suspects, prisoners, or the mentally ill. This course is only offered as part of the POST Academy.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "121",
+    "title": "Horn - Lower Division",
+    "credits": 2,
+    "description": "Provides personal introduction to the study and performance of music for horn. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "164",
+    "title": "Prin of Investigation",
+    "credits": 3,
+    "description": "Prerequisites: CRJ 104 or consent of instructorExamines the fundamentals of investigation: crime scene search and recording of information, collection and presentation of physical evidence, sources of information, scientific aids, case preparation, and interviews and interrogation procedures.",
+    "prerequisite_text": "CRJ 104 or consent of instructorExamines the fundamentals of investigation: crime scene search and recording of information, collection and presentation of physical evidence, sources of information, scientific aids, case preparation, and interviews and interrogation procedures.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "98",
+    "title": "Developmental Mathematics",
+    "credits": 5,
+    "description": "Prerequisite: NonePrepares students for college-level mathematics. Self-paced, computer aided course designed to provide students with the concepts and skills of pre, elementary and intermediate algebra.",
+    "prerequisite_text": "NonePrepares students for college-level mathematics. Self-paced, computer aided course designed to provide students with the concepts and skills of pre, elementary and intermediate algebra.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FT",
+    "number": "291",
+    "title": "Fire Emergency Services Admin",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduces the student to the organization and management of a fire and emergency services department and the relationship of government agencies to the fire service. Emphasis on fire and emergency service, ethics and leadership from the perspective of the company officer. FESHE Non-Core Course.",
+    "prerequisite_text": "NoneIntroduces the student to the organization and management of a fire and emergency services department and the relationship of government agencies to the fire service. Emphasis on fire and emergency service, ethics and leadership from the perspective of the company officer. FESHE Non-Core Course.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "152",
+    "title": "Foundtns Pharmacology I",
+    "credits": 1,
+    "description": "Prerequisites: admission to the nursing program. Provides students with an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs; with special consideration given to the physiological and psycho/social needs of patients. Explores indications, modes of action, effects, contraindications and interactions for selected drugs. Specific nursing responsibilities related to drug administration are emphasized.",
+    "prerequisite_text": "admission to the nursing program. Provides students with an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs; with special consideration given to the physiological and psycho/social needs of patients. Explores indications, modes of action, effects, contraindications and interactions for selected drugs. Specific",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CH",
+    "number": "212",
+    "title": "Science,Tech & Society Mod Era",
+    "credits": 3,
+    "description": "Prerequisite: Eng 101Analyzes history and culture of the modern world, exploration of scientific revolutions and methods, rise and global spread of science-based technologies, and their impact on nature, the human body, society and the world.",
+    "prerequisite_text": "Eng 101Analyzes history and culture of the modern world, exploration of scientific revolutions and methods, rise and global spread of science-based technologies, and their impact on nature, the human body, society and the world.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTT",
+    "number": "102",
+    "title": "BT Telecomm Tech Level II",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 2 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 2 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GRC",
+    "number": "116",
+    "title": "Intro Digital Art and Design",
+    "credits": 3,
+    "description": "Prerequisites: Basic Computer SkillsIntroduces students to the Adobe Creative Cloud Software (Illustrator, InDesign, Photoshop and Acrobat). Students will explore design ideation, process, and effective design thinking and analysis as it relates to Graphic Design. Presents projects and design exercises that will increase student's technical fluency in industry-standards for Graphic Design software applications.",
+    "prerequisite_text": "Basic Computer SkillsIntroduces students to the Adobe Creative Cloud Software (Illustrator, InDesign, Photoshop and Acrobat). Students will explore design ideation, process, and effective design thinking and analysis as it relates to Graphic Design. Presents projects and design exercises that will increase student's technical fluency in industry-standards for Graphic Design software applications.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "485",
+    "title": "Applied Business Ethics",
+    "credits": 3,
+    "description": "Prerequisites: Admission to BAS Organization and Project Management ProgramProvides a specific focus on ethical decision-making, skill development and critical thinking. Examines the ethical problems and conflicts leaders and managers encounter in relating their organizations to a multi-stakeholder environment.",
+    "prerequisite_text": "Admission to BAS Organization and Project Management ProgramProvides a specific focus on ethical decision-making, skill development and critical thinking. Examines the ethical problems and conflicts leaders and managers encounter in relating their organizations to a multi-stakeholder environment.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HUM",
+    "number": "101",
+    "title": "Intro to Humanities",
+    "credits": 3,
+    "description": "Offers an interdisciplinary approach to the humanities. Students study major works in art, music, literature, and philosophy with historical framework.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACC",
+    "number": "415",
+    "title": "Accounting for Management",
+    "credits": 3,
+    "description": "Prerequisites: Admissions to the Bachelor of Applied Science degree program.; Advanced management accounting topics including planning and budgeting for profit, decentralization and transfer pricing, joint costing, process costing, and performance measurement.",
+    "prerequisite_text": "Admissions to the Bachelor of Applied Science degree program.; Advanced management accounting topics including planning and budgeting for profit, decentralization and transfer pricing, joint costing, process costing, and performance measurement.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "204",
+    "title": "Theatre Technology I",
+    "credits": 3,
+    "description": "Introduces the backstage world of the theatre by the study of lighting and sound systems and of technical stage riggings. Students will gain practical experience by serving as the crew for a college theatrical production.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "100",
+    "title": "Introduction to Economics",
+    "credits": 3,
+    "description": "Recommended prerequisite: MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "prerequisite_text": "MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACC",
+    "number": "198",
+    "title": "Special Topics in Acc",
+    "credits": 3,
+    "description": "Applies to a variety of topics including short courses and workshops covering a variety of subjects in accounting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "212",
+    "title": "Second Year French II",
+    "credits": 3,
+    "description": "Prerequisites: FREN211 or equivalent or consent of instructor Continues structural review, conversation and writing and reading in modern literature.",
+    "prerequisite_text": "FREN211 or equivalent or consent of instructor Continues structural review, conversation and writing and reading in modern literature.",
+    "prerequisite_courses": [
+      "FREN 211"
+    ]
+  },
+  {
+    "prefix": "BTE",
+    "number": "104",
+    "title": "Bt Electrical Level IV",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "114",
+    "title": "Geol Lava Beds Natl Monmnt",
+    "credits": 1,
+    "description": "Provides a general field experience in geology for students with little or no earth science background. Teaches the basics of volcanic rock and landform identification, and the recognition of modern and ancient geologic events through field study of Lava Beds National Monument.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "112",
+    "title": "Baseball",
+    "credits": 1,
+    "description": "Focuses on advanced baseball skill development, competition techniques and strategy for highly skilled, first year participants in competitive baseball. May be repeated for up to six credits",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AV",
+    "number": "210",
+    "title": "Instrument Ground School",
+    "credits": 4,
+    "description": "Prerequisite: None. Recommend AV 110This course provides in-depth study of the purpose, use and operation of flight instruments in airport departures, en route navigation, approaches and other aspects of instrument flight.",
+    "prerequisite_text": "None. Recommend AV 110This course provides in-depth study of the purpose, use and operation of flight instruments in airport departures, en route navigation, approaches and other aspects of instrument flight.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "101",
+    "title": "Drawing I",
+    "credits": 3,
+    "description": "Develops drawing skills through practice with a broad variety of drawing tools and techniques. 1 hour lecture/4 hours studio per week.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MKT",
+    "number": "262",
+    "title": "Intro to Advertising",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "prerequisite_text": "BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MKT 210"
+    ]
+  },
+  {
+    "prefix": "BIOL",
+    "number": "135",
+    "title": "Introduction to Ornithology",
+    "credits": 3,
+    "description": "Prerequisites: NoneIntroduction to the biology of birds with a focus on avian biology, behavior, ecology, mechanism of flight, and migration; along with opportunities for field identification of birds common to Western Nevada. Includes classroom lectures, hands-on activities, four laboratory experiences and field trips.",
+    "prerequisite_text": "NoneIntroduction to the biology of birds with a focus on avian biology, behavior, ecology, mechanism of flight, and migration; along with opportunities for field identification of birds common to Western Nevada. Includes classroom lectures, hands-on activities, four laboratory experiences and field trips.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTP",
+    "number": "102",
+    "title": "Bt Plumbing Level II",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "241",
+    "title": "Intro Abnormal Psychology",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Covers causes, symptoms, and treatments of major psychological disorders, including anxiety, dissociative, mood, somatoform, eating, schizophrenia and substance-related disorders.",
+    "prerequisite_text": "PSY101 or consent of instructor Covers causes, symptoms, and treatments of major psychological disorders, including anxiety, dissociative, mood, somatoform, eating, schizophrenia and substance-related disorders.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "AC",
+    "number": "113",
+    "title": "Schematic Reading for HVAC/R",
+    "credits": 3,
+    "description": "Prerequisites: NoneApplication of principles and skills in reading schematics seen in HVAC/R. Followed by the operation of air conditioning, heating and Refrigeration equipment. Topics covered are the cooling cycle, gas furnaces, Ice-Machines and Refrigeration systems both residential and commercial.",
+    "prerequisite_text": "NoneApplication of principles and skills in reading schematics seen in HVAC/R. Followed by the operation of air conditioning, heating and Refrigeration equipment. Topics covered are the cooling cycle, gas furnaces, Ice-Machines and Refrigeration systems both residential and commercial.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "112",
+    "title": "First Year French II",
+    "credits": 4,
+    "description": "Prerequisites: FREN111 or equivalent or consent of instructor Continues with the second semester of the course to build on speaking, writing and reading skills in the French language.",
+    "prerequisite_text": "FREN111 or equivalent or consent of instructor Continues with the second semester of the course to build on speaking, writing and reading skills in the French language.",
+    "prerequisite_courses": [
+      "FREN 111"
+    ]
+  },
+  {
+    "prefix": "BTT",
+    "number": "101",
+    "title": "BT Telecomm Technician Level I",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 1 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 1 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "203",
+    "title": "Interpreting Sign Lng III",
+    "credits": 3,
+    "description": "Prerequisites: AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "prerequisite_text": "AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "prerequisite_courses": [
+      "AM 202"
+    ]
+  },
+  {
+    "prefix": "BTE",
+    "number": "112",
+    "title": "Bt Elec Resi Level IV",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELM",
+    "number": "127",
+    "title": "Introduction to AC Controls",
+    "credits": 3,
+    "description": "Prerequisite(s): NoneFamiliarizes students with critical electronic components in an industrial control setting. Control of electric motors is explored through the use of schematic symbols, diagrams, relay logic and solderless circuit boards. Students conduct laboratory experiments, building control circuits and learn troubleshooting methodologies.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "266",
+    "title": "Popular Literature",
+    "credits": 3,
+    "description": "Prerequisites: ENG102 or consent of instructor Studies various forms of popular writing, e.g., best-sellers, the western, science fiction, fantasy, the detective story.",
+    "prerequisite_text": "ENG102 or consent of instructor Studies various forms of popular writing, e.g., best-sellers, the western, science fiction, fantasy, the detective story.",
+    "prerequisite_courses": [
+      "ENG 102"
+    ]
+  },
+  {
+    "prefix": "BTL",
+    "number": "109",
+    "title": "MSHA New Miner Training",
+    "credits": 1,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCovers operations for new miners at Part 46 mining facilities and fulfills the MSHA training requirements to work for contractors at these facilities. Note: This training is not a substitute for site-specific training that your employer is required to provide.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCovers operations for new miners at Part 46 mining facilities and fulfills the MSHA training requirements to work for contractors at these facilities. Note: This training is not a substitute for site-specific training that your employer is required to provide.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "143",
+    "title": "Karate",
+    "credits": 2,
+    "description": "Covers the basic history, philosophy and origins of Karate systems. Students are provided with demonstrations of the basic moves and are allowed to practice the moves with feedback. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPD",
+    "number": "123",
+    "title": "Career Choices & Changes",
+    "credits": 3,
+    "description": "Offers career development and job seeking strategies and connections to campus resources and events. Acquaints students in choosing a suitable career and the necessary work readiness skills to gain and maintain successful employment. Includes Career assessment activities and employability skills training, such as job application, resume, and job interview skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "107",
+    "title": "Pipelaying Part 2",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programCourse covers polyethylene pipe fusion, utility locating programs, tapping, pressure pipe techniques and the tools, PPE, and equipment to perform the work. Safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programCourse covers polyethylene pipe fusion, utility locating programs, tapping, pressure pipe techniques and the tools, PPE, and equipment to perform the work. Safety practices will be reviewed and practiced during hands-on exercises.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "111",
+    "title": "Bt Elec Resi Level III",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTT",
+    "number": "104",
+    "title": "BT Telecomm Tech Level IV",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 4 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 4 of the Telecommunication Technician Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "110",
+    "title": "Chemistry for Health Sci.",
+    "credits": 4,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "121",
+    "title": "Electrical Control Systems",
+    "credits": 3,
+    "description": "Prerequisite: AIT 101Covers the function and operation of logic control circuits used in industrial, commercial and residential applications. Relays, limit switches and time-delays are introduced for a variety of uses. Automation with electrical control is common in many settings, using components wired together in specific configurations that form the logic needed to determine the sequences of machine operations.",
+    "prerequisite_text": "AIT 101Covers the function and operation of logic control circuits used in industrial, commercial and residential applications. Relays, limit switches and time-delays are introduced for a variety of uses. Automation with electrical control is common in many settings, using components wired together in specific configurations that form the logic needed to determine the sequences of machine operat",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DAN",
+    "number": "110",
+    "title": "Dance for Flex & Tone",
+    "credits": 1,
+    "description": "Introduction to basic techniques for dance flexibility. Students will learn some simple basic Jazz technique, terminology and choreography that includes kicks and leaps, strengthening the core muscles.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NS",
+    "number": "105",
+    "title": "Introduction to Neuroscience",
+    "credits": 3,
+    "description": "Presents basic principles in biological science, including neural function and cognition. Topics will range from the electrical basis of brain function to higher-order cognitive processes and neurodegenerative diseases. Applications will also be introduced, from the treatment and impact of neurological diseases on society, to how we can use computational models of the brain. Same as BIOL 150 & PSY 105.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "299",
+    "title": "Spec Topics in Sign Lang",
+    "credits": 3,
+    "description": "Includes short courses and experimental classes covering a variety of subjects. May be repeated for up to six credits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "151",
+    "title": "General Physics I",
+    "credits": 4,
+    "description": "Prerequisites: MATH126 & MATH127,or MATH128 or equivalent. For non-physical science majors. Topics include kinematics, Newton's laws of motion, energy and momentum conservation, rotational dynamics, thermodynamics, fluids, harmonic motion, and sound. Laboratory experiments illustrate many of these fundemental principles.",
+    "prerequisite_text": "MATH126 & MATH127,or MATH128 or equivalent. For non-physical science majors. Topics include kinematics, Newton's laws of motion, energy and momentum conservation, rotational dynamics, thermodynamics, fluids, harmonic motion, and sound. Laboratory experiments illustrate many of these fundemental principles.",
+    "prerequisite_courses": [
+      "MATH 126",
+      "MATH 127",
+      "MATH 128"
+    ]
+  },
+  {
+    "prefix": "MGT",
+    "number": "235",
+    "title": "Organizational Behavior",
+    "credits": 3,
+    "description": "Prerequisites:BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and control systems on human behavior.",
+    "prerequisite_text": "BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and contro",
+    "prerequisite_courses": [
+      "BUS 101",
+      "MGT 201"
+    ]
+  },
+  {
+    "prefix": "ELM",
+    "number": "198",
+    "title": "SPECIAL TOPICS IN ELECTRICAL",
+    "credits": 4,
+    "description": "Prerequisite(s): Must be admitted to an approved apprenticeship program.Basic understanding and hands-on experience of current theories in electrical and mechanical technologies as well as advanced technologies utilized in industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FT",
+    "number": "152",
+    "title": "Legal Aspects Emergency Svcs",
+    "credits": 3,
+    "description": "Prerequisites: FT 101 or Instructor ApprovalAddresses the Federal, State, and local laws that regulate emergency services and include a review of national standards, regulations and consensus standards. FESHE Non-Core Course.",
+    "prerequisite_text": "FT 101 or Instructor ApprovalAddresses the Federal, State, and local laws that regulate emergency services and include a review of national standards, regulations and consensus standards. FESHE Non-Core Course.",
+    "prerequisite_courses": [
+      "FT 101"
+    ]
+  },
+  {
+    "prefix": "MUSE",
+    "number": "131",
+    "title": "Jazz Ensemble",
+    "credits": 1,
+    "description": "Prerequisites: intermediate proficiency on a band instrument Introduces study and performance of jazz ensemble literature. May be repeated for up to 4 credits.",
+    "prerequisite_text": "intermediate proficiency on a band instrument Introduces study and performance of jazz ensemble literature. May be repeated for up to 4 credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "176",
+    "title": "Musical Theatre Practicum I",
+    "credits": 3,
+    "description": "Performance ensemble, centered on public performance of musical theatre literature. Repeatable up to 9 units.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUS",
+    "number": "121",
+    "title": "Music Appreciation",
+    "credits": 3,
+    "description": "Analyzes styles and forms of music from the Middle Ages through the 20th century, and discusses musical instruments and major composers.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENG",
+    "number": "114",
+    "title": "Comp II/Non-Native Eng Sp",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FT",
+    "number": "109",
+    "title": "Internship in the Fire Science",
+    "credits": 1,
+    "description": "Prerequisites: FT 101Provides work experience and skills signoffs that meet the National Fire Protection Association's Firefighter I criteria. Course qualifies students to take the Nevada Fire Fighter I exam. Students must have proof of insurance.",
+    "prerequisite_text": "FT 101Provides work experience and skills signoffs that meet the National Fire Protection Association's Firefighter I criteria. Course qualifies students to take the Nevada Fire Fighter I exam. Students must have proof of insurance.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "227",
+    "title": "Eng Performance II",
+    "credits": 4,
+    "description": "Prerequisites: AUTO225Automotive emission control systems. Preparation on current gas analyzers for the purpose of diagnosis and repair of specific emission devices. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO225Automotive emission control systems. Preparation on current gas analyzers for the purpose of diagnosis and repair of specific emission devices. Prepares students for ASE certification.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "198",
+    "title": "Special Topics in Agriculture",
+    "credits": 6,
+    "description": "Prerequisite: NoneSelected agricultural topics offered for general interest in the agricultural community. Repeatable to a maximum of six units.",
+    "prerequisite_text": "NoneSelected agricultural topics offered for general interest in the agricultural community. Repeatable to a maximum of six units.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "271",
+    "title": "Introduction to Employment Law",
+    "credits": 3,
+    "description": "Prerequisite: BUS 101. Recommend MGT 283Provides a framework to develop productive and effective employers and employees in the workplace. Topics include federal and state labor and employment laws and how they impact employers, employees and the workforce environment.",
+    "prerequisite_text": "BUS 101. Recommend MGT 283Provides a framework to develop productive and effective employers and employees in the workplace. Topics include federal and state labor and employment laws and how they impact employers, employees and the workforce environment.",
+    "prerequisite_courses": [
+      "BUS 101"
+    ]
+  },
+  {
+    "prefix": "AGSC",
+    "number": "163",
+    "title": "Horsemanship",
+    "credits": 2,
+    "description": "Prerequisite: NoneDemonstrates Western horseback riding techniques and equitation. Provides the foundation for good, basic, and effective horsemanship that can later be developed into more specialized. riding. Includes safety, handling, grooming, saddling, staling, feeding, health, exercise, and riding. All levels of ability are welcome as lab assignments are tailored to the skill levels of both student and horse.",
+    "prerequisite_text": "NoneDemonstrates Western horseback riding techniques and equitation. Provides the foundation for good, basic, and effective horsemanship that can later be developed into more specialized. riding. Includes safety, handling, grooming, saddling, staling, feeding, health, exercise, and riding. All levels of ability are welcome as lab assignments are tailored to the skill levels of both student and hor",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "164",
+    "title": "Building Infiltration Duct Lkg",
+    "credits": 1,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to test building airflow using blower door and pressure diagnostics, duct testing, and tightness verification, and for success on the BPI Infiltration and Duct Leakage (BPI IDL) Certification examination.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to test building airflow using blower door and press",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "124",
+    "title": "Beginning Printmaking",
+    "credits": 3,
+    "description": "Introduces printmaking processes emphasizing relief, intaglio, lithographic, and screen processes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "115",
+    "title": "Adv Emergency Medical Tech",
+    "credits": 7.5,
+    "description": "Prerequisite: Certified as a Nationally Registered EMT within the last two years. CPR Certificate. Must be at least 18 year of age at the time of enrollment.Prepares students to incorporate knowledge of basic and advanced emergency medical care for critically ill and emergent patients to reduce the morbidity and mortally associated with acute out-of-hospital medical and traumatic emergencies. The A-EMT is educated to safely provide more advanced airway maintenance skills and the ability to recognize basic electrocardiography (ECG) arrhythmia's and utilize pharmacological interventions within the scope of practices. Other competencies include interventions such as suctioning, initiation of IV therapy, control of breathing and shock, and cardiopulmonary resuscitation. The A-EMT provides care based on site assessment data and works alongside other EMS and health care professionals as an integral part of the emergency care team.",
+    "prerequisite_text": "Certified as a Nationally Registered EMT within the last two years. CPR Certificate. Must be at least 18 year of age at the time of enrollment.Prepares students to incorporate knowledge of basic and advanced emergency medical care for critically ill and emergent patients to reduce the morbidity and mortally associated with acute out-of-hospital medical and traumatic emergencies. The A-EMT is educa",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "155",
+    "title": "Steering & Suspension",
+    "credits": 4,
+    "description": "Prerequisites: AUTO 101Diagnosis/service of suspension components including shocks, springs, ball joints, manual and power steering system, and four wheel alignment are some areas covered. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO 101Diagnosis/service of suspension components including shocks, springs, ball joints, manual and power steering system, and four wheel alignment are some areas covered. Prepares students for ASE certification.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHIL",
+    "number": "145",
+    "title": "Religion in Amer Life",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THTR",
+    "number": "219",
+    "title": "Projects in Tech Theater",
+    "credits": 3,
+    "description": "Offers an in-depth study of some technical aspect of theater. Through practical application students can explore lighting, set art, set construction, sound, set design or rigging.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSA",
+    "number": "131",
+    "title": "Saxophone-Lower Division",
+    "credits": 2,
+    "description": "Introduces students to the study and performance of music for saxophone. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "130",
+    "title": "Human Sexuality",
+    "credits": 3,
+    "description": "Covers major topics in human sexuality such as gender, sexual anatomy, sexually-transmitted diseases, sexual response and disorders, sexual orientation, sexual coercion, and commercial sex.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LTE",
+    "number": "101",
+    "title": "Fundamental Phlebotomy",
+    "credits": 4,
+    "description": "Prerequisites: Vaccinations and major medical insurance required (see requirements for LTE under the Nursing and Allied Health division)Provides knowledge and skills necessary to perform basic collection, identification, and preservation of blood samples as applied to venipuncture techniques. Incorporates finger stick procedures and patient contact methodologies carried out within the ethical, legal and professional boundaries of the roles. Successful completion of LTE 102 is required to sit for national certification examinations offered through a variety of certifying organizations, including the American Society for Clinical Pathology (ASCP).",
+    "prerequisite_text": "Vaccinations and major medical insurance required (see requirements for LTE under the Nursing and Allied Health division)Provides knowledge and skills necessary to perform basic collection, identification, and preservation of blood samples as applied to venipuncture techniques. Incorporates finger stick procedures and patient contact methodologies carried out within the ethical, legal and professi",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "271",
+    "title": "Adv Clncl Nurs I Clinical",
+    "credits": 2,
+    "description": "Prerequisites: successful completion of the first year of the nursing program. Corequisites: NURS270 Requires students to use the nursing process to identify and prioritize health care needs in the provision of care for patients experiencing complex/acute alterations in health. Expands upon previous clinical learning to include the teaching/learning process and administration of intravenous fluids and medications in the acute care setting.",
+    "prerequisite_text": "successful completion of the first year of the nursing program. Corequisites: NURS270 Requires students to use the nursing process to identify and prioritize health care needs in the provision of care for patients experiencing complex/acute alterations in health. Expands upon previous clinical learning to include the teaching/learning process and administration of intravenous fluids and medication",
+    "prerequisite_courses": [
+      "NURS 270"
+    ]
+  },
+  {
+    "prefix": "PEX",
+    "number": "136",
+    "title": "Snow Boarding",
+    "credits": 1,
+    "description": "Prerequisites: intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the ski area.",
+    "prerequisite_text": "intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the s",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "122",
+    "title": "Intercollegiate Rodeo",
+    "credits": 2,
+    "description": "Prerequisite: NoneDesigned for men and women interested in rodeo as a knowledgeable spectator, producer, or participant. Covers rodeo history, current rules, equipment use, and physical and mental conditioning.",
+    "prerequisite_text": "NoneDesigned for men and women interested in rodeo as a knowledgeable spectator, producer, or participant. Covers rodeo history, current rules, equipment use, and physical and mental conditioning.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "170",
+    "title": "Physical Train Law Enforcement",
+    "credits": 1,
+    "description": "Prerequisites: NoneProvides the physical training necessary for all police recruits to meet or exceed State of Nevada Peace Officer Standards and Training requirements in order to be certified as a peace officer. This course offered only as part of the POST Academy.",
+    "prerequisite_text": "NoneProvides the physical training necessary for all police recruits to meet or exceed State of Nevada Peace Officer Standards and Training requirements in order to be certified as a peace officer. This course offered only as part of the POST Academy.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "114",
+    "title": "Bt Elec Resi Level Vi",
+    "credits": 5,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOG",
+    "number": "211",
+    "title": "Intro to Maps and Compass",
+    "credits": 2,
+    "description": "Introduces the basics of map interpretation. Covers the characteristics of the map, emphasizing its blending of scientific and artistic aspects. Students will delve into map making, interpretation, aerial photography and the use of a GPS to construct maps.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSY",
+    "number": "240",
+    "title": "Intro to Research Methods",
+    "credits": 3,
+    "description": "Prerequisites: PSY101 or consent of instructor Introduces how hypotheses are objectively tested in the social sciences, including research design, data collection, and interpretation of results.",
+    "prerequisite_text": "PSY101 or consent of instructor Introduces how hypotheses are objectively tested in the social sciences, including research design, data collection, and interpretation of results.",
+    "prerequisite_courses": [
+      "PSY 101"
+    ]
+  },
+  {
+    "prefix": "GEOL",
+    "number": "105",
+    "title": "Intro Geology of Natl Parks",
+    "credits": 3,
+    "description": "Studies geologic processes through the lens of the national park system. Concepts of geologic time, plate tectonics, and the rock cycle will be explored by studying national parks and monuments that highlight geologic examples of the material presented.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "295",
+    "title": "Work Experience I",
+    "credits": 6,
+    "description": "Prerequisites: consent of instructor Studies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_text": "consent of instructor Studies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CADD",
+    "number": "100",
+    "title": "Intro to Comp Aid Dft",
+    "credits": 3,
+    "description": "Prerequisite: IS 101 and MATH 110 or higherUses AutoCAD software to produce working drawings. Emphasizes constructing and editing two-dimensional geometry and placing drawing annotation.",
+    "prerequisite_text": "IS 101 and MATH 110 or higherUses AutoCAD software to produce working drawings. Emphasizes constructing and editing two-dimensional geometry and placing drawing annotation.",
+    "prerequisite_courses": [
+      "IS 101",
+      "MATH 110"
+    ]
+  },
+  {
+    "prefix": "CHEM",
+    "number": "100",
+    "title": "Molecules Life Mod World",
+    "credits": 4,
+    "description": "Prerequisites: MATH120 or higher Introduces chemistry with emphasis on impacts on human society, environmental issues, energy sources and life processes. Includes four laboratory experiments.",
+    "prerequisite_text": "MATH120 or higher Introduces chemistry with emphasis on impacts on human society, environmental issues, energy sources and life processes. Includes four laboratory experiments.",
+    "prerequisite_courses": [
+      "MATH 120"
+    ]
+  },
+  {
+    "prefix": "EPD",
+    "number": "163",
+    "title": "PPST/Praxis I Writing Review",
+    "credits": 1,
+    "description": "Prerequisites: NoneReview of writing skills and test-taking strategies in preparation for taking the PPST/Praxis I Writing Exam. This course is graded as Pass/Fail.",
+    "prerequisite_text": "NoneReview of writing skills and test-taking strategies in preparation for taking the PPST/Praxis I Writing Exam. This course is graded as Pass/Fail.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDU",
+    "number": "210",
+    "title": "Nevada School Law",
+    "credits": 3,
+    "description": "Identifies legal issues in education and illustrates the implications of laws/mandates in the schools. Guidelines for teachers will provide information on avoiding situations that may lead to litigations. Concepts covered include teacher liability, teacher/student right to free speech and privacy, and accommodations for religious practices and students with disabilities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SW",
+    "number": "101",
+    "title": "Intro to Social Work",
+    "credits": 3,
+    "description": "Introduces the profession of social work within a historical context. Emphasis on values, human diversity, analysis of social problem solving and fields of practice.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "198",
+    "title": "Special Topics in Biology",
+    "credits": 3,
+    "description": "Prerequisites: NoneIncludes short courses and experimental classes covering a variety of subjects.",
+    "prerequisite_text": "NoneIncludes short courses and experimental classes covering a variety of subjects.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "205",
+    "title": "Manual Drivetrain and Axles",
+    "credits": 3,
+    "description": "Prerequisite(s): AUTO 101Covers theory and operation of the automotive and light truck manual drive trains and axles. Emphasis is placed on operation, maintenance, diagnosis, repair, clutch assemblies, differentials, drivelines, axles and manual transaxles. Components will be inspected for wear and failure. Drive train components will be reassembled to manufactures specifications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ET",
+    "number": "155",
+    "title": "Home Tech Convergence",
+    "credits": 4,
+    "description": "Introduction to the components and technologies that make up the \"Smart Home\". The convergence of home entertainment audio/visual equipment, surveillance and security systems, computer networks, and telecommunications will be taught in both theory and application. Students will build, configure and install cables, wallplates, jacks, control modules and equipment to bring alive the multiple technologies commonly used in a home or small office environment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSC",
+    "number": "231",
+    "title": "Intro International Relations",
+    "credits": 3,
+    "description": "Prerequisite: None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Explores policy making institutions, foreign policies and politics of various nations.",
+    "prerequisite_text": "None. Recommended: Completion or corequisite of ENG 101 or eligibility to enroll in ENG 101.Explores policy making institutions, foreign policies and politics of various nations.",
+    "prerequisite_courses": [
+      "ENG 101"
+    ]
+  },
+  {
+    "prefix": "EMS",
+    "number": "207",
+    "title": "Airway Management/Ventilation",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Integrates complex knowledge of anatomy, physiology, and pathophysiology into the assessment to develop and implement a treatment plan with the goal of ensuring a patient airway, adequate mechanical ventilation, and respiration for patients of all ages.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Integrates complex knowledge of anatomy, physiology, and pathophysiology into the assessment to develop and implement a treatment plan with the goal of ensuring a patient airway, adequate mechanical ventilation, and respiration for patients of all ages.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AIT",
+    "number": "131",
+    "title": "Basic Industry 4.0 Cert",
+    "credits": 4,
+    "description": "Prerequisites: NoneSmart Automation Certification Alliance Industry 4.0 Associate - Basic Operations Certification prepares individuals to succeed in operations and assembly positions in modern production environments that use Industry 4.0 automation technologies. Class provides the knowledge and skills necessary to earn this nationally recognized certification and it is also ideal for individuals in related occupations who want to learn more about automated equipment and processes. Topics include: concepts & terminology of smart manufacturing, basic setup, adjustment & operation of automated machines, safety, hand tools, blueprint & schematic reading, precision measurement, basic electrical control, pneumatic & sensor systems operation, basic robot operation & terminology and production monitoring via HMI.",
+    "prerequisite_text": "NoneSmart Automation Certification Alliance Industry 4.0 Associate - Basic Operations Certification prepares individuals to succeed in operations and assembly positions in modern production environments that use Industry 4.0 automation technologies. Class provides the knowledge and skills necessary to earn this nationally recognized certification and it is also ideal for individuals in related occ",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "226",
+    "title": "Span for Heritage Speakers I",
+    "credits": 3,
+    "description": "Prerequisite: None; students should have some bilingual communications skills.Designed for native Spanish speaking students who want to improve their literacy in the language. Students will study and practice basic Spanish grammar for improving and developing written and oral communications and reading skills while exploring some of the most interesting and important aspects of their own history and culture.",
+    "prerequisite_text": "None; students should have some bilingual communications skills.Designed for native Spanish speaking students who want to improve their literacy in the language. Students will study and practice basic Spanish grammar for improving and developing written and oral communications and reading skills while exploring some of the most interesting and important aspects of their own history and culture.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FIN",
+    "number": "101",
+    "title": "Personal Finance",
+    "credits": 3,
+    "description": "Introduces personal financial planning. Emphasizes budgeting, obtaining credit, buying decisions for a home, auto or other large purchases, investment decisions, and retirement planning.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AC",
+    "number": "107",
+    "title": "Electrical & Controls for HVAC",
+    "credits": 6,
+    "description": "Prerequisites: NoneFamiliarizes students with electrical applications and controls used in HVAC/R. Topics include basic electricity, wiring, schematics and controls found in heating, ventilation, air conditioning and refrigeration.",
+    "prerequisite_text": "NoneFamiliarizes students with electrical applications and controls used in HVAC/R. Topics include basic electricity, wiring, schematics and controls found in heating, ventilation, air conditioning and refrigeration.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "101",
+    "title": "Intro to General Mech",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automobiles. Includes safety, use of manuals, selection and use of hand tools, and hand-held test instruments. Introduces general maintenance of various systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CONS",
+    "number": "111",
+    "title": "Commercial Building Codes",
+    "credits": 3,
+    "description": "Introduces the international residential building code. Covers aspects of any code and how to search, interrupt, understand, and implement the code.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SUR",
+    "number": "161",
+    "title": "Elementary Surveying",
+    "credits": 4,
+    "description": "Prerequisites: MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "prerequisite_text": "MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "prerequisite_courses": [
+      "MATH 127"
+    ]
+  },
+  {
+    "prefix": "ART",
+    "number": "211",
+    "title": "Ceramics I",
+    "credits": 3,
+    "description": "Offers a beginning studio course in ceramic construction and decoration. Lecture and laboratory methods are used to give special attention to the development of individual student's skills. Uses potter's wheels. One hour lecture and four hours studio per week.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "216",
+    "title": "Receptive ASL",
+    "credits": 4,
+    "description": "Prerequisites: AM147 Provides opportunities for students to develop receptive skills with a wide variety of signers. Receptive language of children, teens, adults with various socio-economic levels, and senior signers will be developed. Acquisition and comprehension of regional signs, \"slang\" signs, and generational signs will also be emphasized.",
+    "prerequisite_text": "AM147 Provides opportunities for students to develop receptive skills with a wide variety of signers. Receptive language of children, teens, adults with various socio-economic levels, and senior signers will be developed. Acquisition and comprehension of regional signs, \"slang\" signs, and generational signs will also be emphasized.",
+    "prerequisite_courses": [
+      "AM 147"
+    ]
+  },
+  {
+    "prefix": "CEM",
+    "number": "432",
+    "title": "Temp Construction Structures",
+    "credits": 3,
+    "description": "Additional prerequisites: CONS 109 and MATH 126.Introduces the analysis, design, and construction of temporary structures including formwork, false work, shoring, rigging, and access units. Addresses cost analysis, load and pressure calculations and safety considerations and requirements.",
+    "prerequisite_text": "CONS 109 and MATH 126.Introduces the analysis, design, and construction of temporary structures including formwork, false work, shoring, rigging, and access units. Addresses cost analysis, load and pressure calculations and safety considerations and requirements.",
+    "prerequisite_courses": [
+      "CONS 109",
+      "MATH 126"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "137",
+    "title": "Foundation Nursing Lab",
+    "credits": 1,
+    "description": "Prerequisites: admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedures and the scientific rationale for performing the procedures correctly.",
+    "prerequisite_text": "admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedure",
+    "prerequisite_courses": [
+      "NURS 136"
+    ]
+  },
+  {
+    "prefix": "HIST",
+    "number": "111",
+    "title": "Survey of U.S. Const History",
+    "credits": 3,
+    "description": "Teaches the origin, development, history of the Nevada and United States constitutions. Examines the American judicial system through a number of significant decisions and will analyze the individuals who made those decisions.Satisfies the U.S. and Nevada Constitution requirements.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "230",
+    "title": "Criminal Law",
+    "credits": 3,
+    "description": "Prerequisites: CRJ101,LAW101 Examines substantive criminal law with particular attention to crime, intent, attempts, search and seizure, and the laws of arrest. Relates criminal law to the working police officer. Covers rights and duties of citizen and officer under criminal law.",
+    "prerequisite_text": "CRJ101,LAW101 Examines substantive criminal law with particular attention to crime, intent, attempts, search and seizure, and the laws of arrest. Relates criminal law to the working police officer. Covers rights and duties of citizen and officer under criminal law.",
+    "prerequisite_courses": [
+      "CRJ 101",
+      "LAW 101"
+    ]
+  },
+  {
+    "prefix": "CRJ",
+    "number": "219",
+    "title": "Emergency Vehicle Operation",
+    "credits": 3,
+    "description": "Prerequisites: NoneTeaches police recruits methods of emergency vehicle operation and control in such areas as shuffle steering, steering motion dynamics and vehicle braking (lock-wheel, ABS, impending), pursuit driving and defensive techniques. This course only offered as part of the POST Academy.",
+    "prerequisite_text": "NoneTeaches police recruits methods of emergency vehicle operation and control in such areas as shuffle steering, steering motion dynamics and vehicle braking (lock-wheel, ABS, impending), pursuit driving and defensive techniques. This course only offered as part of the POST Academy.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "102",
+    "title": "Drawing II",
+    "credits": 3,
+    "description": "Prerequisites: ART101 Continues ART 101 with increased emphasis on the refinement of drawing skills. One hour lecture/ four hours studio per week.",
+    "prerequisite_text": "ART101 Continues ART 101 with increased emphasis on the refinement of drawing skills. One hour lecture/ four hours studio per week.",
+    "prerequisite_courses": [
+      "ART 101"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "330",
+    "title": "Linear Algebra",
+    "credits": 3,
+    "description": "Prerequisite: Math 283Vector analysis continued; abstract vector spaces; bases, inner products; projections; orthogonal complements, least squares; linear maps, structure theorems; elementary spectral theory; applications.",
+    "prerequisite_text": "Math 283Vector analysis continued; abstract vector spaces; bases, inner products; projections; orthogonal complements, least squares; linear maps, structure theorems; elementary spectral theory; applications.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTL",
+    "number": "112",
+    "title": "Concrete Worker Part 2",
+    "credits": 2,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programIntroductes concrete work; increases knowledge and practical experience in the placement and finishing of concrete.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programIntroductes concrete work; increases knowledge and practical experience in the placement and finishing of concrete.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "260",
+    "title": "911 Dispatch Academy",
+    "credits": 12,
+    "description": "Prerequisites: 4 hour sit-in in Dispatch Center (prior to class start date) Focuses on the skills needed to become a dispatcher with law enforcement agencies, fire centers, trucking firms, taxicab companies, etc. During the 12-credit semester-long course, students will be required to spend 44 hours job shadowing dispatchers, fire fighters and law enforcement officers. They will attend law classes, build their communication and typing skills, and participate in practical scenarios.",
+    "prerequisite_text": "4 hour sit-in in Dispatch Center (prior to class start date) Focuses on the skills needed to become a dispatcher with law enforcement agencies, fire centers, trucking firms, taxicab companies, etc. During the 12-credit semester-long course, students will be required to spend 44 hours job shadowing dispatchers, fire fighters and law enforcement officers. They will attend law classes, build their co",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRJ",
+    "number": "296",
+    "title": "Wk Exp - Juvenile Just",
+    "credits": 6,
+    "description": "Prerequisites: CRJ 104 or consent of instructor Provides the student with on-the job, supervised and educationally directed work experience.",
+    "prerequisite_text": "CRJ 104 or consent of instructor Provides the student with on-the job, supervised and educationally directed work experience.",
+    "prerequisite_courses": [
+      "CRJ 104"
+    ]
+  },
+  {
+    "prefix": "PEX",
+    "number": "127",
+    "title": "Tennis",
+    "credits": 2,
+    "description": "Introduces the basic rules, techniques, fundamentals, and strategies concerned with the game of tennis. Intermediate and advanced levels perfect and build upon the skills taught in the beginning level. May be offered at the beginning, intermediate and advanced levels.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CSCO",
+    "number": "280",
+    "title": "Ccnp Advanced Routing",
+    "credits": 4,
+    "description": "Prerequisites: CSCO221 or CCNA Certification Prepares students with the knowledge and skills to necessary to use advanced IP addressing and routing in implementing scalability for Cisco ISR routers connected to LANs and WANs. Covers topics on Advanced IP Addressing, Routing Principles, Multicast Routing, IPv6, Manipulating Routing Updates, and configuring basic BGP, Configuring EIGRP, OSPF, and IS-IS. Recommended preparation for the Building Scalable Cisco Internetworks exam required to become a Cisco Certified Network Professional (CCNP).",
+    "prerequisite_text": "CSCO221 or CCNA Certification Prepares students with the knowledge and skills to necessary to use advanced IP addressing and routing in implementing scalability for Cisco ISR routers connected to LANs and WANs. Covers topics on Advanced IP Addressing, Routing Principles, Multicast Routing, IPv6, Manipulating Routing Updates, and configuring basic BGP, Configuring EIGRP, OSPF, and IS-IS. Recommende",
+    "prerequisite_courses": [
+      "CSCO 221"
+    ]
+  },
+  {
+    "prefix": "CSCO",
+    "number": "130",
+    "title": "Fundamental Wireless Lans",
+    "credits": 4,
+    "description": "Introduces wireless LAN concepts and focuses on the design, planning, implementation, operation and troubleshooting of wireless networks. Covers a comprehensive overview of technologies, security and design best practices with particular emphasis on hands-on skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "214",
+    "title": "Microsoft Azure Administration",
+    "credits": 5,
+    "description": "Prerequisites: CIT213 or consent of instructor Through lectures, discussions, demonstrations, textbook study, and hands-on lab exercises, teaches the basic skills and knowledge necessary to implement, administer and maintain a Microsoft Directory Services environment.",
+    "prerequisite_text": "CIT213 or consent of instructor Through lectures, discussions, demonstrations, textbook study, and hands-on lab exercises, teaches the basic skills and knowledge necessary to implement, administer and maintain a Microsoft Directory Services environment.",
+    "prerequisite_courses": [
+      "CIT 213"
+    ]
+  },
+  {
+    "prefix": "MUSA",
+    "number": "101",
+    "title": "Bass-Lower Division",
+    "credits": 2,
+    "description": "Provides a personal introduction to the study and performance of music for bass. Class may be repeated for a total of four credits. Fee covers cost of 14 half-hour private lessons.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "193",
+    "title": "Intercollegiate Soccer",
+    "credits": 3,
+    "description": "Prerequisites: must be a member of the WNC soccer team Participation on the intercollegiate soccer team. May be repeated for up to 6 credits.",
+    "prerequisite_text": "must be a member of the WNC soccer team Participation on the intercollegiate soccer team. May be repeated for up to 6 credits.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EMS",
+    "number": "203",
+    "title": "Paramedic Skills",
+    "credits": 3,
+    "description": "Prerequisite: Admission to the Paramedicine Program. Familiarizes the Paramedic student with nationally recognized testing. Provides skill-based practice and assessments in a laboratory environment.",
+    "prerequisite_text": "Admission to the Paramedicine Program. Familiarizes the Paramedic student with nationally recognized testing. Provides skill-based practice and assessments in a laboratory environment.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "227",
+    "title": "Watercolor II",
+    "credits": 3,
+    "description": "Prerequisites: ART127 Continues exploration of watercolor techniques and concepts including gouache and related media.",
+    "prerequisite_text": "ART127 Continues exploration of watercolor techniques and concepts including gouache and related media.",
+    "prerequisite_courses": [
+      "ART 127"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "141",
+    "title": "American Sign Language III&IV",
+    "credits": 6,
+    "description": "Prerequisites: AM 140 or AM 145 / AM 146American Sign Language III promotes the shift from comprehension to production of ASL to bring the students current ASL fluency to a point of self-generated ASL. American Sign Language IV encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_text": "AM 140 or AM 145 / AM 146American Sign Language III promotes the shift from comprehension to production of ASL to bring the students current ASL fluency to a point of self-generated ASL. American Sign Language IV encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_courses": [
+      "AM 140",
+      "AM 145"
+    ]
+  },
+  {
+    "prefix": "MTT",
+    "number": "230",
+    "title": "Comp Numerical Control",
+    "credits": 4,
+    "description": "Prerequisite: None. Offers an introductory class to provide a basic understanding of computer numerical control. The student is introduced to the axis systems, absolute and incremental programming, tool offsets, controller operation, and fixture offsets. To better understand CNC programming process, CNC II is recommended as a follow-up. Includes three hours lecture, three hours lab per week.",
+    "prerequisite_text": "None. Offers an introductory class to provide a basic understanding of computer numerical control. The student is introduced to the axis systems, absolute and incremental programming, tool offsets, controller operation, and fixture offsets. To better understand CNC programming process, CNC II is recommended as a follow-up. Includes three hours lecture, three hours lab per week.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MPT",
+    "number": "114",
+    "title": "Manufacturing & Automation III",
+    "credits": 3,
+    "description": "Prerequisite(s): MPT 112 or concurrent enrollmentA continuation of MPT 112. Production and automation systems management and control are further developed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SW",
+    "number": "230",
+    "title": "Crisis Intervention",
+    "credits": 3,
+    "description": "Analyzes types of crisis theory, effects of crisis on the individual, family and community. Looks at methods and resources for crisis intervention.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GRC",
+    "number": "210",
+    "title": "Typography I",
+    "credits": 3,
+    "description": "Prerequisites: GRC 116Introduces students to designing with type for graphic design. Offers readings that outline the historical context of letter forms, while studio-based projects focus on practical analysis, visual and conceptual interaction of type and image, and the creative exploration of type as a formal element.",
+    "prerequisite_text": "GRC 116Introduces students to designing with type for graphic design. Offers readings that outline the historical context of letter forms, while studio-based projects focus on practical analysis, visual and conceptual interaction of type and image, and the creative exploration of type as a formal element.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTE",
+    "number": "106",
+    "title": "Bt Electrical Level Vi",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "148",
+    "title": "American Sign Language IV",
+    "credits": 4,
+    "description": "Prerequisites: AM147 Encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_text": "AM147 Encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "prerequisite_courses": [
+      "AM 147"
+    ]
+  },
+  {
+    "prefix": "BTC",
+    "number": "101",
+    "title": "Building Trades Carpentry I",
+    "credits": 5,
+    "description": "Prerequisite: Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 1 of the Carpentry Apprenticeship Program.",
+    "prerequisite_text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 1 of the Carpentry Apprenticeship Program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "290",
+    "title": "Internship in Welding",
+    "credits": 8,
+    "description": "Prerequisites: consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_text": "consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EDCT",
+    "number": "110",
+    "title": "Communication Skills for Teach",
+    "credits": 3,
+    "description": "Prerequisites: NoneThis course covers the principles of classroom communication for teachers that are new to Career and Technical Education (CTE). Emphasis will be placed on the strategies teachers use to communicate with students, colleagues, administration, parents and community members, as well as how communication supports the high-level instructional practices and educator professional responsibilities often used to measure educator performance. Topics will include types and methods of communication, barriers to communication, and how to facilitate and improve communication to strengthen collaborative relationships, set clear expectations, respond to challenges, and encourage engagement.",
+    "prerequisite_text": "NoneThis course covers the principles of classroom communication for teachers that are new to Career and Technical Education (CTE). Emphasis will be placed on the strategies teachers use to communicate with students, colleagues, administration, parents and community members, as well as how communication supports the high-level instructional practices and educator professional responsibilities ofte",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGT",
+    "number": "497",
+    "title": "Business Plan Creation",
+    "credits": 3,
+    "description": "Prerequisite Admission to BAS Organization and Project Management Program and MGT 310 and FIN 310Teaches how to create investor quality business plans. Follows a step-by-step process to develop a business plan from an opening executive summary to a financial offering.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "26",
+    "title": "Learning Support for MATH 126",
+    "credits": 3,
+    "description": "Prerequisites: None. Corequisite: Enrollment in designated section of Math 126. Provides foundational material to support students in Math 126, Precalculus I.",
+    "prerequisite_text": "None. Corequisite: Enrollment in designated section of Math 126. Provides foundational material to support students in Math 126, Precalculus I.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EPD",
+    "number": "410",
+    "title": "Contemporary Pedagogical Strat",
+    "credits": 3,
+    "description": "Prerequisite: Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
+    "prerequisite_text": "Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACC",
+    "number": "135",
+    "title": "Bookkeeping I",
+    "credits": 3,
+    "description": "Introduces the basic principles of bookkeeping and applied accounting for a business enterprise with special emphasis on accounting for sole proprietorships, service and merchandising companies. Includes debits and credits, the accounting cycle, journals, ledgers, bank reconciliations, payroll, and the preparation of simple financial statements. May include a computerized component.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "270",
+    "title": "Adv. Clin. Nurs I Theory",
+    "credits": 3,
+    "description": "Prerequisites: successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students will also apply concepts of community care, case management, health teaching and discharge planning.",
+    "prerequisite_text": "successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students",
+    "prerequisite_courses": [
+      "NURS 271"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "120",
+    "title": "Fund of College Math",
+    "credits": 3,
+    "description": "Prerequisite: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Studies probability, statistics, business, finance and consumer mathematics. Course is broad in scope and emphasizes applications.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Studies probability, statistics, business, finance and consumer mathematics. Course is broad in scope and emphasizes applications.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "140",
+    "title": "Auto Brake Systems",
+    "credits": 3,
+    "description": "Introduces principles, design, construction and maintenance of automotive brake systems including antilock systems. Includes safety, use of manuals, selection and use of hand tools, power tools and hand-held test instruments. Introduces general maintenance of a variety of different systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "263",
+    "title": "It Project Management",
+    "credits": 3,
+    "description": "Introduces students to the concepts of project management as used within the information technology fields of study.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTT",
+    "number": "261",
+    "title": "Machine Projects",
+    "credits": 6,
+    "description": "Prerequisites: consent of instructor Permits students to work on special projects of their own choosing and/or explore areas of special interest under the direction of a college instructor.",
+    "prerequisite_text": "consent of instructor Permits students to work on special projects of their own choosing and/or explore areas of special interest under the direction of a college instructor.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "231",
+    "title": "Welding III",
+    "credits": 3,
+    "description": "Prerequisites: WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 232Includes theory and practice in gas metal-arc welding and gas tungsten-arc welding.",
+    "prerequisite_text": "WELD 221 and WELD 222, or consent of instructor; Corequisite: WELD 232Includes theory and practice in gas metal-arc welding and gas tungsten-arc welding.",
+    "prerequisite_courses": [
+      "WELD 221",
+      "WELD 222"
+    ]
+  },
+  {
+    "prefix": "AUTO",
+    "number": "225",
+    "title": "Eng Performance I",
+    "credits": 4,
+    "description": "Prerequisites: AUTO 101 A study of engine related subsystems which include ignition, fuel, cooling, starting, and charging systems. Theory and testing of computerized engine management systems. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO 101 A study of engine related subsystems which include ignition, fuel, cooling, starting, and charging systems. Theory and testing of computerized engine management systems. Prepares students for ASE certification.",
+    "prerequisite_courses": [
+      "AUTO 101"
+    ]
+  },
+  {
+    "prefix": "FREN",
+    "number": "101",
+    "title": "Conversational French I",
+    "credits": 3,
+    "description": "Emphasizes spoken communication. Listening, reading and writing skills will be explored. A vocabulary of French-English words can be developed to suit student needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTB",
+    "number": "120",
+    "title": "Automotive Collision I",
+    "credits": 3,
+    "description": "Provides fundamental instruction of hands-on skill and knowledge in auto body construction, tools, and safety. Students will also work with metal, plastics, fiberglass and trim.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PHYS",
+    "number": "182L",
+    "title": "Physics Science/Eng Lab III",
+    "credits": 1,
+    "description": "Prerequisites: MATH182 & PHYS181; Corequisites: PHYS182 Explores light, optical systems, relativity, wave aspects of particles, quantum mechanics, statistical mechanics, semiconductors, radioactivity, nuclear physics and particles. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_text": "MATH182 & PHYS181; Corequisites: PHYS182 Explores light, optical systems, relativity, wave aspects of particles, quantum mechanics, statistical mechanics, semiconductors, radioactivity, nuclear physics and particles. Students must co-enroll in both lecture and lab to receive credit.",
+    "prerequisite_courses": [
+      "MATH 182",
+      "PHYS 181",
+      "PHYS 182"
+    ]
+  },
+  {
+    "prefix": "AM",
+    "number": "208",
+    "title": "Observ/Pract in Interpreting",
+    "credits": 3,
+    "description": "Prerequisite: Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "prerequisite_text": "Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPD",
+    "number": "102",
+    "title": "Career Exploration",
+    "credits": 3,
+    "description": "Acquaints students in choosing a career suitable to them. Involves a systematic approach to making a career choice, covering self-assessment, decision making techniques, and current occupational information. Appropriate for those undecided as to a career direction or who wish more career information prior to focusing their academic studies.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "285",
+    "title": "Special Topics: Nursing",
+    "credits": 6,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "EE",
+    "number": "220L",
+    "title": "Circuits I Laboratory",
+    "credits": 1,
+    "description": "Prerequisite: PHYS 181 with a \"C\" or better. Corequisites: EE 220. This laboratory course introduces students to fundamental analysis methods and network theorems used to describe the operation of electric circuits. (Required for BME and EE majors)",
+    "prerequisite_text": "PHYS 181 with a \"C\" or better. Corequisites: EE 220. This laboratory course introduces students to fundamental analysis methods and network theorems used to describe the operation of electric circuits. (Required for BME and EE majors)",
+    "prerequisite_courses": [
+      "PHYS 181",
+      "EE 220"
+    ]
+  },
+  {
+    "prefix": "ATMS",
+    "number": "117",
+    "title": "Meteorology",
+    "credits": 3,
+    "description": "Covers the elements that make up meteorology, potential climate change, severe weather, and weather forecasting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "166",
+    "title": "Energy Auditor Leadership",
+    "credits": 2,
+    "description": "Prerequisites: ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to integrate all elements of the Energy Audit Process, data collection and recommendations for improvements to develop a scope of work, understand how to execute the project, and verify that all work has been completed with an emphasis on ensuring quality in completed work. Students will also be prepared for success on the BPI Crew Leader certification examination which is supported by the US Department of Energy and its National Renewable Energy Laboratory.",
+    "prerequisite_text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to integrate all elements of the Energy Audit Proces",
+    "prerequisite_courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  {
+    "prefix": "PSC",
+    "number": "100",
+    "title": "Nevada Constitution",
+    "credits": 1,
+    "description": "Prerequisite: None. An introduction to the political system of Nevada through an examination of the state¿s constitution. PSC 100 satisfies the Nevada Constitution requirement.",
+    "prerequisite_text": "None. An introduction to the political system of Nevada through an examination of the state¿s constitution. PSC 100 satisfies the Nevada Constitution requirement.",
+    "prerequisite_courses": [
+      "PSC 100"
+    ]
+  },
+  {
+    "prefix": "THTR",
+    "number": "176",
+    "title": "Musical Theatre Wkshp I",
+    "credits": 8,
+    "description": "Features performance of musical theatre productions. May be repeated to a maximum of eight credits. Same as MUS 176.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CIT",
+    "number": "280",
+    "title": "Intro to Blockchain Concepts",
+    "credits": 3,
+    "description": "Prerequisites: MATH 124 or higherIntroduction to Blockchain technology; a type of distributed ledger technology. Covers what blockchain is, how blockchain was developed, how blockchain works, and the primary issues, challenges and opportunities blockchain faces. Engages students in hands-on contextualized code exercises, to lay a strong foundation for blockchain development.",
+    "prerequisite_text": "MATH 124 or higherIntroduction to Blockchain technology; a type of distributed ledger technology. Covers what blockchain is, how blockchain was developed, how blockchain works, and the primary issues, challenges and opportunities blockchain faces. Engages students in hands-on contextualized code exercises, to lay a strong foundation for blockchain development.",
+    "prerequisite_courses": [
+      "MATH 124"
+    ]
+  },
+  {
+    "prefix": "AUTO",
+    "number": "115",
+    "title": "Auto Elect I",
+    "credits": 4,
+    "description": "Prerequisites: AUTO 101Topics include mastery of DC electricity, use of digital multimeters, troubleshooting electrical problems in starting, charging and accessory systems. Prepares students for ASE certification.",
+    "prerequisite_text": "AUTO 101Topics include mastery of DC electricity, use of digital multimeters, troubleshooting electrical problems in starting, charging and accessory systems. Prepares students for ASE certification.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AM",
+    "number": "146",
+    "title": "Amer Sign Lang II",
+    "credits": 4,
+    "description": "Prerequisites: AM145 Continues to stress the development of basic conversational skills with emphasis on expanding vocabulary and expressive skills.",
+    "prerequisite_text": "AM145 Continues to stress the development of basic conversational skills with emphasis on expanding vocabulary and expressive skills.",
+    "prerequisite_courses": [
+      "AM 145"
+    ]
+  },
+  {
+    "prefix": "MTT",
+    "number": "106",
+    "title": "Machine Shop Practice I",
+    "credits": 2,
+    "description": "Corequisite: MTT 105. Expands the student's manual skills by putting into practice the theories, and user skills introduced in MTT 105. The emphasis will be geared to a more practical, hands-on experience through the use of lathes, layout techniques, vertical and horizontal band saws, measuring instruments and some vertical mill work. Shop safety and cleanup are always stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "283",
+    "title": "Calculus III",
+    "credits": 4,
+    "description": "Prerequisites: MATH182 or equivalent or consent of instructor Covers infinite series, vectors, differential and integral calculus of functions of several variables, and introduction to vector analysis.",
+    "prerequisite_text": "MATH182 or equivalent or consent of instructor Covers infinite series, vectors, differential and integral calculus of functions of several variables, and introduction to vector analysis.",
+    "prerequisite_courses": [
+      "MATH 182"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "176",
+    "title": "Intro Calc for Bus/Socsci",
+    "credits": 3,
+    "description": "Prerequisites: MATH 124, 126 or 128 or equivalent with a grade of C- or better; or, ACT MATH score of 25 or higher or SAT MATH score of 560 or higher; or, a grade of B- or better in high school precalculus; or, appropriate score on the WNC placement exam; or consent of instructor.Instructs students in fundamental ideas of analytical geometry and calculus. Includes plane coordinates, graphs, functions, limits, derivatives, integrals, the fundamental theorem of calculus. Includes applications to rates, extremalization, and interpretation of integrals.",
+    "prerequisite_text": "MATH 124, 126 or 128 or equivalent with a grade of C- or better; or, ACT MATH score of 25 or higher or SAT MATH score of 560 or higher; or, a grade of B- or better in high school precalculus; or, appropriate score on the WNC placement exam; or consent of instructor.Instructs students in fundamental ideas of analytical geometry and calculus. Includes plane coordinates, graphs, functions, limits, de",
+    "prerequisite_courses": [
+      "MATH 124"
+    ]
+  },
+  {
+    "prefix": "CEM",
+    "number": "453",
+    "title": "Construction Scheduling",
+    "credits": 3,
+    "description": "Additional Prerequisites: CONS 109, 281, and MATH 126Provides an overview of scheduling and resource optimization. Includes short-interval scheduling, Gantt charts, linear, and matrix scheduling formats. Covers network techniques including CPM and PERT concepts and calculations and computer applications using Microsoft Project.",
+    "prerequisite_text": "CONS 109, 281, and MATH 126Provides an overview of scheduling and resource optimization. Includes short-interval scheduling, Gantt charts, linear, and matrix scheduling formats. Covers network techniques including CPM and PERT concepts and calculations and computer applications using Microsoft Project.",
+    "prerequisite_courses": [
+      "CONS 109"
+    ]
+  },
+  {
+    "prefix": "CONS",
+    "number": "295",
+    "title": "Work Experience I",
+    "credits": 6,
+    "description": "Prerequisites: consent of instructor Studies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_text": "consent of instructor Studies project management techniques on-site under the supervision of a project manager or superintendent.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AGSC",
+    "number": "206",
+    "title": "Fund of Animal Nutrition",
+    "credits": 3,
+    "description": "Prerequisite: AGSC 100 or 105Provides an overview of animal nutrition as the basis for livestock feeding and nutrition. Discusses the fundamentals of digestion and absorption in both ruminants and non-ruminants. Emphasizes the nutritive value of feeds as they relate to the formulation of livestock rations, including by-product feeding.",
+    "prerequisite_text": "AGSC 100 or 105Provides an overview of animal nutrition as the basis for livestock feeding and nutrition. Discusses the fundamentals of digestion and absorption in both ruminants and non-ruminants. Emphasizes the nutritive value of feeds as they relate to the formulation of livestock rations, including by-product feeding.",
+    "prerequisite_courses": [
+      "AGSC 100"
+    ]
+  },
+  {
+    "prefix": "FT",
+    "number": "105",
+    "title": "Fire Behavior and Combustion",
+    "credits": 3,
+    "description": "Prerequisites: NoneExplores the theories and fundamentals of how and why fires start, spread and are controlled. FESHE Core Course",
+    "prerequisite_text": "NoneExplores the theories and fundamentals of how and why fires start, spread and are controlled. FESHE Core Course",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "111",
+    "title": "First Year French I",
+    "credits": 4,
+    "description": "Develops language skills through practice in listening, speaking, reading, writing and structural analysis. Includes an introduction to French culture.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENRG",
+    "number": "140",
+    "title": "Battery Basics",
+    "credits": 1,
+    "description": "Prerequisites: ELM 110; This course provides comprehensive training on the safe disassembly of rechargeable batteries, with a focus on electric vehicle (EV) battery packs. Students will learn to identify hazards, implement safety protocols, and utilize appropriate tools and personal protective equipment (PPE). The course covers key topics, including battery construction, electrical safety, discharge methods, and recycling practices. Designed for professionals in battery recycling and manufacturing, this training emphasizes safety, efficiency, and environmental sustainability.",
+    "prerequisite_text": "ELM 110; This course provides comprehensive training on the safe disassembly of rechargeable batteries, with a focus on electric vehicle (EV) battery packs. Students will learn to identify hazards, implement safety protocols, and utilize appropriate tools and personal protective equipment (PPE). The course covers key topics, including battery construction, electrical safety, discharge methods,",
+    "prerequisite_courses": [
+      "ELM 110"
+    ]
+  },
+  {
+    "prefix": "MATH",
+    "number": "126",
+    "title": "Precalculus Mathematics I",
+    "credits": 3,
+    "description": "Prerequisite: Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Provides a third course in algebra. Topics include: polynomial, rational and radical equations; absolute value and quadratic inequalities; relations and functions; linear, quadratic, polynomial exponential and logarithmic functions, their graphs and applications; and systems of equations.",
+    "prerequisite_text": "Success in intermediate algebra, algebra II, MATH 96 or similar course is recommended as preparation for this course. Students should meet with a Counselor to determine readiness based on placement or equivalent exam, high school coursework, or other factors.Provides a third course in algebra. Topics include: polynomial, rational and radical equations; absolute value and quadratic inequalities; r",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "JOUR",
+    "number": "103",
+    "title": "Intro to Media and Society",
+    "credits": 3,
+    "description": "Course designed to create more critically engaged consumers and producers of media. Gain an understanding of how print, broadcast, audio, video and digital media influence and interact with social conditions on the individual, national, and international levels. Systematically observe, interpret, and critique mass and networked media using principles grounded in the social sciences.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BTP",
+    "number": "101",
+    "title": "Bt Plumbing Level I",
+    "credits": 5,
+    "description": "Prerequisite: Admitted to an approved apprenticeship program.",
+    "prerequisite_text": "Admitted to an approved apprenticeship program.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "160",
+    "title": "Auto Air Cond & Heating",
+    "credits": 3,
+    "description": "Introduces principles design, construction and maintenance of automotive air conditioning systems. Includes safety, use of manuals, selection and use of hand tools, and hand-held test instruments, evacuating systems, charging/recovery systems and other specialized air conditioning tools. Introduces general maintenance of a variety of different air conditioning systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUS",
+    "number": "110",
+    "title": "Human Relations for Empl",
+    "credits": 3,
+    "description": "Provides students/prospective employees with knowledge and understanding of self and others for effective interactions in the workplace. Emphasizes employability skills such as communication, work habits and attitudes, ethics, conflict management, motivation and problem solving.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ART",
+    "number": "111",
+    "title": "Beginning Ceramics",
+    "credits": 3,
+    "description": "Introduces basic ceramic techniques and concepts including both hand-built and wheel thrown vessels as well as both utilitarian and non-utilitarian ceramic forms.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "107",
+    "title": "Swimming",
+    "credits": 1,
+    "description": "Covers water safety, floating, the backstroke, Austrian crawl and other strokes. May be offered at the beginning or intermediate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PEX",
+    "number": "105",
+    "title": "Scuba",
+    "credits": 1,
+    "description": "Features PADI Open Water Dive and teaches foundational knowledge and skills needed to dive with a buddy, independent of supervision. Open Water Divers are qualified to obtain air fills, equipment, and services, and may plan, conduct, and log no stop dives in conditions with which they have training and experience.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  }
+]

--- a/data/nv/prereqs.json
+++ b/data/nv/prereqs.json
@@ -140,6 +140,10 @@
       "PHYS 100"
     ]
   },
+  "AC 102": {
+    "text": "NoneIntroduction to the fundamental principles of mechanical refrigeration. Designed for those pursuing a career in servicing, repairing and/or installing refrigeration and air conditioning equipment as well as building maintenance.",
+    "courses": []
+  },
   "AC 106": {
     "text": "Prerequisite: AC 102 and AC 107",
     "courses": [
@@ -147,11 +151,19 @@
       "AC 107"
     ]
   },
+  "AC 107": {
+    "text": "NoneFamiliarizes students with electrical applications and controls used in HVAC/R. Topics include basic electricity, wiring, schematics and controls found in heating, ventilation, air conditioning and refrigeration.",
+    "courses": []
+  },
   "AC 108": {
     "text": "Prerequisite: AC 107",
     "courses": [
       "AC 107"
     ]
+  },
+  "AC 113": {
+    "text": "NoneApplication of principles and skills in reading schematics seen in HVAC/R. Followed by the operation of air conditioning, heating and Refrigeration equipment. Topics covered are the cooling cycle, gas furnaces, Ice-Machines and Refrigeration systems both residential and commercial.",
+    "courses": []
   },
   "AC 150": {
     "text": "Prerequisite: AC 102 and AC 107",
@@ -189,6 +201,13 @@
     "text": "Prerequisite: ACC 135",
     "courses": [
       "ACC 135"
+    ]
+  },
+  "ACC 180": {
+    "text": "ACC135,ACC201 or equivalent work experience Introduces payroll and employee benefit reporting to federal state, and local government agencies. Includes an overview of federal and state labor laws and specialized reporting requirements including both manual and computerized payroll accounting systems.",
+    "courses": [
+      "ACC 135",
+      "ACC 201"
     ]
   },
   "ACC 201": {
@@ -258,6 +277,10 @@
     "text": "Core and Major requirement completed. Minimum 2.5 GPA",
     "courses": []
   },
+  "ACC 415": {
+    "text": "Admissions to the Bachelor of Applied Science degree program.; Advanced management accounting topics including planning and budgeting for profit, decentralization and transfer pricing, joint costing, process costing, and performance measurement.",
+    "courses": []
+  },
   "ADT 202": {
     "text": "ADT 201B or Instructor Approval",
     "courses": [
@@ -296,6 +319,22 @@
     "text": "Current enrollment in UNLV AFROTC and department chair approval",
     "courses": []
   },
+  "AGSC 102": {
+    "text": "NoneDesigned for students interested in pursuing an agricultural career. Provides students with an in depth investigation into personal and interpersonal leadership. Teaches students to strengthen their leadership influence through a personal application of leadership skills, attitudes and dispositions.",
+    "courses": []
+  },
+  "AGSC 122": {
+    "text": "NoneDesigned for men and women interested in rodeo as a knowledgeable spectator, producer, or participant. Covers rodeo history, current rules, equipment use, and physical and mental conditioning.",
+    "courses": []
+  },
+  "AGSC 163": {
+    "text": "NoneDemonstrates Western horseback riding techniques and equitation. Provides the foundation for good, basic, and effective horsemanship that can later be developed into more specialized. riding. Includes safety, handling, grooming, saddling, staling, feeding, health, exercise, and riding. All levels of ability are welcome as lab assignments are tailored to the skill levels of both student and hor",
+    "courses": []
+  },
+  "AGSC 198": {
+    "text": "NoneSelected agricultural topics offered for general interest in the agricultural community. Repeatable to a maximum of six units.",
+    "courses": []
+  },
   "AGSC 206": {
     "text": "Prerequisite: AGSC 100 and CHEM 121",
     "courses": [
@@ -307,6 +346,49 @@
     "text": "Prerequisites: AGSC 100",
     "courses": [
       "AGSC 100"
+    ]
+  },
+  "AIT 121": {
+    "text": "AIT 101Covers the function and operation of logic control circuits used in industrial, commercial and residential applications. Relays, limit switches and time-delays are introduced for a variety of uses. Automation with electrical control is common in many settings, using components wired together in specific configurations that form the logic needed to determine the sequences of machine operat",
+    "courses": []
+  },
+  "AIT 125": {
+    "text": "AIT 101Covers the fundamentals of industrial robotics found in modern manufacturing, logistics and distribution environments. Covers servo robot system components, prepares students to perform robotic movement using articular and/or Cartesian coordinates, ensures exposure to the design of programs for point-to-point and task activities, includes analysis of industrial robotic integration to standa",
+    "courses": []
+  },
+  "AIT 131": {
+    "text": "NoneSmart Automation Certification Alliance Industry 4.0 Associate - Basic Operations Certification prepares individuals to succeed in operations and assembly positions in modern production environments that use Industry 4.0 automation technologies. Class provides the knowledge and skills necessary to earn this nationally recognized certification and it is also ideal for individuals in related occ",
+    "courses": []
+  },
+  "AIT 270": {
+    "text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Topics include closed loop and other technologies used in process control in the context of a complex mechatronic system are included. Students will understand and establis",
+    "courses": []
+  },
+  "AIT 271": {
+    "text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Introduces the Siemens concept of Totally Integrated Automation by looking at field level analogue sensors and actuators and up to the control level with programming and ne",
+    "courses": []
+  },
+  "AIT 272": {
+    "text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Course is divided into two main sections: Manufacturing Technologies, including CNC, CAD and CAM, and Microcontrollers and Programming, which constitute essential tools in",
+    "courses": []
+  },
+  "AIT 273": {
+    "text": "AIT 253Covers general machine operation, different types of braking and loads on a motor, and motor efficiency and power. Different control techniques are introduced, including different methods of starting a motor, controlling voltage and frequency, and the role of different sensors in relation to motor operation. Troubleshooting techniques and an examination of the various causes of motor failur",
+    "courses": []
+  },
+  "AIT 275": {
+    "text": "AIT 253Covers content specifically outlined by the Siemens Mechatronic Systems Certification Program (SMSCP) exam objectives and is part of a six-course series to prepare students for the SMSCP Level 2 industry credential exam. Course is divided into two main sections: process management, and function and importance of a hands-on design project. Lessons and labs explore engineering technology in w",
+    "courses": []
+  },
+  "AIT 290": {
+    "text": "Consent of Instructor.Allows students to apply knowledge to real on-the-job situations in a program designed by a company official and faculty advisor to maximize learning experiences.",
+    "courses": []
+  },
+  "AM 141": {
+    "text": "AM 140 or AM 145 / AM 146American Sign Language III promotes the shift from comprehension to production of ASL to bring the students current ASL fluency to a point of self-generated ASL. American Sign Language IV encourages the student to expand his or her command of discourse in ASL on various everyday topics.",
+    "courses": [
+      "AM 140",
+      "AM 145"
     ]
   },
   "AM 146": {
@@ -323,6 +405,40 @@
   },
   "AM 148": {
     "text": "Must have completed AM 147",
+    "courses": [
+      "AM 147"
+    ]
+  },
+  "AM 150": {
+    "text": "AM149 Final course in the American Sign Language series, covering a culmination of all signs, pragmatics, grammar and fingerspelling skills acquired throughout the series. Emphasis is on utilizing all ASL skills simultaneously and fluently.",
+    "courses": [
+      "AM 149"
+    ]
+  },
+  "AM 152": {
+    "text": "AM151 or current enrollment in AM 151 Improves receptive and expressive fingerspelling skills to intermediate/advanced levels.",
+    "courses": [
+      "AM 151"
+    ]
+  },
+  "AM 203": {
+    "text": "AM202 Develops the student's receptive and expressive skills in interpreting for deaf individuals. Follows a sequenced series of consecutive interpretation to simultaneous interpretation skills.",
+    "courses": [
+      "AM 202"
+    ]
+  },
+  "AM 208": {
+    "text": "Instructor ApprovalProvides opportunities to shadow, observe, and interact with professional interpreters in a supervised observation/practicum setting.",
+    "courses": []
+  },
+  "AM 215": {
+    "text": "AM147 Focuses on the natural use of American Sign Language. Appropriate use of ASL grammar and vocabulary in conversational situations is stressed. Students master appropriate pragmatics, use of facial expressions, space, fingerspelling and classifiers, simultaneously for conversational fluency.",
+    "courses": [
+      "AM 147"
+    ]
+  },
+  "AM 216": {
+    "text": "AM147 Provides opportunities for students to develop receptive skills with a wide variety of signers. Receptive language of children, teens, adults with various socio-economic levels, and senior signers will be developed. Acquisition and comprehension of regional signs, \"slang\" signs, and generational signs will also be emphasized.",
     "courses": [
       "AM 147"
     ]
@@ -519,6 +635,10 @@
       "ART 141"
     ]
   },
+  "ART 151": {
+    "text": "NoneIntroduces Time-Based Media/Videography using still and moving images. Lecture and studio study using broadcast video as a means of personal expression. Discussion of technical and theoretical themes; production by students of short videos that demonstrate understanding of these concepts.",
+    "courses": []
+  },
   "ART 160H": {
     "text": "Admission to the Honors program",
     "courses": []
@@ -545,6 +665,22 @@
     "text": "Prerequisite: ART 211",
     "courses": [
       "ART 211"
+    ]
+  },
+  "ART 214": {
+    "text": "NoneIntroduction to the book as a physical object. Course covers the field of artists' books as a form of artistic expression and inquiry as well as antiquarian books. Course introduces the mechanics of printing on cylinder and platen presses and several binding structures.",
+    "courses": []
+  },
+  "ART 218": {
+    "text": "ART 214 or instructor permissionProvides the opportunity for students to create a limited-edition, letterpress-printed artist's book edition of 12-15 copies. Students will write original text, generate imagery using traditional and alternative printing techniques, hand set type, letterpress print on antique printing pressed, and hand-bind each copy of their artist's book.",
+    "courses": [
+      "ART 214"
+    ]
+  },
+  "ART 227": {
+    "text": "ART127 Continues exploration of watercolor techniques and concepts including gouache and related media.",
+    "courses": [
+      "ART 127"
     ]
   },
   "ART 231": {
@@ -614,6 +750,20 @@
       "MATH 120"
     ]
   },
+  "AST 109": {
+    "text": "MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to current concepts of the solar system, modern observational techniques, and their results. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
+  "AST 110": {
+    "text": "MATH120,MATH126 or higher or consent of instructor Offers a descriptive introduction to stellar and galactic systems, the life cycle of stars, theories of the universe and its formation. Utilizes telescopes and observatory facilities. Includes four laboratory experiences.",
+    "courses": [
+      "MATH 120",
+      "MATH 126"
+    ]
+  },
   "AUTO 111": {
     "text": "Prerequisite: AUTO 101 or DT 101 or DT 250. AUTO 101 may be taken as a co-requisite",
     "courses": [
@@ -626,6 +776,16 @@
     "text": "Co-requisite/Prerequisite: AUTO 111 or instructor permission. Course may be taken concurrently with AUTO 111",
     "courses": [
       "AUTO 111"
+    ]
+  },
+  "AUTO 115": {
+    "text": "AUTO 101Topics include mastery of DC electricity, use of digital multimeters, troubleshooting electrical problems in starting, charging and accessory systems. Prepares students for ASE certification.",
+    "courses": []
+  },
+  "AUTO 117": {
+    "text": "AUTO115 Advanced AC and DC automotive electronic circuits. Troubleshooting electronically controlled components including supplemental restraint systems and convenience accessories. Prepares students for ASE certification.",
+    "courses": [
+      "AUTO 115"
     ]
   },
   "AUTO 136": {
@@ -645,6 +805,10 @@
     "courses": [
       "AUTO 101"
     ]
+  },
+  "AUTO 155": {
+    "text": "AUTO 101Diagnosis/service of suspension components including shocks, springs, ball joints, manual and power steering system, and four wheel alignment are some areas covered. Prepares students for ASE certification.",
+    "courses": []
   },
   "AUTO 165": {
     "text": "Prerequisite: AUTO 111 or instructor permission",
@@ -704,6 +868,10 @@
     "text": "Instructor approval",
     "courses": []
   },
+  "AV 110": {
+    "text": "NoneA study of aviation fundamentals including principles of flight, aircraft and engine operations, weather, navigation, and radio communications as required by the Federal Aviation Administration (FAA) regulations. Topics will include general service, maintenance, and safety practices.",
+    "courses": []
+  },
   "AV 111": {
     "text": "Instructor approval (or the corequisite)",
     "courses": []
@@ -737,6 +905,10 @@
       "MATH 126",
       "MATH 126E"
     ]
+  },
+  "BIOL 135": {
+    "text": "NoneIntroduction to the biology of birds with a focus on avian biology, behavior, ecology, mechanism of flight, and migration; along with opportunities for field identification of birds common to Western Nevada. Includes classroom lectures, hands-on activities, four laboratory experiences and field trips.",
+    "courses": []
   },
   "BIOL 137": {
     "text": "Co-requisite or Pre-requisite: ENG 100 or ENG 101",
@@ -811,6 +983,10 @@
       "MATH 124",
       "MATH 126"
     ]
+  },
+  "BIOL 198": {
+    "text": "NoneIncludes short courses and experimental classes covering a variety of subjects.",
+    "courses": []
   },
   "BIOL 207": {
     "text": "Instructor Approval",
@@ -1006,6 +1182,190 @@
       "BRL 151"
     ]
   },
+  "BTC 101": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 1 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 102": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 2 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 103": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 3 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 104": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 4 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 105": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 5 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 106": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 6 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 107": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 7 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTC 108": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction carpentry through classroom and hands-on instruction. This class is Level 8 of the Carpentry Apprenticeship Program.",
+    "courses": []
+  },
+  "BTE 102": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTE 103": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTE 104": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTE 105": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTE 106": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTE 107": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTL 104": {
+    "text": "Must be admitted to an approved apprenticeship programPresents print-reading fundamentals through the use of actual blueprints and work assignments to grasp concepts. Highway construction plans will be introduced. PPE required.",
+    "courses": []
+  },
+  "BTL 106": {
+    "text": "Must be admitted to an approved apprenticeship programCovers gravity flow pipe systems, the math used during layout and installation, and the tools, PPE, and equipment to perform the work. Trench and excavation safety practices will be reviewed and practiced during hands-on exercises.",
+    "courses": []
+  },
+  "BTL 107": {
+    "text": "Must be admitted to an approved apprenticeship programCourse covers polyethylene pipe fusion, utility locating programs, tapping, pressure pipe techniques and the tools, PPE, and equipment to perform the work. Safety practices will be reviewed and practiced during hands-on exercises.",
+    "courses": []
+  },
+  "BTL 108": {
+    "text": "Must be admitted to an approved apprenticeship programCovers the hazards associated with working in confined spaces and safety precautions that must be taken during this work. Hands-on activities include preparing for and entering a mock confined space.",
+    "courses": []
+  },
+  "BTL 109": {
+    "text": "Must be admitted to an approved apprenticeship programCovers operations for new miners at Part 46 mining facilities and fulfills the MSHA training requirements to work for contractors at these facilities. Note: This training is not a substitute for site-specific training that your employer is required to provide.",
+    "courses": []
+  },
+  "BTL 111": {
+    "text": "Must be admitted to an approved apprenticeship programIntroduces concrete work; increases knowledge and practical experience in the placement and finishing of concrete.",
+    "courses": []
+  },
+  "BTL 112": {
+    "text": "Must be admitted to an approved apprenticeship programIntroductes concrete work; increases knowledge and practical experience in the placement and finishing of concrete.",
+    "courses": []
+  },
+  "BTL 113": {
+    "text": "Must be admitted to an approved apprenticeship programCovers safety and the procedures for working safely around cranes. Hands-on activities include: calculate weights of loads, choose proper rigging hardware and rig the load properly, and signal the crane operator to pick and move the load.",
+    "courses": []
+  },
+  "BTL 114": {
+    "text": "Must be admitted to an approved apprenticeship programIntroduces students to working with asphalt. Hands-on activities include: asphalt placement, raking, patching and repairing.",
+    "courses": []
+  },
+  "BTL 115": {
+    "text": "Must be admitted to an approved apprenticeship programIntroduces students to building scaffold. Topics include building frame scaffold, scaffold building tools and PPE, systems scaffold, tube and clamp scaffold, and scaffold user safety.",
+    "courses": []
+  },
+  "BTL 118": {
+    "text": "Must be admitted to an approved apprenticeship programCovers workplace safety and health hazards and the regulations that protect employee on the jobsite. Many construction contractors are requiring employees to have an OSHA 30 card.",
+    "courses": []
+  },
+  "BTL 119": {
+    "text": "Must be admitted to an approved apprenticeship programPrepares laborers to become foremen. Topics include the foreman's role, assuring crew and job site safely, record-keeping and documentation, project planning and management, effective communication, and employee supervision.",
+    "courses": []
+  },
+  "BTO 101": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 1 of the Heavy Equipment Operator Apprenticeship Program.",
+    "courses": []
+  },
+  "BTO 103": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 3 of the Heavy Equipment Operator Apprenticeship Program.",
+    "courses": []
+  },
+  "BTO 104": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 4 of the Heavy Equipment Operator Apprenticeship Program.",
+    "courses": []
+  },
+  "BTO 105": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 5 of the Heavy Equipment Operator Apprenticeship Program.",
+    "courses": []
+  },
+  "BTO 106": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in operating heavy equipment including earth moving equipment such as dozers, scrapers, compactors, backhoes, motor graders, cranes, etc. through classroom and hands-on instruction. This class is Level 6 of the Heavy Equipment Operator Apprenticeship Program.",
+    "courses": []
+  },
+  "BTP 101": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTP 102": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTP 103": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTP 104": {
+    "text": "Admitted to an approved apprenticeship program. Covers building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 4 of the Plumbing Apprenticeship program.",
+    "courses": []
+  },
+  "BTP 106": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTP 107": {
+    "text": "Admitted to an approved apprenticeship program. Offers advanced building trade skills and practices in the field of plumbing through classroom and hands-on instruction. Level 7 of the Plumbing Apprenticeship program.",
+    "courses": []
+  },
+  "BTP 108": {
+    "text": "Admitted to an approved apprenticeship program.",
+    "courses": []
+  },
+  "BTS 102": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 2 of the Construction Sheet Metal Apprenticeship Program.",
+    "courses": []
+  },
+  "BTS 104": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 4 of the Construction Sheet Metal Apprenticeship Program.",
+    "courses": []
+  },
+  "BTS 105": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 5 of the Construction Sheet Metal Apprenticeship Program.",
+    "courses": []
+  },
+  "BTS 108": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of construction sheet metal through classroom and hands-on instruction. This class is Level 8 of the Construction Sheet Metal Apprenticeship Program.",
+    "courses": []
+  },
+  "BTT 101": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 1 of the Telecommunication Technician Apprenticeship Program.",
+    "courses": []
+  },
+  "BTT 102": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 2 of the Telecommunication Technician Apprenticeship Program.",
+    "courses": []
+  },
+  "BTT 104": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 4 of the Telecommunication Technician Apprenticeship Program.",
+    "courses": []
+  },
+  "BTT 106": {
+    "text": "Must be admitted to an approved apprenticeship programProvides building trade skills and practices in the field of telecommunication technician through classroom and hands-on instruction. This class is Level 6 of the Telecommunication Technician Apprenticeship Program.",
+    "courses": []
+  },
   "BUS 101": {
     "text": "Prerequisite: ENG 100, 101, ENG 113, BUS 108, or equivalent",
     "courses": [
@@ -1038,6 +1398,12 @@
       "MATH 120"
     ]
   },
+  "BUS 271": {
+    "text": "BUS 101. Recommend MGT 283Provides a framework to develop productive and effective employers and employees in the workplace. Topics include federal and state labor and employment laws and how they impact employers, employees and the workforce environment.",
+    "courses": [
+      "BUS 101"
+    ]
+  },
   "BUS 274": {
     "text": "Must have completed BUS 273",
     "courses": [
@@ -1046,6 +1412,10 @@
   },
   "BUS 290": {
     "text": "Available to students who have completed all core and major requirements and have a 2.5 GPA",
+    "courses": []
+  },
+  "BUS 299": {
+    "text": "Completion of a minimum of 45 units of requirements for an AAS degree in business or consent of instructor.Concludes various business concepts introduced throughout the business program by merging acquired skills and concepts through the business plan with additional emphasis on job preparation and business ethics.",
     "courses": []
   },
   "BUS 325": {
@@ -1067,6 +1437,25 @@
       "BUS 176"
     ]
   },
+  "CADD 100": {
+    "text": "IS 101 and MATH 110 or higherUses AutoCAD software to produce working drawings. Emphasizes constructing and editing two-dimensional geometry and placing drawing annotation.",
+    "courses": [
+      "IS 101",
+      "MATH 110"
+    ]
+  },
+  "CADD 105": {
+    "text": "CADD100 or consent of instructor Provides instruction and training in advanced two-dimension AutoCAD commands. Covers the use of symbols and symbol libraries. Introduces three-dimensional drawing.",
+    "courses": [
+      "CADD 100"
+    ]
+  },
+  "CADD 120": {
+    "text": "CADD100 or equivalent experience Stresses blueprint reading skills. Introduces residential working drawing concepts leading to a full set of professional level working drawings.",
+    "courses": [
+      "CADD 100"
+    ]
+  },
   "CADD 142": {
     "text": "CADD 140",
     "courses": [
@@ -1082,6 +1471,41 @@
     "courses": [
       "CADD 105"
     ]
+  },
+  "CEM 432": {
+    "text": "CONS 109 and MATH 126.Introduces the analysis, design, and construction of temporary structures including formwork, false work, shoring, rigging, and access units. Addresses cost analysis, load and pressure calculations and safety considerations and requirements.",
+    "courses": [
+      "CONS 109",
+      "MATH 126"
+    ]
+  },
+  "CEM 451": {
+    "text": "CONS 109 and MATH 126Covers principles and procedures used in estimating construction costs. Includes application of quality determination, estimate pricing, specifications, subcontractor and supplier solicitation, risk assessment and risk analysis, and final bidding preparation. Computer based estimating software used for semester project.",
+    "courses": [
+      "CONS 109"
+    ]
+  },
+  "CEM 452": {
+    "text": "ACC 201 and MATH 126Covers construction cost management including productivity and cost reporting/analysis concepts. Includes financial/cost issues/cash flow for the construction firm including reporting methods and percentage of completion techniques. Covers performance/profitability enhancement, earned value management, construction bonding and insurance issues, and firm and job-site analysis.",
+    "courses": [
+      "ACC 201"
+    ]
+  },
+  "CEM 453": {
+    "text": "CONS 109, 281, and MATH 126Provides an overview of scheduling and resource optimization. Includes short-interval scheduling, Gantt charts, linear, and matrix scheduling formats. Covers network techniques including CPM and PERT concepts and calculations and computer applications using Microsoft Project.",
+    "courses": [
+      "CONS 109"
+    ]
+  },
+  "CEM 454": {
+    "text": "CEM 330 and MATH 126Covers characteristics, capabilities, limitations, uses, and selection techniques for heavy construction methods and equipment process planning, simulation, fleet operations, and maintenance programs",
+    "courses": [
+      "CEM 330"
+    ]
+  },
+  "CEM 485": {
+    "text": "CONS 118Provides information on legal problems in the construction process. Covers stipulated sum, unit price, cost-plus contracts, construction lien rights and bond rights, scope of work issues, builders risk issues, risk-shifting, and case studies.",
+    "courses": []
   },
   "CH 201": {
     "text": "Prerequisite: ENG 101, 100 or ENG 113 or completion of CH 202 or CH 203 with a 'D' or better",
@@ -1109,6 +1533,10 @@
       "ENG 101",
       "ENG 113"
     ]
+  },
+  "CH 212": {
+    "text": "Eng 101Analyzes history and culture of the modern world, exploration of scientific revolutions and methods, rise and global spread of science-based technologies, and their impact on nature, the human body, society and the world.",
+    "courses": []
   },
   "CHEM 100": {
     "text": "Must have completed with a C or better: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 124 or MATH 126 or MATH 126E or higher; or be currently enrolled in MATH 116 or MATH 120 or MATH 126 or higher",
@@ -1193,11 +1621,31 @@
     "text": "Instructor approval",
     "courses": []
   },
+  "CIT 112": {
+    "text": "NoneIntroduction to the concepts and practices needed to function in an entry level network technician capacity. Course content is mapped to current domains within the Comp/TIA Network+ Certification",
+    "courses": []
+  },
+  "CIT 129": {
+    "text": "IS101 or consent of instructor Offers a language-independent, introductory course on computer program design and development. Emphasizes identification and solution of business problems through various design tools.",
+    "courses": [
+      "IS 101"
+    ]
+  },
   "CIT 130": {
     "text": "Must have completed CIT 129",
     "courses": [
       "CIT 129"
     ]
+  },
+  "CIT 133": {
+    "text": "CIT129 or consent of instructor Teaches the \"C++\" programming language. Object-oriented programming techniques and hands-on learning will be emphasized. Students will complete several computer programming projects.",
+    "courses": [
+      "CIT 129"
+    ]
+  },
+  "CIT 134": {
+    "text": "CIT 128Introduction to the C# programming language. Uses C# programming language for solving problems. Covers C#'s control structures, Object Oriented Concepts, simple graphical displays, file input/output and error handling.",
+    "courses": []
   },
   "CIT 136": {
     "text": "Pre-requisites: CIT 135 - Introduction to Swift Coding",
@@ -1226,10 +1674,20 @@
       "CS 138"
     ]
   },
+  "CIT 173": {
+    "text": "Basic computer literacy skills. Provides an introduction to the Linux Operating System. Topics include Linux origins, file system, user commands and utilities, graphical user interfaces, editors, manual pages and shells.",
+    "courses": []
+  },
   "CIT 176": {
     "text": "Prerequisite: CIT 173",
     "courses": [
       "CIT 173"
+    ]
+  },
+  "CIT 180": {
+    "text": "CIT129 or equivalent programming experience or consent of instructor Teaches basic principles of data modeling and relational database design. Class is targeted for people with little or no SQL knowledge. Provides a comprehensive overview of query writing, focusing on practical techniques for the IT professional new to relational databases. Course accents hands-on learning in a Structured Query La",
+    "courses": [
+      "CIT 129"
     ]
   },
   "CIT 202": {
@@ -1397,12 +1855,22 @@
       "CIT 114"
     ]
   },
+  "CIT 270": {
+    "text": "CIT 112 or Consent of InstructorIntroduces current needed tools and techniques to effectively enumerate, map, document, investigate, and configure within current network architectures and environments. Focuses on tools and methods needed in computer and network technician, and cybersecurity roles.",
+    "courses": [
+      "CIT 112"
+    ]
+  },
   "CIT 274": {
     "text": "Prerequisite: C or better in CIT 112, or C or better in CSCO 120",
     "courses": [
       "CIT 112",
       "CSCO 120"
     ]
+  },
+  "CIT 275": {
+    "text": "Instructor ConsentProvides key baseline knowledge and practices in the digital forensic domains including file systems, operating systems, network and database systems, websites and email.",
+    "courses": []
   },
   "CIT 280": {
     "text": "Prerequisite: MATH 124 or higher",
@@ -1417,11 +1885,21 @@
       "MATH 124"
     ]
   },
+  "CIT 285": {
+    "text": "CIT 284Teaches the ability to create VR experiences and programs within Unity software. The course objectives are aligned with current industry standards set by professionals and educators.",
+    "courses": []
+  },
   "CIT 303": {
     "text": "Must have completed an AAS degree and either COT 204 or CIT 211",
     "courses": [
       "CIT 211",
       "COT 204"
+    ]
+  },
+  "CIT 330": {
+    "text": "CIT 112 and CIT 211Teaches students to install, configure, and manage vSphere; to install a complete virtual network on VMware Workstation consisting of ESXi hosts, a domain controller, a vCenter server, and an iScsi SAN. Course prepares students for VCA-DCV and VCP-DCV certifications.",
+    "courses": [
+      "CIT 112"
     ]
   },
   "CIT 361": {
@@ -1597,6 +2075,10 @@
     "text": "Admission to the Honors program",
     "courses": []
   },
+  "COM 113": {
+    "text": "NoneIntroduces principles and theories of speech communication. Includes participation in public speaking and interpersonal communication.",
+    "courses": []
+  },
   "COM 196": {
     "text": "Approval of the station, newspaper, agency or firm where internship will be completed; and approval from the Department of Communication Internship Coordinator",
     "courses": []
@@ -1607,14 +2089,24 @@
       "ENG 102"
     ]
   },
+  "COM 215": {
+    "text": "NoneIntroduces communication as it functions within small task groups. Emphasizes observation and analysis of actual small group behavior and on improvement of communication skills within the small group setting. Topics to include leadership, conflict, norms, role structure, cohesiveness and decision making. Course stresses student involvement in exercises, discussions and group projects.",
+    "courses": []
+  },
   "COM 340": {
-    "text": "Admission to a CSN Bachelor’s Program",
+    "text": "Admission to a CSN Bachelor\u2019s Program",
     "courses": []
   },
   "CONS 109": {
     "text": "Prerequisite: CONS 108",
     "courses": [
       "CONS 108"
+    ]
+  },
+  "CONS 121": {
+    "text": "CONS 120 and CONS 216Presents basic criteria and procedure for estimating labor and material in residential and commercial applications.",
+    "courses": [
+      "CONS 120"
     ]
   },
   "CONS 129B": {
@@ -1629,19 +2121,48 @@
       "CONS 121"
     ]
   },
+  "CONS 261": {
+    "text": "CONS260B Provides instruction on all of the under-floor components that the Certified Inspector of Structures must inspect to complete a certified inspection per 645D of the Nevada Administrative Code. Students will complete two supervised under-floor inspections and prepare extensive narrative inspection reports for evaluation. They will be required to sign \"hold harmless\" waivers when conductin",
+    "courses": [
+      "CONS 260B"
+    ]
+  },
+  "CONS 270": {
+    "text": "CONS 260 or Consent of InstructorProvides the necessary lecture and laboratory experience to satisfy the state regulations concerning the General Level Inspection Regulation NAC 645D.120. Course number or instructor approval needed.",
+    "courses": [
+      "CONS 260",
+      "NAC 645D"
+    ]
+  },
   "CONS 285B": {
     "text": "Prerequisite:",
+    "courses": []
+  },
+  "CONS 290": {
+    "text": "NoneStudies project management techniques on-site under the supervision of a project manager or superintendent.",
     "courses": []
   },
   "CONS 295": {
     "text": "Instructor approval",
     "courses": []
   },
+  "CONS 451": {
+    "text": "CONS 281 and consent of instructor.Studies advanced project management techniques on-site under the supervision of a project manager or superintendent and instructor. In consultation with the student, based on the specific internship, instructor determines additional learning objectives in addition to standard course learning objectives. Includes interaction with the instructor on a weekly basis.",
+    "courses": [
+      "CONS 281"
+    ]
+  },
   "COT 240": {
     "text": "Prerequisite: BUS 106 or BUS 108; or qualifying Accuplacer score; or with instructor approval",
     "courses": [
       "BUS 106",
       "BUS 108"
+    ]
+  },
+  "COT 262": {
+    "text": "IS101 or consent of instructor Studies the concepts and capabilities of computer spreadsheet systems. Teaches command and macro generation. Students gain experience generating spreadsheet templates, graphs and macros as business problem-solving tools. When offered for variable credit, content will be divided as follows: A) Concepts and capabilities of the computer spreadsheet with spreadsheet gene",
+    "courses": [
+      "IS 101"
     ]
   },
   "COT 301": {
@@ -1687,11 +2208,37 @@
     "text": "Students must be accepted to the Northern Nevada Law Enforcement Academy",
     "courses": []
   },
+  "CRJ 115": {
+    "text": "Acceptance to the Police Officers Standards and Training AcademyProvides necessary training to recognize cultural awareness and bias recognition in the practice of patrol for law enforcement. Includes proper training and history of patrol basics with the integration of communication of various types, such as interpersonal, and cultural diversity.",
+    "courses": []
+  },
+  "CRJ 116": {
+    "text": "Acceptance to the Police Officers Standards and Training AcademyProvides the fundamental knowledge and training to conduct interrogations and basic criminal investigation for Category I peace officers. Overview of correctional institutions and supervision of offenders for Category I and III peace officers as required for Nevada POST certification.",
+    "courses": []
+  },
+  "CRJ 117": {
+    "text": "Acceptance to the Police Officers Standards and Training AcademyProvides crisis intervention training and de-escalation techniques for the peace officer standards and training academy. Teaches skills that will allow the peace officer to interact in a safer manner with possible threats they may encounter and to assist in the prevention of escalated force.",
+    "courses": []
+  },
+  "CRJ 164": {
+    "text": "CRJ 104 or consent of instructorExamines the fundamentals of investigation: crime scene search and recording of information, collection and presentation of physical evidence, sources of information, scientific aids, case preparation, and interviews and interrogation procedures.",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 170": {
+    "text": "NoneProvides the physical training necessary for all police recruits to meet or exceed State of Nevada Peace Officer Standards and Training requirements in order to be certified as a peace officer. This course offered only as part of the POST Academy.",
+    "courses": []
+  },
   "CRJ 201": {
     "text": "Must have completed CRJ 104",
     "courses": [
       "CRJ 104"
     ]
+  },
+  "CRJ 219": {
+    "text": "NoneTeaches police recruits methods of emergency vehicle operation and control in such areas as shuffle steering, steering motion dynamics and vehicle braking (lock-wheel, ABS, impending), pursuit driving and defensive techniques. This course only offered as part of the POST Academy.",
+    "courses": []
   },
   "CRJ 220": {
     "text": "Must have completed CRJ 104",
@@ -1705,6 +2252,10 @@
       "CRJ 101",
       "CRJ 104"
     ]
+  },
+  "CRJ 229": {
+    "text": "NoneProvides police recruits with training in the areas of self-protection against armed persons armed with dangerous and/or deadly weapons. Training in the use of holds, come alongs, restraints, and baton use on uncooperative suspects, prisoners, or the mentally ill. This course is only offered as part of the POST Academy.",
+    "courses": []
   },
   "CRJ 230": {
     "text": "Must have completed CRJ 104",
@@ -1738,6 +2289,30 @@
   },
   "CRJ 289": {
     "text": "Must have completed CRJ 104",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 295": {
+    "text": "CRJ 104 or consent of instructorProvides the student with on-the job, supervised and educationally directed work experience.",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 296": {
+    "text": "CRJ 104 or consent of instructor Provides the student with on-the job, supervised and educationally directed work experience.",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 297": {
+    "text": "CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "courses": [
+      "CRJ 104"
+    ]
+  },
+  "CRJ 298": {
+    "text": "CRJ 104 or consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
     "courses": [
       "CRJ 104"
     ]
@@ -1881,10 +2456,23 @@
       "CSCO 121"
     ]
   },
+  "CSCO 221": {
+    "text": "CSCO121 & CSCO220 Explains the principles of traffic control and access control lists (ACLs) and provides an overview of the services and protocols at the data link layer for wide-area access. Students learn how to implement and configure Point-to-Point Protocol (PPP), Point-to-Point Protocol over Ethernet (PPPoE), DSL, and Frame Relay. WAN security concepts, tunneling, and VPN basics are also in",
+    "courses": [
+      "CSCO 121",
+      "CSCO 220"
+    ]
+  },
   "CSCO 230": {
     "text": "Must have completed CSCO 121",
     "courses": [
       "CSCO 121"
+    ]
+  },
+  "CSCO 280": {
+    "text": "CSCO221 or CCNA Certification Prepares students with the knowledge and skills to necessary to use advanced IP addressing and routing in implementing scalability for Cisco ISR routers connected to LANs and WANs. Covers topics on Advanced IP Addressing, Routing Principles, Multicast Routing, IPv6, Manipulating Routing Updates, and configuring basic BGP, Configuring EIGRP, OSPF, and IS-IS. Recommende",
+    "courses": [
+      "CSCO 221"
     ]
   },
   "CSCO 480": {
@@ -2131,6 +2719,12 @@
     "text": "Prerequisite: DAN 144",
     "courses": [
       "DAN 144"
+    ]
+  },
+  "DAN 260": {
+    "text": "DAN160B Teaches intermediate techniques of hip-hop dance. May be repeated for up to 4 credits.",
+    "courses": [
+      "DAN 160B"
     ]
   },
   "DAN 281": {
@@ -2591,6 +3185,10 @@
     "text": "Must have completed the ECE AA and be authorized to student teach in ECE by the Teacher Education Committee by applying by Sept. 15 or Feb. 15 the preceding semester",
     "courses": []
   },
+  "ECON 100": {
+    "text": "MATH 95 or higherOffers an introductory overview to supply and demand, the four types of product markets (perfect competition, monopolistic competition, oligopoly and monopoly), operations of markets, consumer and enterprise behavior, price determination. Also covers the measurement of the levels of national income, employment and general prices, and basic causes for fluctuation for these levels.",
+    "courses": []
+  },
   "ECON 102": {
     "text": "Prerequisite: BUS 117, MATH 120, MATH 124, MATH 126 or higher. Or co-requisite: BUS 117, MATH 124, MATH 126, or MATH 120 without support",
     "courses": [
@@ -2628,6 +3226,18 @@
   },
   "ECON 365": {
     "text": "Must have completed an associate's degree",
+    "courses": []
+  },
+  "EDCT 101": {
+    "text": "NoneIn this course, students will learn about the educational framework and classroom practices that will prepare them for employment as a secondary career and technical education (CTE) teacher and/or post-secondary opportunities in a CTE field. Topics include the general knowledge CTE teachers need in order to develop professionally and experience success in their first years of teaching and deve",
+    "courses": []
+  },
+  "EDCT 110": {
+    "text": "NoneThis course covers the principles of classroom communication for teachers that are new to Career and Technical Education (CTE). Emphasis will be placed on the strategies teachers use to communicate with students, colleagues, administration, parents and community members, as well as how communication supports the high-level instructional practices and educator professional responsibilities ofte",
+    "courses": []
+  },
+  "EDCT 298": {
+    "text": "NoneVarious short courses and experimental classes covering a variety of subjects. The class will be a variable credit of one-half to six credits depending upon class content and number of hours required. The course may be repeated for up to six credits.",
     "courses": []
   },
   "EDCT 302": {
@@ -2891,6 +3501,18 @@
     "text": "Must be admitted into the Teacher Education Program and be taking EDEL 491",
     "courses": [
       "EDEL 491"
+    ]
+  },
+  "EDU 112": {
+    "text": "EDU 110 or Instructor ConsentSupervised work and learning experience in research, public, education, business or government organizations related to Elementary or Secondary Education.",
+    "courses": [
+      "EDU 110"
+    ]
+  },
+  "EDU 206": {
+    "text": "EDU201 Presents the function and analysis of elementary school classrooms, daily activities, and methods of behavior management. Includes field experience. A background check may be required for field experience.",
+    "courses": [
+      "EDU 201"
     ]
   },
   "EDU 208": {
@@ -3476,6 +4098,12 @@
       "ENG 113"
     ]
   },
+  "ENG 226": {
+    "text": "ENG102 or consent of instructor Offers a writing-intensive class which explores various approaches to writing memoirs, autobiography, family history, autobiography-based fiction, or other \"life stories,\" incorporating the classic elements of the personal essay.",
+    "courses": [
+      "ENG 102"
+    ]
+  },
   "ENG 240": {
     "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
     "courses": [
@@ -3509,8 +4137,20 @@
       "ENG 205"
     ]
   },
+  "ENG 266": {
+    "text": "ENG102 or consent of instructor Studies various forms of popular writing, e.g., best-sellers, the western, science fiction, fantasy, the detective story.",
+    "courses": [
+      "ENG 102"
+    ]
+  },
   "ENG 267": {
     "text": "Must have completed ENG 102",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 271": {
+    "text": "ENG102 or consent of instructor Examines Shakespeare's principal plays read for their social interest and their literary excellence.",
     "courses": [
       "ENG 102"
     ]
@@ -3535,6 +4175,12 @@
     "courses": [
       "ENG 101",
       "ENG 113"
+    ]
+  },
+  "ENG 295": {
+    "text": "ENG102 Allows students to pursue individual writing or research projects under the close supervision and guidance of the instructor.",
+    "courses": [
+      "ENG 102"
     ]
   },
   "ENG 298": {
@@ -3754,6 +4400,51 @@
       "PHYS 180"
     ]
   },
+  "ENRG 140": {
+    "text": "ELM 110; This course provides comprehensive training on the safe disassembly of rechargeable batteries, with a focus on electric vehicle (EV) battery packs. Students will learn to identify hazards, implement safety protocols, and utilize appropriate tools and personal protective equipment (PPE). The course covers key topics, including battery construction, electrical safety, discharge methods,",
+    "courses": [
+      "ELM 110"
+    ]
+  },
+  "ENRG 162": {
+    "text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent) and ENRG 161 or BPI BA-T certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to use energy modeling software to model the energy upgrade potential of a home, develop a scope of work and for succes",
+    "courses": [
+      "ENRG 160",
+      "ENRG 161"
+    ]
+  },
+  "ENRG 164": {
+    "text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to test building airflow using blower door and press",
+    "courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  "ENRG 165": {
+    "text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to learn the most advanced methods for testing build",
+    "courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  "ENRG 166": {
+    "text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this course concurrently with the prerequisites with instructor approval.This course prepares students to integrate all elements of the Energy Audit Proces",
+    "courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
+  "ENRG 167": {
+    "text": "ENRG 160 or BPI Building Science Principles certification (or other national equivalent), ENRG 161 or BPI BA-T certification (or other national equivalent) and ENRG 162 or BPI BA-P certification (or other national equivalent). Students can take this concurrently with the prerequisites with instructor approval.This course prepares students to become a quality control inspector with the skills to en",
+    "courses": [
+      "ENRG 160",
+      "ENRG 161",
+      "ENRG 162"
+    ]
+  },
   "ENV 100": {
     "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
     "courses": [
@@ -3765,8 +4456,28 @@
       "MATH 126E"
     ]
   },
+  "ENV 101": {
+    "text": "Math 120 or consent of instructor.Explores the fundamental components and interactions of earth's natural systems, the relationships between humans and environment, and solutions to current and potential environmental problems.",
+    "courses": []
+  },
+  "EPD 163": {
+    "text": "NoneReview of writing skills and test-taking strategies in preparation for taking the PPST/Praxis I Writing Exam. This course is graded as Pass/Fail.",
+    "courses": []
+  },
+  "EPD 164": {
+    "text": "NoneReview of math concepts, solving problems, quantitative reasoning, and test-taking strategies in preparation for taking the PPST/Praxis I Math Exam. This course is graded as Pass/Fail.",
+    "courses": []
+  },
   "EPD 350": {
     "text": "Basic computer and word processing skills",
+    "courses": []
+  },
+  "EPD 400": {
+    "text": "Educator within the Nevada Department of Education System or permission of instructor.Offers insight and methods for improving curriculum design and delivery. Provides students opportunities to design and refine assessment projects for PreK-12 curriculum. Project-based course.May be repeated up to three units.",
+    "courses": []
+  },
+  "EPD 410": {
+    "text": "Instructor ApprovalStudents choose a book(s) to study for professional growth. Each book chosen will include weekly reflections of required reading, lab work, and a self-designed final project. Weekly online discussions required.",
     "courses": []
   },
   "FIN 310": {
@@ -3797,6 +4508,14 @@
       "FREN 211"
     ]
   },
+  "FT 104": {
+    "text": "FT 101Designed to familiarize the student with the general rules and regulations of fire fighting, use and explanation of forcible entry, protective breathing apparatus, fire streams, first aid, ropes, salvage, fire hose, nozzles and apparatus, ladders, ventilation, inspection, rescue, sprinklers, fire alarms and communications, safety and fire behavior.",
+    "courses": []
+  },
+  "FT 105": {
+    "text": "NoneExplores the theories and fundamentals of how and why fires start, spread and are controlled. FESHE Core Course",
+    "courses": []
+  },
   "FT 106": {
     "text": "Prerequisite: FT 102. Corequisite courses: FT 131, EMS 101, FT 110, EMHS 200. Students will be concurrently enrolled in these courses during the academy",
     "courses": [
@@ -3811,6 +4530,10 @@
     "text": "Prerequisite: Students must have completed all required core and major coursework in the Fire Technology program, possess a minimum GPA of 2.5, and obtain departmental approval",
     "courses": []
   },
+  "FT 110": {
+    "text": "NoneAddresses the basic elements of wildland fire protection, fire behavior, department organization, apparatus and equipment, fire safety and incident command organization.",
+    "courses": []
+  },
   "FT 146": {
     "text": "Prerequisite: FT 110",
     "courses": [
@@ -3821,11 +4544,29 @@
     "text": "Prerequisite: MATH 96 or equivalent or Accuplacer, ACT/SAT test results",
     "courses": []
   },
+  "FT 152": {
+    "text": "FT 101 or Instructor ApprovalAddresses the Federal, State, and local laws that regulate emergency services and include a review of national standards, regulations and consensus standards. FESHE Non-Core Course.",
+    "courses": [
+      "FT 101"
+    ]
+  },
+  "FT 154": {
+    "text": "NoneIntroduces the basic principles and history related to the national firefighter life safety initiatives, focusing on the need for cultural and behavior change throughout the emergency services. FESHE Core Course.",
+    "courses": []
+  },
   "FT 206": {
     "text": "Prerequisite: FT 106 or Firefighter I Certification",
     "courses": [
       "FT 106"
     ]
+  },
+  "FT 224": {
+    "text": "NoneProvides information relating to the features of design and operation of fire alarm systems, water-based fire suppression systems, special hazard fire suppression systems, water supply for fire protection and portable fire extinguishers. FESHE Core Course.",
+    "courses": []
+  },
+  "FT 291": {
+    "text": "NoneIntroduces the student to the organization and management of a fire and emergency services department and the relationship of government agencies to the fire service. Emphasis on fire and emergency service, ethics and leadership from the perspective of the company officer. FESHE Non-Core Course.",
+    "courses": []
   },
   "GEOG 103": {
     "text": "Must have completed with a C or better or be currently enrolled in: MATH 116 or MATH 116E or MATH 120 or MATH 120E or MATH 126 or MATH 126E or higher",
@@ -3866,6 +4607,12 @@
   },
   "GEOL 102": {
     "text": "Must have completed GEOL 101",
+    "courses": [
+      "GEOL 101"
+    ]
+  },
+  "GEOL 201": {
+    "text": "GEOL101 or consent of instructor Studies how Nevada\u00bfs geology has changed through time. Includes Nevada\u00bfs fossils, rocks and minerals, earthquakes and geothermal resources. Includes at least four lab experiences.",
     "courses": [
       "GEOL 101"
     ]
@@ -4582,6 +5329,20 @@
       "TA 100"
     ]
   },
+  "ITAL 111": {
+    "text": "NoneIntroduces the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "courses": []
+  },
+  "ITAL 112": {
+    "text": "ITAL111 or consent of instructorContinues study of the Italian language through the development of language skills and structural analysis. Includes an introduction to Italian culture.",
+    "courses": [
+      "ITAL 111"
+    ]
+  },
+  "ITAL 212": {
+    "text": "ITAL211Continues structural review, conversation and writing, and readings in modern literature.",
+    "courses": []
+  },
   "JOUR 108": {
     "text": "Prerequisite: ENG 101 or ENG 100 with a grade of C- or better, or concurrent enrollment in ENG 100 or ENG 101",
     "courses": [
@@ -4589,11 +5350,25 @@
       "ENG 101"
     ]
   },
+  "JOUR 201": {
+    "text": "JOUR103. Teaches writing in journalistic and persuasive styles for mass media. Emphasis on analysis and organization of information, and clarity of expression.",
+    "courses": [
+      "JOUR 103"
+    ]
+  },
   "JOUR 298": {
     "text": "Must have completed JOUR 205",
     "courses": [
       "JOUR 205"
     ]
+  },
+  "JPN 111": {
+    "text": "NoneIntroduces the language through structural analysis and the writing system. Includes some conversation and an introduction to Japanese culture.",
+    "courses": []
+  },
+  "JPN 112": {
+    "text": "JPN 111Continues study of the language through structural analysis and the writing system. Includes some conversation and an introduction to Japanese culture.",
+    "courses": []
   },
   "LAW 198": {
     "text": "Prerequisite: LAW 101",
@@ -4822,6 +5597,16 @@
     "text": "Prerequisite: Declared BAS - Logistics Operations Management and 45 credits completed in the core requirements with a cumulative 2.5 GPA or higher",
     "courses": []
   },
+  "LTE 101": {
+    "text": "Vaccinations and major medical insurance required (see requirements for LTE under the Nursing and Allied Health division)Provides knowledge and skills necessary to perform basic collection, identification, and preservation of blood samples as applied to venipuncture techniques. Incorporates finger stick procedures and patient contact methodologies carried out within the ethical, legal and professi",
+    "courses": []
+  },
+  "LTE 102": {
+    "text": "LTE 101 with C or better. Vaccinations and major medical insurance. See Nursing and Allied Health Division student requirements for LTE.Provides 100 hours of clinical phlebotomy experience (of clinical phlebotomy to apply knowledge and skills learned in LTE 101. Under the guidance of a laboratory technician preceptor, students will perform a minimum of 100 successful, documented blood draws with",
+    "courses": [
+      "LTE 101"
+    ]
+  },
   "MAPE 110": {
     "text": "Must be accepted into the Medical Assistant with Phlebotomy Technician and EKG program",
     "courses": []
@@ -4957,6 +5742,10 @@
     "text": "Prerequisite - Must be 18 years or older",
     "courses": []
   },
+  "MATH 100": {
+    "text": "NoneReviews basic mathematics with emphasis on those skills that apply to calculating drug dosages. Includes fractions, decimals, proportions, percents, English apothecary and metric systems of measurements.",
+    "courses": []
+  },
   "MATH 106": {
     "text": "Prerequisite: Qualifying Accuplacer, ACT/SAT test results (taken within 2 years)",
     "courses": []
@@ -5075,6 +5864,10 @@
       "MATH 283"
     ]
   },
+  "MATH 299": {
+    "text": "Consent of instructor.Provides individual study conducted under the direction of a faculty member.",
+    "courses": []
+  },
   "MATH 310": {
     "text": "Must have completed MATH 283 with a grade of 'C-' or higher",
     "courses": [
@@ -5134,11 +5927,23 @@
     "text": "Prerequisite: Qualifying Accuplacer score, ACT/SAT test results",
     "courses": []
   },
+  "MATH 92": {
+    "text": "Previous success in Intermediate Algebra or Algebra II or higher algebra course. Provides a review of algebra that will refresh previously taught concepts. Designed for students who have successfully completed Algebra II or Intermediate Algebra or similar course sometime in the past. Provides a condensed review of topics from Intermediate Algebra intended to help students place into the appropriat",
+    "courses": []
+  },
+  "MATH 93": {
+    "text": "MATH91 or equivalent or consent of instructor Prepares students for MATH 95. Helps students who have experienced difficulties with math to get an introduction to the language and concepts of algebra. Provides a transition from self-paced, basic math to the quick pace required in MATH 95.",
+    "courses": []
+  },
   "MATH 96": {
     "text": "Prerequisite: A grade of 'C' or better in MATH 95, or MATH 120, or equivalent or qualifying ACCUPLACER, ACT/SAT test results (taken within 2 years)",
     "courses": [
       "MATH 120"
     ]
+  },
+  "MATH 98": {
+    "text": "NonePrepares students for college-level mathematics. Self-paced, computer aided course designed to provide students with the concepts and skills of pre, elementary and intermediate algebra.",
+    "courses": []
   },
   "MCOD 110": {
     "text": "Must be admitted into the Medical Coding and Billing Program",
@@ -5183,6 +5988,10 @@
       "MCOD 140"
     ]
   },
+  "ME 198": {
+    "text": "enrollment in engineering program Guides students in preparation of written reports based on cooperative program assignments.",
+    "courses": []
+  },
   "ME 241": {
     "text": "Prerequisites: PHYS 180 and Co or prerequisite: MATH 182",
     "courses": [
@@ -5203,11 +6012,29 @@
       "MET 101"
     ]
   },
+  "MGT 235": {
+    "text": "BUS 101 and MGT 201 or consent of instructor. Studies concepts, theories and case studies concerning the behavior of people in modern business organizations. Analyzes the internal organization structure, and managerial roles and functions, in the business and other goal-oriented institutions. Studies theory and design of organizational structure, impact of work flow, leadership styles, and contro",
+    "courses": [
+      "BUS 101",
+      "MGT 201"
+    ]
+  },
+  "MGT 283": {
+    "text": "BUS 101 and MGT 201 or consent of instructor.Develops an understanding of the duties and responsibilities of personnel at the mid-management level.",
+    "courses": [
+      "BUS 101",
+      "MGT 201"
+    ]
+  },
   "MGT 310": {
     "text": "Must have sophomore standing or higher and have completed ENG 102",
     "courses": [
       "ENG 102"
     ]
+  },
+  "MGT 320": {
+    "text": "Admission to BAS Organization and Project Management ProgramFocuses on the key drivers of a successful organization. Emphasizes organization theories and models to analyze and improve performance in the organization. skills and Knowledge of project management and introduced and linked to organization performance.",
+    "courses": []
   },
   "MGT 323": {
     "text": "Must have sophomore standing or higher",
@@ -5221,6 +6048,14 @@
   },
   "MGT 367": {
     "text": "Must have sophomore standing or higher",
+    "courses": []
+  },
+  "MGT 371": {
+    "text": "Admission to BAS Organizational and Project Management Program or permission of division director and MGT 310Focuses on the skills of effective leaders and managers. Emphasis on leadership emergence in work settings, how to lead and manage others effectively, and leadership challenges in the contemporary business landscape such as the intersection of leadership with ethics.",
+    "courses": []
+  },
+  "MGT 412": {
+    "text": "Admission to BAS Organizational and Project Management ProgramExplores critical issues in institutional change, including change management, change readiness and change resistance. Designed to provide techniques and principles on how to introduce change into organizations.",
     "courses": []
   },
   "MGT 430": {
@@ -5267,6 +6102,12 @@
       "MGT 310"
     ]
   },
+  "MGT 496": {
+    "text": "Admission to BAS Organization and Project Management Program, FIN 310, MGT 310Emphasis on the application of knowledge from all functional areas of business to organizational problems and the formulation and implementation of organizational strategies.",
+    "courses": [
+      "FIN 310"
+    ]
+  },
   "MINE 102": {
     "text": "Must have completed MINE 101",
     "courses": [
@@ -5287,6 +6128,20 @@
       "BUS 111",
       "ENG 101",
       "ENG 113"
+    ]
+  },
+  "MKT 261": {
+    "text": "BUS 101 and MKT 210 or consent of instructorIntroduces the techniques of public relations for those holding supervisory or higher positions in management and marketing. Identifies the principles of creating and maintaining good public relations, including employee-employer relations. Customer-employee relations receive emphasis. Focuses on the programming of the total public relations effort and s",
+    "courses": [
+      "BUS 101",
+      "MKT 210"
+    ]
+  },
+  "MKT 262": {
+    "text": "BUS 101 and MKT 210 or consent of instructorPresents methods and techniques in modern advertising, giving information to do the entire advertising job.",
+    "courses": [
+      "BUS 101",
+      "MKT 210"
     ]
   },
   "MPT 104": {
@@ -5365,6 +6220,25 @@
       "ELM 110"
     ]
   },
+  "MT 115": {
+    "text": "AIT 101Introduces the concepts of Programmable Logic Controllers (PLC) and computerized control operations. Covers basic PLC programming by describing numbering systems, PLC memory organization, PLC programming software and PLC program logic elements.",
+    "courses": []
+  },
+  "MT 130": {
+    "text": "NoneIntroduces the natural gas industry. Includes history of the gas industry, safety issues, and field operations",
+    "courses": []
+  },
+  "MT 132": {
+    "text": "MT 130Introduces the concepts of natural gas pipe joining. Includes plastic pipe and metal pipe joining. Covers types of joining: plastic solvent, compression coupling, heat fusion, welded and bolted.",
+    "courses": []
+  },
+  "MT 134": {
+    "text": "MT 130, MT 132 (May be co-enrolled in MT 132)Introduces natural gas pipe leak detection. Includes various pipeline leak configurations and subsystems. Key devices/tools used in the detection of leaks are evaluated. Demonstrates classification, grading and surveying of leaks.",
+    "courses": [
+      "MT 130",
+      "MT 132"
+    ]
+  },
   "MTT 105": {
     "text": "Must be enrolled in MTT 106",
     "courses": [
@@ -5416,6 +6290,15 @@
       "MTT 292"
     ]
   },
+  "MTT 250": {
+    "text": "MTT110 and DFT110 or consent of instructor. Corequisite: MTT 251 or consent of instructor.Expands skills introduced in MTT 105 and MTT 110 to a more advanced level by developing projects that emphasize tolerances, plan of procedure and blueprint reading. Introduces further skills for surface grinding and tool and cutter grinding.",
+    "courses": [
+      "MTT 110",
+      "DFT 110",
+      "MTT 251",
+      "MTT 105"
+    ]
+  },
   "MTT 260": {
     "text": "Prerequisite: MTT 250. Course may be taken concurrently with MTT 250",
     "courses": [
@@ -5454,6 +6337,12 @@
     "courses": [
       "MTT 234",
       "MTT 293"
+    ]
+  },
+  "MUS 104": {
+    "text": "MUS103 Continues the skills learned in MUS 103.",
+    "courses": [
+      "MUS 103"
     ]
   },
   "MUS 107": {
@@ -5503,6 +6392,10 @@
       "MUS 211"
     ]
   },
+  "MUS 224": {
+    "text": "pianists should be of intermediate level proficiency Focuses in depth on a special topic in music literature. Topics might include Baroque, classical, romantic, or 20th century keyboard literature. Students will explore musical topics through both lecture and their own performance of representative works. Class may be repeated for up to six credits.",
+    "courses": []
+  },
   "MUS 231": {
     "text": "Co-requisite: MUS 239 Virtual Studio Technology I",
     "courses": [
@@ -5527,6 +6420,12 @@
     "courses": [
       "MUS 232",
       "MUS 239"
+    ]
+  },
+  "MUS 276": {
+    "text": "Six units of MUS 176.Continues skills learned in MUS 176.Repeatable up to 9 units.",
+    "courses": [
+      "MUS 176"
     ]
   },
   "MUS 301": {
@@ -5604,6 +6503,14 @@
     "text": "Co-requisite: Any student enrolled in Applied Music Lessons must also be enrolled in a music ensemble course (MUSE)",
     "courses": []
   },
+  "MUSE 131": {
+    "text": "intermediate proficiency on a band instrument Introduces study and performance of jazz ensemble literature. May be repeated for up to 4 credits.",
+    "courses": []
+  },
+  "MUSE 135": {
+    "text": "instrumentalists should be of intermediate level proficiency. No prerequisites for vocalists Explores a variety of musical styles, including pop, rock and jazz. Class may be repeated for a total of eight credits.",
+    "courses": []
+  },
   "NRES 210": {
     "text": "Prerequisite: MATH 126",
     "courses": [
@@ -5649,12 +6556,52 @@
     "text": "Must be accepted to the Nursing Program",
     "courses": []
   },
+  "NURS 136": {
+    "text": "admission to the nursing program; Corequisites: NURS137 & NURS141 Introduces students to the role of the associate degree nurse in contemporary practice. Students are guided to utilize knowledge from the sciences, humanities and nursing to understand man as a bio/psycho being. Students are introduced to the nursing program organizing concepts and outcomes which include professional behaviors, comm",
+    "courses": [
+      "NURS 137",
+      "NURS 141"
+    ]
+  },
+  "NURS 137": {
+    "text": "admission to the nursing program; Corequisites: NURS136 & NURS141Provides students with knowledge and practical application of basic nursing skills while incorporating concepts learned in NURS 136. Students learn and practice basic nursing bedside nursing skills in personal care, sterile technique, patient safety, and medication administration. Emphasizes the critical elements of nursing procedure",
+    "courses": [
+      "NURS 136"
+    ]
+  },
   "NURS 138": {
     "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
     "courses": []
   },
+  "NURS 141": {
+    "text": "admission to the nursing program; Corequisites: NURS136 & NURS137 Provides opportunities for students to utilize knowledge, concepts and skills learned in first semester nursing courses to meet the bio/psycho/social needs of patients in a long term acute care facility. Students use the nursing process and Maslow's Hierarchy of Needs at a beginning level to assess, plan, implement and evaluate nurs",
+    "courses": [
+      "NURS 136",
+      "NURS 137"
+    ]
+  },
   "NURS 142": {
     "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 147": {
+    "text": "admission to the nursing program; Corequisites: NURS148 Provides opportunities for students to gain knowledge necessary to holistically assess adult and elder patients. Students utilize concepts of previously learned content from pre-requisite and co-requisite nursing courses including the nursing process and methods of prioritizing to perform nursing assessment and nursing diagnosis. Students lea",
+    "courses": [
+      "NURS 148"
+    ]
+  },
+  "NURS 148": {
+    "text": "admission to the nursing program. Incorporates knowledge from NURS 147 to provide students with learning opportunities to collect, organize, analyze and synthesize health assessment data for adult and elder patients in a laboratory setting using simulated and peer assessment models.",
+    "courses": [
+      "NURS 147"
+    ]
+  },
+  "NURS 152": {
+    "text": "admission to the nursing program. Provides students with an overview of pharmacology with an emphasis on clinical applications within the context of the nursing process and prioritization of needs; with special consideration given to the physiological and psycho/social needs of patients. Explores indications, modes of action, effects, contraindications and interactions for selected drugs. Specific",
+    "courses": []
+  },
+  "NURS 153": {
+    "text": "Successful completion of the first semester of the nursing program. Provides a continuation of study of pharmacological principles and practices to achieve safe administration of medications. Selected drug classifications are presented, with an emphasis on understanding intended and unintended effects of drugs on body systems. Provides an overview of pharmacology with an emphasis on clinical appli",
     "courses": []
   },
   "NURS 154": {
@@ -5665,6 +6612,10 @@
     "text": "Must be accepted to the Nursing Program",
     "courses": []
   },
+  "NURS 156": {
+    "text": "admission to the nursing program and NURS 153Provides a continuation of study of pharmacological principles and practices through in-depth application of principles of pharmacology, pharmacokinetics and pharmacodynamics. Designed to expand the nursing student's knowledge of pharmacotherapeutics, which includes the cellular response level, for the clinical application within the context of the nurs",
+    "courses": []
+  },
   "NURS 158": {
     "text": "Must be accepted to the Nursing Program",
     "courses": []
@@ -5672,6 +6623,20 @@
   "NURS 159": {
     "text": "Must be accepted to the Nursing Program",
     "courses": []
+  },
+  "NURS 165": {
+    "text": "successful completion of the first semester of the nursing program; Corequisites: NURS166 & NURS167 Assists students to integrate knowledge derived from the bio/psycho/social sciences, humanities, nursing and current literature to achieve safe, competent care of adult patients experiencing common alterations in body systems. Organized by the nursing process to achieve best practice outcomes in an",
+    "courses": [
+      "NURS 166",
+      "NURS 167"
+    ]
+  },
+  "NURS 167": {
+    "text": "successful completion of the first semester of the nursing program. Corequisites: NURS165 & NURS166 Provides opportunities for students to utilize knowledge from the bio/psycho/social sciences, humanities, nursing and current literature to provide safe, competent care of adult patients experiencing common alterations in body systems. Organized by the nursing process to achieve best practice outcom",
+    "courses": [
+      "NURS 165",
+      "NURS 166"
+    ]
   },
   "NURS 170": {
     "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
@@ -5709,12 +6674,44 @@
     "text": "Must be accepted to the Nursing Program",
     "courses": []
   },
+  "NURS 261": {
+    "text": "successful completion of the first year of the nursing program. Corequsitie: NURS 262Focuses on basic concepts of nursing associated with care of the family experiencing pregnancy, birth, and the care of children. Incorporates knowledge of normal patterns of growth and development, health promotion, and disease prevention strategies. Students analyze care of patients with common health disruptions",
+    "courses": []
+  },
+  "NURS 270": {
+    "text": "successful completion of the first year of the nursing program. ; Corequisites: NURS271 Offers clinical theory organized around the nursing process and its application to patient needs. Requires students to apply the principles of providing a safe care environment, while addressing health promotion and health maintenance needs for persons experiencing complex/acute alterations in health. Students",
+    "courses": [
+      "NURS 271"
+    ]
+  },
+  "NURS 271": {
+    "text": "successful completion of the first year of the nursing program. Corequisites: NURS270 Requires students to use the nursing process to identify and prioritize health care needs in the provision of care for patients experiencing complex/acute alterations in health. Expands upon previous clinical learning to include the teaching/learning process and administration of intravenous fluids and medication",
+    "courses": [
+      "NURS 270"
+    ]
+  },
   "NURS 273": {
     "text": "Must be accepted to the Nursing Program",
     "courses": []
   },
   "NURS 274": {
     "text": "Prerequisite: Open to students with declared Nursing major and accepted into the Nursing program",
+    "courses": []
+  },
+  "NURS 276": {
+    "text": "successful completion of the third semester of the nursing program. ; Corequisites: NURS277 Assists students to gain knowledge of nursing care for the patient experiencing primary threats to physiological integrity due to complex multisystem disruption in cardiovascular, respiratory, neurological, integumentary, elimination, and digestive systems. Students apply the nursing process to address need",
+    "courses": [
+      "NURS 277"
+    ]
+  },
+  "NURS 277": {
+    "text": "successful completion of the third semester of the nursing program. ; Corequisites: NURS276 Requires students to apply knowledge and skills to the care of adult patients in a simulated laboratory and acute care environments experiencing needs resulting from complex multisystem disruptions. Students apply the nursing process and utilize information literacy skills to achieve deliberative and compet",
+    "courses": [
+      "NURS 276"
+    ]
+  },
+  "NURS 284": {
+    "text": "successful completion of the third semester of the nursing program. Utilizes a capstone laboratory/clinical to facilitate the role transition from student to graduate nurse. Students integrate knowledge derived from the bio/psycho/social sciences, humanities and nursing to achieve best practice outcomes for multiple patients and their significant others in the acute care setting. Students apply a",
     "courses": []
   },
   "NURS 326": {
@@ -5892,6 +6889,10 @@
     "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
     "courses": []
   },
+  "PEX 136": {
+    "text": "intermediate snowboarding ability Teaches skidded turn with good speed and control on green and blue terrain. Consists of a combination of on-the-snow classes at an established ski area and classroom instruction at the college. Students will be assigned to small groups based on their present snowboarding ability. Any additional on-snow instruction will be by certified instructors employed by the s",
+    "courses": []
+  },
   "PEX 180": {
     "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
     "courses": []
@@ -5935,6 +6936,12 @@
   "PEX 293": {
     "text": "Must be a member of the TMCC Intercollegiate Soccer Team or have instructor permission to enroll",
     "courses": []
+  },
+  "PHIL 101": {
+    "text": "ENG 101 recommendedStudies basic problems in different areas of philosophy such as ethics, political theory, metaphysics, and epistemology.",
+    "courses": [
+      "ENG 101"
+    ]
   },
   "PHIL 129": {
     "text": "Must have completed ENG 100 or ENG 101 or have satisfactory score in Accuplacer, ACT, or SAT placement tests for ENG 102",
@@ -6003,8 +7010,22 @@
       "MATH 127"
     ]
   },
+  "PHYS 151A": {
+    "text": "MATH126 & MATH127,or MATH128 or equivalent. For non-physical science majors. Topics include kinematics, Newton's laws of motion, energy and momentum conservation, rotational dynamics, thermodynamics, fluids, harmonic motion, and sound.",
+    "courses": [
+      "MATH 126",
+      "MATH 127",
+      "MATH 128"
+    ]
+  },
   "PHYS 152": {
     "text": "Must have completed PHYS 151",
+    "courses": [
+      "PHYS 151"
+    ]
+  },
+  "PHYS 152A": {
+    "text": "PHYS151. For non-physical science majors. Topics include electricity, magnetism, electromagnetic waves, optics, relativity, introductory quantum physics, atomic physics, and nuclear physics.",
     "courses": [
       "PHYS 151"
     ]
@@ -6047,6 +7068,13 @@
     "courses": [
       "PHYS 181",
       "PHYS 182"
+    ]
+  },
+  "PHYS 293": {
+    "text": "PHYS151 or PHYS180 Provides individual study conducted under the direction of a faculty member. May be repeated for up to six credits.",
+    "courses": [
+      "PHYS 151",
+      "PHYS 180"
     ]
   },
   "PHYS 483": {
@@ -6159,6 +7187,12 @@
     "text": "Must have completed 40 or more credits including one 3 credit lower-division PSC",
     "courses": []
   },
+  "PSY 120": {
+    "text": "PSY101 or consent of instructor Surveys the psychology of human performance. Explores the psychological, emotional, and strategic dimensions of human performance. Emphasis will be to provide students with a comprehensive background that they can apply to their own performance areas.",
+    "courses": [
+      "PSY 101"
+    ]
+  },
   "PSY 205": {
     "text": "Prerequisite: PSY 101",
     "courses": [
@@ -6173,6 +7207,24 @@
       "SOC 101"
     ]
   },
+  "PSY 220": {
+    "text": "PSY101 or consent of instructor Introduces the application of psychology principles of learning and cognitive development.",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 233": {
+    "text": "PSY101 or consent of instructor Explains the growth and development of children from conception through early adolescence.",
+    "courses": [
+      "PSY 101"
+    ]
+  },
+  "PSY 234": {
+    "text": "PSY101 or consent of instructor Examines psychological development during adolescence with emphasis on special problems in American society: drug abuse, pregnancy, and familial problems.",
+    "courses": [
+      "PSY 101"
+    ]
+  },
   "PSY 240": {
     "text": "Prerequisite: PSY 101",
     "courses": [
@@ -6183,6 +7235,14 @@
     "text": "Must have completed PSY 101",
     "courses": [
       "PSY 101"
+    ]
+  },
+  "PSY 257": {
+    "text": "PSY101. Recommended: COM102 and SOC 101.Explores the scope of this new branch of Psychology. Key topics include: the history of Positive Psychology, positivity, learned optimism, purpose, handling adversity and resilience, happiness and well-being, personality development and integration, and positive relationships.",
+    "courses": [
+      "PSY 101",
+      "COM 102",
+      "SOC 101"
     ]
   },
   "PSY 275": {
@@ -6203,6 +7263,12 @@
       "MATH 126",
       "MATH 126E",
       "STAT 152"
+    ]
+  },
+  "PSY 342": {
+    "text": "PSY 101 or consent of instructor; Demonstrate reason in criminal law and the difference between psychological syndromes and psychological profiles; identify the effects of unsupported scientific concepts in the US legal system; define the biological and ethological explanations of aggression and understand why antisocial and narcissistic personalities are prone to aggression; explain the various",
+    "courses": [
+      "PSY 101"
     ]
   },
   "PSY 412": {
@@ -6384,6 +7450,20 @@
     "text": "Admission to the BAS radiologic technology program",
     "courses": []
   },
+  "RE 103": {
+    "text": "RE101 Provides in-depth study of the real estate profession including Nevada real estate laws. Covers rules and regulations pertaining to NRS 645 and NRS 119, along with listing procedures, contracts, closing statements and office procedures.",
+    "courses": [
+      "RE 101",
+      "NRS 645",
+      "NRS 119"
+    ]
+  },
+  "READ 135": {
+    "text": "READ093 with a C or better, reading placement exam, or consent of instructor Helps the average reader improve reading efficiency through practice with advanced comprehension skills. Reading rate is thereby improved indirectly. Students with heavy academic or on-the-job reading will benefit. Attention is also given to expanding reading vocabularies.",
+    "courses": [
+      "READ 093"
+    ]
+  },
   "RS 151": {
     "text": "Prerequisite: RS 101",
     "courses": [
@@ -6442,6 +7522,12 @@
       "SMTL 201"
     ]
   },
+  "SOC 102": {
+    "text": "SOC101 or consent of instructor Acquaints students with selected social problems, their causes and possible solutions.",
+    "courses": [
+      "SOC 101"
+    ]
+  },
   "SOC 210": {
     "text": "Prerequisite: Completion of PSY 101, or SOC 101; NGQAS score of 263-275, or equivalent ACT/SAT score, or completion of MATH 120 or higher",
     "courses": [
@@ -6454,6 +7540,12 @@
     "text": "Must have completed SPAN 101",
     "courses": [
       "SPAN 101"
+    ]
+  },
+  "SPAN 103": {
+    "text": "SPAN102B or consent of instructor Further develops skills learned in previous semesters.",
+    "courses": [
+      "SPAN 102B"
     ]
   },
   "SPAN 112": {
@@ -6536,6 +7628,18 @@
       "MATH 120",
       "MATH 126",
       "MATH 126E"
+    ]
+  },
+  "SUR 119": {
+    "text": "CONS108 or consent of instructor Presents care and use of surveying equipment. Profile elevation and closed traverse projects will provide hands-on experience. Construction staking will be explained in detail.",
+    "courses": [
+      "CONS 108"
+    ]
+  },
+  "SUR 161": {
+    "text": "MATH127 or higher Offers a beginning course designed to introduce students to modern techniques in land surveying.",
+    "courses": [
+      "MATH 127"
     ]
   },
   "SUR 280": {
@@ -6978,6 +8082,10 @@
     "courses": [
       "WELD 220"
     ]
+  },
+  "WELD 290": {
+    "text": "consent of instructor Provides the student with on-the-job, supervised and educationally directed work experience.",
+    "courses": []
   },
   "WF 205": {
     "text": "S-110, S-130, S-190, L-180 , ICS 100 & 700 (FT 110)",

--- a/scripts/nv/scrape-catalog-prereqs.ts
+++ b/scripts/nv/scrape-catalog-prereqs.ts
@@ -5,7 +5,7 @@
  *   - CSN: Acalog (catalog.csn.edu)
  *   - GBC: Custom HTML (gbcnv.edu/catalog/current/courses/)
  *   - TMCC: Courseleaf (catalog.tmcc.edu)
- *   - WNC: Coursedog SPA — skipped (requires headless browser)
+ *   - WNC: Coursedog SPA (catalog.wnc.edu) via Playwright
  *
  * Merges all prereqs into data/nv/prereqs.json keyed by "PREFIX NUMBER".
  * When multiple colleges list the same course, first-seen wins.
@@ -18,6 +18,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { scrapeCoursedogCatalog } from "../lib/scrape-coursedog";
 
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -293,6 +294,40 @@ async function scrapeTMCC(limit: number): Promise<Record<string, PrereqEntry>> {
 }
 
 // ---------------------------------------------------------------------------
+// WNC — Coursedog SPA (catalog.wnc.edu) via Playwright
+// ---------------------------------------------------------------------------
+
+async function scrapeWNC(): Promise<Record<string, PrereqEntry>> {
+  console.log("\n📚 WNC (Coursedog via Playwright)");
+
+  const result = await scrapeCoursedogCatalog({
+    state: "nv",
+    slug: "western-nevada-college",
+    catalogDomain: "catalog.wnc.edu",
+  });
+
+  if (result.error) {
+    console.log(`  ⚠ ${result.error}`);
+    return {};
+  }
+
+  const prereqs: Record<string, PrereqEntry> = {};
+  let withPrereqs = 0;
+
+  for (const course of result.courses) {
+    if (!course.prerequisite_text) continue;
+    const key = `${course.prefix} ${course.number}`;
+    const text = course.prerequisite_text.replace(/\s+/g, " ").trim();
+    if (!isNonTrivialPrereq(text) || prereqs[key]) continue;
+    prereqs[key] = { text, courses: course.prerequisite_courses };
+    withPrereqs++;
+  }
+
+  console.log(`  ✓ ${withPrereqs} courses with prereqs (from ${result.coursesCount} total)`);
+  return prereqs;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -310,6 +345,7 @@ async function main() {
     { name: "csn", fn: () => scrapeCSN(limit) },
     { name: "gbc", fn: () => scrapeGBC(limit) },
     { name: "tmcc", fn: () => scrapeTMCC(limit) },
+    { name: "wnc", fn: () => scrapeWNC() },
   ];
 
   for (const { name, fn } of colleges) {


### PR DESCRIPTION
## What changes for someone using the site

222 more courses now have prerequisite data in Nevada — all from Western Nevada College. Total NV prereqs: 1,398 (was 1,176).

## What changes technically

The NV prereq scraper now includes WNC via the existing `scrape-coursedog.ts` Playwright template. WNC's catalog is a Coursedog SPA at catalog.wnc.edu — Playwright captures the tenant/catalog IDs from network requests, then fetches all 881 courses via the Coursedog API. 222 unique prereqs were added after deduplication against the other 3 colleges.

## Test plan

- [x] Scraper runs clean, WNC adds 222 new prereqs
- [x] Spot-checked merged output (1,398 entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)