### PR TITLE
feat(state-audit): --check-prod flag detects local-vs-Supabase coverage gaps

### DIFF
--- a/.claude/skills/state-audit/SKILL.md
+++ b/.claude/skills/state-audit/SKILL.md
@@ -14,13 +14,30 @@ Performs a deep quality audit of one or all states in the registry. The key insi
 Run the bundled collector script. It reads every state's data files and config, outputting structured JSON with all 7 audit dimensions pre-computed:
 
 ```bash
-npx tsx .claude/skills/state-audit/scripts/collect-audit-data.ts [state-slug]
+npx tsx .claude/skills/state-audit/scripts/collect-audit-data.ts [state-slug] [--check-prod]
 ```
 
-- No argument → audits all states in the registry
-- With argument → audits just that state (e.g. `ny`)
+- No positional arg → audits all states in the registry
+- With positional arg → audits just that state (e.g. `ny`)
+- `--check-prod` → for each college with non-empty local data, hits the
+  prod page at `communitycollegepath.com/{state}/college/{slug}` and
+  counts unique course-code mentions in the rendered HTML. Pages with
+  Supabase data have hundreds of matches; pages where the Supabase
+  import skipped the college have 0. Populates `prodCoverage` on each
+  state's result. **Slow** (~2s per college serial, polite to the CDN)
+  — typical state takes 10–30s, NC's 58 colleges ~2 min, CA's 35
+  ~70s. Skip the flag unless you're investigating an import gap.
 
 The script outputs JSON to stdout. Capture it for grading.
+
+**When to use `--check-prod`:** the default audit checks on-disk
+data only. It will count SCKTC as "covered" if `data/ky/courses/
+southcentral-kentucky-community-and-technical-college/*.json` files
+exist, even if Supabase has zero rows and the prod page shows nothing.
+If a user reports "this college page is empty on the live site" or
+you're auditing the gap between "we shipped data" and "users can
+see it", add `--check-prod` and inspect `prodCoverage.missingOnProd`
+per state.
 
 ### 2. Grade each state
 

--- a/.claude/skills/state-audit/scripts/collect-audit-data.ts
+++ b/.claude/skills/state-audit/scripts/collect-audit-data.ts
@@ -80,6 +80,28 @@ interface AuditResult {
     scorecard: boolean;
     courseColleges: string[];
   };
+  /**
+   * Optional prod-vs-local coverage check (only populated when --check-prod
+   * is passed). For each college with >0 local sections, fetches
+   * https://communitycollegepath.com/{state}/college/{slug} and counts
+   * course-code occurrences in the rendered HTML. Pages with Supabase data
+   * have hundreds of occurrences; pages where the Supabase import skipped
+   * the college have zero. The audit's `coveredColleges` count reflects
+   * on-disk data only — this dimension surfaces the gap between "we
+   * committed sections to git" and "students can actually find them".
+   * Real-world example: SCKTC in KY had 823 sections on disk but 0 on
+   * prod because its data landed before import-on-merge.yml existed and
+   * no subsequent KY-courses import ever ran.
+   */
+  prodCoverage?: {
+    checked: boolean;
+    /** Slugs with local sections but 0 course codes on the prod page. */
+    missingOnProd: string[];
+    /** Slugs successfully verified on prod (>=20 course-code mentions). */
+    verifiedOnProd: string[];
+    /** Slugs where the prod fetch errored (network / 404 / parse). */
+    fetchErrors: string[];
+  };
 }
 
 function getStates(): string[] {
@@ -408,14 +430,79 @@ function auditState(slug: string): AuditResult {
   };
 }
 
