### PR TITLE
fix(refingerprint): IPEDS fallback for missing homepage_url

### DIFF
--- a/scripts/lib/refingerprint-sweep.ts
+++ b/scripts/lib/refingerprint-sweep.ts
@@ -37,6 +37,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAllStates } from "../../lib/states/registry";
+import { discoverPublicCommunityColleges } from "./discover-colleges";
 import { fingerprint, type Platform } from "./fingerprint-college";
 
 const BASELINE_PATH = "data/state-health/fingerprint-baseline.json";
@@ -100,6 +101,7 @@ interface InstitutionEntry {
   college_slug?: string;
   slug?: string;
   name?: string;
+  unitid?: number;
   homepage_url?: string;
   url?: string;
   primaryUrl?: string;
@@ -241,19 +243,58 @@ function computeDiff(prev: Baseline | null, current: CollegeEntry[]): DiffEntry[
 async function main() {
   console.log(`Refingerprint sweep (states=${targetStates.length}, concurrency=${concurrency}, dry-run=${dryRun})`);
 
-  // Build task list
+  // Build task list. URLs come from institutions.json when available, with
+  // a fallback to IPEDS via discover-colleges. The fallback is necessary
+  // because most states' institutions.json files were bootstrapped without
+  // a homepage_url field — only NV currently has it. Looking up via IPEDS
+  // by unitid means refingerprint can see all ~500 supported colleges
+  // without backfilling every state's data file.
   const tasks: SweepTask[] = [];
+  let urlsFromInstitutionsJson = 0;
+  let urlsFromIpeds = 0;
+  let skippedNoUrl = 0;
   for (const state of targetStates) {
     const insts = loadInstitutions(state);
+    if (insts.length === 0) continue;
+    // Build the IPEDS unitid → primaryUrl map for this state once. Skip
+    // the IPEDS fetch entirely if every institution already has a URL —
+    // saves a real API roundtrip and works fine for the NV case.
+    const missingUrlCount = insts.filter((i) => !institutionUrl(i)).length;
+    const ipedsByUnitid = new Map<number, string>();
+    if (missingUrlCount > 0) {
+      try {
+        const discovered = await discoverPublicCommunityColleges(state);
+        for (const d of discovered) {
+          if (d.primaryUrl) ipedsByUnitid.set(d.unitid, d.primaryUrl);
+        }
+        console.log(`  ${state}: ${missingUrlCount} colleges missing homepage_url → IPEDS returned URLs for ${ipedsByUnitid.size}`);
+      } catch (err) {
+        console.error(`  ${state}: IPEDS lookup failed (${err instanceof Error ? err.message : err}); will skip colleges without local URLs`);
+      }
+    }
     for (const inst of insts) {
-      const url = institutionUrl(inst);
       const slug = institutionSlug(inst);
       const name = (inst.name ?? slug) as string | undefined;
-      if (!url || !slug) continue;
+      if (!slug) {
+        skippedNoUrl++;
+        continue;
+      }
+      let url = institutionUrl(inst);
+      if (url) {
+        urlsFromInstitutionsJson++;
+      } else if (typeof inst.unitid === "number") {
+        url = ipedsByUnitid.get(inst.unitid) ?? null;
+        if (url) urlsFromIpeds++;
+      }
+      if (!url) {
+        skippedNoUrl++;
+        continue;
+      }
       tasks.push({ state, slug, name: name ?? slug, url });
     }
   }
   console.log(`Tasks: ${tasks.length} colleges across ${targetStates.length} states`);
+  console.log(`  URL sources: ${urlsFromInstitutionsJson} from institutions.json, ${urlsFromIpeds} from IPEDS fallback, ${skippedNoUrl} skipped`);
 
   if (tasks.length === 0) {
     console.error("No tasks — empty institutions or unknown states.");


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-visible — but unblocks the monthly refingerprint sweep ([#523](../../pull/523)) which was silently fingerprinting only 4 colleges out of ~500. After this merges and the workflow re-triggers, we'll finally see whether [PR #528](../../pull/528)'s fingerprinter improvements reclassify a meaningful chunk of the 301-untouchable list.

## The bug

The refingerprint workflow ran in production today and reported "0 platform changes" — but it only fingerprinted 4 colleges (all from NV). Looking at the script: it reads `homepage_url` from each state's `institutions.json`, but only NV's file was bootstrapped with that field. Every other state's institutions.json lacks it, so ~480 colleges were silently skipped. The script's "skip if no URL" branch fired ~480 times without surfacing it as an error.

## The fix

For each state with institutions missing `homepage_url`, call `discoverPublicCommunityColleges(state)` once (the same IPEDS API the original sweep uses), build a `unitid → primaryUrl` map, and look up missing URLs that way. The IPEDS call is skipped entirely when all institutions already have URLs, so NV continues to work exactly as before.

## Why not backfill `homepage_url` into all institutions.json files (Option B)

Considered and rejected for this PR:
- Touching 17 state data files = ~500-line diff, hard to review carefully
- Risk of overwriting hand-curation in any institutions.json that was manually edited
- Schema-drift risk — some states might already have a URL under `url` or `website` and we'd create competing fields
- Only refingerprint needs this data right now; no second consumer justifies committing URLs as canonical

If a future feature renders college homepages on the site, backfilling becomes worth doing. For now, IPEDS-at-fingerprint-time is simpler and risk-free.

## Verification

Local dry-run across NV + NC:

```
Refingerprint sweep (states=2, concurrency=6, dry-run=true)
  nc: 58 colleges missing homepage_url → IPEDS returned URLs for 59
Tasks: 62 colleges across 2 states
  URL sources: 4 from institutions.json, 58 from IPEDS fallback, 0 skipped
  62/62 fingerprinted
```

NV path unchanged (4 from institutions.json). NC path uses fallback (58 from IPEDS). Extrapolates to ~5 minutes for all 17 supported states.

## Test plan

- [ ] Reviewer eyeballs the change — the new code is gated on "institutions missing URL," so the NV path is provably untouched
- [ ] After merge: `gh workflow run refingerprint-sweep.yml` — should commit a much larger `fingerprint-baseline.json` (~500 colleges instead of 4)
- [ ] Cross-check: count of `custom`/`unknown` in the new baseline vs `data/fingerprint-sweep.json` (May 9 snapshot) — gap tells us how many colleges PR #528's improvements reclassified

🤖 Generated with [Claude Code](https://claude.com/claude-code)