### PR TITLE
fix(ar): replace auto-add-state placeholders — Arkansas, not 'Ar'

### DIFF
--- a/lib/states/ar/config.ts
+++ b/lib/states/ar/config.ts
@@ -2,10 +2,16 @@ import type { StateConfig } from "../registry";
 
 const arConfig: StateConfig = {
   slug: "ar",
-  name: "Ar",
+  name: "Arkansas",
   systemName: "Public 2-year",
-  systemFullName: "Ar Public 2-year Colleges",
-  systemUrl: "",
+  systemFullName: "Arkansas Public 2-year Colleges",
+  // Arkansas has no single community college system. Oversight comes from
+  // the Arkansas Division of Higher Education (ADHE), which also operates
+  // ACTS (the statewide course-transfer common-numbering system). Several
+  // AR community colleges are affiliated with the University of Arkansas
+  // System (UACC-Batesville, -Hope, -Morrilton, -Rich Mountain, Phillips
+  // CC, Cossatot, UAPTC); the rest are independent.
+  systemUrl: "https://adhe.edu/",
   collegeCount: 14,
   seniorWaiver: {
     ageThreshold: 60,
@@ -21,8 +27,8 @@ const arConfig: StateConfig = {
 
   transferSupported: true,
   popularCourses: ["ENGL 1013", "PSYC 2003", "ENGL 1023", "MATH 1203", "BIOL 1544", "PLSC 2003"],
-  defaultZip: "",
-  defaultZipCity: "",
+  defaultZip: "72201",
+  defaultZipCity: "Little Rock",
 
   courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
     "https://www.example.edu/",
@@ -31,14 +37,16 @@ const arConfig: StateConfig = {
     "https://www.example.edu/",
 
   branding: {
-    siteName: "Community College Path Ar",
-    tagline: "Search Public 2-year courses across all 14 colleges.",
-    footerText: "Community College Path Ar — Find courses across all 14 Public 2-year colleges.",
-    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by Ar Public 2-year Colleges.",
+    siteName: "Community College Path Arkansas",
+    tagline: "Search course schedules across Arkansas's 14 community colleges.",
+    footerText: "Community College Path Arkansas — Find courses across all 14 Arkansas community colleges.",
+    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by Arkansas's community colleges, the Arkansas Division of Higher Education (ADHE), or the ACTS Course Transfer System.",
     metaKeywords: [
-      "Ar community college courses",
-      "Public 2-year course search",
-      "Ar Public 2-year Colleges",
+      "Arkansas community college courses",
+      "Arkansas course search",
+      "NWACC NorthWest Arkansas community college",
+      "UACC Batesville Hope Morrilton Rich Mountain",
+      "ACTS Arkansas Course Transfer System",
     ],
   },
   scrapers: {


### PR DESCRIPTION
## What changes for users

The AR state shows as **"Arkansas"** everywhere instead of the truncated **"Ar"**. Same fix for the system name, site name, footer, and disclaimer. The `/ar` zip-search now defaults to a real ZIP (`72201`, Little Rock) instead of an empty placeholder.

Before:
- Homepage state card: "Ar"
- `/ar/colleges` header: "Community College Path Ar"
- Disclaimer: "...sponsored by Ar Public 2-year Colleges"
- ZIP search field: empty placeholder

After:
- "Arkansas" / "Community College Path Arkansas" / proper ADHE+ACTS disclaimer / `72201` Little Rock placeholder

## What changes technically

AR was bootstrapped via `/auto-add-state` (PR series before this) but the curated config values were left as placeholders. This is the known *auto-add-state-leaves-placeholders* pattern called out in memory — same fix shape as previous post-bootstrap config polishes.

Concrete diff (config-only, no code):

```diff
- name: "Ar"
+ name: "Arkansas"
- systemFullName: "Ar Public 2-year Colleges"
+ systemFullName: "Arkansas Public 2-year Colleges"
- systemUrl: ""
+ systemUrl: "https://adhe.edu/"
- defaultZip: "" / defaultZipCity: ""
+ defaultZip: "72201" / defaultZipCity: "Little Rock"

- branding.siteName: "Community College Path Ar"
+ branding.siteName: "Community College Path Arkansas"
   (plus tagline, footerText, disclaimer, metaKeywords)
```

Also adds a comment explaining AR has no single CC system — it's a mix of UA-System affiliates (UACC-Batesville/Hope/Morrilton/Rich Mountain, Phillips, Cossatot, UAPTC) and independents, with the Arkansas Division of Higher Education (ADHE) as the regulator + operator of ACTS.

## What this PR does NOT address

These are the *other* AR gaps surfaced in the audit but out of scope here (each gets its own PR):

- **4 colleges still missing course data**: arkansas-northeastern-college, black-river-technical-college, south-arkansas-college, university-of-arkansas-community-college-morrilton
- **7 transfer receivers still uncovered**: UALR, UAFS, UAPB, SAU, ASU-Jonesboro, HSU, UAM (per PR #552's deferred list)
- **Programs**: no scraper yet
- **collegeCount: 14** — accurate vs the institutions.json count, no fix needed

## Test plan

- [ ] After merge, `communitycollegepath.com/` homepage shows the AR state card as "Arkansas"
- [ ] `/ar/colleges` page header reads "Community College Path Arkansas"
- [ ] `/ar` zip-search field shows the Little Rock placeholder
- [ ] No regressions on the existing 10/14 course-data colleges or the 264 transfer mappings from PR #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
