### PR TITLE
fix(cron): resolve 5 scraper failures from 2026-05-25 run

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -134,11 +134,13 @@ jobs:
         if: matrix.state == 'nc'
         run: pip install --quiet pdfplumber
 
-      - name: Install poppler-utils (AZ scrape-dine.ts shells out to pdftotext)
-        # scripts/az/scrape-dine.ts parses Diné College's per-semester
-        # schedule PDFs via `pdftotext -layout` (poppler-utils package).
+      - name: Install poppler-utils (AZ/AR/WV scrapers shell out to pdftotext)
+        # scripts/az/scrape-dine.ts — Diné College PDF schedule
+        # scripts/ar/scrape-uaccm.ts — UACCM PDF schedule
+        # scripts/ar/scrape-seark-pdf-programs.ts — SEARK PDF catalog
+        # scripts/wv/scrape-eastern-wv.ts — Eastern WV PDF schedule
         # The Ubuntu runner doesn't ship poppler-utils by default.
-        if: matrix.state == 'az'
+        if: matrix.state == 'az' || matrix.state == 'ar' || matrix.state == 'wv'
         run: sudo apt-get install -y --no-install-recommends poppler-utils
 
       - name: Resolve terms

--- a/lib/states/nv/config.ts
+++ b/lib/states/nv/config.ts
@@ -44,7 +44,9 @@ const nvConfig: StateConfig = {
   },
   scrapers: {
     courses: [
-      { scripts: ["scripts/nv/scrape-peoplesoft.ts"], runner: "playwright" },
+      // termSystem: "banner" causes the cron to pass --term "Spring 2026,Summer 2026"
+      // (or whatever the current+next semesters are) — required by scrape-peoplesoft.ts.
+      { scripts: ["scripts/nv/scrape-peoplesoft.ts"], runner: "playwright", termSystem: "banner" },
     ],
     transfers: [
       { scripts: ["scripts/nv/scrape-nv-transfers.ts"], runner: "http" },

--- a/scripts/ca/scrape-banner-ssb.ts
+++ b/scripts/ca/scrape-banner-ssb.ts
@@ -13,7 +13,10 @@
  */
 import { scrapeBannerSsbState } from "../lib/scrape-banner-ssb";
 
-await scrapeBannerSsbState({
+// Top-level await is not supported with the CJS output format used by the
+// cron runner's esbuild step. Wrap in main() so it compiles cleanly.
+async function main() {
+  await scrapeBannerSsbState({
   state: "ca",
   hosts: {
     "antelope-valley-community-college-district": "https://ssb.avc.edu",
@@ -30,5 +33,7 @@ await scrapeBannerSsbState({
     "santa-rosa-junior-college":                  "https://reg-prod.santarosajc.elluciancloud.com:8103",
     "sierra-college":                             "https://ss.oci.sierracollege.edu",
     "college-of-the-siskiyous":                   "https://reg-prod.cloud.siskiyous.edu",
-  },
-});
+  });
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/oh/scrape-banner-ssb.ts
+++ b/scripts/oh/scrape-banner-ssb.ts
@@ -22,7 +22,8 @@
  */
 import { scrapeBannerSsbState } from "../lib/scrape-banner-ssb";
 
-await scrapeBannerSsbState({
+async function main() {
+  await scrapeBannerSsbState({
   state: "oh",
   hosts: {
     "cuyahoga-community-college-district": "https://banstup.tri-c.edu",
@@ -33,5 +34,7 @@ await scrapeBannerSsbState({
     // and verified the StudentRegistrationSsb body marker. Unusually,
     // Banner SSB 9 is at the root domain rather than a subdomain.
     "zane-state-college": "https://zanestate.edu",
-  },
-});
+  });
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/or/scrape-banner-ssb.ts
+++ b/scripts/or/scrape-banner-ssb.ts
@@ -11,12 +11,15 @@
  */
 import { scrapeBannerSsbState } from "../lib/scrape-banner-ssb";
 
-await scrapeBannerSsbState({
+async function main() {
+  await scrapeBannerSsbState({
   state: "or",
   hosts: {
     "chemeketa-community-college":       "https://reg-ss.chemeketa.edu",
     "central-oregon-community-college":  "https://reg-prod.cocc.edu",
     "lane-community-college":            "https://my.lanecc.edu",
     "linn-benton-community-college":     "https://banner.linnbenton.edu:8458",
-  },
-});
+  });
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/tx/scrape-kilgore.ts
+++ b/scripts/tx/scrape-kilgore.ts
@@ -224,38 +224,53 @@ async function selectTermAndSearch(page: Page, termValue: string): Promise<void>
 }
 
 async function extractRowsFromCurrentPage(page: Page): Promise<RawRow[]> {
-  return page.evaluate(() => {
-    // The results table is the one that contains a header row with "Course code".
-    const tables = Array.from(document.querySelectorAll<HTMLTableElement>("table"));
-    const resultsTable = tables.find((t) =>
-      Array.from(t.querySelectorAll("th, td")).some((c) =>
-        /Course\s*code/i.test(c.textContent || "")
-      )
-    );
-    if (!resultsTable) return [];
-    const rows = Array.from(resultsTable.querySelectorAll<HTMLTableRowElement>("tr"));
-    const out: RawRow[] = [];
-    for (const r of rows) {
-      const cells = Array.from(r.querySelectorAll("td")).map((td) =>
-        (td.innerText || td.textContent || "").trim()
-      );
-      // A data row has a course code in cells[2] (cells[0] is Add checkbox, cells[1] is Textbook link)
-      if (cells.length < 10) continue;
-      const code = cells[2];
-      if (!code || !/^[A-Z]{2,4}\s*\d{3,4}/.test(code)) continue;
-      out.push({
-        code,
-        name: cells[3] || "",
-        faculty: cells[4] || "",
-        seats: cells[5] || "",
-        status: cells[6] || "",
-        schedule: cells[7] || "",
-        credits: cells[8] || "",
-        beginDate: cells[9] || "",
+  // page.evaluate can throw "Execution context was destroyed" if a navigation
+  // fires while it's running (transient race on slow CI). Retry up to 3×.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await page.waitForLoadState("domcontentloaded", { timeout: 15000 }).catch(() => {});
+      return await page.evaluate(() => {
+        // The results table is the one that contains a header row with "Course code".
+        const tables = Array.from(document.querySelectorAll<HTMLTableElement>("table"));
+        const resultsTable = tables.find((t) =>
+          Array.from(t.querySelectorAll("th, td")).some((c) =>
+            /Course\s*code/i.test(c.textContent || "")
+          )
+        );
+        if (!resultsTable) return [];
+        const rows = Array.from(resultsTable.querySelectorAll<HTMLTableRowElement>("tr"));
+        const out: { code: string; name: string; faculty: string; seats: string; status: string; schedule: string; credits: string; beginDate: string }[] = [];
+        for (const r of rows) {
+          const cells = Array.from(r.querySelectorAll("td")).map((td) =>
+            (td.innerText || td.textContent || "").trim()
+          );
+          // A data row has a course code in cells[2] (cells[0] is Add checkbox, cells[1] is Textbook link)
+          if (cells.length < 10) continue;
+          const code = cells[2];
+          if (!code || !/^[A-Z]{2,4}\s*\d{3,4}/.test(code)) continue;
+          out.push({
+            code,
+            name: cells[3] || "",
+            faculty: cells[4] || "",
+            seats: cells[5] || "",
+            status: cells[6] || "",
+            schedule: cells[7] || "",
+            credits: cells[8] || "",
+            beginDate: cells[9] || "",
+          });
+        }
+        return out;
       });
+    } catch (e) {
+      if (attempt < 2 && /Execution context was destroyed|context/i.test(String(e))) {
+        console.warn(`    extractRows attempt ${attempt + 1} failed (nav race), retrying...`);
+        await new Promise((r) => setTimeout(r, 1500));
+        continue;
+      }
+      throw e;
     }
-    return out;
-  });
+  }
+  return [];
 }
 
 async function goToNextPage(page: Page): Promise<boolean> {


### PR DESCRIPTION
## What broke and what changed

Today's cron run had 6 failures across 5 distinct root causes. This PR fixes all of them except the FL transfer (infrastructure glitch, not code).

### 1. CA, OH, OR — `scrape-banner-ssb.ts` (build error, regression)

**Error:** `Top-level await is currently not supported with the "cjs" output format`

These three states' scrapers used `await scrapeBannerSsbState(...)` at module scope. esbuild bundles scrapers as CommonJS; top-level await is ESM-only. Every other state's Banner SSB wrapper uses `main().catch(...)` — these three were the only exceptions. Fixed by wrapping in `async function main() { ... } main().catch(...)`.

### 2. WV — `scrape-eastern-wv.ts` (missing system dependency)

**Error:** `spawnSync pdftotext ENOENT`

`scrape-eastern-wv.ts` shells out to `pdftotext -layout` (poppler-utils). The workflow installed poppler only for AZ. Extended the install condition to `az || ar || wv` (AR also has two pdftotext scrapers: `scrape-uaccm.ts` and `scrape-seark-pdf-programs.ts`).

### 3. NV — `scrape-peoplesoft.ts` (missing cron argument)

**Error:** `Error: --term is required. Example: --term "Fall 2026"`

The NV PeopleSoft scraper requires `--term` but the `StateConfig.scrapers.courses` entry had no `termSystem`, so the cron never resolved or passed a term. Added `termSystem: "banner"` so `resolve-terms.ts` computes the current/upcoming semesters automatically.

### 4. TX — `scrape-kilgore.ts` (Playwright race condition, regression)

**Error:** `page.evaluate: Execution context was destroyed, most likely because of a navigation`

Kilgore's Jenzabar occasionally triggers a background navigation mid-evaluate on slow CI. Added a 3-attempt retry loop with `waitForLoadState("domcontentloaded")` guard before each attempt and 1.5s back-off.

### 5. FL transfers (2026-05-24) — not a code bug

**Error:** `fatal: could not read Username for 'https://github.com': terminal prompts disabled`

GitHub Actions checkout auth failed transiently. FL transfers ran successfully today (3 OK, 0 FAIL). No code change needed.

## Files changed

| File | Change |
|------|--------|
| `scripts/ca/scrape-banner-ssb.ts` | Wrap top-level await in `main()` |
| `scripts/oh/scrape-banner-ssb.ts` | Wrap top-level await in `main()` |
| `scripts/or/scrape-banner-ssb.ts` | Wrap top-level await in `main()` |
| `.github/workflows/scheduled-scrape.yml` | Add `ar` and `wv` to poppler-utils install condition |
| `lib/states/nv/config.ts` | Add `termSystem: "banner"` to courses scraper |
| `scripts/tx/scrape-kilgore.ts` | Add 3-attempt retry for `Execution context destroyed` |

## Test plan

- [ ] Next cron run: CA/OH/OR Banner SSB jobs turn green
- [ ] Next cron run: WV Eastern WV job turns green (pdftotext found)
- [ ] Next cron run: NV PeopleSoft job turns green (term resolved + passed)
- [ ] Next cron run: TX Kilgore job turns green (or retries past the race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)