### PR TITLE
data: first full fingerprint-baseline (652 colleges) after PR #528 + #529

### DIFF
--- a/data/state-health/fingerprint-baseline.json
+++ b/data/state-health/fingerprint-baseline.json
@@ -1,6 +1,5631 @@
 {
-  "generatedAt": "2026-05-24T22:56:44.826Z",
+  "generatedAt": "2026-05-25T00:10:43.748Z",
   "perCollege": {
+    "va-cvcc": {
+      "state": "va",
+      "slug": "cvcc",
+      "name": "Central Virginia Community College",
+      "primaryUrl": "centralvirginia.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:33:34.789Z"
+    },
+    "va-camp": {
+      "state": "va",
+      "slug": "camp",
+      "name": "Camp Community College",
+      "primaryUrl": "pdc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:33:37.488Z"
+    },
+    "va-reynolds": {
+      "state": "va",
+      "slug": "reynolds",
+      "name": "Reynolds Community College",
+      "primaryUrl": "reynolds.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:38.415Z"
+    },
+    "va-nova": {
+      "state": "va",
+      "slug": "nova",
+      "name": "Northern Virginia Community College",
+      "primaryUrl": "nvcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:33:38.539Z"
+    },
+    "va-dcc": {
+      "state": "va",
+      "slug": "dcc",
+      "name": "Danville Community College",
+      "primaryUrl": "danville.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:40.897Z"
+    },
+    "va-brightpoint": {
+      "state": "va",
+      "slug": "brightpoint",
+      "name": "Brightpoint Community College",
+      "primaryUrl": "brightpoint.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:45.883Z"
+    },
+    "va-mecc": {
+      "state": "va",
+      "slug": "mecc",
+      "name": "Mountain Empire Community College",
+      "primaryUrl": "mecc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:33:46.233Z"
+    },
+    "va-brcc": {
+      "state": "va",
+      "slug": "brcc",
+      "name": "Blue Ridge Community College",
+      "primaryUrl": "brcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:33:46.784Z"
+    },
+    "va-mgcc": {
+      "state": "va",
+      "slug": "mgcc",
+      "name": "Mountain Gateway Community College",
+      "primaryUrl": "mgcc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:46.929Z"
+    },
+    "va-escc": {
+      "state": "va",
+      "slug": "escc",
+      "name": "Eastern Shore Community College",
+      "primaryUrl": "es.vccs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:47.970Z"
+    },
+    "va-pvcc": {
+      "state": "va",
+      "slug": "pvcc",
+      "name": "Piedmont Virginia Community College",
+      "primaryUrl": "pvcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:33:51.935Z"
+    },
+    "va-nrcc": {
+      "state": "va",
+      "slug": "nrcc",
+      "name": "New River Community College",
+      "primaryUrl": "nr.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:54.362Z"
+    },
+    "va-svcc": {
+      "state": "va",
+      "slug": "svcc",
+      "name": "Southside Virginia Community College",
+      "primaryUrl": "southside.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:55.398Z"
+    },
+    "va-swcc": {
+      "state": "va",
+      "slug": "swcc",
+      "name": "Southwest Virginia Community College",
+      "primaryUrl": "sw.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:33:57.283Z"
+    },
+    "va-tcc": {
+      "state": "va",
+      "slug": "tcc",
+      "name": "Tidewater Community College",
+      "primaryUrl": "tcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:34:00.762Z"
+    },
+    "va-gcc": {
+      "state": "va",
+      "slug": "gcc",
+      "name": "Germanna Community College",
+      "primaryUrl": "germanna.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:02.439Z"
+    },
+    "va-vhcc": {
+      "state": "va",
+      "slug": "vhcc",
+      "name": "Virginia Highlands Community College",
+      "primaryUrl": "vhcc.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:02.675Z"
+    },
+    "va-laurelridge": {
+      "state": "va",
+      "slug": "laurelridge",
+      "name": "Laurel Ridge Community College",
+      "primaryUrl": "laurelridge.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:34:03.306Z"
+    },
+    "va-vpcc": {
+      "state": "va",
+      "slug": "vpcc",
+      "name": "Virginia Peninsula Community College",
+      "primaryUrl": "vpcc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:03.396Z"
+    },
+    "va-vwcc": {
+      "state": "va",
+      "slug": "vwcc",
+      "name": "Virginia Western Community College",
+      "primaryUrl": "virginiawestern.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:05.559Z"
+    },
+    "nc-beaufort-county": {
+      "state": "nc",
+      "slug": "beaufort-county",
+      "name": "Beaufort County Community College",
+      "primaryUrl": "beaufortccc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:34:10.772Z"
+    },
+    "nc-blue-ridge": {
+      "state": "nc",
+      "slug": "blue-ridge",
+      "name": "Blue Ridge Community College",
+      "primaryUrl": "blueridge.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:12.483Z"
+    },
+    "nc-alamance": {
+      "state": "nc",
+      "slug": "alamance",
+      "name": "Alamance Community College",
+      "primaryUrl": "alamancecc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:13.415Z"
+    },
+    "va-rcc": {
+      "state": "va",
+      "slug": "rcc",
+      "name": "Rappahannock Community College",
+      "primaryUrl": "rappahannock.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:17.001Z"
+    },
+    "va-phcc": {
+      "state": "va",
+      "slug": "phcc",
+      "name": "Patrick & Henry Community College",
+      "primaryUrl": "patrickhenry.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:20.696Z"
+    },
+    "nc-cape-fear": {
+      "state": "nc",
+      "slug": "cape-fear",
+      "name": "Cape Fear Community College",
+      "primaryUrl": "cfcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:26.915Z"
+    },
+    "nc-carteret": {
+      "state": "nc",
+      "slug": "carteret",
+      "name": "Carteret Community College",
+      "primaryUrl": "carteret.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:34:32.152Z"
+    },
+    "nc-central-carolina": {
+      "state": "nc",
+      "slug": "central-carolina",
+      "name": "Central Carolina Community College",
+      "primaryUrl": "cccc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:33.160Z"
+    },
+    "nc-asheville-buncombe-technical": {
+      "state": "nc",
+      "slug": "asheville-buncombe-technical",
+      "name": "Asheville-Buncombe Technical Community College",
+      "primaryUrl": "abtech.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:36.380Z"
+    },
+    "nc-bladen": {
+      "state": "nc",
+      "slug": "bladen",
+      "name": "Bladen Community College",
+      "primaryUrl": "bladencc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:41.055Z"
+    },
+    "nc-coastal-carolina": {
+      "state": "nc",
+      "slug": "coastal-carolina",
+      "name": "Coastal Carolina Community College",
+      "primaryUrl": "coastalcarolina.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:42.518Z"
+    },
+    "va-wcc": {
+      "state": "va",
+      "slug": "wcc",
+      "name": "Wytheville Community College",
+      "primaryUrl": "wcc.vccs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:42.784Z"
+    },
+    "nc-brunswick": {
+      "state": "nc",
+      "slug": "brunswick",
+      "name": "Brunswick Community College",
+      "primaryUrl": "brunswickcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:46.042Z"
+    },
+    "nc-college-of-the-albemarle": {
+      "state": "nc",
+      "slug": "college-of-the-albemarle",
+      "name": "College of The Albemarle",
+      "primaryUrl": "albemarle.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:34:51.432Z"
+    },
+    "nc-durham-technical": {
+      "state": "nc",
+      "slug": "durham-technical",
+      "name": "Durham Technical Community College",
+      "primaryUrl": "durhamtech.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:51.736Z"
+    },
+    "nc-fayetteville-technical": {
+      "state": "nc",
+      "slug": "fayetteville-technical",
+      "name": "Fayetteville Technical Community College",
+      "primaryUrl": "faytechcc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:34:55.197Z"
+    },
+    "nc-forsyth-technical": {
+      "state": "nc",
+      "slug": "forsyth-technical",
+      "name": "Forsyth Technical Community College",
+      "primaryUrl": "forsythtech.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:02.707Z"
+    },
+    "nc-cleveland": {
+      "state": "nc",
+      "slug": "cleveland",
+      "name": "Cleveland Community College",
+      "primaryUrl": "clevelandcc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:06.528Z"
+    },
+    "nc-gaston": {
+      "state": "nc",
+      "slug": "gaston",
+      "name": "Gaston College",
+      "primaryUrl": "gaston.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:12.519Z"
+    },
+    "nc-craven": {
+      "state": "nc",
+      "slug": "craven",
+      "name": "Craven Community College",
+      "primaryUrl": "cravencc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:12.653Z"
+    },
+    "nc-guilford-technical": {
+      "state": "nc",
+      "slug": "guilford-technical",
+      "name": "Guilford Technical Community College",
+      "primaryUrl": "gtcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:12.884Z"
+    },
+    "nc-edgecombe": {
+      "state": "nc",
+      "slug": "edgecombe",
+      "name": "Edgecombe Community College",
+      "primaryUrl": "edgecombe.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:35:15.442Z"
+    },
+    "nc-haywood": {
+      "state": "nc",
+      "slug": "haywood",
+      "name": "Haywood Community College",
+      "primaryUrl": "haywood.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:18.139Z"
+    },
+    "nc-halifax": {
+      "state": "nc",
+      "slug": "halifax",
+      "name": "Halifax Community College",
+      "primaryUrl": "halifaxcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:20.530Z"
+    },
+    "nc-johnston": {
+      "state": "nc",
+      "slug": "johnston",
+      "name": "Johnston Community College",
+      "primaryUrl": "johnstoncc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:20.694Z"
+    },
+    "nc-central-piedmont": {
+      "state": "nc",
+      "slug": "central-piedmont",
+      "name": "Central Piedmont Community College",
+      "primaryUrl": "cpcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:35:24.923Z"
+    },
+    "nc-martin": {
+      "state": "nc",
+      "slug": "martin",
+      "name": "Martin Community College",
+      "primaryUrl": "martincc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:35:25.792Z"
+    },
+    "nc-james-sprunt": {
+      "state": "nc",
+      "slug": "james-sprunt",
+      "name": "James Sprunt Community College",
+      "primaryUrl": "jamessprunt.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:26.779Z"
+    },
+    "nc-catawba-valley": {
+      "state": "nc",
+      "slug": "catawba-valley",
+      "name": "Catawba Valley Community College",
+      "primaryUrl": "cvcc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:29.840Z"
+    },
+    "nc-mcdowell-technical": {
+      "state": "nc",
+      "slug": "mcdowell-technical",
+      "name": "McDowell Technical Community College",
+      "primaryUrl": "mcdowelltech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:35:30.703Z"
+    },
+    "nc-nash": {
+      "state": "nc",
+      "slug": "nash",
+      "name": "Nash Community College",
+      "primaryUrl": "nashcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:40.400Z"
+    },
+    "nc-davidson-davie": {
+      "state": "nc",
+      "slug": "davidson-davie",
+      "name": "Davidson-Davie Community College",
+      "primaryUrl": "davidsondavie.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:35:42.154Z"
+    },
+    "nc-caldwell": {
+      "state": "nc",
+      "slug": "caldwell",
+      "name": "Caldwell Community College and Technical Institute",
+      "primaryUrl": "cccti.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:51.932Z"
+    },
+    "nc-mayland": {
+      "state": "nc",
+      "slug": "mayland",
+      "name": "Mayland Community College",
+      "primaryUrl": "mayland.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:52.943Z"
+    },
+    "nc-lenoir": {
+      "state": "nc",
+      "slug": "lenoir",
+      "name": "Lenoir Community College",
+      "primaryUrl": "lenoircc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:55.294Z"
+    },
+    "nc-pitt": {
+      "state": "nc",
+      "slug": "pitt",
+      "name": "Pitt Community College",
+      "primaryUrl": "pittcc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:35:57.262Z"
+    },
+    "nc-richmond": {
+      "state": "nc",
+      "slug": "richmond",
+      "name": "Richmond Community College",
+      "primaryUrl": "richmondcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:00.504Z"
+    },
+    "nc-roanoke-chowan": {
+      "state": "nc",
+      "slug": "roanoke-chowan",
+      "name": "Roanoke-Chowan Community College",
+      "primaryUrl": "roanokechowan.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:01.910Z"
+    },
+    "nc-isothermal": {
+      "state": "nc",
+      "slug": "isothermal",
+      "name": "Isothermal Community College",
+      "primaryUrl": "isothermal.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:05.555Z"
+    },
+    "nc-robeson": {
+      "state": "nc",
+      "slug": "robeson",
+      "name": "Robeson Community College",
+      "primaryUrl": "robeson.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:11.795Z"
+    },
+    "nc-rockingham": {
+      "state": "nc",
+      "slug": "rockingham",
+      "name": "Rockingham Community College",
+      "primaryUrl": "rockinghamcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:12.231Z"
+    },
+    "nc-piedmont": {
+      "state": "nc",
+      "slug": "piedmont",
+      "name": "Piedmont Community College",
+      "primaryUrl": "piedmontcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:14.744Z"
+    },
+    "nc-sandhills": {
+      "state": "nc",
+      "slug": "sandhills",
+      "name": "Sandhills Community College",
+      "primaryUrl": "sandhills.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:21.069Z"
+    },
+    "nc-randolph": {
+      "state": "nc",
+      "slug": "randolph",
+      "name": "Randolph Community College",
+      "primaryUrl": "randolph.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:21.676Z"
+    },
+    "nc-sampson": {
+      "state": "nc",
+      "slug": "sampson",
+      "name": "Sampson Community College",
+      "primaryUrl": "sampsoncc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:28.510Z"
+    },
+    "nc-mitchell": {
+      "state": "nc",
+      "slug": "mitchell",
+      "name": "Mitchell Community College",
+      "primaryUrl": "mitchellcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:31.054Z"
+    },
+    "nc-southwestern": {
+      "state": "nc",
+      "slug": "southwestern",
+      "name": "Southwestern Community College",
+      "primaryUrl": "southwesterncc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:31.766Z"
+    },
+    "nc-southeastern": {
+      "state": "nc",
+      "slug": "southeastern",
+      "name": "Southeastern Community College",
+      "primaryUrl": "sccnc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:32.981Z"
+    },
+    "nc-pamlico": {
+      "state": "nc",
+      "slug": "pamlico",
+      "name": "Pamlico Community College",
+      "primaryUrl": "pamlicocc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:35.990Z"
+    },
+    "nc-surry": {
+      "state": "nc",
+      "slug": "surry",
+      "name": "Surry Community College",
+      "primaryUrl": "surry.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:36.052Z"
+    },
+    "nc-montgomery": {
+      "state": "nc",
+      "slug": "montgomery",
+      "name": "Montgomery Community College",
+      "primaryUrl": "montgomery.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:36.515Z"
+    },
+    "nc-tri-county": {
+      "state": "nc",
+      "slug": "tri-county",
+      "name": "Tri-County Community College",
+      "primaryUrl": "tricountycc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:37.170Z"
+    },
+    "nc-rowan-cabarrus": {
+      "state": "nc",
+      "slug": "rowan-cabarrus",
+      "name": "Rowan-Cabarrus Community College",
+      "primaryUrl": "rccc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:37.185Z"
+    },
+    "nc-wilson": {
+      "state": "nc",
+      "slug": "wilson",
+      "name": "Wilson Community College",
+      "primaryUrl": "wilsoncc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:41.545Z"
+    },
+    "nc-wake-technical": {
+      "state": "nc",
+      "slug": "wake-technical",
+      "name": "Wake Technical Community College",
+      "primaryUrl": "waketech.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:46.938Z"
+    },
+    "sc-aiken": {
+      "state": "sc",
+      "slug": "aiken",
+      "name": "Aiken Technical College",
+      "primaryUrl": "atc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:47.215Z"
+    },
+    "nc-wilkes": {
+      "state": "nc",
+      "slug": "wilkes",
+      "name": "Wilkes Community College",
+      "primaryUrl": "wilkescc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:47.960Z"
+    },
+    "nc-south-piedmont": {
+      "state": "nc",
+      "slug": "south-piedmont",
+      "name": "South Piedmont Community College",
+      "primaryUrl": "spcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:48.033Z"
+    },
+    "sc-greenville": {
+      "state": "sc",
+      "slug": "greenville",
+      "name": "Greenville Technical College",
+      "primaryUrl": "gvltec.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:36:52.554Z"
+    },
+    "sc-florence-darlington": {
+      "state": "sc",
+      "slug": "florence-darlington",
+      "name": "Florence-Darlington Technical College",
+      "primaryUrl": "fdtc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:54.992Z"
+    },
+    "nc-wayne": {
+      "state": "nc",
+      "slug": "wayne",
+      "name": "Wayne Community College",
+      "primaryUrl": "waynecc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:36:59.351Z"
+    },
+    "sc-horry-georgetown": {
+      "state": "sc",
+      "slug": "horry-georgetown",
+      "name": "Horry-Georgetown Technical College",
+      "primaryUrl": "hgtc.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:00.510Z"
+    },
+    "nc-stanly": {
+      "state": "nc",
+      "slug": "stanly",
+      "name": "Stanly Community College",
+      "primaryUrl": "stanly.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:05.805Z"
+    },
+    "sc-central-carolina": {
+      "state": "sc",
+      "slug": "central-carolina",
+      "name": "Central Carolina Technical College",
+      "primaryUrl": "cctech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:05.813Z"
+    },
+    "nc-vance-granville": {
+      "state": "nc",
+      "slug": "vance-granville",
+      "name": "Vance-Granville Community College",
+      "primaryUrl": "vgcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:07.564Z"
+    },
+    "sc-northeastern": {
+      "state": "sc",
+      "slug": "northeastern",
+      "name": "Northeastern Technical College",
+      "primaryUrl": "netc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:07.568Z"
+    },
+    "sc-tri-county": {
+      "state": "sc",
+      "slug": "tri-county",
+      "name": "Tri-County Technical College",
+      "primaryUrl": "tctc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:37:11.652Z"
+    },
+    "sc-piedmont": {
+      "state": "sc",
+      "slug": "piedmont",
+      "name": "Piedmont Technical College",
+      "primaryUrl": "ptc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:11.814Z"
+    },
+    "sc-trident": {
+      "state": "sc",
+      "slug": "trident",
+      "name": "Trident Technical College",
+      "primaryUrl": "tridenttech.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:16.233Z"
+    },
+    "sc-lowcountry": {
+      "state": "sc",
+      "slug": "lowcountry",
+      "name": "Technical College of the Lowcountry",
+      "primaryUrl": "tcl.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:21.928Z"
+    },
+    "sc-york": {
+      "state": "sc",
+      "slug": "york",
+      "name": "York Technical College",
+      "primaryUrl": "yorktech.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:22.281Z"
+    },
+    "sc-midlands": {
+      "state": "sc",
+      "slug": "midlands",
+      "name": "Midlands Technical College",
+      "primaryUrl": "midlandstech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:37:26.143Z"
+    },
+    "md-aacc": {
+      "state": "md",
+      "slug": "aacc",
+      "name": "Anne Arundel Community College",
+      "primaryUrl": "aacc.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:30.837Z"
+    },
+    "sc-spartanburg": {
+      "state": "sc",
+      "slug": "spartanburg",
+      "name": "Spartanburg Community College",
+      "primaryUrl": "sccsc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:34.080Z"
+    },
+    "nc-western-piedmont": {
+      "state": "nc",
+      "slug": "western-piedmont",
+      "name": "Western Piedmont Community College",
+      "primaryUrl": "wpcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:35.662Z"
+    },
+    "md-cecil": {
+      "state": "md",
+      "slug": "cecil",
+      "name": "Cecil College",
+      "primaryUrl": "cecil.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:47.444Z"
+    },
+    "md-allegany": {
+      "state": "md",
+      "slug": "allegany",
+      "name": "Allegany College of Maryland",
+      "primaryUrl": "allegany.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:49.885Z"
+    },
+    "sc-williamsburg": {
+      "state": "sc",
+      "slug": "williamsburg",
+      "name": "Williamsburg Technical College",
+      "primaryUrl": "wiltech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:37:51.978Z"
+    },
+    "md-chesapeake": {
+      "state": "md",
+      "slug": "chesapeake",
+      "name": "Chesapeake College",
+      "primaryUrl": "chesapeake.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:37:52.166Z"
+    },
+    "md-csm": {
+      "state": "md",
+      "slug": "csm",
+      "name": "College of Southern Maryland",
+      "primaryUrl": "csmd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:53.007Z"
+    },
+    "md-ccbc": {
+      "state": "md",
+      "slug": "ccbc",
+      "name": "Community College of Baltimore County",
+      "primaryUrl": "ccbcmd.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:37:54.939Z"
+    },
+    "md-garrett": {
+      "state": "md",
+      "slug": "garrett",
+      "name": "Garrett College",
+      "primaryUrl": "garrettcollege.edu/index.php",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:01.087Z"
+    },
+    "md-carroll": {
+      "state": "md",
+      "slug": "carroll",
+      "name": "Carroll Community College",
+      "primaryUrl": "carrollcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:03.762Z"
+    },
+    "md-frederick": {
+      "state": "md",
+      "slug": "frederick",
+      "name": "Frederick Community College",
+      "primaryUrl": "frederick.edu",
+      "platform": "courseleaf",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:09.773Z"
+    },
+    "sc-orangeburg-calhoun": {
+      "state": "sc",
+      "slug": "orangeburg-calhoun",
+      "name": "Orangeburg-Calhoun Technical College",
+      "primaryUrl": "octech.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:09.794Z"
+    },
+    "md-pgcc": {
+      "state": "md",
+      "slug": "pgcc",
+      "name": "Prince George's Community College",
+      "primaryUrl": "pgcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:14.267Z"
+    },
+    "sc-denmark": {
+      "state": "sc",
+      "slug": "denmark",
+      "name": "Denmark Technical College",
+      "primaryUrl": "denmarktech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:16.174Z"
+    },
+    "md-wor-wic": {
+      "state": "md",
+      "slug": "wor-wic",
+      "name": "Wor-Wic Community College",
+      "primaryUrl": "worwic.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:19.866Z"
+    },
+    "ga-albany-tech": {
+      "state": "ga",
+      "slug": "albany-tech",
+      "name": "Albany Technical College",
+      "primaryUrl": "albanytech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:21.811Z"
+    },
+    "md-hagerstown": {
+      "state": "md",
+      "slug": "hagerstown",
+      "name": "Hagerstown Community College",
+      "primaryUrl": "hagerstowncc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:25.284Z"
+    },
+    "ga-athens-tech": {
+      "state": "ga",
+      "slug": "athens-tech",
+      "name": "Athens Technical College",
+      "primaryUrl": "athenstech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:26.319Z"
+    },
+    "md-harford": {
+      "state": "md",
+      "slug": "harford",
+      "name": "Harford Community College",
+      "primaryUrl": "harford.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:27.542Z"
+    },
+    "md-bccc": {
+      "state": "md",
+      "slug": "bccc",
+      "name": "Baltimore City Community College",
+      "primaryUrl": "bccc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:27.643Z"
+    },
+    "ga-chattahoochee-tech": {
+      "state": "ga",
+      "slug": "chattahoochee-tech",
+      "name": "Chattahoochee Technical College",
+      "primaryUrl": "chattahoocheetech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:30.784Z"
+    },
+    "ga-atlanta-tech": {
+      "state": "ga",
+      "slug": "atlanta-tech",
+      "name": "Atlanta Technical College",
+      "primaryUrl": "atlantatech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:31.357Z"
+    },
+    "md-howardcc": {
+      "state": "md",
+      "slug": "howardcc",
+      "name": "Howard Community College",
+      "primaryUrl": "howardcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:31.561Z"
+    },
+    "ga-central-ga-tech": {
+      "state": "ga",
+      "slug": "central-ga-tech",
+      "name": "Central Georgia Technical College",
+      "primaryUrl": "centralgatech.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:33.316Z"
+    },
+    "ga-columbus-tech": {
+      "state": "ga",
+      "slug": "columbus-tech",
+      "name": "Columbus Technical College",
+      "primaryUrl": "columbustech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:36.612Z"
+    },
+    "ga-ga-northwestern-tech": {
+      "state": "ga",
+      "slug": "ga-northwestern-tech",
+      "name": "Georgia Northwestern Technical College",
+      "primaryUrl": "gntc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:37.041Z"
+    },
+    "ga-ga-piedmont-tech": {
+      "state": "ga",
+      "slug": "ga-piedmont-tech",
+      "name": "Georgia Piedmont Technical College",
+      "primaryUrl": "gptc.edu",
+      "platform": "ellucian-experience",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:40.487Z"
+    },
+    "ga-coastal-pines-tech": {
+      "state": "ga",
+      "slug": "coastal-pines-tech",
+      "name": "Coastal Pines Technical College",
+      "primaryUrl": "coastalpines.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:43.063Z"
+    },
+    "ga-oconee-fall-line-tech": {
+      "state": "ga",
+      "slug": "oconee-fall-line-tech",
+      "name": "Oconee Fall Line Technical College",
+      "primaryUrl": "oftc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:44.861Z"
+    },
+    "ga-ogeechee-tech": {
+      "state": "ga",
+      "slug": "ogeechee-tech",
+      "name": "Ogeechee Technical College",
+      "primaryUrl": "ogeecheetech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:45.369Z"
+    },
+    "ga-augusta-tech": {
+      "state": "ga",
+      "slug": "augusta-tech",
+      "name": "Augusta Technical College",
+      "primaryUrl": "augustatech.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:47.879Z"
+    },
+    "md-montgomery": {
+      "state": "md",
+      "slug": "montgomery",
+      "name": "Montgomery College",
+      "primaryUrl": "montgomerycollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:55.496Z"
+    },
+    "ga-southern-crescent-tech": {
+      "state": "ga",
+      "slug": "southern-crescent-tech",
+      "name": "Southern Crescent Technical College",
+      "primaryUrl": "sctech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:38:59.361Z"
+    },
+    "ga-lanier-tech": {
+      "state": "ga",
+      "slug": "lanier-tech",
+      "name": "Lanier Technical College",
+      "primaryUrl": "laniertech.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:38:59.771Z"
+    },
+    "ga-southern-regional-tech": {
+      "state": "ga",
+      "slug": "southern-regional-tech",
+      "name": "Southern Regional Technical College",
+      "primaryUrl": "southernregional.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:06.280Z"
+    },
+    "ga-gwinnett-tech": {
+      "state": "ga",
+      "slug": "gwinnett-tech",
+      "name": "Gwinnett Technical College",
+      "primaryUrl": "gwinnetttech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:07.030Z"
+    },
+    "ga-west-ga-tech": {
+      "state": "ga",
+      "slug": "west-ga-tech",
+      "name": "West Georgia Technical College",
+      "primaryUrl": "westgatech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:10.568Z"
+    },
+    "de-dtcc": {
+      "state": "de",
+      "slug": "dtcc",
+      "name": "Delaware Technical Community College",
+      "primaryUrl": "dtcc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:13.107Z"
+    },
+    "ga-wiregrass-tech": {
+      "state": "ga",
+      "slug": "wiregrass-tech",
+      "name": "Wiregrass Georgia Technical College",
+      "primaryUrl": "wiregrass.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:18.489Z"
+    },
+    "ga-south-ga-tech": {
+      "state": "ga",
+      "slug": "south-ga-tech",
+      "name": "South Georgia Technical College",
+      "primaryUrl": "southgatech.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:19.118Z"
+    },
+    "tn-jackson-state": {
+      "state": "tn",
+      "slug": "jackson-state",
+      "name": "Jackson State Community College",
+      "primaryUrl": "jscc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:23.484Z"
+    },
+    "tn-motlow-state": {
+      "state": "tn",
+      "slug": "motlow-state",
+      "name": "Motlow State Community College",
+      "primaryUrl": "mscc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:25.817Z"
+    },
+    "ga-north-ga-tech": {
+      "state": "ga",
+      "slug": "north-ga-tech",
+      "name": "North Georgia Technical College",
+      "primaryUrl": "northgatech.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:26.369Z"
+    },
+    "tn-northeast-state": {
+      "state": "tn",
+      "slug": "northeast-state",
+      "name": "Northeast State Community College",
+      "primaryUrl": "northeaststate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:32.205Z"
+    },
+    "tn-nashville-state": {
+      "state": "tn",
+      "slug": "nashville-state",
+      "name": "Nashville State Community College",
+      "primaryUrl": "nscc.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:33.856Z"
+    },
+    "tn-chattanooga-state": {
+      "state": "tn",
+      "slug": "chattanooga-state",
+      "name": "Chattanooga State Community College",
+      "primaryUrl": "chattanoogastate.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:34.535Z"
+    },
+    "tn-cleveland-state": {
+      "state": "tn",
+      "slug": "cleveland-state",
+      "name": "Cleveland State Community College",
+      "primaryUrl": "clevelandstatecc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:38.068Z"
+    },
+    "tn-volunteer-state": {
+      "state": "tn",
+      "slug": "volunteer-state",
+      "name": "Volunteer State Community College",
+      "primaryUrl": "volstate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:41.500Z"
+    },
+    "tn-columbia-state": {
+      "state": "tn",
+      "slug": "columbia-state",
+      "name": "Columbia State Community College",
+      "primaryUrl": "columbiastate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:42.791Z"
+    },
+    "tn-pellissippi-state": {
+      "state": "tn",
+      "slug": "pellissippi-state",
+      "name": "Pellissippi State Community College",
+      "primaryUrl": "pstcc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:43.813Z"
+    },
+    "ga-southeastern-tech": {
+      "state": "ga",
+      "slug": "southeastern-tech",
+      "name": "Southeastern Technical College",
+      "primaryUrl": "southeasterntech.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:46.442Z"
+    },
+    "ny-bmcc": {
+      "state": "ny",
+      "slug": "bmcc",
+      "name": "Borough of Manhattan Community College",
+      "primaryUrl": "bmcc.cuny.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:46.790Z"
+    },
+    "tn-dyersburg-state": {
+      "state": "tn",
+      "slug": "dyersburg-state",
+      "name": "Dyersburg State Community College",
+      "primaryUrl": "dscc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:39:50.366Z"
+    },
+    "ny-kingsborough-cc": {
+      "state": "ny",
+      "slug": "kingsborough-cc",
+      "name": "Kingsborough Community College",
+      "primaryUrl": "kbcc.cuny.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:55.583Z"
+    },
+    "ny-guttman-cc": {
+      "state": "ny",
+      "slug": "guttman-cc",
+      "name": "Stella and Charles Guttman Community College",
+      "primaryUrl": "guttman.cuny.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:57.780Z"
+    },
+    "ny-queensborough-cc": {
+      "state": "ny",
+      "slug": "queensborough-cc",
+      "name": "Queensborough Community College",
+      "primaryUrl": "qcc.cuny.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:39:59.308Z"
+    },
+    "ga-savannah-tech": {
+      "state": "ga",
+      "slug": "savannah-tech",
+      "name": "Savannah Technical College",
+      "primaryUrl": "savannahtech.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:05.120Z"
+    },
+    "ri-ccri": {
+      "state": "ri",
+      "slug": "ccri",
+      "name": "Community College of Rhode Island",
+      "primaryUrl": "ccri.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:40:06.096Z"
+    },
+    "tn-walters-state": {
+      "state": "tn",
+      "slug": "walters-state",
+      "name": "Walters State Community College",
+      "primaryUrl": "ws.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:40:07.642Z"
+    },
+    "me-cmcc": {
+      "state": "me",
+      "slug": "cmcc",
+      "name": "Central Maine Community College",
+      "primaryUrl": "cmcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:12.457Z"
+    },
+    "ct-ct-state": {
+      "state": "ct",
+      "slug": "ct-state",
+      "name": "CT State Community College",
+      "primaryUrl": "ctstate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:40:15.112Z"
+    },
+    "ny-hostos-cc": {
+      "state": "ny",
+      "slug": "hostos-cc",
+      "name": "Eugenio María de Hostos Community College",
+      "primaryUrl": "hostos.cuny.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:18.640Z"
+    },
+    "ny-laguardia-cc": {
+      "state": "ny",
+      "slug": "laguardia-cc",
+      "name": "Fiorello H. LaGuardia Community College",
+      "primaryUrl": "lagcc.cuny.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:19.154Z"
+    },
+    "ny-bronx-cc": {
+      "state": "ny",
+      "slug": "bronx-cc",
+      "name": "Bronx Community College",
+      "primaryUrl": "bcc.cuny.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:19.692Z"
+    },
+    "me-kvcc": {
+      "state": "me",
+      "slug": "kvcc",
+      "name": "Kennebec Valley Community College",
+      "primaryUrl": "kvcc.me.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:24.227Z"
+    },
+    "me-wccc": {
+      "state": "me",
+      "slug": "wccc",
+      "name": "Washington County Community College",
+      "primaryUrl": "wccc.me.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:33.183Z"
+    },
+    "me-emcc": {
+      "state": "me",
+      "slug": "emcc",
+      "name": "Eastern Maine Community College",
+      "primaryUrl": "emcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:40.620Z"
+    },
+    "vt-ccv": {
+      "state": "vt",
+      "slug": "ccv",
+      "name": "Community College of Vermont",
+      "primaryUrl": "ccv.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:49.162Z"
+    },
+    "me-nmcc": {
+      "state": "me",
+      "slug": "nmcc",
+      "name": "Northern Maine Community College",
+      "primaryUrl": "nmcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:51.333Z"
+    },
+    "me-smcc": {
+      "state": "me",
+      "slug": "smcc",
+      "name": "Southern Maine Community College",
+      "primaryUrl": "smccme.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:40:55.067Z"
+    },
+    "pa-ccbc": {
+      "state": "pa",
+      "slug": "ccbc",
+      "name": "Community College of Beaver County",
+      "primaryUrl": "ccbc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:40:57.801Z"
+    },
+    "pa-ccp": {
+      "state": "pa",
+      "slug": "ccp",
+      "name": "Community College of Philadelphia",
+      "primaryUrl": "ccp.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:41:03.229Z"
+    },
+    "pa-hacc": {
+      "state": "pa",
+      "slug": "hacc",
+      "name": "Harrisburg Area Community College",
+      "primaryUrl": "hacc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:03.531Z"
+    },
+    "pa-luzerne": {
+      "state": "pa",
+      "slug": "luzerne",
+      "name": "Luzerne County Community College",
+      "primaryUrl": "luzerne.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:08.225Z"
+    },
+    "pa-ccac": {
+      "state": "pa",
+      "slug": "ccac",
+      "name": "Community College of Allegheny County",
+      "primaryUrl": "ccac.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:17.012Z"
+    },
+    "pa-dccc": {
+      "state": "pa",
+      "slug": "dccc",
+      "name": "Delaware County Community College",
+      "primaryUrl": "dccc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:23.830Z"
+    },
+    "pa-northampton": {
+      "state": "pa",
+      "slug": "northampton",
+      "name": "Northampton Community College",
+      "primaryUrl": "northampton.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:24.032Z"
+    },
+    "me-yccc": {
+      "state": "me",
+      "slug": "yccc",
+      "name": "York County Community College",
+      "primaryUrl": "yccc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:41:28.963Z"
+    },
+    "pa-lccc": {
+      "state": "pa",
+      "slug": "lccc",
+      "name": "Lehigh Carbon Community College",
+      "primaryUrl": "lccc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:29.438Z"
+    },
+    "pa-racc": {
+      "state": "pa",
+      "slug": "racc",
+      "name": "Reading Area Community College",
+      "primaryUrl": "racc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:29.993Z"
+    },
+    "pa-mc3": {
+      "state": "pa",
+      "slug": "mc3",
+      "name": "Montgomery County Community College",
+      "primaryUrl": "mc3.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:37.767Z"
+    },
+    "nj-atlantic-cape": {
+      "state": "nj",
+      "slug": "atlantic-cape",
+      "name": "Atlantic Cape Community College",
+      "primaryUrl": "atlanticcape.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:38.845Z"
+    },
+    "pa-bucks": {
+      "state": "pa",
+      "slug": "bucks",
+      "name": "Bucks County Community College",
+      "primaryUrl": "bucks.edu",
+      "platform": "workday",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:45.822Z"
+    },
+    "pa-butler": {
+      "state": "pa",
+      "slug": "butler",
+      "name": "Butler County Community College",
+      "primaryUrl": "bc3.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:41:48.965Z"
+    },
+    "pa-penn-college": {
+      "state": "pa",
+      "slug": "penn-college",
+      "name": "Pennsylvania College of Technology",
+      "primaryUrl": "pct.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:49.318Z"
+    },
+    "pa-pa-highlands": {
+      "state": "pa",
+      "slug": "pa-highlands",
+      "name": "Pennsylvania Highlands Community College",
+      "primaryUrl": "pennhighlands.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:49.843Z"
+    },
+    "nj-bergen": {
+      "state": "nj",
+      "slug": "bergen",
+      "name": "Bergen Community College",
+      "primaryUrl": "bergen.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:53.006Z"
+    },
+    "nj-hccc": {
+      "state": "nj",
+      "slug": "hccc",
+      "name": "Hudson County Community College",
+      "primaryUrl": "hccc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:41:57.874Z"
+    },
+    "nj-mercer": {
+      "state": "nj",
+      "slug": "mercer",
+      "name": "Mercer County Community College",
+      "primaryUrl": "mccc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:01.298Z"
+    },
+    "nj-brookdale": {
+      "state": "nj",
+      "slug": "brookdale",
+      "name": "Brookdale Community College",
+      "primaryUrl": "brookdalecc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:03.393Z"
+    },
+    "nj-middlesex": {
+      "state": "nj",
+      "slug": "middlesex",
+      "name": "Middlesex College",
+      "primaryUrl": "middlesexcollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:03.957Z"
+    },
+    "nj-ccm": {
+      "state": "nj",
+      "slug": "ccm",
+      "name": "County College of Morris",
+      "primaryUrl": "ccm.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:06.438Z"
+    },
+    "nj-camden": {
+      "state": "nj",
+      "slug": "camden",
+      "name": "Camden County College",
+      "primaryUrl": "camdencc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:06.731Z"
+    },
+    "nj-rcsj-cumberland": {
+      "state": "nj",
+      "slug": "rcsj-cumberland",
+      "name": "Rowan College of South Jersey - Cumberland Campus",
+      "primaryUrl": "rcsj.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:12.862Z"
+    },
+    "nj-passaic": {
+      "state": "nj",
+      "slug": "passaic",
+      "name": "Passaic County Community College",
+      "primaryUrl": "web.pccc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:14.310Z"
+    },
+    "nj-rcsj-gloucester": {
+      "state": "nj",
+      "slug": "rcsj-gloucester",
+      "name": "Rowan College of South Jersey - Gloucester Campus",
+      "primaryUrl": "rcsj.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:15.270Z"
+    },
+    "nj-salem": {
+      "state": "nj",
+      "slug": "salem",
+      "name": "Salem Community College",
+      "primaryUrl": "salemcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:17.491Z"
+    },
+    "pa-westmoreland": {
+      "state": "pa",
+      "slug": "westmoreland",
+      "name": "Westmoreland County Community College",
+      "primaryUrl": "westmoreland.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:21.646Z"
+    },
+    "nj-rvcc": {
+      "state": "nj",
+      "slug": "rvcc",
+      "name": "Raritan Valley Community College",
+      "primaryUrl": "raritanval.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:32.939Z"
+    },
+    "nj-rcbc": {
+      "state": "nj",
+      "slug": "rcbc",
+      "name": "Rowan College at Burlington County",
+      "primaryUrl": "rcbc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:36.116Z"
+    },
+    "nj-warren": {
+      "state": "nj",
+      "slug": "warren",
+      "name": "Warren County Community College",
+      "primaryUrl": "warren.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:43.792Z"
+    },
+    "nj-ucnj": {
+      "state": "nj",
+      "slug": "ucnj",
+      "name": "UCNJ Union College",
+      "primaryUrl": "ucc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:42:48.148Z"
+    },
+    "nh-gbcc": {
+      "state": "nh",
+      "slug": "gbcc",
+      "name": "Great Bay Community College",
+      "primaryUrl": "greatbay.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:48.342Z"
+    },
+    "nh-lrcc": {
+      "state": "nh",
+      "slug": "lrcc",
+      "name": "Lakes Region Community College",
+      "primaryUrl": "lrcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:42:49.066Z"
+    },
+    "nj-ocean": {
+      "state": "nj",
+      "slug": "ocean",
+      "name": "Ocean County College",
+      "primaryUrl": "ocean.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:00.474Z"
+    },
+    "nh-nashuacc": {
+      "state": "nh",
+      "slug": "nashuacc",
+      "name": "Nashua Community College",
+      "primaryUrl": "nashuacc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:43:07.315Z"
+    },
+    "nj-sussex": {
+      "state": "nj",
+      "slug": "sussex",
+      "name": "Sussex County Community College",
+      "primaryUrl": "sussex.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:07.907Z"
+    },
+    "nh-mccnh": {
+      "state": "nh",
+      "slug": "mccnh",
+      "name": "Manchester Community College",
+      "primaryUrl": "mccnh.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:08.777Z"
+    },
+    "nj-essex": {
+      "state": "nj",
+      "slug": "essex",
+      "name": "Essex County College",
+      "primaryUrl": "essex.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:09.143Z"
+    },
+    "ma-bhcc": {
+      "state": "ma",
+      "slug": "bhcc",
+      "name": "Bunker Hill Community College",
+      "primaryUrl": "bhcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:18.974Z"
+    },
+    "ma-bristol": {
+      "state": "ma",
+      "slug": "bristol",
+      "name": "Bristol Community College",
+      "primaryUrl": "bristolcc.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:21.511Z"
+    },
+    "nh-rvcc": {
+      "state": "nh",
+      "slug": "rvcc",
+      "name": "River Valley Community College",
+      "primaryUrl": "rivervalley.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:43:22.861Z"
+    },
+    "nh-wmcc": {
+      "state": "nh",
+      "slug": "wmcc",
+      "name": "White Mountains Community College",
+      "primaryUrl": "wmcc.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:25.368Z"
+    },
+    "ma-capecod": {
+      "state": "ma",
+      "slug": "capecod",
+      "name": "Cape Cod Community College",
+      "primaryUrl": "capecod.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:26.211Z"
+    },
+    "ma-gcc": {
+      "state": "ma",
+      "slug": "gcc",
+      "name": "Greenfield Community College",
+      "primaryUrl": "gcc.mass.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:27.826Z"
+    },
+    "ma-massbay": {
+      "state": "ma",
+      "slug": "massbay",
+      "name": "MassBay Community College",
+      "primaryUrl": "massbay.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:43:27.984Z"
+    },
+    "ma-hcc": {
+      "state": "ma",
+      "slug": "hcc",
+      "name": "Holyoke Community College",
+      "primaryUrl": "hcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:43:33.442Z"
+    },
+    "ma-massasoit": {
+      "state": "ma",
+      "slug": "massasoit",
+      "name": "Massasoit Community College",
+      "primaryUrl": "massasoit.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:35.194Z"
+    },
+    "ma-northshore": {
+      "state": "ma",
+      "slug": "northshore",
+      "name": "North Shore Community College",
+      "primaryUrl": "northshore.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:36.094Z"
+    },
+    "ma-rcc": {
+      "state": "ma",
+      "slug": "rcc",
+      "name": "Roxbury Community College",
+      "primaryUrl": "rcc.mass.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:40.673Z"
+    },
+    "ma-qcc": {
+      "state": "ma",
+      "slug": "qcc",
+      "name": "Quinsigamond Community College",
+      "primaryUrl": "qcc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:40.734Z"
+    },
+    "ma-stcc": {
+      "state": "ma",
+      "slug": "stcc",
+      "name": "Springfield Technical Community College",
+      "primaryUrl": "stcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:44.399Z"
+    },
+    "wv-bridgevalley": {
+      "state": "wv",
+      "slug": "bridgevalley",
+      "name": "BridgeValley Community and Technical College",
+      "primaryUrl": "bridgevalley.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:43:47.124Z"
+    },
+    "nh-nhti": {
+      "state": "nh",
+      "slug": "nhti",
+      "name": "NHTI, Concord's Community College",
+      "primaryUrl": "nhti.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:47.219Z"
+    },
+    "wv-mountwest": {
+      "state": "wv",
+      "slug": "mountwest",
+      "name": "Mountwest Community and Technical College",
+      "primaryUrl": "mctc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:51.187Z"
+    },
+    "ma-middlesex": {
+      "state": "ma",
+      "slug": "middlesex",
+      "name": "Middlesex Community College",
+      "primaryUrl": "middlesex.mass.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:56.740Z"
+    },
+    "ma-mwcc": {
+      "state": "ma",
+      "slug": "mwcc",
+      "name": "Mount Wachusett Community College",
+      "primaryUrl": "mwcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:43:58.826Z"
+    },
+    "ma-berkshire": {
+      "state": "ma",
+      "slug": "berkshire",
+      "name": "Berkshire Community College",
+      "primaryUrl": "berkshirecc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:59.255Z"
+    },
+    "wv-newriver": {
+      "state": "wv",
+      "slug": "newriver",
+      "name": "New River Community and Technical College",
+      "primaryUrl": "newriver.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:43:59.379Z"
+    },
+    "wv-blueridge": {
+      "state": "wv",
+      "slug": "blueridge",
+      "name": "Blue Ridge Community and Technical College",
+      "primaryUrl": "blueridgectc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:44:01.609Z"
+    },
+    "ma-necc": {
+      "state": "ma",
+      "slug": "necc",
+      "name": "Northern Essex Community College",
+      "primaryUrl": "necc.mass.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:44:01.838Z"
+    },
+    "fl-broward": {
+      "state": "fl",
+      "slug": "broward",
+      "name": "Broward College",
+      "primaryUrl": "broward.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:44:06.857Z"
+    },
+    "wv-wvncc": {
+      "state": "wv",
+      "slug": "wvncc",
+      "name": "West Virginia Northern Community College",
+      "primaryUrl": "wvncc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:08.839Z"
+    },
+    "fl-chipola": {
+      "state": "fl",
+      "slug": "chipola",
+      "name": "Chipola College",
+      "primaryUrl": "chipola.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:44:12.089Z"
+    },
+    "wv-southern": {
+      "state": "wv",
+      "slug": "southern",
+      "name": "Southern West Virginia Community and Technical College",
+      "primaryUrl": "southernwv.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:17.791Z"
+    },
+    "fl-daytonastate": {
+      "state": "fl",
+      "slug": "daytonastate",
+      "name": "Daytona State College",
+      "primaryUrl": "daytonastate.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:18.778Z"
+    },
+    "fl-easternflorida": {
+      "state": "fl",
+      "slug": "easternflorida",
+      "name": "Eastern Florida State College",
+      "primaryUrl": "easternflorida.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:44:19.406Z"
+    },
+    "fl-fgc": {
+      "state": "fl",
+      "slug": "fgc",
+      "name": "Florida Gateway College",
+      "primaryUrl": "fgc.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:21.542Z"
+    },
+    "wv-pierpont": {
+      "state": "wv",
+      "slug": "pierpont",
+      "name": "Pierpont Community and Technical College",
+      "primaryUrl": "pierpont.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:22.196Z"
+    },
+    "fl-cfk": {
+      "state": "fl",
+      "slug": "cfk",
+      "name": "The College of the Florida Keys",
+      "primaryUrl": "cfk.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:28.839Z"
+    },
+    "wv-eastern": {
+      "state": "wv",
+      "slug": "eastern",
+      "name": "Eastern West Virginia Community and Technical College",
+      "primaryUrl": "easternwv.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:29.748Z"
+    },
+    "fl-gulfcoast": {
+      "state": "fl",
+      "slug": "gulfcoast",
+      "name": "Gulf Coast State College",
+      "primaryUrl": "gulfcoast.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:30.611Z"
+    },
+    "fl-mdc": {
+      "state": "fl",
+      "slug": "mdc",
+      "name": "Miami Dade College",
+      "primaryUrl": "mdc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:38.843Z"
+    },
+    "fl-cf": {
+      "state": "fl",
+      "slug": "cf",
+      "name": "College of Central Florida",
+      "primaryUrl": "cf.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:44:46.265Z"
+    },
+    "fl-fscj": {
+      "state": "fl",
+      "slug": "fscj",
+      "name": "Florida State College at Jacksonville",
+      "primaryUrl": "fscj.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:54.524Z"
+    },
+    "fl-lssc": {
+      "state": "fl",
+      "slug": "lssc",
+      "name": "Lake-Sumter State College",
+      "primaryUrl": "lssc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:56.131Z"
+    },
+    "fl-fsw": {
+      "state": "fl",
+      "slug": "fsw",
+      "name": "Florida SouthWestern State College",
+      "primaryUrl": "fsw.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:59.046Z"
+    },
+    "fl-palmbeachstate": {
+      "state": "fl",
+      "slug": "palmbeachstate",
+      "name": "Palm Beach State College",
+      "primaryUrl": "palmbeachstate.edu",
+      "platform": "workday",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:44:59.955Z"
+    },
+    "fl-irsc": {
+      "state": "fl",
+      "slug": "irsc",
+      "name": "Indian River State College",
+      "primaryUrl": "irsc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:00.713Z"
+    },
+    "fl-pensacolastate": {
+      "state": "fl",
+      "slug": "pensacolastate",
+      "name": "Pensacola State College",
+      "primaryUrl": "pensacolastate.edu",
+      "platform": "workday",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:06.713Z"
+    },
+    "fl-sfcollege": {
+      "state": "fl",
+      "slug": "sfcollege",
+      "name": "Santa Fe College",
+      "primaryUrl": "sfcollege.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:45:07.235Z"
+    },
+    "fl-phsc": {
+      "state": "fl",
+      "slug": "phsc",
+      "name": "Pasco-Hernando State College",
+      "primaryUrl": "phsc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:08.996Z"
+    },
+    "fl-nfc": {
+      "state": "fl",
+      "slug": "nfc",
+      "name": "North Florida College",
+      "primaryUrl": "nfc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:45:10.504Z"
+    },
+    "fl-polk": {
+      "state": "fl",
+      "slug": "polk",
+      "name": "Polk State College",
+      "primaryUrl": "polk.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:10.674Z"
+    },
+    "fl-hccfl": {
+      "state": "fl",
+      "slug": "hccfl",
+      "name": "Hillsborough Community College",
+      "primaryUrl": "hccfl.edu",
+      "platform": "workday",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:19.118Z"
+    },
+    "fl-seminolestate": {
+      "state": "fl",
+      "slug": "seminolestate",
+      "name": "Seminole State College of Florida",
+      "primaryUrl": "seminolestate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:45:20.189Z"
+    },
+    "fl-sjrstate": {
+      "state": "fl",
+      "slug": "sjrstate",
+      "name": "St. Johns River State College",
+      "primaryUrl": "sjrstate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:21.499Z"
+    },
+    "fl-southflorida": {
+      "state": "fl",
+      "slug": "southflorida",
+      "name": "South Florida State College",
+      "primaryUrl": "southflorida.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:24.443Z"
+    },
+    "fl-valencia": {
+      "state": "fl",
+      "slug": "valencia",
+      "name": "Valencia College",
+      "primaryUrl": "valenciacollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:28.095Z"
+    },
+    "ky-ashland-community-and-technical-college": {
+      "state": "ky",
+      "slug": "ashland-community-and-technical-college",
+      "name": "Ashland Community and Technical College",
+      "primaryUrl": "ashland.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:29.122Z"
+    },
+    "ky-southcentral-kentucky-community-and-technical-college": {
+      "state": "ky",
+      "slug": "southcentral-kentucky-community-and-technical-college",
+      "name": "Southcentral Kentucky Community and Technical College",
+      "primaryUrl": "southcentral.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:31.281Z"
+    },
+    "fl-nwfsc": {
+      "state": "fl",
+      "slug": "nwfsc",
+      "name": "Northwest Florida State College",
+      "primaryUrl": "nwfsc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:35.356Z"
+    },
+    "ky-bluegrass-community-and-technical-college": {
+      "state": "ky",
+      "slug": "bluegrass-community-and-technical-college",
+      "name": "Bluegrass Community and Technical College",
+      "primaryUrl": "bluegrass.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:35.397Z"
+    },
+    "ky-elizabethtown-community-and-technical-college": {
+      "state": "ky",
+      "slug": "elizabethtown-community-and-technical-college",
+      "name": "Elizabethtown Community and Technical College",
+      "primaryUrl": "elizabethtown.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:37.875Z"
+    },
+    "ky-hazard-community-and-technical-college": {
+      "state": "ky",
+      "slug": "hazard-community-and-technical-college",
+      "name": "Hazard Community and Technical College",
+      "primaryUrl": "hazard.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:39.029Z"
+    },
+    "ky-hopkinsville-community-college": {
+      "state": "ky",
+      "slug": "hopkinsville-community-college",
+      "name": "Hopkinsville Community College",
+      "primaryUrl": "hopkinsville.kctcs.edu/index.aspx",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:45.185Z"
+    },
+    "ky-henderson-community-college": {
+      "state": "ky",
+      "slug": "henderson-community-college",
+      "name": "Henderson Community College",
+      "primaryUrl": "henderson.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:46.531Z"
+    },
+    "ky-jefferson-community-and-technical-college": {
+      "state": "ky",
+      "slug": "jefferson-community-and-technical-college",
+      "name": "Jefferson Community and Technical College",
+      "primaryUrl": "jefferson.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:48.322Z"
+    },
+    "ky-madisonville-community-college": {
+      "state": "ky",
+      "slug": "madisonville-community-college",
+      "name": "Madisonville Community College",
+      "primaryUrl": "madisonville.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:49.701Z"
+    },
+    "fl-scf": {
+      "state": "fl",
+      "slug": "scf",
+      "name": "State College of Florida, Manatee-Sarasota",
+      "primaryUrl": "scf.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:49.703Z"
+    },
+    "fl-tcc-fl": {
+      "state": "fl",
+      "slug": "tcc-fl",
+      "name": "Tallahassee Community College",
+      "primaryUrl": "tcc.fl.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:45:51.220Z"
+    },
+    "ky-maysville-community-and-technical-college": {
+      "state": "ky",
+      "slug": "maysville-community-and-technical-college",
+      "name": "Maysville Community and Technical College",
+      "primaryUrl": "maysville.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:57.066Z"
+    },
+    "ky-gateway-community-and-technical-college": {
+      "state": "ky",
+      "slug": "gateway-community-and-technical-college",
+      "name": "Gateway Community and Technical College",
+      "primaryUrl": "gateway.kctcs.edu/index.aspx",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:45:58.597Z"
+    },
+    "ky-west-kentucky-community-and-technical-college": {
+      "state": "ky",
+      "slug": "west-kentucky-community-and-technical-college",
+      "name": "West Kentucky Community and Technical College",
+      "primaryUrl": "westkentucky.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:03.026Z"
+    },
+    "ky-big-sandy-community-and-technical-college": {
+      "state": "ky",
+      "slug": "big-sandy-community-and-technical-college",
+      "name": "Big Sandy Community and Technical College",
+      "primaryUrl": "bigsandy.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:04.628Z"
+    },
+    "ky-somerset-community-college": {
+      "state": "ky",
+      "slug": "somerset-community-college",
+      "name": "Somerset Community College",
+      "primaryUrl": "somerset.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:04.701Z"
+    },
+    "ky-southeast-kentucky-community-and-technical-college": {
+      "state": "ky",
+      "slug": "southeast-kentucky-community-and-technical-college",
+      "name": "Southeast Kentucky Community & Technical College",
+      "primaryUrl": "southeast.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:05.304Z"
+    },
+    "ky-owensboro-community-and-technical-college": {
+      "state": "ky",
+      "slug": "owensboro-community-and-technical-college",
+      "name": "Owensboro Community and Technical College",
+      "primaryUrl": "owensboro.kctcs.edu",
+      "platform": "peoplesoft",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:06.952Z"
+    },
+    "fl-spcollege": {
+      "state": "fl",
+      "slug": "spcollege",
+      "name": "St. Petersburg College",
+      "primaryUrl": "spcollege.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:46:07.164Z"
+    },
+    "al-coastal-alabama-community-college": {
+      "state": "al",
+      "slug": "coastal-alabama-community-college",
+      "name": "Coastal Alabama Community College",
+      "primaryUrl": "coastalalabama.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:16.997Z"
+    },
+    "al-chattahoochee-valley-community-college": {
+      "state": "al",
+      "slug": "chattahoochee-valley-community-college",
+      "name": "Chattahoochee Valley Community College",
+      "primaryUrl": "cv.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:46:26.038Z"
+    },
+    "al-george-c-wallace-state-community-college-selma": {
+      "state": "al",
+      "slug": "george-c-wallace-state-community-college-selma",
+      "name": "George C Wallace State Community College-Selma",
+      "primaryUrl": "wccs.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:46:29.597Z"
+    },
+    "al-enterprise-state-community-college": {
+      "state": "al",
+      "slug": "enterprise-state-community-college",
+      "name": "Enterprise State Community College",
+      "primaryUrl": "escc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:46:40.497Z"
+    },
+    "al-gadsden-state-community-college": {
+      "state": "al",
+      "slug": "gadsden-state-community-college",
+      "name": "Gadsden State Community College",
+      "primaryUrl": "gadsdenstate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:40.861Z"
+    },
+    "al-jefferson-state-community-college": {
+      "state": "al",
+      "slug": "jefferson-state-community-college",
+      "name": "Jefferson State Community College",
+      "primaryUrl": "jeffersonstate.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:42.156Z"
+    },
+    "al-lurleen-b-wallace-community-college": {
+      "state": "al",
+      "slug": "lurleen-b-wallace-community-college",
+      "name": "Lurleen B Wallace Community College",
+      "primaryUrl": "lbwcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:46:47.489Z"
+    },
+    "al-marion-military-institute": {
+      "state": "al",
+      "slug": "marion-military-institute",
+      "name": "Marion Military Institute",
+      "primaryUrl": "marionmilitary.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:46:53.769Z"
+    },
+    "al-central-alabama-community-college": {
+      "state": "al",
+      "slug": "central-alabama-community-college",
+      "name": "Central Alabama Community College",
+      "primaryUrl": "cacc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:46:54.207Z"
+    },
+    "al-john-c-calhoun-state-community-college": {
+      "state": "al",
+      "slug": "john-c-calhoun-state-community-college",
+      "name": "John C Calhoun State Community College",
+      "primaryUrl": "calhoun.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:01.111Z"
+    },
+    "al-northeast-alabama-community-college": {
+      "state": "al",
+      "slug": "northeast-alabama-community-college",
+      "name": "Northeast Alabama Community College",
+      "primaryUrl": "nacc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:06.747Z"
+    },
+    "al-lawson-state-community-college": {
+      "state": "al",
+      "slug": "lawson-state-community-college",
+      "name": "Lawson State Community College",
+      "primaryUrl": "lawsonstate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:07.965Z"
+    },
+    "al-george-c-wallace-community-college-dothan": {
+      "state": "al",
+      "slug": "george-c-wallace-community-college-dothan",
+      "name": "George C Wallace Community College-Dothan",
+      "primaryUrl": "wallace.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:13.804Z"
+    },
+    "al-shelton-state-community-college": {
+      "state": "al",
+      "slug": "shelton-state-community-college",
+      "name": "Shelton State Community College",
+      "primaryUrl": "sheltonstate.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:21.118Z"
+    },
+    "al-george-c-wallace-state-community-college-hanceville": {
+      "state": "al",
+      "slug": "george-c-wallace-state-community-college-hanceville",
+      "name": "George C Wallace State Community College-Hanceville",
+      "primaryUrl": "wallacestate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:24.124Z"
+    },
+    "al-bishop-state-community-college": {
+      "state": "al",
+      "slug": "bishop-state-community-college",
+      "name": "Bishop State Community College",
+      "primaryUrl": "bishop.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:27.141Z"
+    },
+    "al-northwest-shoals-community-college": {
+      "state": "al",
+      "slug": "northwest-shoals-community-college",
+      "name": "Northwest Shoals Community College",
+      "primaryUrl": "nwscc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:28.179Z"
+    },
+    "al-reid-state-technical-college": {
+      "state": "al",
+      "slug": "reid-state-technical-college",
+      "name": "Reid State Technical College",
+      "primaryUrl": "rstc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:35.441Z"
+    },
+    "tn-southwest-tn": {
+      "state": "tn",
+      "slug": "southwest-tn",
+      "name": "Southwest Tennessee Community College",
+      "primaryUrl": "southwest.tn.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:37.683Z"
+    },
+    "al-j-f-drake-state-community-and-technical-college": {
+      "state": "al",
+      "slug": "j-f-drake-state-community-and-technical-college",
+      "name": "J. F. Drake State Community and Technical College",
+      "primaryUrl": "drakestate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:38.341Z"
+    },
+    "al-southern-union-state-community-college": {
+      "state": "al",
+      "slug": "southern-union-state-community-college",
+      "name": "Southern Union State Community College",
+      "primaryUrl": "suscc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:38.960Z"
+    },
+    "al-snead-state-community-college": {
+      "state": "al",
+      "slug": "snead-state-community-college",
+      "name": "Snead State Community College",
+      "primaryUrl": "snead.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:40.509Z"
+    },
+    "al-h-councill-trenholm-state-community-college": {
+      "state": "al",
+      "slug": "h-councill-trenholm-state-community-college",
+      "name": "H Councill Trenholm State Community College",
+      "primaryUrl": "trenholmstate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:44.875Z"
+    },
+    "ms-east-central-community-college": {
+      "state": "ms",
+      "slug": "east-central-community-college",
+      "name": "East Central Community College",
+      "primaryUrl": "eccc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:46.509Z"
+    },
+    "ms-copiah-lincoln-community-college": {
+      "state": "ms",
+      "slug": "copiah-lincoln-community-college",
+      "name": "Copiah-Lincoln Community College",
+      "primaryUrl": "colin.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:48.484Z"
+    },
+    "ms-east-mississippi-community-college": {
+      "state": "ms",
+      "slug": "east-mississippi-community-college",
+      "name": "East Mississippi Community College",
+      "primaryUrl": "eastms.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:50.126Z"
+    },
+    "ms-jones-county-junior-college": {
+      "state": "ms",
+      "slug": "jones-county-junior-college",
+      "name": "Jones County Junior College",
+      "primaryUrl": "jcjc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:51.476Z"
+    },
+    "ms-holmes-community-college": {
+      "state": "ms",
+      "slug": "holmes-community-college",
+      "name": "Holmes Community College",
+      "primaryUrl": "holmescc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:47:53.038Z"
+    },
+    "ms-coahoma-community-college": {
+      "state": "ms",
+      "slug": "coahoma-community-college",
+      "name": "Coahoma Community College",
+      "primaryUrl": "coahomacc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:55.951Z"
+    },
+    "ms-mississippi-delta-community-college": {
+      "state": "ms",
+      "slug": "mississippi-delta-community-college",
+      "name": "Mississippi Delta Community College",
+      "primaryUrl": "msdelta.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:47:57.428Z"
+    },
+    "al-bevill-state-community-college": {
+      "state": "al",
+      "slug": "bevill-state-community-college",
+      "name": "Bevill State Community College",
+      "primaryUrl": "bscc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:02.325Z"
+    },
+    "ms-meridian-community-college": {
+      "state": "ms",
+      "slug": "meridian-community-college",
+      "name": "Meridian Community College",
+      "primaryUrl": "meridiancc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:48:06.434Z"
+    },
+    "ms-northwest-mississippi-community-college": {
+      "state": "ms",
+      "slug": "northwest-mississippi-community-college",
+      "name": "Northwest Mississippi Community College",
+      "primaryUrl": "northwestms.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:09.279Z"
+    },
+    "oh-central-ohio-technical-college": {
+      "state": "oh",
+      "slug": "central-ohio-technical-college",
+      "name": "Central Ohio Technical College",
+      "primaryUrl": "cotc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:48:19.485Z"
+    },
+    "ms-pearl-river-community-college": {
+      "state": "ms",
+      "slug": "pearl-river-community-college",
+      "name": "Pearl River Community College",
+      "primaryUrl": "prcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:20.932Z"
+    },
+    "oh-cincinnati-state-technical-and-community-college": {
+      "state": "oh",
+      "slug": "cincinnati-state-technical-and-community-college",
+      "name": "Cincinnati State Technical and Community College",
+      "primaryUrl": "cincinnatistate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:22.455Z"
+    },
+    "ms-southwest-mississippi-community-college": {
+      "state": "ms",
+      "slug": "southwest-mississippi-community-college",
+      "name": "Southwest Mississippi Community College",
+      "primaryUrl": "smcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:22.732Z"
+    },
+    "ms-northeast-mississippi-community-college": {
+      "state": "ms",
+      "slug": "northeast-mississippi-community-college",
+      "name": "Northeast Mississippi Community College",
+      "primaryUrl": "nemcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:23.787Z"
+    },
+    "ms-itawamba-community-college": {
+      "state": "ms",
+      "slug": "itawamba-community-college",
+      "name": "Itawamba Community College",
+      "primaryUrl": "iccms.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:25.410Z"
+    },
+    "ms-mississippi-gulf-coast-community-college": {
+      "state": "ms",
+      "slug": "mississippi-gulf-coast-community-college",
+      "name": "Mississippi Gulf Coast Community College",
+      "primaryUrl": "mgccc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:48:29.181Z"
+    },
+    "oh-clark-state-college": {
+      "state": "oh",
+      "slug": "clark-state-college",
+      "name": "Clark State College",
+      "primaryUrl": "clarkstate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:31.346Z"
+    },
+    "ms-hinds-community-college": {
+      "state": "ms",
+      "slug": "hinds-community-college",
+      "name": "Hinds Community College",
+      "primaryUrl": "hindscc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:48:33.966Z"
+    },
+    "oh-marion-technical-college": {
+      "state": "oh",
+      "slug": "marion-technical-college",
+      "name": "Marion Technical College",
+      "primaryUrl": "mtc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:33.969Z"
+    },
+    "oh-zane-state-college": {
+      "state": "oh",
+      "slug": "zane-state-college",
+      "name": "Zane State College",
+      "primaryUrl": "zanestate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:48:39.128Z"
+    },
+    "oh-james-a-rhodes-state-college": {
+      "state": "oh",
+      "slug": "james-a-rhodes-state-college",
+      "name": "James A. Rhodes State College",
+      "primaryUrl": "rhodesstate.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:48:58.228Z"
+    },
+    "oh-washington-state-community-college": {
+      "state": "oh",
+      "slug": "washington-state-community-college",
+      "name": "Washington State Community College",
+      "primaryUrl": "wscc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:13.902Z"
+    },
+    "oh-sinclair-community-college": {
+      "state": "oh",
+      "slug": "sinclair-community-college",
+      "name": "Sinclair Community College",
+      "primaryUrl": "sinclair.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:15.818Z"
+    },
+    "oh-columbus-state-community-college": {
+      "state": "oh",
+      "slug": "columbus-state-community-college",
+      "name": "Columbus State Community College",
+      "primaryUrl": "cscc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:24.498Z"
+    },
+    "oh-lorain-county-community-college": {
+      "state": "oh",
+      "slug": "lorain-county-community-college",
+      "name": "Lorain County Community College",
+      "primaryUrl": "lorainccc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:49:29.200Z"
+    },
+    "oh-edison-state-community-college": {
+      "state": "oh",
+      "slug": "edison-state-community-college",
+      "name": "Edison State Community College",
+      "primaryUrl": "edisonohio.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:49:31.272Z"
+    },
+    "oh-hocking-college": {
+      "state": "oh",
+      "slug": "hocking-college",
+      "name": "Hocking College",
+      "primaryUrl": "hocking.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:33.036Z"
+    },
+    "oh-lakeland-community-college": {
+      "state": "oh",
+      "slug": "lakeland-community-college",
+      "name": "Lakeland Community College",
+      "primaryUrl": "lakelandcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:49:36.254Z"
+    },
+    "oh-owens-community-college": {
+      "state": "oh",
+      "slug": "owens-community-college",
+      "name": "Owens Community College",
+      "primaryUrl": "owens.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:49:37.009Z"
+    },
+    "oh-belmont-college": {
+      "state": "oh",
+      "slug": "belmont-college",
+      "name": "Belmont College",
+      "primaryUrl": "belmontcollege.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:46.671Z"
+    },
+    "oh-north-central-state-college": {
+      "state": "oh",
+      "slug": "north-central-state-college",
+      "name": "North Central State College",
+      "primaryUrl": "ncstatecollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:48.450Z"
+    },
+    "oh-cuyahoga-community-college-district": {
+      "state": "oh",
+      "slug": "cuyahoga-community-college-district",
+      "name": "Cuyahoga Community College District",
+      "primaryUrl": "tri-c.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:50.666Z"
+    },
+    "oh-terra-state-community-college": {
+      "state": "oh",
+      "slug": "terra-state-community-college",
+      "name": "Terra State Community College",
+      "primaryUrl": "terra.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:51.435Z"
+    },
+    "mi-henry-ford-college": {
+      "state": "mi",
+      "slug": "henry-ford-college",
+      "name": "Henry Ford College",
+      "primaryUrl": "hfcc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:54.651Z"
+    },
+    "mi-northwestern-michigan-college": {
+      "state": "mi",
+      "slug": "northwestern-michigan-college",
+      "name": "Northwestern Michigan College",
+      "primaryUrl": "nmc.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:49:59.192Z"
+    },
+    "mi-bay-mills-community-college": {
+      "state": "mi",
+      "slug": "bay-mills-community-college",
+      "name": "Bay Mills Community College",
+      "primaryUrl": "bmcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:49:59.753Z"
+    },
+    "oh-stark-state-college": {
+      "state": "oh",
+      "slug": "stark-state-college",
+      "name": "Stark State College",
+      "primaryUrl": "starkstate.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:03.766Z"
+    },
+    "oh-northwest-state-community-college": {
+      "state": "oh",
+      "slug": "northwest-state-community-college",
+      "name": "Northwest State Community College",
+      "primaryUrl": "northweststate.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:50:08.326Z"
+    },
+    "mi-bay-de-noc-community-college": {
+      "state": "mi",
+      "slug": "bay-de-noc-community-college",
+      "name": "Bay de Noc Community College",
+      "primaryUrl": "baycollege.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:09.250Z"
+    },
+    "mi-schoolcraft-community-college-district": {
+      "state": "mi",
+      "slug": "schoolcraft-community-college-district",
+      "name": "Schoolcraft Community College District",
+      "primaryUrl": "schoolcraft.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:10.000Z"
+    },
+    "mi-mott-community-college": {
+      "state": "mi",
+      "slug": "mott-community-college",
+      "name": "Mott Community College",
+      "primaryUrl": "mcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:11.656Z"
+    },
+    "oh-southern-state-community-college": {
+      "state": "oh",
+      "slug": "southern-state-community-college",
+      "name": "Southern State Community College",
+      "primaryUrl": "sscc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:50:17.265Z"
+    },
+    "mi-delta-college": {
+      "state": "mi",
+      "slug": "delta-college",
+      "name": "Delta College",
+      "primaryUrl": "delta.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:24.252Z"
+    },
+    "mi-glen-oaks-community-college": {
+      "state": "mi",
+      "slug": "glen-oaks-community-college",
+      "name": "Glen Oaks Community College",
+      "primaryUrl": "glenoaks.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:30.585Z"
+    },
+    "mi-kalamazoo-valley-community-college": {
+      "state": "mi",
+      "slug": "kalamazoo-valley-community-college",
+      "name": "Kalamazoo Valley Community College",
+      "primaryUrl": "kvcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:50:33.586Z"
+    },
+    "mi-alpena-community-college": {
+      "state": "mi",
+      "slug": "alpena-community-college",
+      "name": "Alpena Community College",
+      "primaryUrl": "alpenacc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:36.557Z"
+    },
+    "mi-kellogg-community-college": {
+      "state": "mi",
+      "slug": "kellogg-community-college",
+      "name": "Kellogg Community College",
+      "primaryUrl": "kellogg.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:37.216Z"
+    },
+    "mi-kirtland-community-college": {
+      "state": "mi",
+      "slug": "kirtland-community-college",
+      "name": "Kirtland Community College",
+      "primaryUrl": "kirtland.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:39.984Z"
+    },
+    "mi-lake-michigan-college": {
+      "state": "mi",
+      "slug": "lake-michigan-college",
+      "name": "Lake Michigan College",
+      "primaryUrl": "lakemichigancollege.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:40.301Z"
+    },
+    "mi-mid-michigan-college": {
+      "state": "mi",
+      "slug": "mid-michigan-college",
+      "name": "Mid Michigan College",
+      "primaryUrl": "midmich.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:47.437Z"
+    },
+    "mi-jackson-college": {
+      "state": "mi",
+      "slug": "jackson-college",
+      "name": "Jackson College",
+      "primaryUrl": "jccmi.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:58.738Z"
+    },
+    "mi-gogebic-community-college": {
+      "state": "mi",
+      "slug": "gogebic-community-college",
+      "name": "Gogebic Community College",
+      "primaryUrl": "gogebic.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:50:59.478Z"
+    },
+    "mi-grand-rapids-community-college": {
+      "state": "mi",
+      "slug": "grand-rapids-community-college",
+      "name": "Grand Rapids Community College",
+      "primaryUrl": "grcc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:00.999Z"
+    },
+    "mi-macomb-community-college": {
+      "state": "mi",
+      "slug": "macomb-community-college",
+      "name": "Macomb Community College",
+      "primaryUrl": "macomb.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:01.205Z"
+    },
+    "mi-montcalm-community-college": {
+      "state": "mi",
+      "slug": "montcalm-community-college",
+      "name": "Montcalm Community College",
+      "primaryUrl": "montcalm.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:01.711Z"
+    },
+    "mi-monroe-county-community-college": {
+      "state": "mi",
+      "slug": "monroe-county-community-college",
+      "name": "Monroe County Community College",
+      "primaryUrl": "monroeccc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:51:05.175Z"
+    },
+    "mi-north-central-michigan-college": {
+      "state": "mi",
+      "slug": "north-central-michigan-college",
+      "name": "North Central Michigan College",
+      "primaryUrl": "ncmich.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:10.662Z"
+    },
+    "mi-southwestern-michigan-college": {
+      "state": "mi",
+      "slug": "southwestern-michigan-college",
+      "name": "Southwestern Michigan College",
+      "primaryUrl": "swmich.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:12.279Z"
+    },
+    "mi-lansing-community-college": {
+      "state": "mi",
+      "slug": "lansing-community-college",
+      "name": "Lansing Community College",
+      "primaryUrl": "lcc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:12.714Z"
+    },
+    "mi-oakland-community-college": {
+      "state": "mi",
+      "slug": "oakland-community-college",
+      "name": "Oakland Community College",
+      "primaryUrl": "oaklandcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:12.797Z"
+    },
+    "mi-wayne-county-community-college-district": {
+      "state": "mi",
+      "slug": "wayne-county-community-college-district",
+      "name": "Wayne County Community College District",
+      "primaryUrl": "wcccd.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:19.308Z"
+    },
+    "mi-washtenaw-community-college": {
+      "state": "mi",
+      "slug": "washtenaw-community-college",
+      "name": "Washtenaw Community College",
+      "primaryUrl": "wccnet.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:20.446Z"
+    },
+    "mi-saginaw-chippewa-tribal-college": {
+      "state": "mi",
+      "slug": "saginaw-chippewa-tribal-college",
+      "name": "Saginaw Chippewa Tribal College",
+      "primaryUrl": "sagchip.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:51:24.522Z"
+    },
+    "ia-des-moines-area-community-college": {
+      "state": "ia",
+      "slug": "des-moines-area-community-college",
+      "name": "Des Moines Area Community College",
+      "primaryUrl": "dmacc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:51:25.894Z"
+    },
+    "ia-ellsworth-community-college": {
+      "state": "ia",
+      "slug": "ellsworth-community-college",
+      "name": "Ellsworth Community College",
+      "primaryUrl": "ecc.iavalley.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:29.977Z"
+    },
+    "mi-keweenaw-bay-ojibwa-community-college": {
+      "state": "mi",
+      "slug": "keweenaw-bay-ojibwa-community-college",
+      "name": "Keweenaw Bay Ojibwa Community College",
+      "primaryUrl": "kbocc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:33.898Z"
+    },
+    "ia-hawkeye-community-college": {
+      "state": "ia",
+      "slug": "hawkeye-community-college",
+      "name": "Hawkeye Community College",
+      "primaryUrl": "hawkeyecollege.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:51:36.016Z"
+    },
+    "ia-eastern-iowa-community-college-district": {
+      "state": "ia",
+      "slug": "eastern-iowa-community-college-district",
+      "name": "Eastern Iowa Community College District",
+      "primaryUrl": "eicc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:40.217Z"
+    },
+    "mi-west-shore-community-college": {
+      "state": "mi",
+      "slug": "west-shore-community-college",
+      "name": "West Shore Community College",
+      "primaryUrl": "westshore.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:46.120Z"
+    },
+    "ia-marshalltown-community-college": {
+      "state": "ia",
+      "slug": "marshalltown-community-college",
+      "name": "Marshalltown Community College",
+      "primaryUrl": "mcc.iavalley.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:49.053Z"
+    },
+    "ia-iowa-western-community-college": {
+      "state": "ia",
+      "slug": "iowa-western-community-college",
+      "name": "Iowa Western Community College",
+      "primaryUrl": "iwcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:54.963Z"
+    },
+    "mi-muskegon-community-college": {
+      "state": "mi",
+      "slug": "muskegon-community-college",
+      "name": "Muskegon Community College",
+      "primaryUrl": "muskegoncc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:57.521Z"
+    },
+    "mi-st-clair-county-community-college": {
+      "state": "mi",
+      "slug": "st-clair-county-community-college",
+      "name": "St Clair County Community College",
+      "primaryUrl": "sc4.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:51:57.827Z"
+    },
+    "ia-indian-hills-community-college": {
+      "state": "ia",
+      "slug": "indian-hills-community-college",
+      "name": "Indian Hills Community College",
+      "primaryUrl": "indianhills.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:00.817Z"
+    },
+    "ia-southeastern-community-college": {
+      "state": "ia",
+      "slug": "southeastern-community-college",
+      "name": "Southeastern Community College",
+      "primaryUrl": "scciowa.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:03.496Z"
+    },
+    "ia-southwestern-community-college": {
+      "state": "ia",
+      "slug": "southwestern-community-college",
+      "name": "Southwestern Community College",
+      "primaryUrl": "swcciowa.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:07.049Z"
+    },
+    "ia-kirkwood-community-college": {
+      "state": "ia",
+      "slug": "kirkwood-community-college",
+      "name": "Kirkwood Community College",
+      "primaryUrl": "kirkwood.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:09.127Z"
+    },
+    "tx-brazosport-college": {
+      "state": "tx",
+      "slug": "brazosport-college",
+      "name": "Brazosport College",
+      "primaryUrl": "brazosport.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:52:18.887Z"
+    },
+    "ia-iowa-central-community-college": {
+      "state": "ia",
+      "slug": "iowa-central-community-college",
+      "name": "Iowa Central Community College",
+      "primaryUrl": "iowacentral.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:18.889Z"
+    },
+    "ia-northeast-iowa-community-college": {
+      "state": "ia",
+      "slug": "northeast-iowa-community-college",
+      "name": "Northeast Iowa Community College",
+      "primaryUrl": "nicc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:27.464Z"
+    },
+    "tx-dallas-college": {
+      "state": "tx",
+      "slug": "dallas-college",
+      "name": "Dallas College",
+      "primaryUrl": "dallascollege.edu/pages/default.aspx",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:28.603Z"
+    },
+    "ia-western-iowa-tech-community-college": {
+      "state": "ia",
+      "slug": "western-iowa-tech-community-college",
+      "name": "Western Iowa Tech Community College",
+      "primaryUrl": "witcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:52:35.442Z"
+    },
+    "tx-galveston-college": {
+      "state": "tx",
+      "slug": "galveston-college",
+      "name": "Galveston College",
+      "primaryUrl": "gc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:37.016Z"
+    },
+    "ia-north-iowa-area-community-college": {
+      "state": "ia",
+      "slug": "north-iowa-area-community-college",
+      "name": "North Iowa Area Community College",
+      "primaryUrl": "niacc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:52:37.507Z"
+    },
+    "tx-grayson-college": {
+      "state": "tx",
+      "slug": "grayson-college",
+      "name": "Grayson College",
+      "primaryUrl": "grayson.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:52:41.572Z"
+    },
+    "tx-austin-community-college-district": {
+      "state": "tx",
+      "slug": "austin-community-college-district",
+      "name": "Austin Community College District",
+      "primaryUrl": "austincc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:52:47.137Z"
+    },
+    "tx-trinity-valley-community-college": {
+      "state": "tx",
+      "slug": "trinity-valley-community-college",
+      "name": "Trinity Valley Community College",
+      "primaryUrl": "tvcc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:50.076Z"
+    },
+    "tx-laredo-college": {
+      "state": "tx",
+      "slug": "laredo-college",
+      "name": "Laredo College",
+      "primaryUrl": "laredo.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:52:50.080Z"
+    },
+    "tx-del-mar-college": {
+      "state": "tx",
+      "slug": "del-mar-college",
+      "name": "Del Mar College",
+      "primaryUrl": "delmar.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:52:51.421Z"
+    },
+    "ia-iowa-lakes-community-college": {
+      "state": "ia",
+      "slug": "iowa-lakes-community-college",
+      "name": "Iowa Lakes Community College",
+      "primaryUrl": "iowalakes.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:00.205Z"
+    },
+    "tx-odessa-college": {
+      "state": "tx",
+      "slug": "odessa-college",
+      "name": "Odessa College",
+      "primaryUrl": "odessa.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:03.493Z"
+    },
+    "tx-lone-star-college-system": {
+      "state": "tx",
+      "slug": "lone-star-college-system",
+      "name": "Lone Star College System",
+      "primaryUrl": "lonestar.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:04.414Z"
+    },
+    "tx-navarro-college": {
+      "state": "tx",
+      "slug": "navarro-college",
+      "name": "Navarro College",
+      "primaryUrl": "navarrocollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:53:09.822Z"
+    },
+    "tx-san-antonio-college": {
+      "state": "tx",
+      "slug": "san-antonio-college",
+      "name": "San Antonio College",
+      "primaryUrl": "alamo.edu/sac",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:10.810Z"
+    },
+    "tx-san-jacinto-community-college": {
+      "state": "tx",
+      "slug": "san-jacinto-community-college",
+      "name": "San Jacinto Community College",
+      "primaryUrl": "sanjac.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:14.939Z"
+    },
+    "ia-northwest-iowa-community-college": {
+      "state": "ia",
+      "slug": "northwest-iowa-community-college",
+      "name": "Northwest Iowa Community College",
+      "primaryUrl": "nwicc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:53:16.674Z"
+    },
+    "tx-midland-college": {
+      "state": "tx",
+      "slug": "midland-college",
+      "name": "Midland College",
+      "primaryUrl": "midland.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:16.975Z"
+    },
+    "tx-weatherford-college": {
+      "state": "tx",
+      "slug": "weatherford-college",
+      "name": "Weatherford College",
+      "primaryUrl": "wc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:53:22.666Z"
+    },
+    "tx-collin-county-community-college-district": {
+      "state": "tx",
+      "slug": "collin-county-community-college-district",
+      "name": "Collin County Community College District",
+      "primaryUrl": "collin.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:22.785Z"
+    },
+    "tx-amarillo-college": {
+      "state": "tx",
+      "slug": "amarillo-college",
+      "name": "Amarillo College",
+      "primaryUrl": "actx.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:24.998Z"
+    },
+    "tx-houston-community-college": {
+      "state": "tx",
+      "slug": "houston-community-college",
+      "name": "Houston Community College",
+      "primaryUrl": "hccs.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:36.982Z"
+    },
+    "tx-coastal-bend-college": {
+      "state": "tx",
+      "slug": "coastal-bend-college",
+      "name": "Coastal Bend College",
+      "primaryUrl": "coastalbend.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:44.145Z"
+    },
+    "tx-angelina-college": {
+      "state": "tx",
+      "slug": "angelina-college",
+      "name": "Angelina College",
+      "primaryUrl": "angelina.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:46.974Z"
+    },
+    "tx-tyler-junior-college": {
+      "state": "tx",
+      "slug": "tyler-junior-college",
+      "name": "Tyler Junior College",
+      "primaryUrl": "tjc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:53:47.033Z"
+    },
+    "tx-alvin-community-college": {
+      "state": "tx",
+      "slug": "alvin-community-college",
+      "name": "Alvin Community College",
+      "primaryUrl": "alvincollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:53:47.799Z"
+    },
+    "tx-clarendon-college": {
+      "state": "tx",
+      "slug": "clarendon-college",
+      "name": "Clarendon College",
+      "primaryUrl": "clarendoncollege.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:53:47.819Z"
+    },
+    "tx-howard-college": {
+      "state": "tx",
+      "slug": "howard-college",
+      "name": "Howard College",
+      "primaryUrl": "howardcollege.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:00.112Z"
+    },
+    "tx-el-paso-community-college": {
+      "state": "tx",
+      "slug": "el-paso-community-college",
+      "name": "El Paso Community College",
+      "primaryUrl": "epcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:00.674Z"
+    },
+    "tx-blinn-college-district": {
+      "state": "tx",
+      "slug": "blinn-college-district",
+      "name": "Blinn College District",
+      "primaryUrl": "blinn.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:01.081Z"
+    },
+    "tx-hill-college": {
+      "state": "tx",
+      "slug": "hill-college",
+      "name": "Hill College",
+      "primaryUrl": "hillcollege.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:01.968Z"
+    },
+    "tx-lamar-state-college-orange": {
+      "state": "tx",
+      "slug": "lamar-state-college-orange",
+      "name": "Lamar State College-Orange",
+      "primaryUrl": "lsco.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:05.243Z"
+    },
+    "tx-north-central-texas-college": {
+      "state": "tx",
+      "slug": "north-central-texas-college",
+      "name": "North Central Texas College",
+      "primaryUrl": "nctc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:06.047Z"
+    },
+    "tx-college-of-the-mainland": {
+      "state": "tx",
+      "slug": "college-of-the-mainland",
+      "name": "College of the Mainland",
+      "primaryUrl": "com.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:07.919Z"
+    },
+    "tx-cisco-college": {
+      "state": "tx",
+      "slug": "cisco-college",
+      "name": "Cisco College",
+      "primaryUrl": "cisco.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:08.348Z"
+    },
+    "tx-lee-college": {
+      "state": "tx",
+      "slug": "lee-college",
+      "name": "Lee College",
+      "primaryUrl": "lee.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:13.598Z"
+    },
+    "tx-northeast-texas-community-college": {
+      "state": "tx",
+      "slug": "northeast-texas-community-college",
+      "name": "Northeast Texas Community College",
+      "primaryUrl": "ntcc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:23.046Z"
+    },
+    "tx-panola-college": {
+      "state": "tx",
+      "slug": "panola-college",
+      "name": "Panola College",
+      "primaryUrl": "panola.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:23.334Z"
+    },
+    "tx-mclennan-community-college": {
+      "state": "tx",
+      "slug": "mclennan-community-college",
+      "name": "McLennan Community College",
+      "primaryUrl": "mclennan.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:23.937Z"
+    },
+    "tx-paris-junior-college": {
+      "state": "tx",
+      "slug": "paris-junior-college",
+      "name": "Paris Junior College",
+      "primaryUrl": "parisjc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:25.896Z"
+    },
+    "tx-texas-southmost-college": {
+      "state": "tx",
+      "slug": "texas-southmost-college",
+      "name": "Texas Southmost College",
+      "primaryUrl": "tsc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:28.497Z"
+    },
+    "tx-lamar-state-college-port-arthur": {
+      "state": "tx",
+      "slug": "lamar-state-college-port-arthur",
+      "name": "Lamar State College-Port Arthur",
+      "primaryUrl": "lamarpa.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:34.446Z"
+    },
+    "tx-kilgore-college": {
+      "state": "tx",
+      "slug": "kilgore-college",
+      "name": "Kilgore College",
+      "primaryUrl": "kilgore.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:36.934Z"
+    },
+    "tx-st-philips-college": {
+      "state": "tx",
+      "slug": "st-philips-college",
+      "name": "St Philip's College",
+      "primaryUrl": "alamo.edu/spc",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:37.832Z"
+    },
+    "tx-ranger-college": {
+      "state": "tx",
+      "slug": "ranger-college",
+      "name": "Ranger College",
+      "primaryUrl": "rangercollege.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:38.196Z"
+    },
+    "tx-temple-college": {
+      "state": "tx",
+      "slug": "temple-college",
+      "name": "Temple College",
+      "primaryUrl": "templejc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:39.478Z"
+    },
+    "tx-tarrant-county-college-district": {
+      "state": "tx",
+      "slug": "tarrant-county-college-district",
+      "name": "Tarrant County College District",
+      "primaryUrl": "tccd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:41.288Z"
+    },
+    "tx-south-plains-college": {
+      "state": "tx",
+      "slug": "south-plains-college",
+      "name": "South Plains College",
+      "primaryUrl": "southplainscollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:47.383Z"
+    },
+    "tx-palo-alto-college": {
+      "state": "tx",
+      "slug": "palo-alto-college",
+      "name": "Palo Alto College",
+      "primaryUrl": "alamo.edu/pac",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:47.845Z"
+    },
+    "tx-victoria-college": {
+      "state": "tx",
+      "slug": "victoria-college",
+      "name": "Victoria College",
+      "primaryUrl": "victoriacollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:48.331Z"
+    },
+    "tx-wharton-county-junior-college": {
+      "state": "tx",
+      "slug": "wharton-county-junior-college",
+      "name": "Wharton County Junior College",
+      "primaryUrl": "wcjc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:48.362Z"
+    },
+    "tx-southwest-college-for-the-deaf": {
+      "state": "tx",
+      "slug": "southwest-college-for-the-deaf",
+      "name": "Southwest College for the Deaf",
+      "primaryUrl": "howardcollege.edu/swcd",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:49.119Z"
+    },
+    "tx-northwest-vista-college": {
+      "state": "tx",
+      "slug": "northwest-vista-college",
+      "name": "Northwest Vista College",
+      "primaryUrl": "alamo.edu/nvc",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:51.085Z"
+    },
+    "tx-texarkana-college": {
+      "state": "tx",
+      "slug": "texarkana-college",
+      "name": "Texarkana College",
+      "primaryUrl": "texarkanacollege.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:54:51.533Z"
+    },
+    "tx-frank-phillips-college": {
+      "state": "tx",
+      "slug": "frank-phillips-college",
+      "name": "Frank Phillips College",
+      "primaryUrl": "fpctx.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:53.039Z"
+    },
+    "tx-northeast-lakeview-college": {
+      "state": "tx",
+      "slug": "northeast-lakeview-college",
+      "name": "Northeast Lakeview College",
+      "primaryUrl": "alamo.edu/nlc",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:54:57.345Z"
+    },
+    "il-black-hawk-college": {
+      "state": "il",
+      "slug": "black-hawk-college",
+      "name": "Black Hawk College",
+      "primaryUrl": "bhc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:00.752Z"
+    },
+    "il-southwestern-illinois-college": {
+      "state": "il",
+      "slug": "southwestern-illinois-college",
+      "name": "Southwestern Illinois College",
+      "primaryUrl": "swic.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:05.981Z"
+    },
+    "tx-western-texas-college": {
+      "state": "tx",
+      "slug": "western-texas-college",
+      "name": "Western Texas College",
+      "primaryUrl": "wtc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:06.159Z"
+    },
+    "tx-vernon-college": {
+      "state": "tx",
+      "slug": "vernon-college",
+      "name": "Vernon College",
+      "primaryUrl": "vernoncollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:55:06.820Z"
+    },
+    "il-city-colleges-of-chicago-malcolm-x-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-malcolm-x-college",
+      "name": "City Colleges of Chicago-Malcolm X College",
+      "primaryUrl": "ccc.edu/colleges/malcolm-x/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:30.535Z"
+    },
+    "il-city-colleges-of-chicago-kennedy-king-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-kennedy-king-college",
+      "name": "City Colleges of Chicago-Kennedy-King College",
+      "primaryUrl": "ccc.edu/colleges/kennedy/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:30.772Z"
+    },
+    "il-city-colleges-of-chicago-olive-harvey-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-olive-harvey-college",
+      "name": "City Colleges of Chicago-Olive-Harvey College",
+      "primaryUrl": "ccc.edu/colleges/olive-harvey/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:32.582Z"
+    },
+    "il-city-colleges-of-chicago-richard-j-daley-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-richard-j-daley-college",
+      "name": "City Colleges of Chicago-Richard J Daley College",
+      "primaryUrl": "ccc.edu/colleges/daley/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:33.262Z"
+    },
+    "il-city-colleges-of-chicago-harry-s-truman-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-harry-s-truman-college",
+      "name": "City Colleges of Chicago-Harry S Truman College",
+      "primaryUrl": "ccc.edu/colleges/truman/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:33.265Z"
+    },
+    "il-carl-sandburg-college": {
+      "state": "il",
+      "slug": "carl-sandburg-college",
+      "name": "Carl Sandburg College",
+      "primaryUrl": "sandburg.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:51.008Z"
+    },
+    "tx-lamar-institute-of-technology": {
+      "state": "tx",
+      "slug": "lamar-institute-of-technology",
+      "name": "Lamar Institute of Technology",
+      "primaryUrl": "lit.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:55:55.522Z"
+    },
+    "il-city-colleges-of-chicago-wilbur-wright-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-wilbur-wright-college",
+      "name": "City Colleges of Chicago-Wilbur Wright College",
+      "primaryUrl": "ccc.edu/colleges/wright/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:57.354Z"
+    },
+    "il-city-colleges-of-chicago-harold-washington-college": {
+      "state": "il",
+      "slug": "city-colleges-of-chicago-harold-washington-college",
+      "name": "City Colleges of Chicago-Harold Washington College",
+      "primaryUrl": "ccc.edu/colleges/washington/pages/default.aspx",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:55:57.375Z"
+    },
+    "il-college-of-dupage": {
+      "state": "il",
+      "slug": "college-of-dupage",
+      "name": "College of DuPage",
+      "primaryUrl": "cod.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:03.311Z"
+    },
+    "il-highland-community-college": {
+      "state": "il",
+      "slug": "highland-community-college",
+      "name": "Highland Community College",
+      "primaryUrl": "highland.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:05.318Z"
+    },
+    "il-illinois-valley-community-college": {
+      "state": "il",
+      "slug": "illinois-valley-community-college",
+      "name": "Illinois Valley Community College",
+      "primaryUrl": "ivcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:06.067Z"
+    },
+    "il-olney-central-college": {
+      "state": "il",
+      "slug": "olney-central-college",
+      "name": "Olney Central College",
+      "primaryUrl": "iecc.edu/occ",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:06.368Z"
+    },
+    "il-elgin-community-college": {
+      "state": "il",
+      "slug": "elgin-community-college",
+      "name": "Elgin Community College",
+      "primaryUrl": "elgin.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:07.032Z"
+    },
+    "il-john-a-logan-college": {
+      "state": "il",
+      "slug": "john-a-logan-college",
+      "name": "John A Logan College",
+      "primaryUrl": "jalc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:07.791Z"
+    },
+    "il-danville-area-community-college": {
+      "state": "il",
+      "slug": "danville-area-community-college",
+      "name": "Danville Area Community College",
+      "primaryUrl": "dacc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:12.574Z"
+    },
+    "il-college-of-lake-county": {
+      "state": "il",
+      "slug": "college-of-lake-county",
+      "name": "College of Lake County",
+      "primaryUrl": "clcillinois.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:13.333Z"
+    },
+    "tx-texas-state-technical-college": {
+      "state": "tx",
+      "slug": "texas-state-technical-college",
+      "name": "Texas State Technical College",
+      "primaryUrl": "tstc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:13.968Z"
+    },
+    "il-lewis-and-clark-community-college": {
+      "state": "il",
+      "slug": "lewis-and-clark-community-college",
+      "name": "Lewis and Clark Community College",
+      "primaryUrl": "lc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:19.307Z"
+    },
+    "il-kaskaskia-college": {
+      "state": "il",
+      "slug": "kaskaskia-college",
+      "name": "Kaskaskia College",
+      "primaryUrl": "kaskaskia.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:20.591Z"
+    },
+    "il-mchenry-county-college": {
+      "state": "il",
+      "slug": "mchenry-county-college",
+      "name": "McHenry County College",
+      "primaryUrl": "mchenry.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:23.517Z"
+    },
+    "il-kankakee-community-college": {
+      "state": "il",
+      "slug": "kankakee-community-college",
+      "name": "Kankakee Community College",
+      "primaryUrl": "kcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:23.720Z"
+    },
+    "il-morton-college": {
+      "state": "il",
+      "slug": "morton-college",
+      "name": "Morton College",
+      "primaryUrl": "morton.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:29.143Z"
+    },
+    "il-john-wood-community-college": {
+      "state": "il",
+      "slug": "john-wood-community-college",
+      "name": "John Wood Community College",
+      "primaryUrl": "jwcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:30.107Z"
+    },
+    "il-oakton-college": {
+      "state": "il",
+      "slug": "oakton-college",
+      "name": "Oakton College",
+      "primaryUrl": "oakton.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:34.239Z"
+    },
+    "il-moraine-valley-community-college": {
+      "state": "il",
+      "slug": "moraine-valley-community-college",
+      "name": "Moraine Valley Community College",
+      "primaryUrl": "morainevalley.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:37.015Z"
+    },
+    "il-kishwaukee-college": {
+      "state": "il",
+      "slug": "kishwaukee-college",
+      "name": "Kishwaukee College",
+      "primaryUrl": "kish.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:38.087Z"
+    },
+    "il-prairie-state-college": {
+      "state": "il",
+      "slug": "prairie-state-college",
+      "name": "Prairie State College",
+      "primaryUrl": "prairiestate.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:40.733Z"
+    },
+    "il-joliet-junior-college": {
+      "state": "il",
+      "slug": "joliet-junior-college",
+      "name": "Joliet Junior College",
+      "primaryUrl": "jjc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:43.855Z"
+    },
+    "il-rock-valley-college": {
+      "state": "il",
+      "slug": "rock-valley-college",
+      "name": "Rock Valley College",
+      "primaryUrl": "rockvalleycollege.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:56:44.088Z"
+    },
+    "il-parkland-college": {
+      "state": "il",
+      "slug": "parkland-college",
+      "name": "Parkland College",
+      "primaryUrl": "parkland.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:45.689Z"
+    },
+    "il-richland-community-college": {
+      "state": "il",
+      "slug": "richland-community-college",
+      "name": "Richland Community College",
+      "primaryUrl": "richland.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:56:52.146Z"
+    },
+    "il-lake-land-college": {
+      "state": "il",
+      "slug": "lake-land-college",
+      "name": "Lake Land College",
+      "primaryUrl": "lakelandcollege.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:57:03.399Z"
+    },
+    "il-rend-lake-college": {
+      "state": "il",
+      "slug": "rend-lake-college",
+      "name": "Rend Lake College",
+      "primaryUrl": "rlc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:05.150Z"
+    },
+    "il-shawnee-community-college": {
+      "state": "il",
+      "slug": "shawnee-community-college",
+      "name": "Shawnee Community College",
+      "primaryUrl": "shawneecc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:15.460Z"
+    },
+    "il-lincoln-land-community-college": {
+      "state": "il",
+      "slug": "lincoln-land-community-college",
+      "name": "Lincoln Land Community College",
+      "primaryUrl": "llcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:15.748Z"
+    },
+    "il-spoon-river-college": {
+      "state": "il",
+      "slug": "spoon-river-college",
+      "name": "Spoon River College",
+      "primaryUrl": "src.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:17.661Z"
+    },
+    "il-southeastern-illinois-college": {
+      "state": "il",
+      "slug": "southeastern-illinois-college",
+      "name": "Southeastern Illinois College",
+      "primaryUrl": "sic.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:21.412Z"
+    },
+    "il-heartland-community-college": {
+      "state": "il",
+      "slug": "heartland-community-college",
+      "name": "Heartland Community College",
+      "primaryUrl": "heartland.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:57:29.561Z"
+    },
+    "il-william-rainey-harper-college": {
+      "state": "il",
+      "slug": "william-rainey-harper-college",
+      "name": "William Rainey Harper College",
+      "primaryUrl": "harpercollege.edu/index.php",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:31.579Z"
+    },
+    "il-triton-college": {
+      "state": "il",
+      "slug": "triton-college",
+      "name": "Triton College",
+      "primaryUrl": "triton.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:57:34.510Z"
+    },
+    "hi-honolulu-community-college": {
+      "state": "hi",
+      "slug": "honolulu-community-college",
+      "name": "Honolulu Community College",
+      "primaryUrl": "honolulu.hawaii.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:57:39.499Z"
+    },
+    "il-waubonsee-community-college": {
+      "state": "il",
+      "slug": "waubonsee-community-college",
+      "name": "Waubonsee Community College",
+      "primaryUrl": "waubonsee.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:58:08.369Z"
+    },
+    "il-sauk-valley-community-college": {
+      "state": "il",
+      "slug": "sauk-valley-community-college",
+      "name": "Sauk Valley Community College",
+      "primaryUrl": "svcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:12.563Z"
+    },
+    "hi-leeward-community-college": {
+      "state": "hi",
+      "slug": "leeward-community-college",
+      "name": "Leeward Community College",
+      "primaryUrl": "leeward.hawaii.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:58:19.144Z"
+    },
+    "hi-kapiolani-community-college": {
+      "state": "hi",
+      "slug": "kapiolani-community-college",
+      "name": "Kapiolani Community College",
+      "primaryUrl": "kapiolani.hawaii.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:20.673Z"
+    },
+    "hi-windward-community-college": {
+      "state": "hi",
+      "slug": "windward-community-college",
+      "name": "Windward Community College",
+      "primaryUrl": "windward.hawaii.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:32.074Z"
+    },
+    "il-south-suburban-college": {
+      "state": "il",
+      "slug": "south-suburban-college",
+      "name": "South Suburban College",
+      "primaryUrl": "ssc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:58:32.415Z"
+    },
+    "hi-hawaii-community-college": {
+      "state": "hi",
+      "slug": "hawaii-community-college",
+      "name": "Hawaii Community College",
+      "primaryUrl": "hawaii.hawaii.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:36.233Z"
+    },
+    "hi-kauai-community-college": {
+      "state": "hi",
+      "slug": "kauai-community-college",
+      "name": "Kauai Community College",
+      "primaryUrl": "kauai.hawaii.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:58:36.893Z"
+    },
+    "mt-aaniiih-nakoda-college": {
+      "state": "mt",
+      "slug": "aaniiih-nakoda-college",
+      "name": "Aaniiih Nakoda College",
+      "primaryUrl": "ancollege.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:39.022Z"
+    },
+    "mt-stone-child-college": {
+      "state": "mt",
+      "slug": "stone-child-college",
+      "name": "Stone Child College",
+      "primaryUrl": "stonechild.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:39.279Z"
+    },
+    "mt-highlands-college-of-montana-tech": {
+      "state": "mt",
+      "slug": "highlands-college-of-montana-tech",
+      "name": "Highlands College of Montana Tech",
+      "primaryUrl": "mtech.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:58:51.015Z"
+    },
+    "mt-salish-kootenai-college": {
+      "state": "mt",
+      "slug": "salish-kootenai-college",
+      "name": "Salish Kootenai College",
+      "primaryUrl": "skc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:56.448Z"
+    },
+    "mt-little-big-horn-college": {
+      "state": "mt",
+      "slug": "little-big-horn-college",
+      "name": "Little Big Horn College",
+      "primaryUrl": "lbhc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:58:57.135Z"
+    },
+    "mt-miles-community-college": {
+      "state": "mt",
+      "slug": "miles-community-college",
+      "name": "Miles Community College",
+      "primaryUrl": "milescc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:00.721Z"
+    },
+    "mt-chief-dull-knife-college": {
+      "state": "mt",
+      "slug": "chief-dull-knife-college",
+      "name": "Chief Dull Knife College",
+      "primaryUrl": "cdkc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:01.631Z"
+    },
+    "mt-dawson-community-college": {
+      "state": "mt",
+      "slug": "dawson-community-college",
+      "name": "Dawson Community College",
+      "primaryUrl": "dawson.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:01.853Z"
+    },
+    "or-mt-hood-community-college": {
+      "state": "or",
+      "slug": "mt-hood-community-college",
+      "name": "Mt Hood Community College",
+      "primaryUrl": "mhcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:08.203Z"
+    },
+    "mt-fort-peck-community-college": {
+      "state": "mt",
+      "slug": "fort-peck-community-college",
+      "name": "Fort Peck Community College",
+      "primaryUrl": "fpcc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:11.915Z"
+    },
+    "or-blue-mountain-community-college": {
+      "state": "or",
+      "slug": "blue-mountain-community-college",
+      "name": "Blue Mountain Community College",
+      "primaryUrl": "bluecc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:14.355Z"
+    },
+    "or-central-oregon-community-college": {
+      "state": "or",
+      "slug": "central-oregon-community-college",
+      "name": "Central Oregon Community College",
+      "primaryUrl": "cocc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:14.469Z"
+    },
+    "or-rogue-community-college": {
+      "state": "or",
+      "slug": "rogue-community-college",
+      "name": "Rogue Community College",
+      "primaryUrl": "roguecc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:21.366Z"
+    },
+    "or-chemeketa-community-college": {
+      "state": "or",
+      "slug": "chemeketa-community-college",
+      "name": "Chemeketa Community College",
+      "primaryUrl": "chemeketa.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:23.197Z"
+    },
+    "or-lane-community-college": {
+      "state": "or",
+      "slug": "lane-community-college",
+      "name": "Lane Community College",
+      "primaryUrl": "lanecc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:26.838Z"
+    },
+    "or-portland-community-college": {
+      "state": "or",
+      "slug": "portland-community-college",
+      "name": "Portland Community College",
+      "primaryUrl": "pcc.edu",
+      "platform": "auth-gated",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:27.037Z"
+    },
+    "mt-flathead-valley-community-college": {
+      "state": "mt",
+      "slug": "flathead-valley-community-college",
+      "name": "Flathead Valley Community College",
+      "primaryUrl": "fvcc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:37.088Z"
+    },
+    "or-columbia-gorge-community-college": {
+      "state": "or",
+      "slug": "columbia-gorge-community-college",
+      "name": "Columbia Gorge Community College",
+      "primaryUrl": "cgcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:44.970Z"
+    },
+    "or-treasure-valley-community-college": {
+      "state": "or",
+      "slug": "treasure-valley-community-college",
+      "name": "Treasure Valley Community College",
+      "primaryUrl": "tvcc.cc",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:47.114Z"
+    },
+    "or-linn-benton-community-college": {
+      "state": "or",
+      "slug": "linn-benton-community-college",
+      "name": "Linn-Benton Community College",
+      "primaryUrl": "linnbenton.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-24T23:59:48.308Z"
+    },
+    "or-clatsop-community-college": {
+      "state": "or",
+      "slug": "clatsop-community-college",
+      "name": "Clatsop Community College",
+      "primaryUrl": "clatsopcc.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:50.073Z"
+    },
+    "or-umpqua-community-college": {
+      "state": "or",
+      "slug": "umpqua-community-college",
+      "name": "Umpqua Community College",
+      "primaryUrl": "umpqua.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-24T23:59:56.190Z"
+    },
+    "or-tillamook-bay-community-college": {
+      "state": "or",
+      "slug": "tillamook-bay-community-college",
+      "name": "Tillamook Bay Community College",
+      "primaryUrl": "tillamookbaycc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:07.022Z"
+    },
+    "or-southwestern-oregon-community-college": {
+      "state": "or",
+      "slug": "southwestern-oregon-community-college",
+      "name": "Southwestern Oregon Community College",
+      "primaryUrl": "socc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:10.318Z"
+    },
+    "or-oregon-coast-community-college": {
+      "state": "or",
+      "slug": "oregon-coast-community-college",
+      "name": "Oregon Coast Community College",
+      "primaryUrl": "oregoncoastcc.org",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:00:18.078Z"
+    },
+    "ca-bakersfield-college": {
+      "state": "ca",
+      "slug": "bakersfield-college",
+      "name": "Bakersfield College",
+      "primaryUrl": "bakersfieldcollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:18.469Z"
+    },
+    "ca-antelope-valley-community-college-district": {
+      "state": "ca",
+      "slug": "antelope-valley-community-college-district",
+      "name": "Antelope Valley Community College District",
+      "primaryUrl": "avc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:21.328Z"
+    },
+    "or-klamath-community-college": {
+      "state": "or",
+      "slug": "klamath-community-college",
+      "name": "Klamath Community College",
+      "primaryUrl": "klamathcc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:00:36.441Z"
+    },
+    "ca-modesto-junior-college": {
+      "state": "ca",
+      "slug": "modesto-junior-college",
+      "name": "Modesto Junior College",
+      "primaryUrl": "mjc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:39.441Z"
+    },
+    "ca-santa-ana-college": {
+      "state": "ca",
+      "slug": "santa-ana-college",
+      "name": "Santa Ana College",
+      "primaryUrl": "sac.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:39.841Z"
+    },
+    "ca-cypress-college": {
+      "state": "ca",
+      "slug": "cypress-college",
+      "name": "Cypress College",
+      "primaryUrl": "cypresscollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:43.447Z"
+    },
+    "ca-san-diego-mesa-college": {
+      "state": "ca",
+      "slug": "san-diego-mesa-college",
+      "name": "San Diego Mesa College",
+      "primaryUrl": "sdmesa.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:43.783Z"
+    },
+    "or-clackamas-community-college": {
+      "state": "or",
+      "slug": "clackamas-community-college",
+      "name": "Clackamas Community College",
+      "primaryUrl": "clackamas.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:50.824Z"
+    },
+    "ca-santa-monica-college": {
+      "state": "ca",
+      "slug": "santa-monica-college",
+      "name": "Santa Monica College",
+      "primaryUrl": "smc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:51.459Z"
+    },
+    "ca-foothill-college": {
+      "state": "ca",
+      "slug": "foothill-college",
+      "name": "Foothill College",
+      "primaryUrl": "foothill.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:00:54.572Z"
+    },
+    "ca-miracosta-college": {
+      "state": "ca",
+      "slug": "miracosta-college",
+      "name": "MiraCosta College",
+      "primaryUrl": "miracosta.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:05.901Z"
+    },
+    "ca-solano-community-college": {
+      "state": "ca",
+      "slug": "solano-community-college",
+      "name": "Solano Community College",
+      "primaryUrl": "welcome.solano.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:19.586Z"
+    },
+    "ca-west-los-angeles-college": {
+      "state": "ca",
+      "slug": "west-los-angeles-college",
+      "name": "West Los Angeles College",
+      "primaryUrl": "wlac.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:27.304Z"
+    },
+    "ca-college-of-alameda": {
+      "state": "ca",
+      "slug": "college-of-alameda",
+      "name": "College of Alameda",
+      "primaryUrl": "alameda.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:27.427Z"
+    },
+    "ca-rio-hondo-college": {
+      "state": "ca",
+      "slug": "rio-hondo-college",
+      "name": "Rio Hondo College",
+      "primaryUrl": "riohondo.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:29.015Z"
+    },
+    "ca-skyline-college": {
+      "state": "ca",
+      "slug": "skyline-college",
+      "name": "Skyline College",
+      "primaryUrl": "skylinecollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:40.116Z"
+    },
+    "ca-feather-river-community-college-district": {
+      "state": "ca",
+      "slug": "feather-river-community-college-district",
+      "name": "Feather River Community College District",
+      "primaryUrl": "frc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:42.572Z"
+    },
+    "ca-shasta-college": {
+      "state": "ca",
+      "slug": "shasta-college",
+      "name": "Shasta College",
+      "primaryUrl": "shastacollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:42.692Z"
+    },
+    "ca-american-river-college": {
+      "state": "ca",
+      "slug": "american-river-college",
+      "name": "American River College",
+      "primaryUrl": "arc.losrios.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:01:54.271Z"
+    },
+    "ca-college-of-the-canyons": {
+      "state": "ca",
+      "slug": "college-of-the-canyons",
+      "name": "College of the Canyons",
+      "primaryUrl": "canyons.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:34.556Z"
+    },
+    "ca-butte-college": {
+      "state": "ca",
+      "slug": "butte-college",
+      "name": "Butte College",
+      "primaryUrl": "butte.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:35.707Z"
+    },
+    "ca-cerritos-college": {
+      "state": "ca",
+      "slug": "cerritos-college",
+      "name": "Cerritos College",
+      "primaryUrl": "cerritos.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:38.561Z"
+    },
+    "ca-allan-hancock-college": {
+      "state": "ca",
+      "slug": "allan-hancock-college",
+      "name": "Allan Hancock College",
+      "primaryUrl": "hancockcollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:41.458Z"
+    },
+    "ca-barstow-community-college": {
+      "state": "ca",
+      "slug": "barstow-community-college",
+      "name": "Barstow Community College",
+      "primaryUrl": "barstow.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:42.199Z"
+    },
+    "ca-cabrillo-college": {
+      "state": "ca",
+      "slug": "cabrillo-college",
+      "name": "Cabrillo College",
+      "primaryUrl": "cabrillo.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:42.377Z"
+    },
+    "ca-cerro-coso-community-college": {
+      "state": "ca",
+      "slug": "cerro-coso-community-college",
+      "name": "Cerro Coso Community College",
+      "primaryUrl": "cerrocoso.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:02:43.225Z"
+    },
+    "ca-chaffey-college": {
+      "state": "ca",
+      "slug": "chaffey-college",
+      "name": "Chaffey College",
+      "primaryUrl": "chaffey.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:01.887Z"
+    },
+    "ca-chabot-college": {
+      "state": "ca",
+      "slug": "chabot-college",
+      "name": "Chabot College",
+      "primaryUrl": "chabotcollege.edu",
+      "platform": "banner-8",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:02.108Z"
+    },
+    "ca-canada-college": {
+      "state": "ca",
+      "slug": "canada-college",
+      "name": "Canada College",
+      "primaryUrl": "canadacollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:06.157Z"
+    },
+    "ca-city-college-of-san-francisco": {
+      "state": "ca",
+      "slug": "city-college-of-san-francisco",
+      "name": "City College of San Francisco",
+      "primaryUrl": "ccsf.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:07.161Z"
+    },
+    "ca-columbia-college": {
+      "state": "ca",
+      "slug": "columbia-college",
+      "name": "Columbia College",
+      "primaryUrl": "gocolumbia.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:09.127Z"
+    },
+    "ca-coastline-community-college": {
+      "state": "ca",
+      "slug": "coastline-community-college",
+      "name": "Coastline Community College",
+      "primaryUrl": "coastline.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:09.223Z"
+    },
+    "ca-compton-college": {
+      "state": "ca",
+      "slug": "compton-college",
+      "name": "Compton College",
+      "primaryUrl": "compton.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:09.239Z"
+    },
+    "ca-contra-costa-college": {
+      "state": "ca",
+      "slug": "contra-costa-college",
+      "name": "Contra Costa College",
+      "primaryUrl": "contracosta.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:22.429Z"
+    },
+    "ca-cosumnes-river-college": {
+      "state": "ca",
+      "slug": "cosumnes-river-college",
+      "name": "Cosumnes River College",
+      "primaryUrl": "crc.losrios.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:33.902Z"
+    },
+    "ca-cuyamaca-college": {
+      "state": "ca",
+      "slug": "cuyamaca-college",
+      "name": "Cuyamaca College",
+      "primaryUrl": "cuyamaca.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:42.089Z"
+    },
+    "ca-crafton-hills-college": {
+      "state": "ca",
+      "slug": "crafton-hills-college",
+      "name": "Crafton Hills College",
+      "primaryUrl": "craftonhills.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:42.212Z"
+    },
+    "ca-college-of-the-desert": {
+      "state": "ca",
+      "slug": "college-of-the-desert",
+      "name": "College of the Desert",
+      "primaryUrl": "collegeofthedesert.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:44.972Z"
+    },
+    "ca-cuesta-college": {
+      "state": "ca",
+      "slug": "cuesta-college",
+      "name": "Cuesta College",
+      "primaryUrl": "cuesta.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:48.685Z"
+    },
+    "ca-diablo-valley-college": {
+      "state": "ca",
+      "slug": "diablo-valley-college",
+      "name": "Diablo Valley College",
+      "primaryUrl": "dvc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:48.930Z"
+    },
+    "ca-east-los-angeles-college": {
+      "state": "ca",
+      "slug": "east-los-angeles-college",
+      "name": "East Los Angeles College",
+      "primaryUrl": "elac.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:03:56.071Z"
+    },
+    "ca-citrus-college": {
+      "state": "ca",
+      "slug": "citrus-college",
+      "name": "Citrus College",
+      "primaryUrl": "citruscollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:00.057Z"
+    },
+    "ca-de-anza-college": {
+      "state": "ca",
+      "slug": "de-anza-college",
+      "name": "De Anza College",
+      "primaryUrl": "deanza.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:02.205Z"
+    },
+    "ca-fresno-city-college": {
+      "state": "ca",
+      "slug": "fresno-city-college",
+      "name": "Fresno City College",
+      "primaryUrl": "fresnocitycollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:02.621Z"
+    },
+    "ca-evergreen-valley-college": {
+      "state": "ca",
+      "slug": "evergreen-valley-college",
+      "name": "Evergreen Valley College",
+      "primaryUrl": "evc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:02.721Z"
+    },
+    "ca-golden-west-college": {
+      "state": "ca",
+      "slug": "golden-west-college",
+      "name": "Golden West College",
+      "primaryUrl": "goldenwestcollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:23.820Z"
+    },
+    "ca-el-camino-community-college-district": {
+      "state": "ca",
+      "slug": "el-camino-community-college-district",
+      "name": "El Camino Community College District",
+      "primaryUrl": "elcamino.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:24.039Z"
+    },
+    "ca-fullerton-college": {
+      "state": "ca",
+      "slug": "fullerton-college",
+      "name": "Fullerton College",
+      "primaryUrl": "fullcoll.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:25.062Z"
+    },
+    "ca-grossmont-college": {
+      "state": "ca",
+      "slug": "grossmont-college",
+      "name": "Grossmont College",
+      "primaryUrl": "grossmont.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:25.419Z"
+    },
+    "ca-imperial-valley-college": {
+      "state": "ca",
+      "slug": "imperial-valley-college",
+      "name": "Imperial Valley College",
+      "primaryUrl": "imperial.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:25.703Z"
+    },
+    "ca-reedley-college": {
+      "state": "ca",
+      "slug": "reedley-college",
+      "name": "Reedley College",
+      "primaryUrl": "reedleycollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:39.088Z"
+    },
+    "ca-laney-college": {
+      "state": "ca",
+      "slug": "laney-college",
+      "name": "Laney College",
+      "primaryUrl": "laney.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:44.370Z"
+    },
+    "ca-irvine-valley-college": {
+      "state": "ca",
+      "slug": "irvine-valley-college",
+      "name": "Irvine Valley College",
+      "primaryUrl": "ivc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:44.445Z"
+    },
+    "ca-hartnell-college": {
+      "state": "ca",
+      "slug": "hartnell-college",
+      "name": "Hartnell College",
+      "primaryUrl": "hartnell.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:45.621Z"
+    },
+    "ca-gavilan-college": {
+      "state": "ca",
+      "slug": "gavilan-college",
+      "name": "Gavilan College",
+      "primaryUrl": "gavilan.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:57.053Z"
+    },
+    "ca-los-angeles-pierce-college": {
+      "state": "ca",
+      "slug": "los-angeles-pierce-college",
+      "name": "Los Angeles Pierce College",
+      "primaryUrl": "lapc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:57.175Z"
+    },
+    "ca-lake-tahoe-community-college": {
+      "state": "ca",
+      "slug": "lake-tahoe-community-college",
+      "name": "Lake Tahoe Community College",
+      "primaryUrl": "ltcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:04:59.385Z"
+    },
+    "ca-glendale-community-college": {
+      "state": "ca",
+      "slug": "glendale-community-college",
+      "name": "Glendale Community College",
+      "primaryUrl": "glendale.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:06.352Z"
+    },
+    "ca-los-angeles-trade-technical-college": {
+      "state": "ca",
+      "slug": "los-angeles-trade-technical-college",
+      "name": "Los Angeles Trade Technical College",
+      "primaryUrl": "lattc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:08.144Z"
+    },
+    "ca-los-angeles-valley-college": {
+      "state": "ca",
+      "slug": "los-angeles-valley-college",
+      "name": "Los Angeles Valley College",
+      "primaryUrl": "lavc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:08.522Z"
+    },
+    "ca-los-angeles-city-college": {
+      "state": "ca",
+      "slug": "los-angeles-city-college",
+      "name": "Los Angeles City College",
+      "primaryUrl": "lacitycollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:14.929Z"
+    },
+    "ca-lassen-community-college": {
+      "state": "ca",
+      "slug": "lassen-community-college",
+      "name": "Lassen Community College",
+      "primaryUrl": "lassencollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:15.576Z"
+    },
+    "ca-los-medanos-college": {
+      "state": "ca",
+      "slug": "los-medanos-college",
+      "name": "Los Medanos College",
+      "primaryUrl": "losmedanos.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:17.886Z"
+    },
+    "ca-long-beach-city-college": {
+      "state": "ca",
+      "slug": "long-beach-city-college",
+      "name": "Long Beach City College",
+      "primaryUrl": "lbcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:20.090Z"
+    },
+    "ca-los-angeles-harbor-college": {
+      "state": "ca",
+      "slug": "los-angeles-harbor-college",
+      "name": "Los Angeles Harbor College",
+      "primaryUrl": "lahc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:20.235Z"
+    },
+    "ca-college-of-marin": {
+      "state": "ca",
+      "slug": "college-of-marin",
+      "name": "College of Marin",
+      "primaryUrl": "marin.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:20.757Z"
+    },
+    "ca-los-angeles-mission-college": {
+      "state": "ca",
+      "slug": "los-angeles-mission-college",
+      "name": "Los Angeles Mission College",
+      "primaryUrl": "lamission.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:23.769Z"
+    },
+    "ca-los-angeles-southwest-college": {
+      "state": "ca",
+      "slug": "los-angeles-southwest-college",
+      "name": "Los Angeles Southwest College",
+      "primaryUrl": "lasc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:25.680Z"
+    },
+    "ca-monterey-peninsula-college": {
+      "state": "ca",
+      "slug": "monterey-peninsula-college",
+      "name": "Monterey Peninsula College",
+      "primaryUrl": "mpc.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:33.245Z"
+    },
+    "ca-moorpark-college": {
+      "state": "ca",
+      "slug": "moorpark-college",
+      "name": "Moorpark College",
+      "primaryUrl": "moorparkcollege.edu/index.shtml",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:46.583Z"
+    },
+    "ca-mt-san-jacinto-community-college-district": {
+      "state": "ca",
+      "slug": "mt-san-jacinto-community-college-district",
+      "name": "Mt San Jacinto Community College District",
+      "primaryUrl": "msjc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:47.851Z"
+    },
+    "ca-merced-college": {
+      "state": "ca",
+      "slug": "merced-college",
+      "name": "Merced College",
+      "primaryUrl": "mccd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:49.042Z"
+    },
+    "ca-orange-coast-college": {
+      "state": "ca",
+      "slug": "orange-coast-college",
+      "name": "Orange Coast College",
+      "primaryUrl": "orangecoastcollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:56.633Z"
+    },
+    "ca-mt-san-antonio-college": {
+      "state": "ca",
+      "slug": "mt-san-antonio-college",
+      "name": "Mt San Antonio College",
+      "primaryUrl": "mtsac.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:57.072Z"
+    },
+    "ca-palo-verde-college": {
+      "state": "ca",
+      "slug": "palo-verde-college",
+      "name": "Palo Verde College",
+      "primaryUrl": "paloverde.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:58.399Z"
+    },
+    "ca-mendocino-college": {
+      "state": "ca",
+      "slug": "mendocino-college",
+      "name": "Mendocino College",
+      "primaryUrl": "mendocino.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:05:59.490Z"
+    },
+    "ca-oxnard-college": {
+      "state": "ca",
+      "slug": "oxnard-college",
+      "name": "Oxnard College",
+      "primaryUrl": "oxnardcollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:03.928Z"
+    },
+    "ca-napa-valley-college": {
+      "state": "ca",
+      "slug": "napa-valley-college",
+      "name": "Napa Valley College",
+      "primaryUrl": "napavalley.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:04.136Z"
+    },
+    "ca-merritt-college": {
+      "state": "ca",
+      "slug": "merritt-college",
+      "name": "Merritt College",
+      "primaryUrl": "merritt.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:06.242Z"
+    },
+    "ca-palomar-college": {
+      "state": "ca",
+      "slug": "palomar-college",
+      "name": "Palomar College",
+      "primaryUrl": "www2.palomar.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:12.440Z"
+    },
+    "ca-riverside-city-college": {
+      "state": "ca",
+      "slug": "riverside-city-college",
+      "name": "Riverside City College",
+      "primaryUrl": "rcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:19.647Z"
+    },
+    "ca-ohlone-college": {
+      "state": "ca",
+      "slug": "ohlone-college",
+      "name": "Ohlone College",
+      "primaryUrl": "ohlone.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:21.143Z"
+    },
+    "ca-porterville-college": {
+      "state": "ca",
+      "slug": "porterville-college",
+      "name": "Porterville College",
+      "primaryUrl": "portervillecollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:21.145Z"
+    },
+    "ca-sacramento-city-college": {
+      "state": "ca",
+      "slug": "sacramento-city-college",
+      "name": "Sacramento City College",
+      "primaryUrl": "scc.losrios.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:21.783Z"
+    },
+    "ca-san-diego-city-college": {
+      "state": "ca",
+      "slug": "san-diego-city-college",
+      "name": "San Diego City College",
+      "primaryUrl": "sdcity.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:26.998Z"
+    },
+    "ca-saddleback-college": {
+      "state": "ca",
+      "slug": "saddleback-college",
+      "name": "Saddleback College",
+      "primaryUrl": "saddleback.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:44.094Z"
+    },
+    "ca-pasadena-city-college": {
+      "state": "ca",
+      "slug": "pasadena-city-college",
+      "name": "Pasadena City College",
+      "primaryUrl": "pasadena.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:44.138Z"
+    },
+    "ca-san-diego-miramar-college": {
+      "state": "ca",
+      "slug": "san-diego-miramar-college",
+      "name": "San Diego Miramar College",
+      "primaryUrl": "sdmiramar.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:53.243Z"
+    },
+    "ca-college-of-the-redwoods": {
+      "state": "ca",
+      "slug": "college-of-the-redwoods",
+      "name": "College of the Redwoods",
+      "primaryUrl": "redwoods.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:54.287Z"
+    },
+    "ca-san-jose-city-college": {
+      "state": "ca",
+      "slug": "san-jose-city-college",
+      "name": "San Jose City College",
+      "primaryUrl": "sjcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:06:55.106Z"
+    },
+    "ca-college-of-the-sequoias": {
+      "state": "ca",
+      "slug": "college-of-the-sequoias",
+      "name": "College of the Sequoias",
+      "primaryUrl": "cos.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:14.134Z"
+    },
+    "ca-santa-barbara-city-college": {
+      "state": "ca",
+      "slug": "santa-barbara-city-college",
+      "name": "Santa Barbara City College",
+      "primaryUrl": "sbcc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:14.139Z"
+    },
+    "ca-san-joaquin-delta-college": {
+      "state": "ca",
+      "slug": "san-joaquin-delta-college",
+      "name": "San Joaquin Delta College",
+      "primaryUrl": "deltacollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:25.213Z"
+    },
+    "ca-san-bernardino-valley-college": {
+      "state": "ca",
+      "slug": "san-bernardino-valley-college",
+      "name": "San Bernardino Valley College",
+      "primaryUrl": "valleycollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:25.356Z"
+    },
+    "ca-college-of-the-siskiyous": {
+      "state": "ca",
+      "slug": "college-of-the-siskiyous",
+      "name": "College of the Siskiyous",
+      "primaryUrl": "siskiyous.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:26.525Z"
+    },
+    "ca-college-of-san-mateo": {
+      "state": "ca",
+      "slug": "college-of-san-mateo",
+      "name": "College of San Mateo",
+      "primaryUrl": "collegeofsanmateo.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:32.762Z"
+    },
+    "ca-santa-rosa-junior-college": {
+      "state": "ca",
+      "slug": "santa-rosa-junior-college",
+      "name": "Santa Rosa Junior College",
+      "primaryUrl": "santarosa.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:33.434Z"
+    },
+    "ca-taft-college": {
+      "state": "ca",
+      "slug": "taft-college",
+      "name": "Taft College",
+      "primaryUrl": "taftcollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:33.484Z"
+    },
+    "ca-southwestern-college": {
+      "state": "ca",
+      "slug": "southwestern-college",
+      "name": "Southwestern College",
+      "primaryUrl": "swccd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:39.527Z"
+    },
+    "ca-berkeley-city-college": {
+      "state": "ca",
+      "slug": "berkeley-city-college",
+      "name": "Berkeley City College",
+      "primaryUrl": "berkeleycitycollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:43.789Z"
+    },
+    "ca-ventura-college": {
+      "state": "ca",
+      "slug": "ventura-college",
+      "name": "Ventura College",
+      "primaryUrl": "venturacollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:44.367Z"
+    },
+    "ca-west-valley-college": {
+      "state": "ca",
+      "slug": "west-valley-college",
+      "name": "West Valley College",
+      "primaryUrl": "westvalley.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:07:44.977Z"
+    },
+    "ca-sierra-college": {
+      "state": "ca",
+      "slug": "sierra-college",
+      "name": "Sierra College",
+      "primaryUrl": "sierracollege.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:04.902Z"
+    },
+    "ca-las-positas-college": {
+      "state": "ca",
+      "slug": "las-positas-college",
+      "name": "Las Positas College",
+      "primaryUrl": "laspositascollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:06.035Z"
+    },
+    "ca-santiago-canyon-college": {
+      "state": "ca",
+      "slug": "santiago-canyon-college",
+      "name": "Santiago Canyon College",
+      "primaryUrl": "sccollege.edu/sitepages/home.aspx",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:10.844Z"
+    },
+    "ca-yuba-college": {
+      "state": "ca",
+      "slug": "yuba-college",
+      "name": "Yuba College",
+      "primaryUrl": "yc.yccd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:10.935Z"
+    },
+    "ca-folsom-lake-college": {
+      "state": "ca",
+      "slug": "folsom-lake-college",
+      "name": "Folsom Lake College",
+      "primaryUrl": "flc.losrios.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:11.370Z"
+    },
+    "ca-victor-valley-college": {
+      "state": "ca",
+      "slug": "victor-valley-college",
+      "name": "Victor Valley College",
+      "primaryUrl": "vvc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:11.640Z"
+    },
+    "ca-norco-college": {
+      "state": "ca",
+      "slug": "norco-college",
+      "name": "Norco College",
+      "primaryUrl": "norcocollege.edu/pages/index.aspx",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:19.298Z"
+    },
+    "ca-moreno-valley-college": {
+      "state": "ca",
+      "slug": "moreno-valley-college",
+      "name": "Moreno Valley College",
+      "primaryUrl": "mvc.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:33.019Z"
+    },
+    "ca-california-indian-nations-college": {
+      "state": "ca",
+      "slug": "california-indian-nations-college",
+      "name": "California Indian Nations College",
+      "primaryUrl": "cincollege.org",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:34.359Z"
+    },
+    "ca-clovis-community-college": {
+      "state": "ca",
+      "slug": "clovis-community-college",
+      "name": "Clovis Community College",
+      "primaryUrl": "cloviscollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:37.454Z"
+    },
+    "ca-woodland-community-college": {
+      "state": "ca",
+      "slug": "woodland-community-college",
+      "name": "Woodland Community College",
+      "primaryUrl": "wcc.yccd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:45.269Z"
+    },
+    "ca-madera-community-college": {
+      "state": "ca",
+      "slug": "madera-community-college",
+      "name": "Madera Community College",
+      "primaryUrl": "maderacollege.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:46.382Z"
+    },
+    "ca-coalinga-college": {
+      "state": "ca",
+      "slug": "coalinga-college",
+      "name": "Coalinga College",
+      "primaryUrl": "westhillscollege.com/coalinga",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:08:53.104Z"
+    },
     "nv-great-basin-college": {
       "state": "nv",
       "slug": "great-basin-college",
@@ -8,25 +5633,16 @@
       "primaryUrl": "https://www.gbcnv.edu",
       "platform": "custom",
       "confidence": "low",
-      "lastChecked": "2026-05-24T22:55:42.749Z"
+      "lastChecked": "2026-05-25T00:08:56.441Z"
     },
