### PR TITLE
feat: email triage alerts for scraper health

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -276,6 +276,51 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
     require JavaScript-only interactions you can't reverse-engineer in
     under ~30 minutes.
 
+    **Re-probe THIS run's first-pass deferral verdicts before accepting
+    them — most are wrong.** When the orchestrator (or your initial
+    investigation, or a research subagent) labels a college "WAF-blocked",
+    "PDF only", "PeopleSoft SSO", or "unidentified dashboard", spend 15
+    minutes verifying before adding it to the deferred list. The
+    AR-2026-05-24 / 2026-05-25 session shipped 6 follow-up scrapers; 4 of
+    those colleges had been deferred for reasons that turned out to be
+    wrong on a second look:
+
+    - **Ozarka** ("WAF-blocked POST") — actual blocker was a missing
+      `Submit=View+Courses` form field name. Pure-Node fetch with the
+      right body works, no Playwright needed. 306 sections shipped (#540).
+    - **NPC** ("PeopleSoft SSO only") — PS instance was SSO-only, but the
+      college also publishes a nightly-refreshed structured PDF schedule
+      that `pdftotext -layout` parses cleanly. 402 sections shipped (#541).
+    - **UARM** ("PDF only") — the Quicklinks dropdown on the student-login
+      page links to an embedded Power BI report (same tenant as PCCUA).
+      97 sections shipped via the shared UA-system scraper (#544).
+    - **PCCUA** ("Power BI half-day Playwright DOM scrape") — same Power
+      BI WD_Courses 12-column schema as UACCB; the rich query just needs
+      the visual *focused* (one click) before it fires. 461 sections
+      shipped with a one-line addition (#546).
+
+    **Per-college 15-minute probe checklist:**
+    1. Open the college homepage in a real browser-like fetch — find a
+       "Course Schedules" / "Class Search" / Quicklinks dropdown link.
+       It's often not on the homepage but in a student-portal page.
+    2. If the link goes to `app.powerbi.com/view?r=...`, that's a Power
+       BI embed — try `scripts/ar/scrape-ua-powerbi.ts` as a template
+       (the DAX RLE+dictionary decoder is generic).
+    3. If it goes to a `.cfm` form, try POSTing with the submit-button
+       name included (`Submit=...`); ColdFusion routes off it.
+    4. If it goes to a PDF, check whether `pdftotext -layout` produces
+       clean fixed-width columns (NPC pattern) before deferring.
+    5. If the orchestrator's fingerprint says PeopleSoft SSO, separately
+       probe whether the college publishes a static schedule view on
+       their `.edu` marketing site (often hidden under
+       `/admissions/class-schedules` or similar).
+
+    The **`untouchable-investigator`** agent (see `.claude/agents/`) is
+    purpose-built for exactly this kind of triage and runs all five
+    probes per college in parallel. Use it via Agent with
+    `subagent_type: "untouchable-investigator"` for any college you're
+    about to defer with a non-obvious reason.
+
     **Re-probe before trusting a "PDF-only" / "auth-gated" / "unavailable"
     comment in an existing scraper.** Findings rot — colleges deploy
     Banner SSB 9, swap into Colleague Self-Service, or replace their

--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -501,14 +501,77 @@ jobs:
           jq -r '.markdown' /tmp/triage.json > /tmp/triage-body.md
 
           if [ -z "$existing" ]; then
-            gh issue create \
+            issue_url=$(gh issue create \
               --title "${title}" \
               --body-file /tmp/triage-body.md \
-              --label "scraper-health,automated,triage"
+              --label "scraper-health,automated,triage")
           else
             gh issue edit "$existing" --body-file /tmp/triage-body.md
             issue_state=$(gh issue view "$existing" --json state --jq .state)
             if [ "$issue_state" = "CLOSED" ]; then
               gh issue reopen "$existing" --comment "Reopening — triage found ${actionable} actionable finding(s)."
             fi
+            issue_url="https://github.com/${{ github.repository }}/issues/${existing}"
           fi
+          echo "issue_url=${issue_url}" >> "$GITHUB_OUTPUT"
+          echo "actionable=${actionable}" >> "$GITHUB_OUTPUT"
+        id: triage
+
+      - name: Email triage alert
+        if: steps.triage.outputs.actionable != '' && steps.triage.outputs.actionable != '0'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: |
+          actionable="${{ steps.triage.outputs.actionable }}"
+          issue_url="${{ steps.triage.outputs.issue_url }}"
+
+          broken=$(jq '[.results[] | select(.classification == "persistent-broken")] | length' /tmp/triage.json)
+          regressions=$(jq '[.results[] | select(.classification == "regression")] | length' /tmp/triage.json)
+          partial=$(jq '[.results[] | select(.classification == "partial-coverage-degraded")] | length' /tmp/triage.json)
+
+          # Build a plain-text summary of what's broken
+          summary=$(jq -r '
+            [.results[] | select(.classification == "persistent-broken" or .classification == "regression" or .classification == "partial-coverage-degraded")]
+            | map("• \(.state | ascii_upcase)/\(.datatype) job \(.job_index): \(.classification) — \(.key_signals | join("; "))")
+            | join("\n")
+          ' /tmp/triage.json)
+
+          subject="⚠️ Scraper triage: ${actionable} finding(s) need attention"
+
+          text="Scraper Health Triage Alert
+
+${actionable} actionable finding(s) from the latest cron run:
+- Persistent-broken: ${broken}
+- Regressions: ${regressions}
+- Partial-coverage: ${partial}
+
+${summary}
+
+View full triage: ${issue_url}
+Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          html="<div style=\"font-family: -apple-system, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;\">
+          <h2 style=\"color: #0d9488;\">Scraper Health Triage</h2>
+          <p><strong>${actionable}</strong> actionable finding(s) from the latest cron run:</p>
+          <ul>
+            <li>🔴 Persistent-broken: <strong>${broken}</strong></li>
+            <li>🟡 Regressions: <strong>${regressions}</strong></li>
+            <li>🟠 Partial-coverage: <strong>${partial}</strong></li>
+          </ul>
+          <pre style=\"background: #f4f4f5; padding: 12px; border-radius: 6px; font-size: 13px; overflow-x: auto;\">${summary}</pre>
+          <p><a href=\"${issue_url}\" style=\"color: #0d9488;\">View full triage →</a></p>
+          <hr style=\"border: none; border-top: 1px solid #eee;\">
+          <p style=\"font-size: 11px; color: #aaa;\">Community College Path · automated alert</p>
+          </div>"
+
+          curl -s -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${RESEND_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg from "Community College Path <notifications@communitycollegepath.com>" \
+              --arg to "rohanuplekar@gmail.com" \
+              --arg subject "$subject" \
+              --arg html "$html" \
+              --arg text "$text" \
+              '{from: $from, to: $to, subject: $subject, html: $html, text: $text}'
+            )"


### PR DESCRIPTION
## What changes for users

Nothing on the site. You'll get an email at rohanuplekar@gmail.com whenever a cron scrape run finds broken or regressing scrapers.

## What changed technically

Added a new step to the `health` job in `scheduled-scrape.yml` that fires after the triage classifier. When actionable findings exist (persistent-broken, regression, or partial-coverage-degraded), it sends an email via the Resend API with:
- Count of broken/regressing/partial scrapers
- One-line summary per finding (e.g. "WV/courses job 0: persistent-broken — 4 consecutive failures")
- Link to the full triage GitHub issue

When everything is healthy, no email is sent.

## Setup required

Add `RESEND_API_KEY` as a GitHub Actions secret (same value as the Vercel env var):
**Settings → Secrets and variables → Actions → New repository secret**

## Test plan

- [ ] Add RESEND_API_KEY to GitHub Actions secrets
- [ ] Next cron run with actionable findings sends email
- [ ] Cron run with all healthy does NOT send email

🤖 Generated with [Claude Code](https://claude.com/claude-code)