### PR TITLE
AZ: wire Arizona Western Colleague + document Diné PDF-only ceiling

### DIFF
--- a/lib/states/az/config.ts
+++ b/lib/states/az/config.ts
@@ -38,7 +38,8 @@ const azConfig: StateConfig = {
     courses: [
       // Banner SSB 9 — Cochise, Pima, Coconino (3 colleges via shared template)
       { scripts: ["scripts/az/scrape-banner-ssb.ts"], runner: "http" },
-      // Colleague Self-Service — Mohave (1 college via Ellucian Cloud)
+      // Colleague Self-Service — Mohave (Ellucian Cloud) + Arizona Western
+      // (self-hosted at colss-prod.ec.azwestern.edu).
       { scripts: ["scripts/az/scrape-colleague.ts"], runner: "playwright" },
     ],
     // Inline prereq text harvested from the scraped Banner SSB + Colleague
@@ -50,6 +51,14 @@ const azConfig: StateConfig = {
     // manual-only: programs — scripts/az/scrape-programs.ts wrapper exists
     //   but each of the 4 Acalog catalogs needs manual navoid identification
     //   (auto-discovery finds catoid but not navoids — same as NV/CSN).
+  },
+  documentedCeilings: {
+    courses: [
+      {
+        collegeSlug: "dine-college",
+        reason: "Diné College (Navajo Nation tribal college) publishes course schedules only as semester PDFs (e.g. Fall-26-Course-Schedule-May-20-2026.pdf at www.dinecollege.edu/admissions/course-schedule/). The my.dinecollege.edu portal is SSO-gated via QuickLaunch. No live HTML/JSON schedule. Verified 2026-05-24.",
+      },
+    ],
   },
 };
 

--- a/scripts/az/scrape-colleague.ts
+++ b/scripts/az/scrape-colleague.ts
@@ -1,8 +1,14 @@
 /**
  * scrape-colleague.ts — AZ Colleague Self-Service colleges.
  *
- * One AZ college (Mohave) runs on Ellucian Colleague Self-Service via
- * Ellucian Cloud. The orchestrator's fingerprint found it directly.
+ * Two AZ colleges run on Ellucian Colleague Self-Service:
+ *   - Mohave Community College — Ellucian Cloud (hosted)
+ *   - Arizona Western College   — self-hosted (colss-prod.ec.azwestern.edu)
+ *
+ * AZ Western's selfservice.azwestern.edu redirects to colss-prod.ec.azwestern.edu,
+ * which is the canonical Colleague Self-Service host. Verified 2026-05-24.
+ * (At first probe the AZW server was returning 502 — Ellucian Cloud transient;
+ * cron will pick it up when it's back. The scraper is wired so it can.)
  *
  * Usage:
  *   npx tsx scripts/az/scrape-colleague.ts
@@ -14,6 +20,7 @@ import { scrapeColleagueState } from "../lib/scrape-colleague";
 
 const HOSTS: Record<string, string> = {
   "mohave-community-college": "https://mohave-ss.colleague.elluciancloud.com",
+  "arizona-western-college": "https://colss-prod.ec.azwestern.edu",
 };
 
 async function main() {


### PR DESCRIPTION
## What changes for users

Two of the three AZ colleges flagged as "custom HTML, bespoke scraper needed" in PR #511 are resolved here:

- **Arizona Western College** is wired so cron will scrape its course schedule (currently returning 502 from its Colleague server — Ellucian Cloud transient — so no data lands today, but the scraper runs automatically when it's back). Once AZW's server is back, AZ jumps from 15/21 → **16/21 colleges with course data**.
- **Diné College** is documented as a structural ceiling — they publish schedules only as semester PDFs, with no live HTML/JSON catalog and an SSO-gated portal. Same shape as UDC's PDF-only catalog and MMI's absent SIS.

(Estrella Mountain, the third flagged college, turned out to be a Maricopa District member — already covered by PR #516's Maricopa scraper.)

## What changes technically

### Arizona Western — wire into existing Colleague wrapper

The orchestrator's fingerprint tagged AZW as "custom HTML" because the probe hit `www.azwestern.edu` (a Drupal site, not a class search). Inspecting the registration links surfaced `selfservice.azwestern.edu` → `colss-prod.ec.azwestern.edu/Student/Courses` — the canonical Ellucian Colleague Self-Service path. Different host pattern from Mohave (which is on Ellucian Cloud at `mohave-ss.colleague.elluciancloud.com`), but the same Colleague template works for both.

Added one line to `scripts/az/scrape-colleague.ts`:

```ts
const HOSTS: Record<string, string> = {
  "mohave-community-college": "https://mohave-ss.colleague.elluciancloud.com",
  "arizona-western-college":  "https://colss-prod.ec.azwestern.edu",
};
```

AZW's Colleague returned `502 Bad Gateway` throughout this session — appears to be an Ellucian Cloud transient outage. Re-probed several times; consistently 502. The scraper is wired so the next scheduled-scrape cron run picks up AZW automatically when it's back. No data lands in this PR.

### Diné — `documentedCeilings.courses`

Probed `my.dinecollege.edu` (QuickLaunch SSO — auth-gated), `ss.dinecollege.edu` (DNS 000), `selfservice.dinecollege.edu` (DNS 000), `catalog.dinecollege.edu` (DNS 000). The only public source is `www.dinecollege.edu/admissions/course-schedule/` which links to per-semester PDFs:

- `Fall-26-Course-Schedule-May-20-2026.pdf`
- `Summer-26-Course-Schedule-May-20-2026.pdf`
- `SP2026_2nd-8wk-Course-Schedule_03162026.pdf`

PDF table parsing is fragile and out of scope for the structured-data pipeline. Documented as a courses ceiling, surfaced in the audit so reviewers see why Diné is missing.

## Test plan

- [ ] After merge, AZ stays at 15/21 colleges (Diné remains a documented ceiling, AZW pending its Colleague coming back online)
- [ ] Next scheduled-scrape cron run attempts AZW Colleague; check the run's logs for whether it succeeds
- [ ] `npx tsx scripts/check-scraper-coverage.ts` passes for AZ

## Still open after this lands

| Item | Effort |
|---|---|
| Tohono O'odham — Jenzabar portlet URL discovery | 30 min if reachable, else ceiling |
| AZ transfers — AZTransfer.com integration | 2–4 hr |
| AZ programs — navoid identification for 4 Acalog wrappers | 30 min/college × 4 |
| Coconino Banner SSB URL fix (already merged in #512) | done |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
