### PR TITLE
ui: remove generic Verified/Unverified college badge

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -547,9 +547,6 @@ export default async function CollegeDetailPage(props: PageProps) {
                     <p className="font-medium text-sm text-gray-900 dark:text-slate-100 group-hover:text-teal-700 dark:group-hover:text-teal-400 transition-colors">
                       {inst.name}
                     </p>
-                    <p className="text-[11px] text-gray-400 dark:text-slate-500 mt-0.5">
-                      {inst.audit_policy.allowed === true ? "Audit verified" : "Contact to confirm"}
-                    </p>
                   </Link>
                 ))}
               </div>

--- a/app/[state]/colleges/page.tsx
+++ b/app/[state]/colleges/page.tsx
@@ -36,13 +36,6 @@ export default async function CollegesPage({ params }: Props) {
     a.name.localeCompare(b.name)
   );
 
-  const verifiedCount = sorted.filter(
-    (i) => i.audit_policy.allowed === true
-  ).length;
-  const unverifiedCount = sorted.filter(
-    (i) => i.audit_policy.allowed === null
-  ).length;
-
   // Pre-compute course counts (async)
   const currentTerm = await getCurrentTerm(state);
   const courseCountMap = new Map<string, number>();
@@ -101,14 +94,13 @@ export default async function CollegesPage({ params }: Props) {
         All {config.collegeCount} {config.systemName} Colleges
       </h1>
       <p className="text-gray-600 dark:text-slate-400 mb-8">
-        Browse courses, check transfers, and find audit policies across all{" "}
-        {config.collegeCount} colleges.
+        Browse courses and transfer info across all {config.collegeCount}{" "}
+        colleges.
       </p>
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {sorted.map((institution) => {
           const courseCount = courseCountMap.get(institution.college_slug) || 0;
-          const allowed = institution.audit_policy.allowed;
 
           return (
             <Link
@@ -116,21 +108,10 @@ export default async function CollegesPage({ params }: Props) {
               href={`/${state}/college/${institution.id}`}
               className="group block rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 transition hover:shadow-md dark:hover:shadow-slate-900/50 hover:border-teal-300"
             >
-              <div className="flex items-start justify-between gap-2 mb-2">
+              <div className="mb-2">
                 <h2 className="font-semibold text-gray-900 dark:text-slate-100 group-hover:text-teal-700 text-sm leading-tight">
                   {institution.name}
                 </h2>
-                {allowed === true ? (
-                  <span className="shrink-0 inline-flex items-center gap-1 rounded-full bg-emerald-50 dark:bg-emerald-900/30 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-400 ring-1 ring-inset ring-emerald-200 dark:ring-emerald-800">
-                    <span className="h-1 w-1 rounded-full bg-emerald-500" />
-                    Verified
-                  </span>
-                ) : (
-                  <span className="shrink-0 inline-flex items-center gap-1 rounded-full bg-amber-50 dark:bg-amber-900/30 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400 ring-1 ring-inset ring-amber-200 dark:ring-amber-800">
-                    <span className="h-1 w-1 rounded-full bg-amber-500" />
-                    Unverified
-                  </span>
-                )}
               </div>
 
               <p className="text-xs text-gray-500 dark:text-slate-400 mb-3">
@@ -150,7 +131,7 @@ export default async function CollegesPage({ params }: Props) {
                     <span className="text-gray-400 dark:text-slate-500">No course data</span>
                   )}
                 </span>
-                {allowed === true &&
+                {institution.audit_policy.allowed === true &&
                   institution.audit_policy.eligibility.senior_discount
                     .available && (
                     <span className="text-teal-600 font-medium">

--- a/app/[state]/starting-soon/StartingSoonClient.tsx
+++ b/app/[state]/starting-soon/StartingSoonClient.tsx
@@ -383,19 +383,6 @@ export default function StartingSoonClient({ state, defaultZip }: { state: strin
                                   : "sections"}
                               </span>
                             </div>
-                            <div className="flex items-center gap-2 shrink-0">
-                              {college.auditAllowed === true && (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 dark:bg-emerald-900/30 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-400 ring-1 ring-inset ring-emerald-200">
-                                  <span className="h-1 w-1 rounded-full bg-emerald-500" />
-                                  Audit OK
-                                </span>
-                              )}
-                              {college.auditAllowed === null && (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 dark:bg-amber-900/30 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400 ring-1 ring-inset ring-amber-200">
-                                  Unverified
-                                </span>
-                              )}
-                            </div>
                           </button>
 
                           {/* Expanded sections */}

--- a/components/CollegeCard.tsx
+++ b/components/CollegeCard.tsx
@@ -15,33 +15,17 @@ export default function CollegeCard({
   state,
 }: CollegeCardProps) {
   const { audit_policy } = institution;
-  const allowed = audit_policy.allowed;
 
   return (
     <div className="group rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 transition hover:shadow-lg dark:hover:shadow-slate-900/50 sm:p-6">
       {/* Header */}
-      <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
-        <div>
-          <h3 className="text-lg font-bold text-gray-900 dark:text-slate-100 group-hover:text-teal-700">
-            {institution.name}
-          </h3>
-          <p className="text-sm text-gray-500 dark:text-slate-400">
-            {distance.toFixed(1)} miles away
-          </p>
-        </div>
-
-        {/* Status badge */}
-        {allowed === true ? (
-          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300 ring-1 ring-inset ring-emerald-200 dark:ring-emerald-800">
-            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-            Verified
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 dark:bg-amber-900/30 px-3 py-1 text-xs font-semibold text-amber-700 dark:text-amber-400 ring-1 ring-inset ring-amber-200 dark:ring-amber-800">
-            <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
-            Contact to Confirm
-          </span>
-        )}
+      <div className="mb-3">
+        <h3 className="text-lg font-bold text-gray-900 dark:text-slate-100 group-hover:text-teal-700">
+          {institution.name}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          {distance.toFixed(1)} miles away
+        </p>
       </div>
 
       {/* Cost summary */}


### PR DESCRIPTION
## What changes for someone using the site

The amber "Unverified" chip that appeared next to every Georgia / NC / Tennessee / etc. college on `/{state}/colleges` is gone. Same for the chip on the homepage college cards, the starting-soon college list, and the subtitle on the related-college links inside a college detail page.

Before this change, students browsing colleges in any state past the original VA/MA saw an "Unverified" badge on every card and reasonably assumed the course data was untrustworthy. The chip was actually keyed off `audit_policy.allowed` — relevant only if you wanted to audit a class as a senior, which is a small fraction of the audience.

The one remaining audit-verified chip is the one on the **college detail page** (`/{state}/college/{id}`) inside the explicit "Audit Policy" section — kept because it's honest disclosure in context.

## What changes on the technical front

Four files, all deletions:

| File | What got removed |
|---|---|
| [app/[state]/colleges/page.tsx](app/%5Bstate%5D/colleges/page.tsx) | Per-card chip JSX, dead `verifiedCount`/`unverifiedCount` counters, and reworded the description from "find audit policies across all N colleges" to "browse courses and transfer info across all N colleges". |
| [components/CollegeCard.tsx](components/CollegeCard.tsx) | Header-corner badge. Senior-discount cost summary block stays — that's useful standalone info. |
| [app/[state]/starting-soon/StartingSoonClient.tsx](app/%5Bstate%5D/starting-soon/StartingSoonClient.tsx) | "Audit OK" / "Unverified" pair appearing in a list of colleges with no audit context. |
| [app/[state]/college/[id]/page.tsx:551](app/%5Bstate%5D/college/%5Bid%5D/page.tsx) | "Audit verified" / "Contact to confirm" subtitle on related-college links (labels a college purely by audit status). |

Net: 4 files, +11 / -62. The audit-policy section on the college detail page (`page.tsx:286-298`) is intentionally untouched.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Local dev: `GET /ga/colleges` returns 22 cards, zero badge text in HTML
- [x] Local dev: `GET /ga/starting-soon` shows colleges without chips
- [ ] After merge: spot-check `/ga/colleges`, `/nc/colleges` on prod — no Unverified chip
- [ ] Confirm the audit-policy section on `/va/college/nova` (a verified state) still renders the in-context "Audit verified" pill correctly