-    "nv-western-nevada-college": {
-      "state": "nv",
-      "slug": "western-nevada-college",
-      "name": "Western Nevada College",
-      "primaryUrl": "https://www.wnc.edu",
-      "platform": "coursedog",
-      "confidence": "high",
-      "lastChecked": "2026-05-24T22:55:43.641Z"
-    },
-    "nv-college-of-southern-nevada": {
-      "state": "nv",
-      "slug": "college-of-southern-nevada",
-      "name": "College of Southern Nevada",
-      "primaryUrl": "https://www.csn.edu",
-      "platform": "acalog",
-      "confidence": "high",
-      "lastChecked": "2026-05-24T22:56:10.257Z"
+    "az-glendale-community-college": {
+      "state": "az",
+      "slug": "glendale-community-college",
+      "name": "Glendale Community College",
+      "primaryUrl": "gccaz.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:11.086Z"
     },
     "nv-truckee-meadows-community-college": {
       "state": "nv",
@@ -35,16 +5651,242 @@
       "primaryUrl": "https://www.tmcc.edu",
       "platform": "custom",
       "confidence": "low",
-      "lastChecked": "2026-05-24T22:56:44.825Z"
+      "lastChecked": "2026-05-25T00:09:13.692Z"
+    },
+    "nv-western-nevada-college": {
+      "state": "nv",
+      "slug": "western-nevada-college",
+      "name": "Western Nevada College",
+      "primaryUrl": "https://www.wnc.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:14.043Z"
+    },
+    "az-rio-salado-college": {
+      "state": "az",
+      "slug": "rio-salado-college",
+      "name": "Rio Salado College",
+      "primaryUrl": "rio.maricopa.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:14.836Z"
+    },
+    "ca-lemoore-college": {
+      "state": "ca",
+      "slug": "lemoore-college",
+      "name": "Lemoore College",
+      "primaryUrl": "westhillscollege.com/lemoore",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:16.077Z"
+    },
+    "az-paradise-valley-community-college": {
+      "state": "az",
+      "slug": "paradise-valley-community-college",
+      "name": "Paradise Valley Community College",
+      "primaryUrl": "paradisevalley.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:21.505Z"
+    },
+    "az-arizona-western-college": {
+      "state": "az",
+      "slug": "arizona-western-college",
+      "name": "Arizona Western College",
+      "primaryUrl": "azwestern.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:28.110Z"
+    },
+    "nv-college-of-southern-nevada": {
+      "state": "nv",
+      "slug": "college-of-southern-nevada",
+      "name": "College of Southern Nevada",
+      "primaryUrl": "https://www.csn.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:30.273Z"
+    },
+    "az-yavapai-college": {
+      "state": "az",
+      "slug": "yavapai-college",
+      "name": "Yavapai College",
+      "primaryUrl": "yc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:30.725Z"
+    },
+    "az-dine-college": {
+      "state": "az",
+      "slug": "dine-college",
+      "name": "Dine College",
+      "primaryUrl": "dinecollege.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:31.159Z"
+    },
+    "ca-copper-mountain-community-college": {
+      "state": "ca",
+      "slug": "copper-mountain-community-college",
+      "name": "Copper Mountain Community College",
+      "primaryUrl": "cmccd.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:35.195Z"
+    },
+    "az-mesa-community-college": {
+      "state": "az",
+      "slug": "mesa-community-college",
+      "name": "Mesa Community College",
+      "primaryUrl": "mesacc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:41.793Z"
+    },
+    "az-gateway-community-college": {
+      "state": "az",
+      "slug": "gateway-community-college",
+      "name": "GateWay Community College",
+      "primaryUrl": "gatewaycc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:42.372Z"
+    },
+    "az-phoenix-college": {
+      "state": "az",
+      "slug": "phoenix-college",
+      "name": "Phoenix College",
+      "primaryUrl": "phoenixcollege.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:52.790Z"
+    },
+    "az-scottsdale-community-college": {
+      "state": "az",
+      "slug": "scottsdale-community-college",
+      "name": "Scottsdale Community College",
+      "primaryUrl": "scottsdalecc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:09:55.919Z"
+    },
+    "az-central-arizona-college": {
+      "state": "az",
+      "slug": "central-arizona-college",
+      "name": "Central Arizona College",
+      "primaryUrl": "centralaz.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:59.298Z"
+    },
+    "az-pima-community-college": {
+      "state": "az",
+      "slug": "pima-community-college",
+      "name": "Pima Community College",
+      "primaryUrl": "pima.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:09:59.514Z"
+    },
+    "az-south-mountain-community-college": {
+      "state": "az",
+      "slug": "south-mountain-community-college",
+      "name": "South Mountain Community College",
+      "primaryUrl": "southmountaincc.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:10:00.136Z"
+    },
+    "az-cochise-county-community-college-district": {
+      "state": "az",
+      "slug": "cochise-county-community-college-district",
+      "name": "Cochise County Community College District",
+      "primaryUrl": "cochise.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:10:00.250Z"
+    },
+    "az-estrella-mountain-community-college": {
+      "state": "az",
+      "slug": "estrella-mountain-community-college",
+      "name": "Estrella Mountain Community College",
+      "primaryUrl": "estrellamountain.edu",
+      "platform": "custom",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:10:03.562Z"
+    },
+    "az-northland-pioneer-college": {
+      "state": "az",
+      "slug": "northland-pioneer-college",
+      "name": "Northland Pioneer College",
+      "primaryUrl": "npc.edu",
+      "platform": "acalog",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:10:14.823Z"
+    },
+    "az-eastern-arizona-college": {
+      "state": "az",
+      "slug": "eastern-arizona-college",
+      "name": "Eastern Arizona College",
+      "primaryUrl": "eac.edu",
+      "platform": "coursedog",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:10:17.591Z"
+    },
+    "az-coconino-community-college": {
+      "state": "az",
+      "slug": "coconino-community-college",
+      "name": "Coconino Community College",
+      "primaryUrl": "coconino.edu",
+      "platform": "banner-ssb-9",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:10:17.594Z"
+    },
+    "az-mohave-community-college": {
+      "state": "az",
+      "slug": "mohave-community-college",
+      "name": "Mohave Community College",
+      "primaryUrl": "mohave.edu",
+      "platform": "colleague",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:10:21.017Z"
+    },
+    "az-chandler-gilbert-community-college": {
+      "state": "az",
+      "slug": "chandler-gilbert-community-college",
+      "name": "Chandler-Gilbert Community College",
+      "primaryUrl": "cgc.maricopa.edu",
+      "platform": "unknown",
+      "confidence": "low",
+      "lastChecked": "2026-05-25T00:10:33.686Z"
+    },
+    "az-tohono-oodham-community-college": {
+      "state": "az",
+      "slug": "tohono-oodham-community-college",
+      "name": "Tohono O'odham Community College",
+      "primaryUrl": "tocc.edu",
+      "platform": "jenzabar",
+      "confidence": "high",
+      "lastChecked": "2026-05-25T00:10:43.747Z"
     }
   },
   "totals": {
-    "statesSwept": 1,
-    "collegesFingerprinted": 4,
+    "statesSwept": 32,
+    "collegesFingerprinted": 652,
     "byPlatform": {
-      "custom": 2,
-      "coursedog": 1,
-      "acalog": 1
+      "unknown": 65,
+      "peoplesoft": 26,
+      "custom": 142,
+      "acalog": 24,
+      "banner-ssb-9": 94,
+      "colleague": 214,
+      "coursedog": 17,
+      "banner-8": 15,
+      "auth-gated": 13,
+      "jenzabar": 36,
+      "courseleaf": 1,
+      "ellucian-experience": 1,
+      "workday": 4
     }
   }
 }


