### PR TITLE
fix(orchestrator-guard): check effective CWD, not hook's own CWD

### DIFF
--- a/.claude/hooks/pre-orchestrator-guard.sh
+++ b/.claude/hooks/pre-orchestrator-guard.sh
@@ -42,10 +42,28 @@ if echo "$CMD" | grep -qE '^(pgrep|pkill|tail|head|cat|ls|wc|grep|stat|test|jq|m
   exit 0
 fi
 
-# Determine the git common dir and whether CWD is the main checkout or a
-# linked worktree. `git rev-parse --git-dir` returns ".git" in the main
+# Determine the *effective* CWD that the command will execute in. The
+# hook is spawned by Claude Code in the project root (always the main
+# checkout), so our own `git rev-parse` would always report the main
+# repo — that would false-block legitimate invocations preceded by
+# `cd .claude/worktrees/<name> && ...`. Parse the command string for a
+# leading `cd <path>` and use that as the effective CWD if present.
+EFFECTIVE_CWD=$(echo "$CMD" | /usr/bin/python3 -c '
+import sys, re, os
+cmd = sys.stdin.read().strip()
+m = re.match(r"^\s*\(?\s*cd\s+([^\s;&]+)", cmd)
+print(m.group(1) if m else "")
+' 2>/dev/null || echo "")
+
+# Resolve the effective CWD to absolute, then ask git what kind of
+# checkout it is. `git rev-parse --git-dir` returns ".git" in the main
 # checkout and a path like ".git/worktrees/<name>" in a linked worktree.
-GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo "")
+if [ -n "$EFFECTIVE_CWD" ] && [ -d "$EFFECTIVE_CWD" ]; then
+  GIT_DIR=$(cd "$EFFECTIVE_CWD" 2>/dev/null && git rev-parse --git-dir 2>/dev/null || echo "")
+else
+  GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo "")
+fi
+
 if [ -z "$GIT_DIR" ]; then
   # Not in a git repo — let the script fail on its own merits.
   exit 0
@@ -53,14 +71,16 @@ fi
 
 case "$GIT_DIR" in
   *worktrees/*)
-    # Running from a linked worktree — exactly what we want.
+    # Will run from a linked worktree — exactly what we want.
     exit 0
     ;;
 esac
 
-# CWD is the main checkout. Derive a suggested worktree command from
-# --state <slug> if present in CMD.
-SLUG=$(echo "$CMD" | grep -oE '(--state|--state=)[[:space:]=]*[a-z]{2}' | grep -oE '[a-z]{2}$' || echo "STATE")
+# Effective CWD is the main checkout. Derive a suggested worktree
+# command from --state <slug> if present in CMD. Use head -1 to defend
+# against the slug regex matching more than one substring on the line.
+SLUG=$(echo "$CMD" | grep -oE '(--state|--state=)[[:space:]=]*[a-z]{2}\b' | grep -oE '[a-z]{2}$' | head -1)
+[ -z "$SLUG" ] && SLUG="STATE"
 SUGGESTED_BRANCH="claude/${SLUG}-auto-add-state"
 SUGGESTED_PATH=".claude/worktrees/${SLUG}-auto-add-state"
 


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-visible. Fixes a regression in the #530 orchestrator guard that was false-blocking legitimate worktree invocations.

## What changes on the technical front

The hook from PR #530 was reading \`git rev-parse --git-dir\` in its own working directory to decide if the orchestrator was being launched from a worktree or the main checkout. But Claude Code spawns PreToolUse hooks in the project root — always the main checkout — regardless of where the Bash command will actually run after its inline \`cd\`. So a perfectly legitimate command like:

\`\`\`
cd .claude/worktrees/ar-auto-add-state && ( nohup npx tsx scripts/lib/add-state.ts --state ar --json > /tmp/x.log 2>&1 < /dev/null & )
\`\`\`

was being false-blocked because the hook's own CWD was the main checkout, not the worktree the command would land in. Hit this on the first attempted AR re-run.

**Fix:** parse the command text for a leading \`cd <path>\` and resolve that to the effective CWD, then run \`git rev-parse --git-dir\` from there. Only fall back to the hook's own CWD when no \`cd\` is present in the command.

**Also fixes** a slug-extraction bug: when the test harness echoed multiple \`--state <slug>\` payloads on one line, the regex matched all of them and the suggested-worktree path in the error message got newlines spliced into it (\`.claude/worktrees/wa\\nar-auto-add-state\`). Anchored the regex with \`\\b\` and added \`head -1\` to take the first match only.

## Test plan

Used file-based fixtures piped to the hook (had to bypass echo'ing \`add-state.ts\` in shell because the installed buggy hook would intercept the test itself):

- [x] Test 1 — bare \`( nohup ... add-state.ts --state wa ... )\` from main checkout → blocks with EXIT 2, clean single-slug suggested path \`.claude/worktrees/wa-auto-add-state\`.
- [x] Test 2 — \`cd /Users/.../worktrees/ar-auto-add-state && ( nohup ... add-state.ts --state ar ... )\` → allows (EXIT 0).
- [x] Test 3 — \`pgrep -f add-state.ts\` → allows (read-only allowlist).
- [ ] After merge: re-run AR auto-add-state from a worktree and confirm the hook no longer blocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)