### PR TITLE
Probe cluster hosts for public guest access (closes #505)

### DIFF
--- a/scripts/lib/add-state.ts
+++ b/scripts/lib/add-state.ts
@@ -487,8 +487,16 @@ async function phaseCluster(
 
   for (const c of clusterResult.clusters) {
     const sortedSlugs = [...c.memberSlugs].sort();
+    // Surface the public-access verdict prominently so reviewers don't waste
+    // cycles trying to scrape an SSO-gated portal.
+    const verdict =
+      c.publicGuestAccess === "public-guest-ok"
+        ? `PUBLIC at ${c.publicGuestUrl ?? c.sharedSignal} — adapt LACCD-pattern scraper`
+        : c.publicGuestAccess === "sso-gated"
+          ? `SSO-GATED at ${c.sharedSignal}${c.publicGuestEvidence ? ` (${c.publicGuestEvidence})` : ""} — DROP, no scraper will work without credentials`
+          : `unknown access at ${c.sharedSignal} — investigate before authoring`;
     todos.push(
-      `[fingerprint-cluster] ${c.id} (${c.memberSlugs.length} colleges share ${c.sharedSignal}, ${c.signalKind}): ${sortedSlugs.join(", ")}. → One bespoke scraper covers all ${c.memberSlugs.length}.`,
+      `[fingerprint-cluster] ${c.id} (${c.memberSlugs.length} colleges, ${c.signalKind}: ${verdict}): ${sortedSlugs.join(", ")}.`,
     );
   }
 

--- a/scripts/lib/cluster-fingerprints.ts
+++ b/scripts/lib/cluster-fingerprints.ts
@@ -46,6 +46,18 @@ export interface ClusterInput {
   fingerprint?: FingerprintResult;
 }
 
+/**
+ * Result of probing a cluster's shared host for public guest class search.
+ * - `public-guest-ok` — found a working public endpoint; scrape-able pattern
+ * - `sso-gated` — redirected to a login wall, or returned a tiny login page
+ * - `unknown` — transient error / endpoint not in our probe list
+ *
+ * Probes run only for `shared-sis-host` clusters; `registrable-domain`
+ * clusters (e.g. losrios.edu) don't have a single shared endpoint to probe,
+ * so they're left as `unknown` — the manual reviewer should investigate.
+ */
+export type PublicGuestAccess = "public-guest-ok" | "sso-gated" | "unknown";
+
 export interface Cluster {
   /** Stable identifier (e.g. "losrios-edu", "laccd-mycollege-guest"). */
   id: string;
@@ -55,6 +67,12 @@ export interface Cluster {
   memberSlugs: string[];
   /** Per-slug URLs/hosts that put each college in the cluster. */
   evidence: Record<string, string[]>;
+  /** Verdict from probing standard guest endpoints. See PublicGuestAccess. */
+  publicGuestAccess: PublicGuestAccess;
+  /** If `public-guest-ok`, the URL that confirmed it. */
+  publicGuestUrl?: string;
+  /** Why we landed on this verdict (HTTP code, final URL after redirects, size). */
+  publicGuestEvidence?: string;
 }
 
 export interface ClusteringResult {
@@ -132,6 +150,9 @@ function clusterByRegistrableDomain(
       signalKind: "registrable-domain",
       memberSlugs: members.map((m) => m.slug),
       evidence,
+      // Registrable-domain clusters don't have a single shared host to probe.
+      // The reviewer should investigate per-college class-search URLs.
+      publicGuestAccess: "unknown",
     });
   }
 
@@ -286,11 +307,208 @@ async function clusterByDeepProbe(
       signalKind: "shared-sis-host",
       memberSlugs: unassigned.map((m) => m.slug),
       evidence,
+      // Filled in by Step 3 (probeClusterPublicAccess) after clustering.
+      publicGuestAccess: "unknown",
     });
   }
 
   const stillOrphans = orphans.filter((c) => !assigned.has(c.slug));
   return { clustered: clusters, stillOrphans };
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — probe shared-sis-host clusters for public guest class search
+// ---------------------------------------------------------------------------
+//
+// For each `shared-sis-host` cluster, probe a small set of standard guest
+// endpoints. If any returns a meaningful 200, the cluster is `public-guest-
+// ok`. Redirects to SSO hosts (login.microsoftonline.com / ADFS / Shibboleth
+// / Ellucian Experience) mark it `sso-gated`. Tiny 200 responses (<5KB) or
+// 200s whose <title> contains "Login" are treated as auth walls too.
+//
+// Probes are best-effort: a transient failure leaves the cluster at the
+// default `unknown` so the reviewer still has the cluster info to act on.
+
+/** Endpoints to try, in order. First meaningful 200 wins. */
+const PUBLIC_GUEST_PROBE_PATHS = [
+  // PeopleSoft Community Access (LACCD pattern). Real form is ~60KB.
+  "/psc/classsearchguest/EMPLOYEE/HRMS/c/COMMUNITY_ACCESS.CLASS_SEARCH.GBL",
+  // Banner SSB 9 anonymous class search
+  "/StudentRegistrationSsb/ssb/classSearch/classSearch",
+  // Colleague Self-Service public courses listing
+  "/Student/Courses",
+  // Banner 8 / pre-SSB schedule lookup
+  "/bwckschd.p_disp_dyn_sched",
+];
+
+/** Hosts that, when reached after redirect, indicate the endpoint is auth-gated. */
+const SSO_HOST_PATTERNS: RegExp[] = [
+  /login\.microsoftonline\.com/i,
+  /\badfs\b/i,
+  /shibboleth/i,
+  /sso\b/i,
+  /idp\b/i,
+  /samlauth/i,
+  /experience\.elluciancloud\.com/i, // portal SSO landing
+  /\/login(\?|$|\/)/i, // generic /login redirect
+];
+
+interface ProbeResult {
+  verdict: PublicGuestAccess;
+  url?: string;
+  evidence?: string;
+}
+
+/**
+ * Generate a few host variants worth probing. Many CCDs run the
+ * public/guest portal on a `*-guest.*` or `guest.*` subdomain even when
+ * cluster detection latched onto a different host. LACCD is the canonical
+ * example: cluster signal points at `mycollege.laccd.edu`, but the
+ * scrape-able guest portal is at `mycollege-guest.laccd.edu`.
+ */
+function hostVariants(host: string): string[] {
+  const variants = new Set<string>([host]);
+  // mycollege.* → mycollege-guest.*  /  myportal.* → myportal-guest.*  etc.
+  const m = host.match(/^([a-z0-9-]+?)(\.)(.+)$/);
+  if (m) {
+    const [, sub, dot, rest] = m;
+    if (!sub.endsWith("-guest") && !sub.startsWith("guest")) {
+      variants.add(`${sub}-guest${dot}${rest}`);
+      variants.add(`guest.${sub}${dot}${rest}`);
+    }
+  }
+  return Array.from(variants);
+}
+
+async function probeForPublicAccess(
+  host: string,
+  signal: AbortSignal,
+): Promise<ProbeResult> {
+  let firstSsoEvidence: string | undefined;
+  for (const variant of hostVariants(host)) {
+    const result = await probeHost(variant, signal);
+    if (result.verdict === "public-guest-ok") return result;
+    if (result.verdict === "sso-gated" && !firstSsoEvidence) {
+      firstSsoEvidence = result.evidence;
+    }
+  }
+  // If no variant returned public-guest-ok but at least one redirected to
+  // SSO, surface the SSO evidence — it's a clearer signal than "unknown".
+  if (firstSsoEvidence) {
+    return { verdict: "sso-gated", evidence: firstSsoEvidence };
+  }
+  return { verdict: "unknown" };
+}
+
+async function probeHost(host: string, signal: AbortSignal): Promise<ProbeResult> {
+  for (const path of PUBLIC_GUEST_PROBE_PATHS) {
+    const url = `https://${host}${path}`;
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+        signal,
+        redirect: "follow",
+      });
+
+      const finalUrl = res.url;
+
+      // SSO redirect — the chain ended on a known auth host.
+      if (SSO_HOST_PATTERNS.some((re) => re.test(finalUrl))) {
+        return {
+          verdict: "sso-gated",
+          evidence: `redirected to ${finalUrl} (HTTP ${res.status})`,
+        };
+      }
+
+      if (res.status === 401 || res.status === 403) {
+        return {
+          verdict: "sso-gated",
+          evidence: `HTTP ${res.status} at ${url}`,
+        };
+      }
+
+      if (!res.ok) continue;
+
+      // 200 — distinguish real class-search page from login redirect that
+      // happens to render as a 200 page (PeopleSoft does this).
+      const body = await res.text();
+      const title = /<title[^>]*>([^<]+)/i.exec(body)?.[1]?.trim() ?? "";
+
+      // Special-case PeopleSoft Community Access auto-guest-login. PS
+      // redirects to `?cmd=login...` on the same host as the initial probe
+      // even when the portal is genuinely public — actual class search loads
+      // after PS sets a guest session cookie. This is the LACCD pattern.
+      const finalHost = new URL(finalUrl).hostname.toLowerCase();
+      const isPsAutoGuestLoop =
+        finalHost === host.toLowerCase() &&
+        /\/psc\/classsearchguest\//i.test(finalUrl) &&
+        /cmd=login/i.test(finalUrl);
+      if (isPsAutoGuestLoop) {
+        return {
+          verdict: "public-guest-ok",
+          url,
+          evidence: `PS Community Access auto-guest-login (same host, ?cmd=login at ${finalUrl.substring(0, 120)})`,
+        };
+      }
+
+      const tinyLoginPage =
+        body.length < 5000 &&
+        (/login|sign[- ]?in|signin/i.test(title) || /Site name is not valid/i.test(body));
+
+      if (tinyLoginPage) {
+        return {
+          verdict: "sso-gated",
+          evidence: `tiny 200 (${body.length}B), title="${title.substring(0, 80)}"`,
+        };
+      }
+
+      // Default-deny on very small responses — real class-search forms are 50KB+.
+      if (body.length < 5000) continue;
+
+      return {
+        verdict: "public-guest-ok",
+        url,
+        evidence: `HTTP 200, ${body.length}B, title="${title.substring(0, 80)}"`,
+      };
+    } catch {
+      // network error / timeout — try the next probe
+      continue;
+    }
+  }
+  return { verdict: "unknown" };
+}
+
+async function probeClusterPublicAccess(
+  clusters: Cluster[],
+  options: { concurrency: number; perColumnTimeoutMs: number; onProgress?: (done: number, total: number) => void },
+): Promise<void> {
+  const probable = clusters.filter((c) => c.signalKind === "shared-sis-host");
+  if (probable.length === 0) return;
+
+  let done = 0;
+  for (let i = 0; i < probable.length; i += options.concurrency) {
+    const chunk = probable.slice(i, i + options.concurrency);
+    await Promise.all(
+      chunk.map(async (cluster) => {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), options.perColumnTimeoutMs);
+        try {
+          const result = await probeForPublicAccess(cluster.sharedSignal, controller.signal);
+          cluster.publicGuestAccess = result.verdict;
+          if (result.url) cluster.publicGuestUrl = result.url;
+          if (result.evidence) cluster.publicGuestEvidence = result.evidence;
+        } finally {
+          clearTimeout(timer);
+        }
+      }),
+    );
+    done += chunk.length;
+    options.onProgress?.(done, probable.length);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -300,6 +518,8 @@ async function clusterByDeepProbe(
 export interface ClusterOptions {
   /** Whether to do step-2 HTTP probing (default: true). */
   probeDeep?: boolean;
+  /** Whether to do step-3 public-access probing for shared-SIS-host clusters (default: true). */
+  probeAccess?: boolean;
   /** Concurrent probes (default: 6). */
   concurrency?: number;
   /** Per-college HTTP timeout in ms (default: 15000). */
@@ -313,6 +533,7 @@ export async function clusterFingerprints(
 ): Promise<ClusteringResult> {
   const opts = {
     probeDeep: options.probeDeep ?? true,
+    probeAccess: options.probeAccess ?? true,
     concurrency: options.concurrency ?? 6,
     perColumnTimeoutMs: options.perColumnTimeoutMs ?? 15000,
     onProgress: options.onProgress,
@@ -335,6 +556,16 @@ export async function clusterFingerprints(
   }
 
   const clusters = [...step1.clustered, ...step2.clustered];
+
+  // Step 3 (optional): probe each shared-sis-host cluster for public guest access
+  if (opts.probeAccess) {
+    await probeClusterPublicAccess(clusters, {
+      concurrency: opts.concurrency,
+      perColumnTimeoutMs: opts.perColumnTimeoutMs,
+      onProgress: opts.onProgress,
+    });
+  }
+
   const singletons = step2.stillOrphans;
   const clusteredCount = clusters.reduce((s, c) => s + c.memberSlugs.length, 0);
 
@@ -362,6 +593,7 @@ async function maybeRunCli(): Promise<void> {
   const args = process.argv.slice(2);
   let state: string | null = null;
   let probeDeep = true;
+  let probeAccess = true;
   let outputJson = false;
 
   for (let i = 0; i < args.length; i++) {
@@ -370,13 +602,15 @@ async function maybeRunCli(): Promise<void> {
       i++;
     } else if (args[i] === "--no-probe-deep") {
       probeDeep = false;
+    } else if (args[i] === "--no-probe-access") {
+      probeAccess = false;
     } else if (args[i] === "--json") {
       outputJson = true;
     }
   }
 
   if (!state) {
-    console.error("Usage: tsx scripts/lib/cluster-fingerprints.ts --state <ca|nv|...> [--no-probe-deep] [--json]");
+    console.error("Usage: tsx scripts/lib/cluster-fingerprints.ts --state <ca|nv|...> [--no-probe-deep] [--no-probe-access] [--json]");
     process.exit(1);
   }
 
@@ -409,6 +643,7 @@ async function maybeRunCli(): Promise<void> {
 
   const result = await clusterFingerprints(colleges, {
     probeDeep,
+    probeAccess,
     onProgress: (done, total) => {
       if (done % 5 === 0 || done === total) {
         process.stderr.write(`\r  probed ${done}/${total}`);
@@ -427,9 +662,20 @@ async function maybeRunCli(): Promise<void> {
     `\n${result.clusters.length} cluster(s), ${result.summary.clusteredCount} colleges clustered, ${result.summary.singletonCount} singletons:\n`,
   );
   for (const c of result.clusters) {
+    const accessTag =
+      c.publicGuestAccess === "public-guest-ok"
+        ? "✅ PUBLIC"
+        : c.publicGuestAccess === "sso-gated"
+          ? "🔒 SSO"
+          : "⚠ UNKNOWN";
     console.log(
-      `  ${c.signalKind === "registrable-domain" ? "🌐" : "🔗"} ${c.id}  (${c.memberSlugs.length} colleges, ${c.signalKind}: ${c.sharedSignal})`,
+      `  ${c.signalKind === "registrable-domain" ? "🌐" : "🔗"} ${c.id}  (${c.memberSlugs.length} colleges, ${c.signalKind}: ${c.sharedSignal})  [${accessTag}]`,
     );
+    if (c.publicGuestUrl) {
+      console.log(`     → ${c.publicGuestUrl}`);
+    } else if (c.publicGuestEvidence) {
+      console.log(`     ↳ ${c.publicGuestEvidence}`);
+    }
     for (const slug of c.memberSlugs) {
       console.log(`     • ${slug}`);
     }


### PR DESCRIPTION
## What changes for someone using the site

No user-visible change — this is a clarity upgrade to the orchestrator's manual-TODO output.

When `auto-add-state` finds a multi-college cluster (e.g. "9 Los Angeles CCs share `mycollege.laccd.edu`"), the TODO it emits now includes a **verdict**: is that shared host actually publicly accessible, or is it behind SSO? Reviewers (you, me, future contributors) no longer have to investigate each cluster manually — the orchestrator pre-tags them.

A new state run will surface things like:

  [fingerprint-cluster] mycollege-laccd-edu (9 colleges, shared-sis-host: PUBLIC at https://mycollege-guest.laccd.edu/psc/classsearchguest/... — adapt LACCD-pattern scraper): east-los-angeles-college, los-angeles-city-college, ...

  [fingerprint-cluster] experience-elluciancloud-com (11 colleges, shared-sis-host: SSO-GATED at experience.elluciancloud.com (redirected to login.microsoftonline.com ...) — DROP, no scraper will work without credentials): cabrillo-college, gavilan-college, ...

The PUBLIC entries become PR-ready follow-ups; the SSO-GATED ones get dropped without further effort. Concretely: this would have saved the ~30 minutes I spent investigating the Ellucian Experience cluster in CA before discovering it's auth-walled.

## What's under the hood

New Step 3 inside `cluster-fingerprints.ts`. After clustering detects shared hosts, probe each `shared-sis-host` cluster against four standard guest endpoints in order:

| Endpoint | Pattern |
|---|---|
| `/psc/classsearchguest/EMPLOYEE/HRMS/c/COMMUNITY_ACCESS.CLASS_SEARCH.GBL` | PeopleSoft Community Access (LACCD, CUNY, NV pattern) |
| `/StudentRegistrationSsb/ssb/classSearch/classSearch` | Banner SSB 9 |
| `/Student/Courses` | Colleague Self-Service |
| `/bwckschd.p_disp_dyn_sched` | Banner 8 |

First meaningful 200 wins. Tiny 200s (<5 KB) with "Login" titles are treated as auth walls. Redirects to known SSO hosts (`login.microsoftonline.com`, ADFS, Shibboleth, `experience.elluciancloud.com`, etc.) are marked `sso-gated`.

Two nuances learned from CA:
- **Host-variant probing.** Cluster detection latches onto the host appearing in outbound links, but the public portal often lives on a `*-guest` subdomain. LACCD's signal is `mycollege.laccd.edu`; the scrape-able host is `mycollege-guest.laccd.edu`. The probe now tries `{sub}-guest.{base}` and `guest.{sub}.{base}` when the original host fails.
- **PS auto-guest-login.** PeopleSoft Community Access portals redirect to `?cmd=login` on the same host even when public — they set a guest session on a second round-trip. A naive `tiny 200 with "Login" title` heuristic would mark this as SSO; we now special-case "same host, `/psc/classsearchguest/` in path, `cmd=login` query" as `public-guest-ok`.

## CA validation

10 clusters, verdicts match my prior manual investigation 1:1:

| Cluster | Verdict | Notes |
|---|---|---|
| LACCD (9) | ✅ PUBLIC | PS auto-guest case; mycollege-guest.laccd.edu |
| Grossmont-Cuyamaca (2) | ✅ PUBLIC | Surprise win — `selfservice.gcccd.edu/Student/Courses` is public even though `/student/` (lowercase) requires login |
| Ellucian Experience SaaS (11) | 🔒 SSO | Redirects to login.microsoftonline.com |
| SD CCD (3) | 🔒 SSO | Tiny 62-byte response on the IHPRD site |
| Foothill-De Anza (2) | 🔒 SSO | Redirects to ssoshib.fhda.edu |
| Los Rios (4) | ⚠ UNKNOWN | Registrable-domain cluster — no single shared host to probe |
| West Hills (2) | ⚠ UNKNOWN | Same |
| Yuba (2) | ⚠ UNKNOWN | Same (already templated via Colleague though) |
| State Center (4) | ⚠ UNKNOWN | uPortal — needs different probe; not in current rules |
| WVM Ellucian (2) | ⚠ UNKNOWN | Was 503 earlier; transient |

The UNKNOWN entries are honest — the reviewer still has to investigate, but the cluster info already gives them a head start.

## Files

- `scripts/lib/cluster-fingerprints.ts` — Step 3 (`probeClusterPublicAccess`, `probeForPublicAccess`, `probeHost`, `hostVariants`), new `publicGuestAccess` field on `Cluster`, new `probeAccess` option (default true), `--no-probe-access` CLI flag, enriched CLI output (✅/🔒/⚠ tag + evidence)
- `scripts/lib/add-state.ts` — `[fingerprint-cluster]` TODO now includes the verdict string ("PUBLIC at ... — adapt LACCD-pattern scraper" / "SSO-GATED at ... — DROP" / "unknown access — investigate")

## Acceptance criteria (from #505)

- [x] `Cluster` interface gains `publicGuestAccess` field
- [x] Probing happens during clustering (Step 3)
- [x] `data/{state}/clusters.json` includes the probe results
- [x] `[fingerprint-cluster]` TODO surfaces the verdict
- [x] Re-running on CA marks Ellucian Experience SSO-gated and LACCD public-guest-ok

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Standalone CLI run on CA — verdicts match expected
- [ ] CI: orchestrator dry-run (no scraper changes; should pass `check:scrapers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)