### PR TITLE
docs(skill): add cluster auth-check guidance to auto-add-state

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -167,6 +167,34 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
     college whose course-search page is publicly accessible (no SSO,
     no login wall), build the scraper now in the same branch.
 
+    **For `[fingerprint-cluster]` entries** (Phase 2a.5 grouped multiple
+    colleges sharing infrastructure): treat the cluster as ONE bespoke-
+    scraper target — but first **verify public guest access** via the
+    cluster's shared host. A cluster signal proves shared infrastructure;
+    it does NOT prove scrape-ability. Probes to run before authoring:
+
+      curl -sIL --max-time 10 -A "Mozilla/5.0" \
+        "https://{host}/psc/classsearchguest/EMPLOYEE/HRMS/c/COMMUNITY_ACCESS.CLASS_SEARCH.GBL"
+      # ↑ PeopleSoft Community Access — LACCD / SD CCD / NV pattern
+      curl -sIL ... "https://{host}/StudentRegistrationSsb/ssb/classSearch/classSearch"
+      # ↑ Banner SSB 9 guest
+      curl -sIL ... "https://{host}/Student/Courses"
+      # ↑ Colleague Self-Service guest
+
+    A 200 = green light, follow the LACCD/SD CCD template. A 302 to
+    `login.microsoftonline.com` / ADFS / Shibboleth / Ellucian Experience
+    SSO = the cluster is auth-gated; **drop it** (file the cluster name in
+    the PR body under "auth-gated clusters" for transparency). Don't waste
+    cycles trying to bypass SSO. See memory:
+    `feedback_verify_public_access_before_cluster_scraper`.
+
+    **Specifically watch out for `experience.elluciancloud.com`** — that's
+    Ellucian's *portal aggregator* product, not a class-search system.
+    Colleges using it have their class data either (a) behind SSO via
+    Banner under the portal, or (b) on the college's own custom public
+    schedule page (heterogeneous; not unifiable). Don't try to build a
+    single scraper for an "Experience cluster."
+
     Why: Deferring custom-HTML scrapers as TODOs creates drag — the user
     has to come back, re-investigate each site, and ship per-college
     follow-ups. One comprehensive PR is preferable.


### PR DESCRIPTION
## What changes for someone using the site

No user-visible change — this is a skill / process update for the next person (or me in a future session) who runs `/auto-add-state` against a state with multi-CCD clusters.

## The story behind it

After #503 landed cluster detection in the orchestrator, I tried to build the next cluster scraper: California's 8-college **Ellucian Experience** cluster (`experience.elluciancloud.com`). ~30 minutes in, the dead ends became obvious:

- The Experience portal itself is Microsoft SSO–gated. Class data never leaves the auth wall.
- Each of the 8 colleges has its own *public* schedule page on its own `.edu`, but they're heterogeneous (custom HTML, embedded PDFs, Google Sheets, etc.) — one scraper does NOT cover them.
- The cluster signal correctly identified "these 8 colleges share infrastructure" but the shared infrastructure is the *portal aggregator*, not class search.

The same dead end exists for several other CA clusters: Foothill-De Anza (SSO via Experience), Grossmont-Cuyamaca (`selfservice.gcccd.edu` redirects to a login wall), and a closer look at San Diego CCD showed its public PS endpoint is also auth-gated (the 200 was a 2941-byte login redirect, not the real ~67 KB PS form LACCD had).

## What this PR does

Updates step 12 of `auto-add-state` skill to make the SSO-vs-public check the *first* step when handling `[fingerprint-cluster]` TODOs:

- Probe the cluster's shared host against standard guest endpoints (PS Community Access, Banner SSB, Colleague Self-Service) BEFORE writing scraper code
- Treat a 302 to `login.microsoftonline.com` / ADFS / Shibboleth / Experience SSO as a hard stop — drop the cluster, don't try to bypass
- Specifically call out `experience.elluciancloud.com` as a portal product, not a class-search system

Cross-references new memory note `feedback_verify_public_access_before_cluster_scraper`.

## Why the skill, not the orchestrator?

The orchestrator (`scripts/lib/cluster-fingerprints.ts`) *could* run these probes automatically — that's filed as a follow-up issue. Until then, the human reader of `[fingerprint-cluster]` TODOs needs to know to probe before committing scraper effort. The skill is the right place for that.

## Files

- `.claude/skills/auto-add-state/SKILL.md` — 28 lines added inside step 12

## Test plan

- [x] No code changes, no CI risk
- [ ] Reviewer: skill text reads cleanly and the auth-check workflow is unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)