### PR TITLE
fix(db): widen courses.location to TEXT — unblocks SCKTC's 1,908 sections

### DIFF
--- a/supabase/migrations/012_widen_courses_location.sql
+++ b/supabase/migrations/012_widen_courses_location.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- Widen courses.location column to TEXT
+-- Run via Supabase Dashboard → SQL Editor
+--
+-- Migration 002 widened campus, crn, days, mode, instructor, and
+-- start_time/end_time to TEXT for similar overflow reasons. `location`
+-- was missed and remained VARCHAR(50), which silently aborted the
+-- per-(college,term) import batch on every SCKTC run since PR #324
+-- landed on 2026-05-10. Example overflow:
+--   "Main Campus Building C Room 17 - 17 - Southcentral KY Comm Tech Coll"
+--   (67 chars)
+--
+-- After applying this migration, re-run
+--   gh workflow run import-on-merge.yml --field state=ky --field datatype=courses
+-- to backfill SCKTC's 1,908 sections (823 FA + 920 SP + 165 SU).
+-- Other states with long location strings will also start importing
+-- cleanly going forward.
+-- ============================================================
+
+ALTER TABLE courses ALTER COLUMN location TYPE TEXT;


### PR DESCRIPTION
## What changes for someone using the site

After this migration is applied (Supabase Dashboard → SQL Editor) and the KY import is re-triggered, **Southcentral Kentucky Community and Technical College** starts showing its **1,908 sections** (823 Fall + 920 Spring + 165 Summer 2026) on the live site. Currently `/ky/college/southcentral-kentucky-community-and-technical-college` renders an empty shell. Other states with similarly long `location` strings will also start importing cleanly going forward — likely several more colleges in the same hole, sweep with `/state-audit --check-prod` after this lands to find them.

## What changes on the technical front

Migration 002 (back in the early days of this repo) widened `campus`, `crn`, `days`, `mode`, `instructor`, and `start_time`/`end_time` from various VARCHARs to TEXT, all for the same reason: real-world course-section data routinely exceeds whatever 20/50/200-char ceiling the initial schema picked. **`location` was missed.** It's been at `VARCHAR(50)` ever since, silently aborting per-(college, term) import batches via:

```
FATAL: Insert failed for southcentral-kentucky-community-and-technical-college/2026FA batch 0:
  value too long for type character varying(50)
```

SCKTC's locations look like `"Main Campus Building C Room 17 - 17 - Southcentral KY Comm Tech Coll"` (67 chars). Jefferson and the other 14 KY colleges happen to use shorter formats and slipped under the 50-char ceiling — that's the only reason 15/16 KY colleges work and 1 doesn't.

**How we found this:**
1. You noticed `/ky/college/southcentral-...` was empty despite the audit reporting KY at 16/16.
2. The `/state-audit` had been counting on-disk data, not Supabase rows. PR #566 added a `--check-prod` flag that re-fetches each college's page and counts course-code mentions — caught SCKTC instantly (0 codes on the page vs hundreds for the other 15).
3. Triggered `import-on-merge.yml` for KY → workflow run 26412611367 succeeded overall but the per-college log revealed the VARCHAR(50) overflow.
4. This migration is the fix.

## What landed

| File | Change |
|---|---|
| `supabase/migrations/012_widen_courses_location.sql` | New 1-line migration: `ALTER TABLE courses ALTER COLUMN location TYPE TEXT;` plus context-rich header comment so the next person to read it understands the why. |

Matches the pattern of migrations 002 + 005 (which fixed the same class of bug for other columns). No schema-shape change for app code — `TEXT` is a strict superset of `VARCHAR(N)` in Postgres.

## How to apply

1. Merge this PR.
2. Open Supabase Dashboard → SQL Editor → paste the contents of `012_widen_courses_location.sql` → Run.
3. Re-trigger the KY courses import:
   ```bash
   gh workflow run import-on-merge.yml --field state=ky --field datatype=courses
   ```
4. After ~10–15 min, verify SCKTC renders on prod:
   ```bash
   curl -s https://communitycollegepath.com/ky/college/southcentral-kentucky-community-and-technical-college | grep -oE '[A-Z]{2,5}[0-9]{2,4}' | sort -u | wc -l
   # Should be 100+, currently 0
   ```

## Test plan

- [x] Read migration 002 for precedent; same ALTER TABLE shape.
- [x] No risk of data loss — Postgres widens VARCHAR → TEXT without rewriting rows.
- [ ] After applying: re-run import, confirm SCKTC sections > 0 in the workflow log.
- [ ] After import: re-run `/state-audit --check-prod` against KY to confirm SCKTC moves from `missingOnProd` to `verifiedOnProd`.
- [ ] Sweep all 35 states with `--check-prod` to find other colleges suffering the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
