### PR TITLE
fix(fingerprint): remove CA from STATE_SYSTEM_HOSTS — prevents 70+ false positives

### DIFF
--- a/scripts/lib/fingerprint-college.ts
+++ b/scripts/lib/fingerprint-college.ts
@@ -254,10 +254,20 @@ const STATE_SYSTEM_HOSTS: Record<string, string[]> = {
   co: ["erpdnssb.cccs.edu"],
   // Alabama Community College System — 22 colleges (Drake, etc.)
   al: ["ssb-prod.ec.accs.edu"],
-  // California — system-by-system, not statewide. SCCCD (Fresno/Reedley/
-  // Clovis), CCCD (Coast — Orange Coast/Coastline/Golden West). Add more
-  // CA systems as their colleges surface in coverage gaps.
-  ca: ["selfservice.scccd.edu", "catalog.cccd.edu"],
+  // California is intentionally excluded. CA has 117 colleges spread
+  // across 73+ multi-college districts (SCCCD, CCCD, Los Rios, Peralta,
+  // SDCCD, etc.), and the SIS lives per-DISTRICT, not per-state. Adding
+  // a state-wide entry like `selfservice.scccd.edu` causes EVERY CA
+  // college to match SCCCD's host (since Colleague at /Student/Courses
+  // returns 200 + markers regardless of which college is asking),
+  // polluting ~70 colleges with the wrong courseSearchUrl. Discovered
+  // during a wire-in attempt: American River, Berkeley City, Cerritos,
+  // etc. all got fingerprinted as Colleague-at-SCCCD when they're
+  // actually on Los Rios / Peralta / their own districts.
+  //
+  // For CA, rely on per-college homepage harvesting + URL_PATTERN
+  // classification (handled by Steps 1-1b of fingerprint()). The
+  // untouchable-investigator agent picks up the residual.
 };
 
 // Substrings that, when found in any URL on the college homepage, are a


### PR DESCRIPTION
## What changes for someone using the site

Indirectly. Prevents a class of wrong scraper wire-ins. Caught a real bug during today's wire-in work — stopped before committing 70 incorrect entries.

## The bug

[PR #528](../../pull/528) added `STATE_SYSTEM_HOSTS["ca"] = ["selfservice.scccd.edu", "catalog.cccd.edu"]` to probe state-system shared SIS hosts for CA, intending to mirror the working pattern for ND/MN/CO/AL.

But CA is structurally different: **117 colleges across 73+ multi-college districts**, with SIS per-DISTRICT rather than per-state. SCCCD only covers Fresno/Reedley/Clovis. CCCD only covers Coast colleges. There's no statewide CA SIS host.

**Result:** every CA college's fingerprint matched SCCCD's selfservice host (since Colleague at `/Student/Courses` returns 200+markers regardless of which college is asking), and got classified as `colleague` with `courseSearchUrl: https://selfservice.scccd.edu/Student/Courses`.

## How I caught it

The 75-college `ca/colleague` wire-in batch from coverage-expansion ([#525](../../pull/525)) showed all 70 candidates with the same URL — American River, Berkeley City, Cerritos, etc., all pointing at SCCCD. Colleges that obviously aren't in SCCCD. Smelled wrong, verified directly, confirmed.

## Verification

| College | Before | After |
|---|---|---|
| arc.losrios.edu | colleague (wrong) | custom (low) ✓ |
| cerritos.edu | colleague (wrong) | courseleaf (high) ✓ bonus |
| fresnocitycollege.edu | colleague (right) | custom (low) ⚠ regression |

Cerritos picks up its real CourseLeaf catalog (`cerritos-public.courseleaf.com`) via the homepage harvest. Fresno (a legitimate SCCCD member) regresses to `custom` — the [untouchable-investigator agent](.claude/agents/untouchable-investigator.md) can recover those 3 real SCCCD colleges separately.

## Trade-off summary

| | Before this PR | After this PR |
|---|---|---|
| False positives (CA colleges wrongly tagged as SCCCD Colleague) | **~70** | 0 |
| Legitimate SCCCD matches lost (Fresno/Reedley/Clovis) | 3 found | 3 lost → recoverable via investigator agent |

## What this PR does NOT do

Doesn't trigger a baseline refresh. The existing `data/state-health/fingerprint-baseline.json` still has the polluted CA entries. They get corrected on the next monthly refingerprint cron OR via `gh workflow run refingerprint-sweep.yml`. Until then, downstream consumers should ignore the CA Colleague candidates from coverage-expansion.

## Test plan

- [ ] Reviewer eyeballs the diff — single change to STATE_SYSTEM_HOSTS map
- [ ] Verification block above confirms the fix
- [ ] After merge: trigger refingerprint via workflow_dispatch (or wait for June 1 cron) to refresh the CA baseline

## Long-term improvement (not in this PR)

Could re-add CA support with a more precise mapping — per-district rather than per-state, keyed by the college's primaryUrl pattern. Out of scope here — the simpler fix unblocks the wire-in work today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