### PR DESCRIPTION
## Summary

The first **full** fingerprint baseline after the cascade of fixes ([#528](../../pull/528) fingerprinter improvements + [#529](../../pull/529) IPEDS fallback). Future monthly refingerprint sweeps diff against this file.

## Headline numbers

**652 colleges fingerprinted across 32 states.** Compared to the May 9 snapshot (`data/fingerprint-sweep.json`):

| Platform | May 9 | Now | Delta |
|---|---|---|---|
| **colleague** | 54 | **214** | **+160** |
| **banner-ssb-9** | 52 | **94** | **+42** |
| peoplesoft | 18 | 26 | +8 |
| custom | 147 | 142 | -5 |

Sample sizes aren't quite identical (May 9 was ~448 productive colleges, now 652 because we also covered states the May 9 sweep skipped due to IPEDS outage), so direct subtraction is approximate. But the magnitude is clear: **PR #528's Colleague marker broadening alone found ~160 colleges** that were previously classified as `custom` or `unknown`.

## Two immediate consequences

### 1. Coverage-expansion will surface 170 wire-in candidates

Running `scripts/lib/coverage-expansion.ts` against this baseline locally:

```
170 candidates (all high-confidence):
  104 Colleague
   34 Jenzabar
   18 Banner SSB 9
   10 Coursedog
    4 Banner 8
```

Once this PR merges, the next Tuesday tick of `coverage-expansion.yml` ([#525](../../pull/525)) opens a rolling issue with these candidates. Each one is "fingerprints as a templated platform, no course data yet" — i.e., extend the existing scraper to include this college.

### 2. Investigator agent's scope is now well-defined

`142 custom + 65 unknown = 207 colleges` remain in the "needs investigation" bucket. That's the agent's target scope. Spot-check showed ~50% will turn out to have public PDF catalogs, articulation portals, or other actionable paths.

## How this was produced

Running the GH workflow hit two issues — the first attempt was the broken pre-#529 script (only fingerprinted 4 NV colleges); the retry was canceled because the GH Actions UI didn't show step-level progress and we couldn't tell if it was wedged. I ran it locally with concurrency 8, took ~25 min with live progress, then committed the result.

Future monthly cron runs (post-#529) should work autonomously.

## Test plan

- [ ] Reviewer eyeballs the totals at the bottom of `fingerprint-baseline.json` — match the table above?
- [ ] After merge: `gh workflow run coverage-expansion.yml` to fire the rolling issue immediately (instead of waiting until Tuesday)
- [ ] Then decide: build the investigator agent against the 207-college "needs investigation" set?

🤖 Generated with [Claude Code](https://claude.com/claude-code)