### PR TITLE
fix(nv): use ScrapeJob[] for prereqs config (fixes build)

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -93,16 +93,17 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
       - Courseleaf → parse `/coursesaz/{subject}/` pages for
         `Enrollment Requirements:` blocks
       - Custom HTML → parse subject pages for `<strong>Prerequisite:`
-      - Coursedog SPA → skip (requires headless browser; defer as TODO)
+      - Coursedog SPA → use `scripts/lib/scrape-coursedog.ts` Playwright template
     - Output format: `{ "PREFIX NUMBER": { "text": "...", "courses": [...] } }`
     - Merge all colleges into one `data/{slug}/prereqs.json`
     - Update `StateConfig.scrapers.prereqs` from
       `{ source: "aggregate-from-courses" }` to
-      `{ source: "catalog-scrape", scripts: ["scripts/{slug}/scrape-catalog-prereqs.ts"] }`
+      `[{ scripts: ["scripts/{slug}/scrape-catalog-prereqs.ts"], runner: "playwright" }]`
+      (the type is `ScrapeJob[] | { source: "aggregate-from-courses" }`)
 
     **When to skip:** Only skip a college's catalog if it's auth-gated (SSO
-    login wall) or uses a Coursedog SPA that can't be scraped without
-    Playwright. Always note skipped colleges in the PR body.
+    login wall). Coursedog SPAs are handled via the Playwright template.
+    Always note skipped colleges in the PR body.
 
 7. **Pre-PR feature check** (per `CLAUDE.md`'s three-checks-in-order rule).
    Per Section "Verifying your work" item 1: load `/{slug}/colleges` in
@@ -134,7 +135,7 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
    # Phase 3 + 4 (if any transfer / prereq data)
    git add data/{slug}/prereqs.json scripts/{slug}/scrape-catalog-prereqs.ts
    git commit -m "feat: {state} prereqs — {N} courses (via {source})"
-   # {source} is "aggregate-from-courses" or "catalog-scrape (Acalog/Courseleaf/...)"
+   # Use ScrapeJob[] when a dedicated catalog scraper exists
 
    # Phase 5 (if any scorecard data — only when COLLEGE_SCORECARD_API_KEY is set)
    git add data/{slug}/scorecard/ data/{slug}/institutions.json data/scorecard-mapping.json

--- a/lib/states/nv/config.ts
+++ b/lib/states/nv/config.ts
@@ -47,10 +47,9 @@ const nvConfig: StateConfig = {
       { scripts: ["scripts/nv/scrape-peoplesoft.ts"], runner: "playwright" },
     ],
     // manual-only: transfers — no articulation portal registered for NV yet.
-    prereqs: {
-      source: "catalog-scrape",
-      scripts: ["scripts/nv/scrape-catalog-prereqs.ts"],
-    },
+    prereqs: [
+      { scripts: ["scripts/nv/scrape-catalog-prereqs.ts"], runner: "playwright" },
+    ],
     // manual-only: programs — Phase 5+.
   },
 };


### PR DESCRIPTION
## What changed

The previous merge introduced `{ source: "catalog-scrape" }` for NV prereqs config, but that's not a valid type — `prereqs` accepts `ScrapeJob[] | { source: "aggregate-from-courses" }`. Changed to `ScrapeJob[]` format. Also fixes the auto-add-state skill docs to use the correct type and to handle Coursedog SPAs via Playwright (not skip them).

## Test plan

- [ ] Vercel build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)