### PR TITLE
feat(tx): TCCNS transfer equivalencies — 186K mappings

### DIFF
--- a/lib/states/il/config.ts
+++ b/lib/states/il/config.ts
@@ -68,12 +68,9 @@ const ilConfig: StateConfig = {
     // Colleague), then aggregated into data/il/prereqs.json by the unified
     // pipeline. Declaring this sentinel lights up the cron prereq job.
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: transfers — iTransfer.org's iManage portal (the IL statewide
-    // articulation tool) is behind login at https://imanage.itransfer.org/IAI/;
-    // the public iTransfer pages only describe IAI codes themselves, not the
-    // per-college crosswalk. Realistic path is CollegeTransfer.net (see
-    // scripts/lib/scrape-collegetransfer.ts) with receiver IDs for IL public
-    // universities (UIUC, UIC, ISU, NIU, SIU, etc.). Not yet built.
+    // manual-only: transfers — CollegeTransfer.Net has zero IL in-state targets
+    // (only Indiana universities). Need iTransfer.org (login-gated) or
+    // individual university articulation pages.
     // manual-only: programs — Phase 5+; no state has program scrapers yet.
   },
 };

--- a/lib/states/mi/config.ts
+++ b/lib/states/mi/config.ts
@@ -82,7 +82,9 @@ const miConfig: StateConfig = {
       { scripts: ["scripts/mi/scrape-banner-ssb.ts"], runner: "http" },
     ],
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: transfers — no articulation portal registered for MI yet.
+    // manual-only: transfers — CollegeTransfer.Net has zero MI in-state targets.
+    // Michigan Transfer Network (michigantransfernetwork.org) or individual
+    // university pages are the realistic path.
     // manual-only: programs — Phase 5+.
   },
 };

--- a/lib/states/oh/config.ts
+++ b/lib/states/oh/config.ts
@@ -54,7 +54,9 @@ const ohConfig: StateConfig = {
       { scripts: ["scripts/oh/scrape-colleague.ts"], runner: "playwright" },
       { scripts: ["scripts/oh/scrape-banner8.ts"], runner: "http" },
     ],
-    // manual-only: transfers — no articulation portal registered for OH yet.
+    // manual-only: transfers — CollegeTransfer.Net has zero OH in-state targets.
+    // OhioTransfer.org / TAG (Transfer Assurance Guides) or individual
+    // university articulation pages are the realistic path.
     prereqs: { source: "aggregate-from-courses" },
     // manual-only: programs — Phase 5+.
   },

--- a/lib/states/tx/config.ts
+++ b/lib/states/tx/config.ts
@@ -29,7 +29,7 @@ const txConfig: StateConfig = {
       "Texas Education Code § 54.365 lets Texas residents aged 65+ take up to 6 credit hours per semester at any state-funded community college without paying tuition, on a space-available basis. Fees still apply; seats are allocated after regular registration. Contact your college's registrar for the timing.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   popularCourses: ["ENGL 1301", "MATH 1314", "ENGL 1302", "HIST 1301", "GOVT 2305", "EDUC 1300"],
   defaultZip: "77002",
   defaultZipCity: "Houston",
@@ -114,7 +114,9 @@ const txConfig: StateConfig = {
         runner: "http",
       },
     ],
-    // manual-only: transfers — Phase 3 (transfer-equiv) not yet wired up.
+    transfers: [
+      { scripts: ["scripts/tx/scrape-transfer-tccns.ts"], runner: "http" },
+    ],
     // manual-only: prereqs — Phase 4.
     // manual-only: programs — Phase 5+.
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "resend": "^6.10.0",
         "topojson-client": "^3.1.0",
         "us-atlas": "^3.0.1",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -3663,6 +3664,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -4129,6 +4139,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4246,6 +4269,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -4317,6 +4349,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -5679,6 +5723,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fsevents": {
