### PR TITLE
feat(state-health): weekly config-URL HEAD check (Plan B: 1/3)

### DIFF
--- a/.github/workflows/config-url-check.yml
+++ b/.github/workflows/config-url-check.yml
@@ -1,0 +1,97 @@
+name: Config URL health check
+
+# Weekly HEAD-request sweep of every URL in StateConfig across every
+# state. Catches:
+#   - 404s when a state agency rebrands or moves a page
+#   - DNS failures (example: MD selfservice.allegany.edu)
+#   - Placeholder URLs left over from auto-add-state (example.edu / .com)
+#
+# Output: a single rolling GitHub issue "Config URL health" that opens
+# on first failure, updates body on each subsequent tick, and auto-closes
+# when all URLs are healthy again. Same pattern as the scraper-health
+# rolling issues (#123, #124, #474).
+#
+# Triggers:
+#   - Monday 14:00 UTC weekly
+#   - workflow_dispatch for manual / on-demand checks
+#
+# Permissions: contents:read; issues:write
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Probe every StateConfig URL
+        id: probe
+        run: |
+          npx tsx scripts/lib/check-config-urls.ts \
+            --status-out /tmp/url-check.json \
+            --timeout-ms 10000
+          echo "failures=$(jq -r '.failures' /tmp/url-check.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo 'body<<URL_BODY_EOF'
+            echo '# Config URL health'
+            echo
+            jq -r '"Generated: \(.generatedAt)\n\n**\(.failures) failure(s) of \(.total) URLs checked.**"' /tmp/url-check.json
+            echo
+            jq -r 'if .failures > 0 then "## Failures\n\n| State | Field | URL | Status | Error |\n| --- | --- | --- | --- | --- |\n\(.results | map(select(.ok == false)) | map("| `\(.state)` | `\(.field)` | <\(.url)> | \(.status // "ERR") | \(.error // "—") |") | join("\n"))\n\n## Probably worth fixing\n\nPlaceholder URLs are bootstrap leftovers from auto-add-state — they need real values in `lib/states/{state}/config.ts`. DNS failures and 4xx/5xx may indicate the source site moved or rebranded.\n" else "All URLs healthy ✅" end' /tmp/url-check.json
+            echo 'URL_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update rolling URL-health issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ steps.probe.outputs.body }}
+          FAILURES: ${{ steps.probe.outputs.failures }}
+        run: |
+          set -e
+          title="Config URL health"
+          existing=$(gh issue list \
+            --search "in:title \"${title}\"" \
+            --state all \
+            --limit 5 \
+            --json number,state,title \
+            --jq ".[] | select(.title == \"${title}\") | .number" \
+            | head -n 1)
+
+          printf '%s\n' "$BODY" > /tmp/issue-body.md
+
+          if [ -z "$existing" ]; then
+            if [ "$FAILURES" = "0" ]; then
+              echo "First run, no failures — not opening an issue."
+              exit 0
+            fi
+            gh issue create \
+              --title "${title}" \
+              --body-file /tmp/issue-body.md \
+              --label "config-health,automated"
+            exit 0
+          fi
+
+          gh issue edit "$existing" --body-file /tmp/issue-body.md
+
+          state=$(gh issue view "$existing" --json state --jq .state)
+          if [ "$FAILURES" = "0" ] && [ "$state" = "OPEN" ]; then
+            gh issue close "$existing" --comment "All config URLs healthy on the latest sweep. Closing — will reopen automatically if a future sweep finds failures."
+          elif [ "$FAILURES" != "0" ] && [ "$state" = "CLOSED" ]; then
+            gh issue reopen "$existing" --comment "Reopening — at least one config URL is failing."
+          fi

