### PR TITLE
fix: drop transfer-equiv.json from serverless bundles

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,14 +16,11 @@ const nextConfig: NextConfig = {
   // /api/[state]/prereqs/* handlers actually read the files.
   outputFileTracingIncludes: {
     "/api/[state]/prereqs/**": ["./data/*/prereqs.json"],
-    // Routes that read transfer-equiv.json at runtime via lib/transfer.ts
-    // (or its sitemap helper). Re-included after the blanket exclusion
-    // below so the data ships only to functions that need it.
-    "/api/[state]/transfer/**": ["./data/*/transfer-equiv.json"],
-    "/sitemap/transfer.xml/**": ["./data/*/transfer-equiv.json"],
-    "/[state]/transfer/**": ["./data/*/transfer-equiv.json"],
-    "/[state]/course/[code]/**": ["./data/*/transfer-equiv.json"],
-    "/[state]/schedule/**": ["./data/*/transfer-equiv.json"],
+    // transfer-equiv.json is NOT re-included here despite the blanket
+    // exclusion below. At ~200 MB across all states, bundling it into
+    // serverless functions blew past Vercel's 250 MB cap. Production
+    // reads transfers from Supabase; the local JSON fallback in
+    // lib/transfer.ts is only exercised in local dev (no size cap).
   },
   // `lib/data-freshness.ts` (#401) calls `fs.readdirSync(path.join(
   // "data", state, "courses", collegeSlug))` with dynamic state+slug

--- a/scripts/lib/supabase-import.ts
+++ b/scripts/lib/supabase-import.ts
@@ -475,23 +475,36 @@ export async function importTransfersToSupabase(
     is_elective: m.is_elective,
   }));
 
-  // Insert in batches — abort on first failure to limit data loss
+  // Insert in batches with retry — abort after retries exhausted
+  const MAX_RETRIES = 3;
   let totalInserted = 0;
   let aborted = false;
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
     const batch = rows.slice(i, i + BATCH_SIZE);
-    const { error: insError } = await sb.from("transfers").insert(batch);
-    if (insError) {
-      console.error(
-        `  FATAL: Insert failed for ${state} transfers batch ${i}: ${insError.message}`
-      );
-      console.error(
-        `  WARNING: ${rows.length - totalInserted} rows lost — delete already committed.`
-      );
-      aborted = true;
-      break;
+    let succeeded = false;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      const { error: insError } = await sb.from("transfers").insert(batch);
+      if (!insError) {
+        succeeded = true;
+        break;
+      }
+      if (attempt < MAX_RETRIES) {
+        console.warn(
+          `  Batch ${i} attempt ${attempt} failed: ${insError.message} — retrying in ${attempt * 2}s...`
+        );
+        await new Promise((r) => setTimeout(r, attempt * 2000));
+      } else {
+        console.error(
+          `  FATAL: Insert failed for ${state} transfers batch ${i} after ${MAX_RETRIES} attempts: ${insError.message}`
+        );
+        console.error(
+          `  WARNING: ${rows.length - totalInserted} rows lost — delete already committed.`
+        );
+        aborted = true;
+      }
     }
-    totalInserted += batch.length;
+    if (aborted) break;
+    if (succeeded) totalInserted += batch.length;
   }
   if (aborted) {
     console.error(`  Aborting remaining transfer batches for ${state}.`);


### PR DESCRIPTION
## What changes for users

Nothing visible — this fixes a deploy failure. The Vercel build was rejecting deploys because serverless functions exceeded the 250 MB unzipped size cap. Transfer pages continue to work exactly as before since production reads from Supabase.

## What changed technically

Transfer-equiv.json files across all states total ~200 MB. The `outputFileTracingIncludes` in next.config.ts was re-bundling every state's file into each transfer-related serverless function (5 route patterns), pushing past Vercel's 250 MB cap after AZ added 28K mappings. Removed those include entries — production uses Supabase first via `lib/transfer.ts`, so the local JSON fallback only fires in local dev where there's no size limit.

Also added retry logic (3 attempts with backoff) to the transfer Supabase import script — the AZ import was failing partway through due to connection timeouts, and the delete-then-insert pattern meant partial failures lost already-deleted data.

## Test plan

- [x] AZ transfers fully imported to Supabase (28,842 rows)
- [ ] Vercel preview deploy succeeds (no 250 MB cap error)
- [ ] Transfer pages still load on preview (Supabase path works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)