-function main() {
-  const targetSlug = process.argv[2]?.toLowerCase();
+// ---------------------------------------------------------------------------
+// Prod-vs-local coverage check
+// ---------------------------------------------------------------------------
+
+const PROD_BASE = "https://communitycollegepath.com";
+const PROD_COURSE_CODE_RE = /\b[A-Z]{2,5}\s*[0-9]{2,4}\b/g;
+const PROD_COURSE_CODE_THRESHOLD = 20; // pages with real Supabase data have hundreds; empty pages have 0
+
+async function fetchProdCollegeCourseCount(
+  state: string,
+  collegeSlug: string,
+): Promise<{ ok: true; codeCount: number } | { ok: false; error: string }> {
+  const url = `${PROD_BASE}/${state}/college/${collegeSlug}`;
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "cc-coursemap-audit/1.0" },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const html = await res.text();
+    const matches = html.match(PROD_COURSE_CODE_RE);
+    return { ok: true, codeCount: matches ? new Set(matches).size : 0 };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function checkProdCoverage(
+  state: string,
+  sectionsByCollege: Record<string, number>,
+): Promise<NonNullable<AuditResult["prodCoverage"]>> {
+  const collegesWithLocalData = Object.entries(sectionsByCollege)
+    .filter(([, n]) => n > 0)
+    .map(([slug]) => slug);
+  const missingOnProd: string[] = [];
+  const verifiedOnProd: string[] = [];
+  const fetchErrors: string[] = [];
+  // Serial requests — keeps us polite to the prod CDN and avoids triggering
+  // any rate-limit / WAF. Even on a 58-college state (NC) this is ~58 *
+  // ~2s = ~2 min, acceptable for an audit invocation.
+  for (const slug of collegesWithLocalData) {
+    const r = await fetchProdCollegeCourseCount(state, slug);
+    if (!r.ok) {
+      fetchErrors.push(`${slug}: ${r.error}`);
+    } else if (r.codeCount < PROD_COURSE_CODE_THRESHOLD) {
+      missingOnProd.push(slug);
+    } else {
+      verifiedOnProd.push(slug);
+    }
+  }
+  return { checked: true, missingOnProd, verifiedOnProd, fetchErrors };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const checkProd = args.includes("--check-prod");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const targetSlug = positional[0]?.toLowerCase();
   const states = targetSlug ? [targetSlug] : getStates();
 
   const results: AuditResult[] = [];
   for (const slug of states) {
     try {
-      results.push(auditState(slug));
+      const r = auditState(slug);
+      if (checkProd) {
+        // eslint-disable-next-line no-await-in-loop
+        r.prodCoverage = await checkProdCoverage(slug, r.courses.sectionsByCollege);
+      }
+      results.push(r);
     } catch (e) {
       console.error(`Error auditing ${slug}: ${e}`);
     }


### PR DESCRIPTION
## What changes for someone using the site

Nothing user-visible. This is an internal-tooling improvement to `/state-audit` so future audits will catch a class of bug they were silently ignoring.

## What changes on the technical front

While auditing KY, you spotted that `/ky/college/southcentral-kentucky-community-and-technical-college` renders empty on prod even though the audit reported KY at 16/16 college coverage. Root cause: the audit's `coveredColleges` metric counts how many colleges have a non-empty `data/{state}/courses/{slug}/` directory **on disk**, not how many actually render on the live site. SCKTC has **823 sections in git for 2026FA alone**, but those rows never made it into Supabase because the data landed in PR #324 (2026-05-10) — six days before `import-on-merge.yml` was added (PR #466, 2026-05-16) — and no subsequent KY-courses import ever ran. Jefferson got lucky in some earlier manual run; SCKTC didn't.

This PR adds an opt-in `--check-prod` flag to the collector script. For each college with `sectionsByCollege[slug] > 0`, it fetches `https://communitycollegepath.com/{state}/college/{slug}` and counts unique `[A-Z]{2,5}[0-9]{2,4}` matches in the rendered HTML. Pages with real Supabase data have hundreds; pages without have 0. Threshold of 20 is conservative — small colleges with 15 sections might still pass it, while empty pages always fail.

A new optional `prodCoverage` field appears on each state's result:
```ts
prodCoverage?: {
  checked: boolean;
  missingOnProd: string[];   // local data but 0 codes on prod
  verifiedOnProd: string[];  // ≥20 unique course codes on prod
  fetchErrors: string[];
}
```

Default is **off** (network calls add CI flakiness and ~2s per college). Opt in with `--check-prod` when investigating a specific gap. Documented in `SKILL.md` with the SCKTC case study as the why.

## What landed

| File | Change |
|---|---|
| `.claude/skills/state-audit/scripts/collect-audit-data.ts` | +80 lines: `fetchProdCollegeCourseCount`, `checkProdCoverage`, `--check-prod` flag wired into `main()` |
| `.claude/skills/state-audit/SKILL.md` | +15 lines documenting the new flag and when to use it |

## Test plan

- [x] `npx tsx ... ky --check-prod` correctly flags SCKTC as `missingOnProd` and verifies the other 15 KY colleges. 0 false positives, 0 fetch errors. ~30s end-to-end.
- [x] Without `--check-prod`, `prodCoverage` field is absent from output (no network calls, no behavior change for the default audit path).
- [ ] After merge: run `npx tsx ... --check-prod 2>&1 | tee /tmp/full-audit.json` against all 35 states (~10 min) to surface any other SCKTC-style gaps across the registry.

## Follow-ups (separate PRs)

- **SCKTC fix itself** — the audit now detects the gap, but doesn't fix it. Either re-trigger `import-on-merge.yml --field state=ky --field datatype=courses` via `workflow_dispatch`, or wait for the next KY course commit to land which will re-import automatically.
- **CI hook** — could wire `--check-prod` into a weekly cron so import-gap regressions are caught automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
