### PR TITLE
chore: monthly sweep of stale term data (retention: current + future + 2 prior)

### DIFF
--- a/.github/workflows/sweep-stale-terms.yml
+++ b/.github/workflows/sweep-stale-terms.yml
@@ -1,0 +1,135 @@
+name: Sweep stale terms
+
+# Monthly cleanup of term data outside the retention window.
+# Policy: keep current term + all future terms + 2 prior terms.
+# See scripts/lib/sweep-stale-terms.md for the full spec.
+#
+# Runs on the 15th of every month at 06:00 UTC — deliberately mid-month,
+# away from term boundaries and the weekly course-scrape crons, so a
+# still-rolling scraper can't race the sweep.
+#
+# Safety:
+#   - Cron default mode = dry-run. Prints what would be deleted, writes
+#     nothing. Flip the workflow_dispatch `mode` input to 'live' once
+#     you've eyeballed a dry-run report and want to actually delete.
+#   - JSON file deletions are committed to a PR, not pushed straight to
+#     main. A human still merges.
+#   - Supabase deletes happen in live mode regardless of the PR — the DB
+#     is the authoritative store, the JSON files are reproducible.
+
+on:
+  schedule:
+    - cron: "0 6 15 * *" # 15th of every month at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Sweep mode"
+        type: choice
+        options: [dry-run, live]
+        default: dry-run
+      state:
+        description: "Limit to one state slug (blank = all states)"
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sweep-stale-terms
+  cancel-in-progress: false
+
+env:
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Resolve mode
+        id: mode
+        run: |
+          # Scheduled cron always starts in dry-run. To actually sweep,
+          # use workflow_dispatch and pick 'live'.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            mode="${{ inputs.mode }}"
+            state="${{ inputs.state }}"
+          else
+            mode="dry-run"
+            state=""
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          if [ -n "$state" ]; then
+            echo "state_flag=--state $state" >> "$GITHUB_OUTPUT"
+          else
+            echo "state_flag=" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$mode" = "dry-run" ]; then
+            echo "dry_flag=--dry-run" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_flag=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Running sweep mode=$mode state=${state:-all}" >&2
+
+      - name: Run sweep
+        id: sweep
+        run: |
+          npx tsx scripts/lib/sweep-stale-terms.ts \
+            ${{ steps.mode.outputs.state_flag }} \
+            ${{ steps.mode.outputs.dry_flag }} \
+            | tee sweep-report.txt
+
+      - name: Upload sweep report
+        uses: actions/upload-artifact@v4
+        with:
+          name: sweep-report-${{ steps.mode.outputs.mode }}-${{ github.run_id }}
+          path: sweep-report.txt
+          retention-days: 90
+
+      # Live mode only: open a PR with the disk-side deletions. Supabase
+      # rows were already deleted by the sweep script above.
+      - name: Check for disk changes
+        if: steps.mode.outputs.mode == 'live'
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No JSON files removed — Supabase already swept (if anything was stale)."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "JSON files removed:"
+            git diff --name-only --diff-filter=D
+          fi
+
+      - name: Open cleanup PR
+        if: steps.mode.outputs.mode == 'live' && steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/sweep-stale-terms-${{ github.run_id }}
+          base: main
+          commit-message: "chore: sweep stale term JSON files (retention policy)"
+          title: "chore: sweep stale term JSON files"
+          body: |
+            Monthly term retention sweep removed JSON files for terms outside
+            the keep window (current + all future + 2 prior).
+
+            Supabase rows for these (state, term) pairs were already deleted
+            by the sweep script in the same run. This PR catches up the
+            committed JSON files so disk and DB stay in sync.
+
+            Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            See `scripts/lib/sweep-stale-terms.md` for the policy.
+          labels: |
+            chore
+            data-cleanup

