### PR TITLE
Harden post-git-checkout hook: refuse to overwrite lock when prior branch has unmerged commits

### DIFF
--- a/.claude/hooks/post-git-checkout.sh
+++ b/.claude/hooks/post-git-checkout.sh
@@ -52,6 +52,31 @@ if [[ "$CMD" =~ git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+([A-Za-z0-9._/-
     exit 0
   fi
 
+  # Second safety check (added 2026-05-24 after PR #524's branch-shift
+  # rescue): don't overwrite a lock pointing to a branch with UNMERGED
+  # commits. When my work is committed and pushed but not yet merged,
+  # another session's `git checkout -b` would otherwise see a clean
+  # tree and silently steal my lock — leading to my next `git commit`
+  # landing on the wrong branch.
+  if [ -f .claude/branch-lock ]; then
+    EXISTING=$(cat .claude/branch-lock 2>/dev/null | tr -d '[:space:]')
+    if [ -n "$EXISTING" ] && [ "$EXISTING" != "$BRANCH" ]; then
+      # Does the locked branch still exist locally?
+      if git rev-parse --verify --quiet "$EXISTING" > /dev/null 2>&1; then
+        UNMERGED=$(git log --oneline "origin/main..$EXISTING" 2>/dev/null | wc -l | tr -d '[:space:]')
+        if [ "$UNMERGED" -gt 0 ]; then
+          echo "⚠️  branch-lock NOT updated to '$BRANCH' — existing lock '$EXISTING' has $UNMERGED unmerged commit(s)." >&2
+          echo "    A parallel session's checkout would otherwise steal the lock and your next commit would land on the wrong branch." >&2
+          echo "    Either:" >&2
+          echo "      a) wait until $EXISTING is merged (auto-overwrite then becomes safe)," >&2
+          echo "      b) finish + stash the work on $EXISTING before the new branch, or" >&2
+          echo "      c) manually override: echo $BRANCH > .claude/branch-lock" >&2
+          exit 0
+        fi
+      fi
+    fi
+  fi
+
   echo "$BRANCH" > .claude/branch-lock
   echo "🔒 branch-lock written: $BRANCH" >&2
 fi


### PR DESCRIPTION
## What changes for users

No user-visible change. Hardens the in-repo guard that prevents Claude commits from landing on the wrong branch when multiple Claude Code sessions share the workspace.

## What changes technically

`.claude/hooks/post-git-checkout.sh` already refused to auto-write the branch-lock when the working tree had tracked uncommitted changes. That covered "I haven't committed yet, don't lose track of where I am." But it missed PR #524's failure mode:

1. I committed my AZ work (Yavapai+EAC+NPC refactor) on `claude/az-yavapai-eac-cmc` and pushed it. Tree clean.
2. A parallel session ran `git checkout -b claude/state-health-coverage-expansion`.
3. The hook saw a clean tree and silently overwrote `.claude/branch-lock` to the parallel session's branch.
4. My next `git commit` ran on the wrong branch (no abort because lock matched), needing a cherry-pick rescue.

Adds a second check: if the existing lock points to a branch that has **unmerged commits relative to `origin/main`**, refuse the overwrite. The lock now only auto-updates when:

- tree is clean (existing check), **AND**
- prior locked branch is empty / merged / non-existent (new check)

For a committed-but-unmerged WIP branch (the actual failure case), the operator must explicitly `echo NEWBRANCH > .claude/branch-lock` to move on — which is the correct workflow signal.

Memory `feedback_branch_guard_mandatory.md` updated with the new behavior + escape hatch.

## Test plan

- [ ] In a fresh worktree, branch `claude/A` with a commit (not merged), then attempt `git checkout -b claude/B` — verify lock stays at `claude/A` and the hook prints the explanation
- [ ] In a fresh worktree, no lock, run `git checkout -b claude/A` — verify lock written
- [ ] Lock points to a merged branch, run `git checkout -b claude/B` — verify lock auto-overwrites
- [ ] Lock matches current branch, run `git checkout -b same-branch` — no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)