--- a/scripts/lib/check-config-urls.ts
+++ b/scripts/lib/check-config-urls.ts
@@ -1,0 +1,216 @@
+/**
+ * check-config-urls.ts
+ *
+ * Daily / weekly HEAD-request sweep of every URL declared in StateConfig
+ * across every state in the registry. Catches dead links in:
+ *   - StateConfig.systemUrl (one per state)
+ *   - StateConfig.seniorWaiver.legalCitation (one per state, when present)
+ *   - StateConfig.courseDiscoveryUrl(...) (sampled with one college's data)
+ *   - StateConfig.collegeCoursesUrl(...) (sampled with one college's data)
+ *
+ * URLs go stale silently: a state agency rebrands, a college closes a
+ * campus, a senior-waiver policy citation moves. Users hit 404s before
+ * we hear about it. This check surfaces those before they reach the
+ * site.
+ *
+ * Output: one JSON status file. Workflow opens / updates a single
+ * rolling issue if any URL fails.
+ *
+ * Usage:
+ *   npx tsx scripts/lib/check-config-urls.ts
+ *   npx tsx scripts/lib/check-config-urls.ts --status-out /tmp/url-check.json
+ *   npx tsx scripts/lib/check-config-urls.ts --timeout-ms 10000
+ */
+
+import { writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAllStates } from "../../lib/states/registry";
+
+interface CheckResult {
+  state: string;
+  field: string;
+  url: string;
+  status: number | null;
+  ok: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i < 0) return fallback;
+  return process.argv[i + 1] ?? fallback;
+}
+
+const statusOut = arg("status-out");
+const timeoutMs = parseInt(arg("timeout-ms") ?? "10000", 10);
+
+// ---------------------------------------------------------------------------
+// URL extraction
+// ---------------------------------------------------------------------------
+
+function pickSampleCollege(state: string): { slug: string; zip: string } | null {
+  const path = join("data", state, "institutions.json");
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8"));
+    const arr = Array.isArray(data) ? data : data.institutions ?? data.colleges ?? [];
+    if (arr.length === 0) return null;
+    const first = arr[0];
+    return {
+      slug: first.slug ?? first.collegeSlug ?? first.id ?? "",
+      zip: first.zip ?? first.zipCode ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function collectUrlsToCheck(): Array<{ state: string; field: string; url: string }> {
+  const out: Array<{ state: string; field: string; url: string }> = [];
+  for (const cfg of getAllStates()) {
+    if (cfg.systemUrl) {
+      out.push({ state: cfg.slug, field: "systemUrl", url: cfg.systemUrl });
+    }
+    if (cfg.seniorWaiver?.legalCitation) {
+      const url = cfg.seniorWaiver.legalCitation;
+      // Some legal citations are not URLs (raw § statute refs). Skip those.
+      if (/^https?:\/\//i.test(url)) {
+        out.push({ state: cfg.slug, field: "seniorWaiver.legalCitation", url });
+      }
+    }
+    // Sample courseDiscoveryUrl / collegeCoursesUrl with one college's data.
+    // We aren't trying to validate every college — just that the URL-shape
+    // generator still produces a URL the source site recognizes.
+    const sample = pickSampleCollege(cfg.slug);
+    if (sample && sample.slug) {
+      try {
+        const url = cfg.courseDiscoveryUrl(sample.slug, "ENG", "101");
+        if (url && /^https?:\/\//i.test(url)) {
+          out.push({ state: cfg.slug, field: "courseDiscoveryUrl(sample)", url });
+        }
+      } catch {
+        // Some states throw if the slug isn't recognized — skip.
+      }
+      try {
+        const url = cfg.collegeCoursesUrl(sample.slug);
+        if (url && /^https?:\/\//i.test(url)) {
+          out.push({ state: cfg.slug, field: "collegeCoursesUrl(sample)", url });
+        }
+      } catch {
+        // Same — skip if slug not recognized.
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// HEAD probe
+// ---------------------------------------------------------------------------
+
+// Placeholder URLs left over from auto-add-state bootstrap that weren't
+// curated. example.edu / example.com both legitimately resolve (returning
+// 200), so probe() can't detect these — we filter them out separately and
+// mark them as failed regardless of HTTP status.
+const PLACEHOLDER_HOSTS = ["example.edu", "example.com", "example.org"];
+
+function isPlaceholder(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return PLACEHOLDER_HOSTS.some((p) => host === p || host.endsWith("." + p));
+  } catch {
+    return false;
+  }
+}
+
+async function probe(url: string): Promise<{ status: number | null; ok: boolean; error?: string }> {
+  if (isPlaceholder(url)) {
+    return { status: null, ok: false, error: "placeholder URL (auto-add-state bootstrap leftover)" };
+  }
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    // Try HEAD first; many servers refuse HEAD with 405, fall back to GET.
+    let resp = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "User-Agent": "cc-coursemap-url-check/1.0" },
+    });
+    if (resp.status === 405 || resp.status === 501) {
+      resp = await fetch(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal,
+        headers: { "User-Agent": "cc-coursemap-url-check/1.0" },
+      });
+    }
+    return { status: resp.status, ok: resp.ok };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { status: null, ok: false, error: msg };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const checks = collectUrlsToCheck();
+  console.log(`Checking ${checks.length} URLs across ${getAllStates().length} states...`);
+
+  // Bounded concurrency: don't pound any single state's host. Sequential by
+  // (state, field) is plenty fast — ~17 states × ~4 URLs each, ~5s per
+  // probe worst case = under 6 minutes.
+  const results: CheckResult[] = [];
+  for (const c of checks) {
+    const r = await probe(c.url);
+    results.push({
+      state: c.state,
+      field: c.field,
+      url: c.url,
+      status: r.status,
+      ok: r.ok,
+      error: r.error,
+    });
+    const flag = r.ok ? "✓" : "✗";
+    console.log(`  ${flag} ${c.state}/${c.field} → ${r.status ?? "ERR"} ${c.url}`);
+  }
+
+  const failures = results.filter((r) => !r.ok);
+  console.log(`\n${failures.length} failure(s) of ${results.length} checked.`);
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    total: results.length,
+    failures: failures.length,
+    results,
+  };
+
+  if (statusOut) {
+    writeFileSync(statusOut, JSON.stringify(summary, null, 2));
+  }
+
+  // Always print the failure list to stdout for workflow logs.
+  if (failures.length > 0) {
+    console.log("\nFailures:");
+    for (const f of failures) {
+      console.log(`  ${f.state}/${f.field}: ${f.status ?? "ERR"} ${f.url}${f.error ? ` — ${f.error}` : ""}`);
+    }
+  }
+
+  // Exit code 0 either way — workflow looks at the JSON to decide whether
+  // to open / update / close the rolling issue.
+}
+
+main().catch((err) => {
+  console.error("URL check failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Indirectly user-facing. Catches dead links and placeholder URLs in `StateConfig` before users hit them. The smoke test against the live registry surfaced 6 real findings today — see "Local smoke test result" below — so this isn't theoretical.

## What changes on the technical front

Two new files:

- **`scripts/lib/check-config-urls.ts`** — HEAD-request sweep across `getAllStates()`. For each state, probes `systemUrl`, `seniorWaiver.legalCitation` (if URL-shaped), and samples `courseDiscoveryUrl(...)` and `collegeCoursesUrl(...)` with one college's data. Falls back HEAD → GET for servers that refuse HEAD with 405/501. Detects placeholder URLs (example.edu/.com/.org) since they legitimately return 200 and HTTP probes can't tell them apart from real URLs.

- **`.github/workflows/config-url-check.yml`** — Monday 14:00 UTC weekly + workflow_dispatch. Maintains a single rolling GitHub issue "Config URL health" with the same open/update/auto-close lifecycle as the existing scraper-health rolling issues (`#123`, `#124`, `#474`). Label: `config-health,automated`.

## Local smoke test (ran against current registry)

```
Total: 101 URLs across 17 active states
Failures: 6
  md/courseDiscoveryUrl(sample): selfservice.allegany.edu — fetch failed (DNS / unreachable)
  md/collegeCoursesUrl(sample):  selfservice.allegany.edu — fetch failed
  mt/courseDiscoveryUrl(sample): example.edu placeholder
  mt/collegeCoursesUrl(sample):  example.edu placeholder
  az/courseDiscoveryUrl(sample): example.edu placeholder
  az/collegeCoursesUrl(sample):  example.edu placeholder
```

The 4 placeholders are exactly what memory `project_auto_add_state_placeholders` warned about — un-curated auto-add-state bootstraps that shipped without real URL generators. The 2 MD failures need separate investigation (Allegany College's selfservice subdomain is unreachable from GH runners; could be IP allowlist, could be a real outage).

None of these would have surfaced via scheduled-scrape, because the scrapers don't hit these specific URL shapes.

## Why HEAD-then-GET fallback

HEAD is cheap and matches the "is this URL alive" question exactly. Servers that refuse HEAD with 405/501 get a GET retry. Two-step is built into `probe()`.

## Why one college per state, not every college

The URL generator is the same function for all colleges in a state. Validating one catches a generator regression; validating all just multiplies cost by ~7x without new signal. Per-college 404s during scraping already surface via the `colleges_missing` field in `history.jsonl`.

## Failure modes considered

- **All checks pass** — workflow exits silently, no issue is opened (or open issue auto-closes if previously failing).
- **Some checks fail** — rolling issue opens or updates body with the failure table.
- **Workflow itself fails** (network outage on GH runner) — Actions log shows it; the rolling issue isn't touched.

## Test plan

- [ ] Reviewer scans the smoke-test failure list above — agree those are real findings worth surfacing?
- [ ] After merge: Actions → "Config URL health check" → Run workflow → confirms the rolling issue opens with the same 6 failures
- [ ] On the *next* Monday's run, if MD's Allegany URL has been fixed or MT/AZ placeholders curated, the rolling issue auto-updates body or closes

## Coverage gaps (not in this PR)

- Per-college URL probing — explicit non-goal; `colleges_missing` from history.jsonl covers it
- URL probes in blog MDX or CLAUDE.md — one-off content, harder to catch automatically
- API endpoint probing for scraping (e.g., is the SIS still up) — already covered by scheduled-scrape

## Plan B status

1. ✅ Config URL HEAD check (this PR)
2. ⏳ Refingerprint sweep — re-fingerprint every college, diff against `data/fingerprint-sweep.json`, catch SIS migrations before scrapers break
3. ⏳ Coverage expansion — suggest registry adds when an untemplated college's fingerprint flips to a templated platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)