--- a/scripts/lib/sweep-stale-terms.md
+++ b/scripts/lib/sweep-stale-terms.md
@@ -1,0 +1,71 @@
+# Term retention policy
+
+## Policy
+
+For every state, the `courses` table in Supabase and the JSON files at
+`data/{state}/courses/{college}/{term}.json` retain:
+
+- **All terms ≥ current term** — the current term (broadest college coverage)
+  plus everything in the future. Future terms appear early because colleges
+  publish next year's schedule months ahead of the term start.
+- **Up to 2 terms strictly older than current** — preserves a short trailing
+  window for "did MTH-154 transfer last spring?" lookups and rollback safety.
+- **Nothing older.** Anything beyond that floor gets swept on the monthly
+  cron.
+
+Term codes are sorted using `termSortKey()` in `lib/term-label.ts`, which
+expects the canonical `YYYY{SP|SU|FA}` shape. Non-standard codes — IL's
+`2026-FL`, CA's `26-FA`, NC's `2026CE1`, etc. — are reported as warnings
+and **never deleted** by the sweep. They need a separate scraper-side fix
+or manual cleanup.
+
+## Mechanism
+
+1. Determine `currentTerm` per state via the `get_term_college_counts` RPC
+   (same logic as `lib/terms.ts#getCurrentTerm`).
+2. List distinct terms in Supabase + JSON files on disk.
+3. Filter to canonical-shape terms only. Sort newest-first.
+4. Compute the keep set: terms with `termSortKey ≥ floor`, where the floor
+   is the 2nd-oldest standard term still inside the window.
+5. For every term outside the keep set:
+   - `DELETE FROM courses WHERE state=? AND term=?`
+   - `rm data/{state}/courses/*/{term}.json`
+
+The sweep is idempotent — re-running with nothing stale to delete is a
+no-op.
+
+## Running it
+
+```bash
+# Dry-run across every state (default behavior for the first cron tick)
+tsx scripts/lib/sweep-stale-terms.ts --dry-run
+
+# Live sweep, all states
+tsx scripts/lib/sweep-stale-terms.ts
+
+# Limit to one state
+tsx scripts/lib/sweep-stale-terms.ts --state va --dry-run
+```
+
+The `--dry-run` flag prints the planned deletes (per-state, per-term) and
+flags any non-standard codes without writing anything.
+
+## Scheduled run
+
+`.github/workflows/sweep-stale-terms.yml` runs on the 15th of every month
+at 06:00 UTC — mid-month, deliberately away from any term boundary or the
+weekly scrape cron, so a still-rolling scraper can't race the sweep.
+
+The first scheduled run is intentionally dry-run only (`SWEEP_MODE=dry-run`
+env var). After the first month you can verify the planned deletions are
+sane, flip the env to `SWEEP_MODE=live`, and let it run.
+
+## What it deliberately does NOT do
+
+- It does **not** rename or normalize non-canonical term codes. That's a
+  scraper-correctness problem, not a retention problem.
+- It does **not** touch transfer, programs, prereq, or articulation data —
+  only `courses` and the per-term JSON files. Those datasets don't have a
+  term dimension.
+- It does **not** vacuum or reindex Supabase post-delete. Postgres
+  handles that itself.

