### PR TITLE
docs(auto-add-state): require 15-min reprobe of first-pass defer verdicts

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -276,6 +276,51 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
     require JavaScript-only interactions you can't reverse-engineer in
     under ~30 minutes.
 
+    **Re-probe THIS run's first-pass deferral verdicts before accepting
+    them — most are wrong.** When the orchestrator (or your initial
+    investigation, or a research subagent) labels a college "WAF-blocked",
+    "PDF only", "PeopleSoft SSO", or "unidentified dashboard", spend 15
+    minutes verifying before adding it to the deferred list. The
+    AR-2026-05-24 / 2026-05-25 session shipped 6 follow-up scrapers; 4 of
+    those colleges had been deferred for reasons that turned out to be
+    wrong on a second look:
+
+    - **Ozarka** ("WAF-blocked POST") — actual blocker was a missing
+      `Submit=View+Courses` form field name. Pure-Node fetch with the
+      right body works, no Playwright needed. 306 sections shipped (#540).
+    - **NPC** ("PeopleSoft SSO only") — PS instance was SSO-only, but the
+      college also publishes a nightly-refreshed structured PDF schedule
+      that `pdftotext -layout` parses cleanly. 402 sections shipped (#541).
+    - **UARM** ("PDF only") — the Quicklinks dropdown on the student-login
+      page links to an embedded Power BI report (same tenant as PCCUA).
+      97 sections shipped via the shared UA-system scraper (#544).
+    - **PCCUA** ("Power BI half-day Playwright DOM scrape") — same Power
+      BI WD_Courses 12-column schema as UACCB; the rich query just needs
+      the visual *focused* (one click) before it fires. 461 sections
+      shipped with a one-line addition (#546).
+
+    **Per-college 15-minute probe checklist:**
+    1. Open the college homepage in a real browser-like fetch — find a
+       "Course Schedules" / "Class Search" / Quicklinks dropdown link.
+       It's often not on the homepage but in a student-portal page.
+    2. If the link goes to `app.powerbi.com/view?r=...`, that's a Power
+       BI embed — try `scripts/ar/scrape-ua-powerbi.ts` as a template
+       (the DAX RLE+dictionary decoder is generic).
+    3. If it goes to a `.cfm` form, try POSTing with the submit-button
+       name included (`Submit=...`); ColdFusion routes off it.
+    4. If it goes to a PDF, check whether `pdftotext -layout` produces
+       clean fixed-width columns (NPC pattern) before deferring.
+    5. If the orchestrator's fingerprint says PeopleSoft SSO, separately
+       probe whether the college publishes a static schedule view on
+       their `.edu` marketing site (often hidden under
+       `/admissions/class-schedules` or similar).
+
+    The **`untouchable-investigator`** agent (see `.claude/agents/`) is
+    purpose-built for exactly this kind of triage and runs all five
+    probes per college in parallel. Use it via Agent with
+    `subagent_type: "untouchable-investigator"` for any college you're
+    about to defer with a non-obvious reason.
+
     **Re-probe before trusting a "PDF-only" / "auth-gated" / "unavailable"
     comment in an existing scraper.** Findings rot — colleges deploy
     Banner SSB 9, swap into Colleague Self-Service, or replace their


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-visible. Skill documentation only — codifies the lesson from the AR 2026-05-25 follow-up session so future `/auto-add-state` runs don't leave easy wins on the table.

## What changes on the technical front

During the AR follow-up sweep (PRs #537/540/541/544/546), 6 colleges that had been deferred from the original AR PR (#534) were re-probed. **4 of those 6 turned out to have an easy path** that a 15-minute deeper investigation surfaced — not the multi-hour rewrites the original defer notes implied. Together those four shipped **1,266 sections** that would have stayed dark if the first-pass verdicts had been accepted as final:

| College | Original defer reason | Actual fix | Sections shipped |
|---|---|---|---|
| Ozarka | "WAF-blocked POST" | Missing `Submit=View+Courses` form field name | 306 |
| NPC | "PeopleSoft SSO only" | Public nightly PDFs, `pdftotext -layout` cleanly extracts | 402 |
| UARM | "PDF only" | Embedded Power BI on Quicklinks dropdown (same tenant as PCCUA) | 97 |
| PCCUA | "half-day Playwright DOM scrape" | Same WD_Courses 12-col schema as UACCB; visual needs one click to fire rich query | 461 |

That's 1,266 / 1,825 = **69% of the session's follow-up sections** would have been left on the table.

This PR adds three things to `.claude/skills/auto-add-state/SKILL.md` step 12:

1. **The rule itself** — "Re-probe THIS run's first-pass deferral verdicts before accepting them — most are wrong." All four case studies named with concrete reasons so the next person can pattern-match.
2. **A 5-step per-college probe checklist** covering the patterns that actually paid off (Power BI Quicklinks, ColdFusion submit name, `pdftotext -layout` viability, hidden static schedule pages, PS-SSO vs static publication).
3. **A pointer to the new `untouchable-investigator` agent** (just made available) — purpose-built for this triage, runs the 5 probes per college in parallel.

Positioned right before the existing "Re-probe a 'PDF-only' / 'auth-gated' / 'unavailable' comment in an existing scraper" block since they're complementary:
- existing block addresses **longitudinal staleness** (sites change over months/years; old skip notes rot)
- new block addresses **first-pass overconfidence** (your initial verdict in *this* run is wrong more often than not)

## Files

| File | Change |
|---|---|
| `.claude/skills/auto-add-state/SKILL.md` | +45 lines under step 12, before the existing "Re-probe before trusting" block |

## Test plan

- [x] Skill file diff reads cleanly (no broken section nesting).
- [ ] After merge: next `/auto-add-state` run should treat the orchestrator's `manualTodos[]` defers + initial agent verdicts as starting hypotheses to probe, not final answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
