### PR TITLE
Populate popularCourses for 13 states from real data

### DIFF
--- a/lib/states/ar/config.ts
+++ b/lib/states/ar/config.ts
@@ -13,7 +13,7 @@ const arConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENGL 1013", "PSYC 2003", "ENGL 1023", "MATH 1203", "BIOL 1544", "PLSC 2003"],
   defaultZip: "",
   defaultZipCity: "",
 

--- a/lib/states/ca/config.ts
+++ b/lib/states/ca/config.ts
@@ -15,7 +15,7 @@ const caConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENGL C1000", "COMM C1000", "STAT C1000", "ENGL C1001", "PSYC C1000", "POLS C1000"],
   defaultZip: "90029",
   defaultZipCity: "Los Angeles",
 

--- a/lib/states/hi/config.ts
+++ b/lib/states/hi/config.ts
@@ -24,7 +24,7 @@ const hiConfig: StateConfig = {
   },
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENG 1007", "ENG 1005", "ENG 1006", "PHYL 141L5", "PHYL 1415", "SP 1515"],
   defaultZip: "96813",
   defaultZipCity: "Honolulu",
 

--- a/lib/states/ia/config.ts
+++ b/lib/states/ia/config.ts
@@ -16,7 +16,7 @@ const iaConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENG 105", "SPC 112", "PSY 111", "SOC 110", "ENG 106", "BIO 168"],
   defaultZip: "50309",
   defaultZipCity: "Des Moines",
 

--- a/lib/states/il/config.ts
+++ b/lib/states/il/config.ts
@@ -14,7 +14,7 @@ const ilConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENGLISH 101", "BIOLOGY 121", "CHEM 121", "ENG 101", "ENGLISH 102", "SPEECH 101-1"],
   defaultZip: "60601",
   defaultZipCity: "Chicago",
 

--- a/lib/states/ky/config.ts
+++ b/lib/states/ky/config.ts
@@ -14,7 +14,7 @@ const kyConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["NAA 100", "ENG 101", "BIO 137", "BIO 139", "MAT 150", "PSY 110"],
   defaultZip: "40202",
   defaultZipCity: "Louisville",
 

--- a/lib/states/mi/config.ts
+++ b/lib/states/mi/config.ts
@@ -34,7 +34,7 @@ const miConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENG 111", "ENG 1510", "ENG 101", "ENGL 101", "ENGL 121", "ENG 1520"],
   defaultZip: "48933",
   defaultZipCity: "Lansing",
 

--- a/lib/states/mo/config.ts
+++ b/lib/states/mo/config.ts
@@ -21,7 +21,7 @@ const moConfig: StateConfig = {
   },
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENG 101", "ENGL 101", "PSY 110", "MTH 128", "ENG 102", "PLS 101"],
   defaultZip: "65101",
   defaultZipCity: "Jefferson City",
 

--- a/lib/states/ms/config.ts
+++ b/lib/states/ms/config.ts
@@ -14,7 +14,7 @@ const msConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["SPT 1113", "ENG 1113", "HPR 2132", "HPR 1132", "BIO 2511", "PSY 1513"],
   defaultZip: "39201",
   defaultZipCity: "Jackson",
 

--- a/lib/states/mt/config.ts
+++ b/lib/states/mt/config.ts
@@ -13,7 +13,7 @@ const mtConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["COLS 111", "ENGL 101", "NASD 101", "ENGL 306", "ENGL 202", "WRIT 101"],
   defaultZip: "59601",
   defaultZipCity: "Helena",
 

--- a/lib/states/oh/config.ts
+++ b/lib/states/oh/config.ts
@@ -21,7 +21,7 @@ const ohConfig: StateConfig = {
   },
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENG 1010", "MATH 1410", "ENG 1020", "PSY 1010", "GEN 1070", "COMM 1010"],
   defaultZip: "43215",
   defaultZipCity: "Columbus",
 

--- a/lib/states/or/config.ts
+++ b/lib/states/or/config.ts
@@ -11,7 +11,7 @@ const orConfig: StateConfig = {
   seniorWaiver: null,
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["WR 121Z", "MTH 111Z", "WR 227Z", "COMM 111Z", "PSY 201Z", "WR 115"],
   defaultZip: "97201",
   defaultZipCity: "Portland",
 

--- a/lib/states/tx/config.ts
+++ b/lib/states/tx/config.ts
@@ -30,7 +30,7 @@ const txConfig: StateConfig = {
   },
 
   transferSupported: false,
-  popularCourses: [],
+  popularCourses: ["ENGL 1301", "MATH 1314", "ENGL 1302", "HIST 1301", "GOVT 2305", "EDUC 1300"],
   defaultZip: "77002",
   defaultZipCity: "Houston",
 


### PR DESCRIPTION
## What changes for users

13 state search pages get useful course suggestions. Before: a blank chip row under the search bar. After: 6 real courses students can click directly into.

Affected states: ar, ca, hi, ia, il, ky, mi, mo, ms, mt, oh, or, tx (everyone whose audit row read \"popularCourses empty\").

## What changes technically

Pure config fix — one line per state in \`lib/states/{slug}/config.ts\`. Each \`popularCourses: []\` becomes the top 6 most-offered courses for that state, derived from a fresh count of \`data/{state}/courses/**/*.json\` (credit-bearing sections only).

Picks reflect what the data actually shows, including states where multiple districts use different prefixes for what's effectively the same course (MI: ENG 111 vs ENG 1510 vs ENGL 101 vs ENGLISH 101 — five separate community college systems with five conventions). I didn't normalize — these are the courses with the most sections, and that's what students will actually search.

Per-state picks live in the commit message.

## Test plan

- [ ] After merge, the AZ-style state pages for each of the 13 show 6 course chips under the search bar (not empty)
- [ ] Next audit pass: \`popularCourses empty\` drops from 14 → 1 (only AZ remains, fixed by parallel PR #536)
🤖 Generated with [Claude Code](https://claude.com/claude-code)