### PR TITLE
feat(state-health): persist courseSearchUrl in fingerprint baseline

### DIFF
--- a/scripts/lib/coverage-expansion.ts
+++ b/scripts/lib/coverage-expansion.ts
@@ -51,6 +51,12 @@ interface BaselineEntry {
   primaryUrl: string;
   platform: string;
   confidence: "high" | "medium" | "low";
+  /** Specific SIS course-search URL discovered during fingerprinting (e.g.
+   *  https://selfservice.cotc.edu/Student/Courses). Required for wire-in
+   *  work since per-state scrapers consume SIS URLs, not the marketing
+   *  homepage. May be missing on older baseline entries written before
+   *  this field was persisted. */
+  courseSearchUrl?: string | null;
   lastChecked: string;
 }
 

--- a/scripts/lib/refingerprint-sweep.ts
+++ b/scripts/lib/refingerprint-sweep.ts
@@ -49,6 +49,14 @@ interface CollegeEntry {
   primaryUrl: string;
   platform: Platform;
   confidence: "high" | "medium" | "low";
+  /**
+   * Specific course-search URL the fingerprinter discovered (e.g.
+   * https://selfservice.cotc.edu/Student/Courses for OH/COTC). Required
+   * for "wire-in" workflow: per-state scrapers consume URLs like this,
+   * not the marketing homepage. Null when the fingerprinter couldn't
+   * identify a usable course-search endpoint.
+   */
+  courseSearchUrl: string | null;
   lastChecked: string; // ISO8601
 }
 
@@ -167,6 +175,7 @@ async function runSweep(tasks: SweepTask[]): Promise<CollegeEntry[]> {
           primaryUrl: t.url,
           platform: result.platform,
           confidence: result.confidence,
+          courseSearchUrl: result.courseSearchUrl,
           lastChecked: new Date().toISOString(),
         });
       } catch (err) {
@@ -177,6 +186,7 @@ async function runSweep(tasks: SweepTask[]): Promise<CollegeEntry[]> {
           primaryUrl: t.url,
           platform: "unknown" as Platform,
           confidence: "low",
+          courseSearchUrl: null,
           lastChecked: new Date().toISOString(),
         });
       }


### PR DESCRIPTION
## Summary

Small infrastructure PR — first step of Path A2 (wire-in 170 coverage candidates with verified SIS URLs). The refingerprint sweep was throwing away the most actionable field on `FingerprintResult`: the specific course-search URL the probe actually hit.

## Why this matters

The 170 wire-in candidates from [PR #532](../../pull/532) need the specific SIS URL per college to actually plug into existing `scripts/{state}/scrape-{platform}.ts` files. The conventional `selfservice.<rootdomain>` pattern works for some but **fails for many**:

| College | Marketing host | Actual SIS URL |
|---|---|---|
| Central Ohio Technical | `cotc.edu` | `https://self-service.cotc.edu:8183/Student/courses` (hyphen, port 8183, lowercase) |
| Washington State CC Ohio | `wscc.edu` | `https://selfservice.wsco.edu/Student/Courses` (different root domain) |
| Fresno City | `fresnocitycollege.edu` | `https://selfservice.scccd.edu/Student/Courses` (system-wide) |

Without the persisted `courseSearchUrl`, every wire-in would be a guess. With it, wire-ins become deterministic: read the field, paste into the scraper's `HOSTS` map.

## Two files changed

- **`scripts/lib/refingerprint-sweep.ts`** — `CollegeEntry` interface gains `courseSearchUrl: string | null`. Both success and error paths set it explicitly.
- **`scripts/lib/coverage-expansion.ts`** — `BaselineEntry` mirrors the field as optional (`courseSearchUrl?: string | null`). Optional so we don't break reads of older baselines that lack it.

## What this does NOT do

- **Doesn't re-run refingerprint** to backfill the existing baseline. That's a manual re-run after merge (~25 min local).
- **Doesn't change the coverage-expansion rolling issue body.** The field is now in the JSON output, but markdown table rendering can be a follow-up. The immediate consumer is the wire-in workflow.

## Next steps after merge

1. Re-run refingerprint locally — re-fingerprints all 652 colleges to capture `courseSearchUrl` for each, ~25 min wall time
2. Commit the refreshed baseline (separate small PR)
3. Bulk wire-ins per (state, platform) cluster — 18 PRs each adding verified SIS URLs to the existing scraper's `HOSTS` map

## Test plan

- [ ] Reviewer eyeballs the diff — two small interface additions, no logic changes
- [ ] Smoke test in this PR already verified: fingerprint on `cotc.edu` returns `courseSearchUrl: https://self-service.cotc.edu:8183/Student/courses`. Pre-fix that field was discarded; post-fix it persists into the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)