--- a/scripts/lib/sweep-stale-terms.ts
+++ b/scripts/lib/sweep-stale-terms.ts
@@ -1,0 +1,293 @@
+/**
+ * Sweep stale term data from Supabase + disk.
+ *
+ * Retention policy (see scripts/lib/sweep-stale-terms.md):
+ *   - Keep all terms ≥ current term (current + future).
+ *   - Keep up to 2 terms prior to current.
+ *   - Delete everything older.
+ *
+ * Only operates on term codes matching the canonical `YYYY{SP|SU|FA}`
+ * pattern. Non-standard codes (e.g. `2026-FL`, `CE26SP`) are reported as
+ * warnings and left untouched — they need manual cleanup or scraper fix.
+ *
+ * Usage:
+ *   tsx scripts/lib/sweep-stale-terms.ts                # all states, real delete
+ *   tsx scripts/lib/sweep-stale-terms.ts --dry-run      # show what would happen
+ *   tsx scripts/lib/sweep-stale-terms.ts --state va     # one state only
+ *   tsx scripts/lib/sweep-stale-terms.ts --state va --dry-run
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { loadEnv } from "./load-env";
+import { getAllStates } from "../../lib/states/registry";
+import { termSortKey } from "../../lib/term-label";
+
+const CANONICAL_TERM_RE = /^(\d{4})(SP|SU|FA)$/;
+const KEEP_PRIOR_COUNT = 2;
+
+interface SweepPlan {
+  state: string;
+  currentTerm: string;
+  keep: string[];
+  deleteTerms: string[];
+  nonStandardTerms: string[];
+  diskFilesToDelete: string[];
+}
+
+function getSupabase(): SupabaseClient {
+  loadEnv();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local"
+    );
+  }
+  return createClient(url, key);
+}
+
+/**
+ * Get the current term for a state from Supabase — defined as the term
+ * with the broadest college coverage, breaking ties by recency. Mirrors
+ * lib/terms.ts but reimplemented here so this script doesn't need to
+ * pull the full server-side cache machinery.
+ */
+async function getCurrentTerm(sb: SupabaseClient, state: string): Promise<string | null> {
+  const { data, error } = await sb.rpc("get_term_college_counts", {
+    p_state: state,
+  });
+  if (error || !data || data.length === 0) return null;
+
+  let bestTerm = data[0].term as string;
+  let bestCount = Number(data[0].college_count);
+  let bestSort = termSortKey(bestTerm);
+
+  for (const row of data) {
+    const term = row.term as string;
+    const count = Number(row.college_count);
+    const sort = termSortKey(term);
+    if (count > bestCount || (count === bestCount && sort > bestSort)) {
+      bestTerm = term;
+      bestCount = count;
+      bestSort = sort;
+    }
+  }
+  return bestTerm;
+}
+
+/**
+ * Distinct terms present in Supabase for this state.
+ */
+async function getDbTerms(sb: SupabaseClient, state: string): Promise<string[]> {
+  const seen = new Set<string>();
+  const PAGE_SIZE = 1000;
+  let page = 0;
+  while (true) {
+    const start = page * PAGE_SIZE;
+    const { data: rows, error } = await sb
+      .from("courses")
+      .select("term")
+      .eq("state", state)
+      .range(start, start + PAGE_SIZE - 1);
+    if (error) throw error;
+    if (!rows || rows.length === 0) break;
+    for (const r of rows) if (r.term) seen.add(r.term);
+    if (rows.length < PAGE_SIZE) break;
+    page++;
+  }
+  return Array.from(seen);
+}
+
+/**
+ * JSON term files on disk for a state — returns `{term, fullPath}` pairs.
+ */
+function getDiskTerms(state: string): { term: string; fullPath: string }[] {
+  const dir = path.join(process.cwd(), "data", state, "courses");
+  if (!fs.existsSync(dir)) return [];
+  const out: { term: string; fullPath: string }[] = [];
+  for (const college of fs.readdirSync(dir)) {
+    const collegeDir = path.join(dir, college);
+    if (!fs.statSync(collegeDir).isDirectory()) continue;
+    for (const file of fs.readdirSync(collegeDir)) {
+      if (!file.endsWith(".json")) continue;
+      const term = file.replace(/\.json$/, "");
+      out.push({ term, fullPath: path.join(collegeDir, file) });
+    }
+  }
+  return out;
+}
+
+/**
+ * Compute the sweep plan for one state without touching anything.
+ */
+async function planState(sb: SupabaseClient, state: string): Promise<SweepPlan> {
+  const currentTerm = await getCurrentTerm(sb, state);
+  if (!currentTerm) {
+    return {
+      state,
+      currentTerm: "",
+      keep: [],
+      deleteTerms: [],
+      nonStandardTerms: [],
+      diskFilesToDelete: [],
+    };
+  }
+
+  const currentSort = termSortKey(currentTerm);
+  if (currentSort === 0) {
+    // Current term itself is non-standard — refuse to sweep. Surface as
+    // a warning and let a human investigate.
+    return {
+      state,
+      currentTerm,
+      keep: [],
+      deleteTerms: [],
+      nonStandardTerms: [currentTerm],
+      diskFilesToDelete: [],
+    };
+  }
+
+  const dbTerms = await getDbTerms(sb, state);
+  const diskTerms = getDiskTerms(state);
+  const allTerms = new Set<string>([
+    ...dbTerms,
+    ...diskTerms.map((d) => d.term),
+  ]);
+
+  // Standard codes only — non-standard get surfaced separately.
+  const standard: string[] = [];
+  const nonStandard: string[] = [];
+  for (const t of allTerms) {
+    if (CANONICAL_TERM_RE.test(t)) standard.push(t);
+    else nonStandard.push(t);
+  }
+
+  // Sort standard terms newest-first.
+  standard.sort((a, b) => termSortKey(b) - termSortKey(a));
+
+  // Determine the floor: 2 standard terms prior to current.
+  // "Prior" = terms strictly older than current. Take the 2 newest of those.
+  const olderThanCurrent = standard.filter(
+    (t) => termSortKey(t) < currentSort
+  );
+  const keepPrior = olderThanCurrent.slice(0, KEEP_PRIOR_COUNT);
+  const floorSort = keepPrior.length > 0
+    ? termSortKey(keepPrior[keepPrior.length - 1])
+    : currentSort; // no priors? floor = current term itself
+
+  const keep = standard.filter((t) => termSortKey(t) >= floorSort);
+  const deleteTerms = standard.filter((t) => termSortKey(t) < floorSort);
+
+  const diskFilesToDelete = diskTerms
+    .filter((d) => deleteTerms.includes(d.term))
+    .map((d) => d.fullPath);
+
+  return {
+    state,
+    currentTerm,
+    keep,
+    deleteTerms,
+    nonStandardTerms: nonStandard,
+    diskFilesToDelete,
+  };
+}
+
+/**
+ * Execute a sweep plan — DELETE from Supabase, unlink JSON files.
+ */
+async function executePlan(sb: SupabaseClient, plan: SweepPlan): Promise<void> {
+  for (const term of plan.deleteTerms) {
+    const { error } = await sb
+      .from("courses")
+      .delete()
+      .eq("state", plan.state)
+      .eq("term", term);
+    if (error) {
+      console.error(`  ✗ ${plan.state}/${term}: ${error.message}`);
+      continue;
+    }
+    console.log(`  ✓ deleted Supabase rows for ${plan.state}/${term}`);
+  }
+  for (const file of plan.diskFilesToDelete) {
+    try {
+      fs.unlinkSync(file);
+      console.log(`  ✓ removed ${path.relative(process.cwd(), file)}`);
+    } catch (err) {
+      console.error(`  ✗ unlink ${file}: ${(err as Error).message}`);
+    }
+  }
+}
+
+function printPlan(plan: SweepPlan, dryRun: boolean): void {
+  const prefix = dryRun ? "[dry-run]" : "[sweep]";
+  console.log(`\n${prefix} ${plan.state.toUpperCase()}`);
+  if (!plan.currentTerm) {
+    console.log("  (no data in Supabase — skipping)");
+    return;
+  }
+  console.log(`  current term: ${plan.currentTerm}`);
+  console.log(`  keep (${plan.keep.length}): ${plan.keep.join(", ") || "—"}`);
+  if (plan.deleteTerms.length > 0) {
+    console.log(`  DELETE (${plan.deleteTerms.length}): ${plan.deleteTerms.join(", ")}`);
+    console.log(`  disk files affected: ${plan.diskFilesToDelete.length}`);
+  } else {
+    console.log("  nothing to delete");
+  }
+  if (plan.nonStandardTerms.length > 0) {
+    console.log(
+      `  ⚠ non-standard terms (skipped, manual cleanup): ${plan.nonStandardTerms.join(", ")}`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const stateIdx = args.indexOf("--state");
+  const targetState = stateIdx >= 0 ? args[stateIdx + 1] : null;
+
+  const sb = getSupabase();
+  const states = getAllStates()
+    .map((s) => s.slug)
+    .filter((s) => !targetState || s === targetState);
+
+  if (states.length === 0) {
+    console.error(`No states match. Available: ${getAllStates().map((s) => s.slug).join(", ")}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Sweep-stale-terms: ${dryRun ? "DRY RUN" : "LIVE"} | states: ${states.join(", ")}`
+  );
+  console.log(
+    `Policy: keep current term + all future terms + ${KEEP_PRIOR_COUNT} prior. Delete the rest.`
+  );
+
+  let totalDeletes = 0;
+  let totalNonStandard = 0;
+  for (const state of states) {
+    const plan = await planState(sb, state);
+    printPlan(plan, dryRun);
+    totalDeletes += plan.deleteTerms.length;
+    totalNonStandard += plan.nonStandardTerms.length;
+    if (!dryRun && plan.deleteTerms.length > 0) {
+      await executePlan(sb, plan);
+    }
+  }
+
+  console.log(
+    `\nDone. ${dryRun ? "(would have)" : ""} deleted ${totalDeletes} (state,term) pair${totalDeletes === 1 ? "" : "s"}.`
+  );
+  if (totalNonStandard > 0) {
+    console.log(
+      `⚠ ${totalNonStandard} non-standard term codes need manual review (see warnings above).`
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible today. Course pages already render current-term-only, so users never saw the old terms that were piling up in Supabase. After this lands, a monthly GitHub Actions job will quietly remove stale term data so the database doesn't bloat forever.

What it removes: term data more than 2 terms older than the current term. So in May 2026 (current = 2026SU), we'd start sweeping `2025SP` and older. We keep `2026SU` (current), `2026FA, 2027SP` (future), and `2026SP, 2025FA` (2 prior).

## What changes on the technical front

A `tsx`-based sweep script + a monthly workflow + a policy doc:

| File | Purpose |
|---|---|
| `scripts/lib/sweep-stale-terms.ts` | Per-state: compute current term from `get_term_college_counts` RPC, intersect with retention window, `DELETE FROM courses` + `rm data/.../{term}.json` for everything outside. `--dry-run` and `--state {slug}` flags. |
| `scripts/lib/sweep-stale-terms.md` | Retention policy doc — what we keep, why, what the sweep deliberately doesn't do. |
| `.github/workflows/sweep-stale-terms.yml` | Cron 15th of every month @ 06:00 UTC. **Cron defaults to dry-run.** Manual `workflow_dispatch` exposes a `live` mode. Live mode deletes Supabase rows in-run and opens a PR for the JSON-file removals (no direct push to main). 90-day artifact retention on the sweep report. |

### Safety properties

- **Cron is dry-run by default** — first scheduled run prints what it would delete; no writes. Flip to live via `workflow_dispatch` only after eyeballing a report.
- **Canonical codes only** — the sweep matches `^\d{4}(SP|SU|FA)$`. Non-standard codes (`2026-FL`, `CE26SP`, `26FA15`, etc.) get a `⚠ non-standard terms` warning and are **never deleted**. Those are scraper-correctness bugs, not retention problems.
- **Idempotent** — re-runs with nothing stale are no-ops.
- **Disk changes go through a PR** — even live mode doesn't push commits directly to main.

### Dry-run results (current data)

Ran locally against current Supabase + JSON. Output summary:

- **3 (state,term) pairs ready to sweep** today (MD/2025FA among them).
- **46 non-standard term codes surfaced for manual review**, mostly in IL (`2026-FL`, `2026SM`, `CE26SP`, `FA26`, `SU26`), MI (`26-FAL`, `F26-27`, `S25-26`, `2026-02`), NJ (`26FA15`, `26SU7E`), CA (`2026SPN`, `26-FA`), and a few others — these need scraper-side fixes to emit canonical codes.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `tsx scripts/lib/sweep-stale-terms.ts --dry-run` against live Supabase — reports plan for all 33 states, flags non-standard codes, no writes
- [x] `tsx scripts/lib/sweep-stale-terms.ts --state va --dry-run` — single-state filter works
- [ ] After merge: workflow_dispatch the first live run with one state (e.g. `--state md`) to verify the PR-creation flow before letting the cron run unattended
- [ ] After first scheduled run (15th of next month): confirm dry-run report artifact uploaded and looks sane