@@ -9401,6 +9454,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -10621,6 +10686,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10650,6 +10733,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "resend": "^6.10.0",
     "topojson-client": "^3.1.0",
     "us-atlas": "^3.0.1",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/scripts/tx/scrape-transfer-tccns.ts
+++ b/scripts/tx/scrape-transfer-tccns.ts
@@ -1,0 +1,287 @@
+/**
+ * scrape-transfer-tccns.ts
+ *
+ * Downloads the TCCNS (Texas Common Course Numbering System) equivalency
+ * matrix from tccns.org and converts it into transfer-equiv.json mappings.
+ *
+ * The TCCNS matrix is a publicly accessible Excel file that maps every
+ * common course number to each TX institution's local equivalent. One
+ * GET request covers all 142 institutions — no auth, no rate limiting.
+ *
+ * Source: https://tccns.org/export/matrix/l:n/yearid:19
+ *         (Fall 2025 – Summer 2026)
+ *
+ * Usage:
+ *   npx tsx scripts/tx/scrape-transfer-tccns.ts
+ *   npx tsx scripts/tx/scrape-transfer-tccns.ts --no-import
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as XLSX from "xlsx";
+import { importTransfersToSupabase } from "../lib/supabase-import.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TransferMapping {
+  state: string;
+  cc_prefix: string;
+  cc_number: string;
+  cc_course: string;
+  cc_title: string;
+  cc_credits: string;
+  university: string;
+  university_name: string;
+  univ_course: string;
+  univ_title: string;
+  univ_credits: string;
+  notes: string;
+  no_credit: boolean;
+  is_elective: boolean;
+}
+
+interface Institution {
+  colIdx: number;
+  name: string;
+  slug: string;
+  isCC: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Our TX community college slugs → TCCNS matrix name mapping
+// ---------------------------------------------------------------------------
+
+const TCCNS_URL = "https://tccns.org/export/matrix/l:n/yearid:19";
+
+const DATA_DIR = path.join(process.cwd(), "data", "tx");
+const OUT_FILE = path.join(DATA_DIR, "transfer-equiv.json");
+const INST_FILE = path.join(DATA_DIR, "institutions.json");
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function parseCourse(cell: string): { prefix: string; number: string } | null {
+  const s = cell.trim();
+  if (!s) return null;
+  const m = s.match(/^([A-Z]{2,5})\s+(\d{4}[A-Z]?)$/);
+  if (m) return { prefix: m[1], number: m[2] };
+  const m2 = s.match(/^([A-Z]{2,5})\s+(\d+)$/);
+  if (m2) return { prefix: m2[1], number: m2[2] };
+  return null;
+}
+
+function isElective(course: string): boolean {
+  const lc = course.toLowerCase();
+  return (
+    lc.includes("elective") ||
+    lc.includes("elna") ||
+    lc.includes("ld") ||
+    course.includes("XXX") ||
+    course.includes("---") ||
+    /TRNS\s/.test(course)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const skipImport = process.argv.includes("--no-import");
+
+  console.log("TCCNS Matrix — Texas Transfer Equivalencies\n");
+
+  // 1. Download the matrix
+  console.log(`Downloading ${TCCNS_URL} ...`);
+  const resp = await fetch(TCCNS_URL);
+  if (!resp.ok) throw new Error(`Download failed: HTTP ${resp.status}`);
+  const buf = Buffer.from(await resp.arrayBuffer());
+  console.log(`  ${(buf.length / 1024).toFixed(0)} KB downloaded\n`);
+
+  // 2. Parse Excel
+  const wb = XLSX.read(buf, { type: "buffer" });
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(ws, { header: 1 }) as any[][];
+
+  // Row 3 (index 2) = institution names
+  const instRow = rows[2];
+
+  // 3. Load our TX institutions to know which slugs are CCs
+  const ourInsts: { id: string; name: string }[] = JSON.parse(
+    fs.readFileSync(INST_FILE, "utf8"),
+  );
+  const ourCCSlugs = new Set(ourInsts.map((i) => i.id));
+
+  // 4. Classify columns as CC or university
+  const institutions: Institution[] = [];
+  for (let c = 3; c < instRow.length; c++) {
+    const name = (instRow[c] || "").toString().trim();
+    if (!name) continue;
+    const slug = slugify(name);
+
+    // Match against our CC list by slug similarity
+    let isCC = false;
+    let matchedSlug = slug;
+
+    for (const ourSlug of Array.from(ourCCSlugs)) {
+      if (
+        slug === ourSlug ||
+        slug.includes(ourSlug) ||
+        ourSlug.includes(slug)
+      ) {
+        isCC = true;
+        matchedSlug = ourSlug;
+        break;
+      }
+    }
+
+    // Also check DCCCD sub-colleges → dallas-college
+    if (name.startsWith("DCCCD ")) {
+      isCC = true;
+      matchedSlug = "dallas-college";
+    }
+    // San Jacinto sub-campuses
+    if (name.startsWith("San Jacinto College")) {
+      isCC = true;
+      matchedSlug = "san-jacinto-community-college";
+    }
+
+    institutions.push({ colIdx: c, name, slug: matchedSlug, isCC });
+  }
+
+  const ccs = institutions.filter((i) => i.isCC);
+  const univs = institutions.filter((i) => !i.isCC);
+  console.log(`Institutions: ${ccs.length} CCs, ${univs.length} universities`);
+
+  // 5. Build transfer mappings
+  // For each course row, for each CC, check if the CC has a local equivalent.
+  // Then for each university, check if it has a local equivalent.
+  // Create a mapping: CC course → University course.
+  const mappings: TransferMapping[] = [];
+
+  for (let r = 3; r < rows.length; r++) {
+    const row = rows[r];
+    const title = (row[0] || "").toString().trim();
+    const commonPrefix = (row[1] || "").toString().trim();
+    const commonNumber = (row[2] || "").toString().trim();
+
+    if (!commonPrefix || !commonNumber) continue;
+    const tccnsCourse = `${commonPrefix} ${commonNumber}`;
+
+    // For each CC that has this course...
+    for (const cc of ccs) {
+      const ccCell = (row[cc.colIdx] || "").toString().trim();
+      if (!ccCell) continue;
+
+      const ccParsed = parseCourse(ccCell);
+      const ccPrefix = ccParsed?.prefix || commonPrefix;
+      const ccNumber = ccParsed?.number || commonNumber;
+      const ccCourse = ccParsed
+        ? `${ccPrefix} ${ccNumber}`
+        : ccCell;
+
+      // ...map to each university that accepts it
+      for (const univ of univs) {
+        const univCell = (row[univ.colIdx] || "").toString().trim();
+        if (!univCell) continue;
+
+        const noCredit =
+          univCell.toLowerCase().includes("no credit") ||
+          univCell.toLowerCase().includes("does not transfer");
+        const elective = !noCredit && isElective(univCell);
+
+        const univParsed = parseCourse(univCell);
+        const univCourse = univParsed
+          ? `${univParsed.prefix} ${univParsed.number}`
+          : univCell;
+
+        mappings.push({
+          state: "tx",
+          cc_prefix: ccPrefix,
+          cc_number: ccNumber,
+          cc_course: ccCourse,
+          cc_title: title,
+          cc_credits: "",
+          university: slugify(univ.name),
+          university_name: univ.name,
+          univ_course: univCourse,
+          univ_title: title,
+          univ_credits: "",
+          notes: `[${cc.slug}] TCCNS ${tccnsCourse}`,
+          no_credit: noCredit,
+          is_elective: elective,
+        });
+      }
+    }
+  }
+
+  // 6. Deduplicate — same CC slug + same cc_course + same university + same univ_course
+  const seen = new Set<string>();
+  const deduped: TransferMapping[] = [];
+  for (const m of mappings) {
+    const key = `${m.notes.match(/^\[([^\]]+)\]/)?.[1]}|${m.cc_course}|${m.university}|${m.univ_course}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(m);
+    }
+  }
+
+  // 7. Summary
+  const transferable = deduped.filter((m) => !m.no_credit);
+  const direct = transferable.filter((m) => !m.is_elective).length;
+  const elective = transferable.filter((m) => m.is_elective).length;
+
+  const byUniv = new Map<string, number>();
+  for (const m of transferable) {
+    byUniv.set(
+      m.university_name,
+      (byUniv.get(m.university_name) || 0) + 1,
+    );
+  }
+  const topUnivs = Array.from(byUniv.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15);
+
+  const byCC = new Map<string, number>();
+  for (const m of deduped) {
+    const slug = m.notes.match(/^\[([^\]]+)\]/)?.[1] || "?";
+    byCC.set(slug, (byCC.get(slug) || 0) + 1);
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`  Total mappings: ${deduped.length}`);
+  console.log(`  Transferable: ${transferable.length}`);
+  console.log(`    Direct equivalencies: ${direct}`);
+  console.log(`    Elective credit: ${elective}`);
+  console.log(`  No transfer: ${deduped.length - transferable.length}`);
+  console.log(`  Unique CCs: ${byCC.size}`);
+  console.log(`  Unique target universities: ${byUniv.size}`);
+  console.log("\n  Top targets:");
+  for (const [univ, count] of topUnivs) {
+    console.log(`    ${univ}: ${count}`);
+  }
+
+  // 8. Write JSON
+  fs.writeFileSync(OUT_FILE, JSON.stringify(deduped, null, 2));
+  console.log(`\nSaved ${deduped.length} mappings → ${OUT_FILE}`);
+
+  // 9. Supabase import
+  if (!skipImport) {
+    console.log("\nImporting to Supabase...");
+    await importTransfersToSupabase("tx");
+    console.log("  Done.");
+  } else {
+    console.log("\nSkipping Supabase import (--no-import).");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for site users

The Texas transfer page (`/tx/transfer`) now shows course-by-course transfer equivalencies. A student at Austin Community College can look up "ACCT 2301" and see exactly what it transfers to at 43 Texas universities — UT Austin, Texas A&M, Texas Tech, and 40 more. 29 of TX's 59 community colleges have populated data; the remaining 30 are registered in the TCCNS matrix but haven't filled in their equivalencies yet.

## How it works

The TCCNS (Texas Common Course Numbering System) publishes a public Excel matrix at `tccns.org/export/matrix/l:n/yearid:19` — one unauthenticated GET downloads the full statewide equivalency grid for all 142 TX institutions. No API keys, no rate limiting, no per-college scraping. The new `scrape-transfer-tccns.ts` parser downloads this file, classifies columns as CCs vs universities (cross-referencing our `institutions.json`), and emits one transfer mapping per CC-course × university-equivalent pair.

CollegeTransfer.Net (the CT.net OData API used by NH, PA, ME, and other states) was investigated first but has zero TX in-state targets — it only returns equivalencies to Indiana universities. The IL, MI, and OH config comments are updated to reflect this finding.

## Summary

- **186,888 transfer mappings** across 29 CCs × 43 universities
- 172,106 direct equivalencies + 14,782 elective credit
- `xlsx` npm package added for Excel parsing
- `transferSupported: true` flipped for TX
- Scraper wired to `StateConfig.scrapers.transfers` for cron
- Data imported to Supabase

## Test plan

- [ ] Verify `/tx/transfer` loads with transfer data
- [ ] Search for a course (e.g. ACCT 2301 at Austin CC) and confirm equivalencies display
- [ ] Confirm build passes (transfer-equiv.json excluded from bundle via `outputFileTracingExcludes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)