### PR TITLE
feat(state-audit): per-dimension grades with worst-dim composite

### DIFF
--- a/.claude/skills/state-audit/SKILL.md
+++ b/.claude/skills/state-audit/SKILL.md
@@ -41,61 +41,58 @@ per state.
 
 ### 2. Grade each state
 
-Apply these grading criteria to each state's collected data. The grades reflect how a real student would experience the state — not how the developer feels about it.
+**Grades are computed by the collector, not by you.** Each state in the output JSON has a `grades` block with five per-dimension grades plus a composite. Your job in this phase is to *read* the grades and surface them clearly to the user — not to re-derive them from the raw counts.
 
-#### Grade A — Fully complete
-All 7 dimensions green:
-- Course coverage: `coveredColleges == collegeCount` (100%)
-- Prereqs: exists, >0 entries, no HTML contamination, scraper wired
-- Transfers: exists, >0 entries, `transferSupported: true`, scraper wired, university count appropriate for state size (1 is fine for single-university states like VT; not fine for states with 5+ public universities)
-- Scorecard: files match `collegeCount`
-- All scrapers declared (no `manual-only` for courses/prereqs/transfers)
-- Config: `seniorWaiver` populated, `popularCourses` non-empty, branding complete
-- Terms: current (within 2 semesters), no suspicious non-credit terms
+Each state's `grades` block looks like:
 
-#### Grade B — Nearly complete
-One minor gap. Examples of "minor":
-- `popularCourses` empty (config-only fix)
-- 1 college missing out of many (>90% coverage)
-- Stale term files lingering alongside current ones
-- Scorecard missing for 1 college
+```jsonc
+"grades": {
+  "courses":   { "grade": "A", "reason": "full coverage (23/23), terms clean" },
+  "prereqs":   { "grade": "A", "reason": "374 entries, wired, clean" },
+  "transfers": { "grade": "D", "reason": "data exists (15483) but scraper not wired — will go stale" },
+  "scorecard": { "grade": "A", "reason": "23/23 scorecards" },
+  "config":    { "grade": "A", "reason": "all config fields populated" },
+  "composite": "D",
+  "limitedBy": "transfers",
+  "ceilingsApplied": []
+}
+```
 
-#### Grade C — Functional but gaps
-Structural gaps that affect the user experience:
-- Transfers or prereqs missing/empty
-- Multiple colleges without course data (but >50% covered)
-- All scrapers `manual-only` (no automated freshness)
-- `seniorWaiver: null` in a state that has a waiver program
+**Composite = worst of the five dimensions.** `limitedBy` names the dimension that produced the composite, so the next fix is always obvious. A state can't earn an A composite while any single dimension is in the gutter.
 
-#### Grade D — Skeleton
-Bootstrap done but major data missing:
-- Courses for <50% of colleges
-- No transfers AND no prereqs
-- Multiple config fields placeholder/null
+**Per-dimension thresholds** (encoded in `collect-audit-data.ts`, summarized here):
 
-#### Grade F — Broken
-Nearly non-functional:
-- <15% course coverage
-- Empty prereqs file
-- Core data files missing or broken
+| Dim | A | B | C | D | F |
+|---|---|---|---|---|---|
+| courses | ≥95% coverage, terms clean | ≥85% OR 1 minor issue | ≥50% | ≥15% | <15% |
+| prereqs | ≥100 entries, no HTML, wired | ≥10 entries, no HTML | HTML contamination OR <10 entries | file empty | no file |
+| transfers | ≥3 universities AND ≥1000 mappings AND wired | ≥2 universities AND ≥500 mappings AND wired | 1 university OR <500 mappings (wired) | data exists but not wired | no data, no ceiling |
+| scorecard | full coverage | ≥80% | ≥50% | <50% | no directory |
+| config | all fields populated | 1 gap | 2 gaps | seniorWaiver placeholder | 4+ gaps |
+
+**Documented ceilings exempt up to B floor.** When a state declares `StateConfig.documentedCeilings.transfers` (e.g. NH: "UNH publishes no public articulation database"), the transfers dimension is capped at B — it can still earn an A on real merit, but it can't drop below B for the documented reason. Same rule for `scorecard`. For `courses`, the documented-college slugs are removed from the coverage denominator. The `ceilingsApplied` array records which exemptions were active.
+
+When the data legitimately shifts a grade, update the expected values in `grade-snapshot.test.ts` in the same commit with a one-line justification.
 
 ### 3. Format the report
 
-Output one line per state, sorted by tier then alphabetically:
+Output one line per state, sorted by composite tier then alphabetically:
 
 ```
-{state} [{tier}] — {one-sentence summary of what's missing or "all green"}
+{state} [{composite}] — limited by {limitedBy}: {reason}  | dims: crs={A} prq={A} trf={D} sc={A} cfg={A}
 ```
 
-End with a summary table:
+End with a tier-distribution table:
 
 ```
 | Tier | Count | States |
 |------|-------|--------|
-| A    | 3     | de, ri, vt |
-| B    | 7     | ct, ga, nc, nh, nv, ny, tn |
+| A    | 9     | ct, de, ga, ky, me, nc, nv, ny, tn |
+| B    | 5     | al, dc, nh, ri, sc |
 ...
 ```
+
+Call out any state where `ceilingsApplied` is non-empty so reviewers know which exemptions are active and *why*.
 
 ### 4. Cross-cutting issues
 
@@ -123,10 +120,17 @@ These are the specific checks that distinguish a deep audit from a surface-level
 
 ## Interpreting results
 
-When presenting to the user, be specific about what's actionable:
-- **Quick wins** (5-15 min): empty `popularCourses`, missing `defaultZip`
-- **Medium effort** (1-2 hr): 1 missing college, HTML cleanup in prereqs, stale term purge
-- **Heavy lift** (3+ hr): missing transfer scraper, multiple colleges need bespoke scrapers
-- **Blocked**: auth-gated colleges, no public articulation portal
+The composite + `limitedBy` tells you *what* to fix; effort estimation is your call. When presenting to the user, group findings by `limitedBy`:
 
-Suggest a prioritized fix order: quick wins first, then B→A transitions, then C→B.
+- **`limitedBy: courses`** — usually heavy: a college needs a bespoke scraper, a Banner SSB host is down, or the SIS is auth-gated. Quick fixes are rare here.
+- **`limitedBy: transfers`** — split by reason:
+  - "not wired" → config-only edit (~5 min per state); wire the existing script to `scrapers.transfers`. Validate the script runs first.
+  - "thin: 1 university" → medium-to-heavy: find a state portal or write a second university scraper.
+  - "no transfer data" → heavy: investigate the state's articulation infrastructure from scratch.
+- **`limitedBy: prereqs`** — usually HTML contamination (medium: regex cleanup pass) or empty file (heavy: need an extractor pass).
+- **`limitedBy: scorecard`** — light: re-run the scorecard fetcher.
+- **`limitedBy: config`** — quick wins: `popularCourses`, `defaultZip`, branding fields are all 1-5 min config edits.
+
+Suggest a prioritized fix order by impact-per-hour: quick `config`/`scorecard` wins first if any, then validated `transfers` cron-wirings, then targeted `courses` gap-fills. Avoid bundling unrelated fixes across states into one PR — each state is its own change.
+
+Ceiling exemptions (`ceilingsApplied`) are not bugs and shouldn't be presented as gaps to fix.

--- a/.claude/skills/state-audit/scripts/collect-audit-data.ts
+++ b/.claude/skills/state-audit/scripts/collect-audit-data.ts
@@ -15,6 +15,27 @@ import * as path from "path";
 
 const ROOT = process.cwd();
 
+export type Grade = "A" | "B" | "C" | "D" | "F";
+export type Dimension = "courses" | "prereqs" | "transfers" | "scorecard" | "config";
+
+export interface GradeResult {
+  grade: Grade;
+  reason: string;
+}
+
+const GRADE_RANK: Record<Grade, number> = { A: 4, B: 3, C: 2, D: 1, F: 0 };
+
+/** Returns the worst (lowest) of two grades. */
+function worse(a: Grade, b: Grade): Grade {
+  return GRADE_RANK[a] <= GRADE_RANK[b] ? a : b;
+}
+
+/** Cap a grade so it cannot drop below B. Used for documented-ceiling exemptions. */
+function capAtB(g: GradeResult, reason: string): GradeResult {
+  if (GRADE_RANK[g.grade] >= GRADE_RANK["B"]) return g;
+  return { grade: "B", reason: `ceiling: ${reason}` };
+}
+
 interface AuditResult {
   slug: string;
   name: string;
@@ -77,8 +98,28 @@ interface AuditResult {
   /** Documented structural ceilings from StateConfig.documentedCeilings. */
   documentedCeilings: {
     transfers: boolean;
+    transfersReason?: string;
     scorecard: boolean;
+    scorecardReason?: string;
     courseColleges: string[];
+  };
+  /**
+   * Deterministic per-dimension grades (A–F) computed by the collector.
+   * Composite = worst of the five dimensions. `limitedBy` names which
+   * dimension produced the composite grade. `ceilingsApplied` records
+   * which documentedCeilings exemptions were used (each caps its
+   * dimension at a B floor — the dimension can still earn A on its own
+   * merits if the data is actually there).
+   */
+  grades: {
+    courses: GradeResult;
+    prereqs: GradeResult;
+    transfers: GradeResult;
+    scorecard: GradeResult;
+    config: GradeResult;
+    composite: Grade;
+    limitedBy: Dimension;
+    ceilingsApplied: Array<{ dimension: Dimension; reason: string }>;
   };
   /**
    * Optional prod-vs-local coverage check (only populated when --check-prod
@@ -177,6 +218,200 @@ function isSuspicious(term: string): boolean {
   const termYear = parseInt(term.substring(0, 4), 10);
   if (termYear > year + 1) return true;
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// Graders — one per dimension, plus composite. Pure functions over the
+// AuditResult sub-objects. Thresholds are documented in SKILL.md and the
+// snapshot test set in grade-snapshot.test.ts.
+// ---------------------------------------------------------------------------
+
+function gradeCourses(
+  courses: AuditResult["courses"],
+  ceilingCourseColleges: string[],
+): GradeResult {
+  // Exempt documented-ceiling colleges from the coverage denominator.
+  const exemptSet = new Set(ceilingCourseColleges);
+  const adjustedTotal = courses.collegeCount - ceilingCourseColleges.length;
+  const adjustedCovered = courses.coveredColleges - courses.missingColleges
+    .filter((s) => exemptSet.has(s))
+    .length;
+  // (If a ceiling slug isn't actually in missingColleges it doesn't change
+  // covered, but the denominator drops — which only helps coverage.)
+  const denom = Math.max(1, adjustedTotal);
+  const coverage = adjustedCovered / denom;
+  const stale = courses.staleTerms.length;
+  const suspicious = courses.suspiciousTerms.length;
+
+  if (coverage < 0.15) {
+    return { grade: "F", reason: `coverage ${(coverage * 100).toFixed(0)}% (${adjustedCovered}/${denom})` };
+  }
+  if (coverage < 0.5) {
+    return { grade: "D", reason: `coverage ${(coverage * 100).toFixed(0)}% (${adjustedCovered}/${denom})` };
+  }
+  if (coverage < 0.85) {
+    return { grade: "C", reason: `coverage ${(coverage * 100).toFixed(0)}% (${adjustedCovered}/${denom})` };
+  }
+  if (coverage < 0.95 || stale > 0 || suspicious > 0) {
+    const bits: string[] = [];
+    if (coverage < 0.95) bits.push(`coverage ${(coverage * 100).toFixed(0)}%`);
+    if (stale > 0) bits.push(`${stale} stale term(s)`);
+    if (suspicious > 0) bits.push(`${suspicious} suspicious term(s)`);
+    return { grade: "B", reason: bits.join("; ") };
+  }
+  return { grade: "A", reason: `full coverage (${adjustedCovered}/${denom}), terms clean` };
+}
+
+function gradeTransfers(
+  transfers: AuditResult["transfers"],
+  ceiling: AuditResult["documentedCeilings"],
+): GradeResult {
+  const wired = transfers.scraperDeclared;
+  const unis = transfers.universityCount;
+  const count = transfers.count;
+  const supported = transfers.transferSupported;
+
+  if (count === 0 && !ceiling.transfers) {
+    return { grade: "F", reason: "no transfer data" };
+  }
+  if (count === 0 && ceiling.transfers) {
+    // Ceiling acknowledged; nothing to grade but ceiling cap will lift to B.
+    return { grade: "F", reason: "no transfer data (ceiling-exempt)" };
+  }
+  if (!wired) {
+    return { grade: "D", reason: `data exists (${count}) but scraper not wired — will go stale` };
+  }
+  if (unis <= 1 || count < 500) {
+    return { grade: "C", reason: `thin: ${unis} university, ${count} mappings` };
+  }
+  if (unis < 3 || count < 1000) {
+    return { grade: "B", reason: `${unis} universities, ${count} mappings` };
+  }
+  if (!supported) {
+    return { grade: "B", reason: `${unis} universities, ${count} mappings, but transferSupported=false` };
+  }
+  return { grade: "A", reason: `${unis} universities, ${count} mappings, wired` };
+}
+
+function gradePrereqs(
+  prereqs: AuditResult["prereqs"],
+  scrapers: AuditResult["scrapers"],
+): GradeResult {
+  if (!prereqs.exists) {
+    return { grade: "F", reason: "no prereqs file" };
+  }
+  if (prereqs.count === 0) {
+    return { grade: "D", reason: "file exists but empty" };
+  }
+  if (prereqs.htmlContaminated > 0) {
+    return { grade: "C", reason: `${prereqs.htmlContaminated} entries have HTML contamination` };
+  }
+  if (prereqs.count < 10) {
+    return { grade: "C", reason: `only ${prereqs.count} entries` };
+  }
+  const wired = scrapers.prereqsWired;
+  if (prereqs.count < 100) {
+    return { grade: "B", reason: `${prereqs.count} entries${wired ? "" : ", not wired"}` };
+  }
+  if (!wired) {
+    return { grade: "B", reason: `${prereqs.count} entries but scraper not wired` };
+  }
+  return { grade: "A", reason: `${prereqs.count} entries, wired, clean` };
+}
+
+function gradeScorecard(
+  scorecard: AuditResult["scorecard"],
+  ceiling: AuditResult["documentedCeilings"],
+): GradeResult {
+  const denom = Math.max(1, scorecard.collegeCount);
+  const coverage = scorecard.files / denom;
+  if (scorecard.files === 0 && !ceiling.scorecard) {
+    return { grade: "F", reason: "no scorecard directory" };
+  }
+  if (scorecard.files === 0 && ceiling.scorecard) {
+    return { grade: "F", reason: "no scorecard (ceiling-exempt)" };
+  }
+  if (coverage < 0.5) {
+    return { grade: "D", reason: `${scorecard.files}/${denom} scorecards (${(coverage * 100).toFixed(0)}%)` };
+  }
+  if (coverage < 0.8) {
+    return { grade: "C", reason: `${scorecard.files}/${denom} scorecards (${(coverage * 100).toFixed(0)}%)` };
+  }
+  if (coverage < 1.0) {
+    return { grade: "B", reason: `${scorecard.files}/${denom} scorecards` };
+  }
+  return { grade: "A", reason: `${scorecard.files}/${denom} scorecards` };
+}
+
+function gradeConfig(config: AuditResult["config"]): GradeResult {
+  // Count gaps. Senior-waiver placeholder is treated as a soft red flag (D).
+  if (config.seniorWaiverPlaceholder) {
+    return { grade: "D", reason: "seniorWaiver placeholder text detected" };
+  }
+  const gaps: string[] = [];
+  if (!config.seniorWaiverSet) gaps.push("seniorWaiver missing");
+  if (config.popularCoursesCount === 0) gaps.push("popularCourses empty");
+  if (!config.defaultZipSet) gaps.push("defaultZip missing");
+  if (!config.brandingComplete) gaps.push(`branding: ${config.brandingGaps.join(", ")}`);
+
+  if (gaps.length === 0) return { grade: "A", reason: "all config fields populated" };
+  if (gaps.length === 1) return { grade: "B", reason: gaps[0] };
+  if (gaps.length === 2) return { grade: "C", reason: gaps.join("; ") };
+  if (gaps.length === 3) return { grade: "D", reason: gaps.join("; ") };
+  return { grade: "F", reason: `skeleton (${gaps.length} gaps): ${gaps.join("; ")}` };
+}
+
+export function computeGrades(r: Omit<AuditResult, "grades">): AuditResult["grades"] {
+  const ceilingsApplied: Array<{ dimension: Dimension; reason: string }> = [];
+
+  // Grade each dimension.
+  let courses = gradeCourses(r.courses, r.documentedCeilings.courseColleges);
+  if (r.documentedCeilings.courseColleges.length > 0) {
+    ceilingsApplied.push({
+      dimension: "courses",
+      reason: `${r.documentedCeilings.courseColleges.length} college(s) exempted from coverage denominator`,
+    });
+  }
+
+  let transfers = gradeTransfers(r.transfers, r.documentedCeilings);
+  if (r.documentedCeilings.transfers && GRADE_RANK[transfers.grade] < GRADE_RANK["B"]) {
+    const reason = r.documentedCeilings.transfersReason || "documented transfer ceiling";
+    transfers = capAtB(transfers, reason);
+    ceilingsApplied.push({ dimension: "transfers", reason });
+  }
+
+  const prereqs = gradePrereqs(r.prereqs, r.scrapers);
+
+  let scorecard = gradeScorecard(r.scorecard, r.documentedCeilings);
+  if (r.documentedCeilings.scorecard && GRADE_RANK[scorecard.grade] < GRADE_RANK["B"]) {
+    const reason = r.documentedCeilings.scorecardReason || "documented scorecard ceiling";
+    scorecard = capAtB(scorecard, reason);
+    ceilingsApplied.push({ dimension: "scorecard", reason });
+  }
+
+  const config = gradeConfig(r.config);
+
+  // Composite = worst dimension. `limitedBy` names that dimension.
+  const dims: Array<[Dimension, GradeResult]> = [
+    ["courses", courses],
+    ["prereqs", prereqs],
+    ["transfers", transfers],
+    ["scorecard", scorecard],
+    ["config", config],
+  ];
+  let composite: Grade = "A";
+  let limitedBy: Dimension = "courses";
+  for (const [name, g] of dims) {
+    const next = worse(composite, g.grade);
+    if (next !== composite) {
+      composite = next;
+      limitedBy = name;
+    } else if (next === g.grade && g.grade !== "A") {
+      // Tie: keep the first one (stable order: courses → prereqs → transfers → scorecard → config).
+    }
+  }
+
+  return { courses, prereqs, transfers, scorecard, config, composite, limitedBy, ceilingsApplied };
 }
 
 function auditState(slug: string): AuditResult {
@@ -344,15 +579,35 @@ function auditState(slug: string): AuditResult {
   // a dimension's gap is a real-world constraint, not unfinished work.
   // The grader treats these as ignored for tier purposes.
   let ceilingTransfers = false;
+  let ceilingTransfersReason: string | undefined;
   let ceilingScorecard = false;
+  let ceilingScorecardReason: string | undefined;
   const ceilingCourseColleges: string[] = [];
   const ceilingBlockMatch = configText.match(
     /documentedCeilings\s*:\s*\{([\s\S]*?)\n\s{0,4}\}/,
   );
   if (ceilingBlockMatch) {
     const body = ceilingBlockMatch[1];
-    ceilingTransfers = /(^|\n)\s*transfers\s*:/.test(body);
-    ceilingScorecard = /(^|\n)\s*scorecard\s*:/.test(body);
+    const transfersReasonMatch = body.match(/(^|\n)\s*transfers\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    const transfersMultiLineMatch = !transfersReasonMatch
+      ? body.match(/(^|\n)\s*transfers\s*:\s*\n?\s*"((?:[^"\\]|\\.)*)"/)
+      : null;
+    if (transfersReasonMatch) {
+      ceilingTransfers = true;
+      ceilingTransfersReason = transfersReasonMatch[2];
+    } else if (transfersMultiLineMatch) {
+      ceilingTransfers = true;
+      ceilingTransfersReason = transfersMultiLineMatch[2];
+    } else if (/(^|\n)\s*transfers\s*:/.test(body)) {
+      ceilingTransfers = true;
+    }
+    const scorecardReasonMatch = body.match(/(^|\n)\s*scorecard\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    if (scorecardReasonMatch) {
+      ceilingScorecard = true;
+      ceilingScorecardReason = scorecardReasonMatch[2];
+    } else if (/(^|\n)\s*scorecard\s*:/.test(body)) {
+      ceilingScorecard = true;
+    }
     const coursesMatch = body.match(/courses\s*:\s*\[([\s\S]*?)\]/);
     if (coursesMatch) {
       const slugs = coursesMatch[1].match(/collegeSlug\s*:\s*"([^"]+)"/g) || [];
@@ -363,7 +618,7 @@ function auditState(slug: string): AuditResult {
     }
   }
 
-  return {
+  const base: Omit<AuditResult, "grades"> = {
     slug,
     name,
     collegeCount,
@@ -424,10 +679,13 @@ function auditState(slug: string): AuditResult {
     },
     documentedCeilings: {
       transfers: ceilingTransfers,
+      ...(ceilingTransfersReason ? { transfersReason: ceilingTransfersReason } : {}),
       scorecard: ceilingScorecard,
+      ...(ceilingScorecardReason ? { scorecardReason: ceilingScorecardReason } : {}),
       courseColleges: ceilingCourseColleges,
     },
   };
+  return { ...base, grades: computeGrades(base) };
 }
 
 // ---------------------------------------------------------------------------

--- a/.claude/skills/state-audit/scripts/grade-snapshot.test.ts
+++ b/.claude/skills/state-audit/scripts/grade-snapshot.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Grade snapshot test for the state-audit rubric.
+ *
+ * Asserts expected per-dim and composite grades for a curated set of
+ * states that exercise the rubric's branches:
+ *
+ *   - Wide-and-deep coverage (NC, NY) → composite A
+ *   - Documented-ceiling exemption (NH) → transfers capped at B
+ *   - Thin transfers (OH, VT, RI)      → transfers C or B
+ *   - Course coverage gaps (FL, MI, TX) → courses D
+ *   - Data-not-wired (VA)              → transfers D
+ *   - Missing dimensions (CA, WV)      → composite F
+ *
+ * When the data legitimately shifts a grade, update the expected value
+ * in the same commit with a one-line justification — the snapshot is a
+ * tripwire, not a wall.
+ *
+ * Usage:
+ *   npx tsx .claude/skills/state-audit/scripts/grade-snapshot.test.ts
+ *
+ * Exits 0 on pass, 1 on fail.
+ */
+
+import { execSync } from "child_process";
+import * as path from "path";
+
+interface Expectation {
+  slug: string;
+  composite?: string;
+  limitedBy?: string;
+  courses?: string;
+  prereqs?: string;
+  transfers?: string;
+  scorecard?: string;
+  config?: string;
+  ceilingsDimensions?: string[]; // which dimensions should have ceilings applied
+  note: string;
+}
+
+const EXPECTATIONS: Expectation[] = [
+  {
+    slug: "nc",
+    composite: "A",
+    courses: "A",
+    transfers: "A",
+    note: "58/58 colleges, 25K transfers across 20 unis, all wired — flagship A",
+  },
+  {
+    slug: "ny",
+    composite: "A",
+    courses: "A",
+    transfers: "A",
+    note: "7/7 colleges, 45K transfers across 14 unis — full coverage",
+  },
+  {
+    slug: "nh",
+    composite: "B",
+    limitedBy: "transfers",
+    transfers: "B",
+    ceilingsDimensions: ["transfers"],
+    note: "1-university ceiling documented (USNH) — capped at B floor, would be C otherwise",
+  },
+  {
+    slug: "oh",
+    composite: "D",
+    limitedBy: "courses",
+    courses: "D",
+    transfers: "C",
+    note: "5/22 colleges → courses D dominates; transfers thin (OSU only)",
+  },
+  {
+    slug: "vt",
+    composite: "C",
+    limitedBy: "transfers",
+    transfers: "C",
+    courses: "A",
+    note: "1/1 college covered but only 345 transfers from 1 uni — transfers C",
+  },
+  {
+    slug: "fl",
+    composite: "D",
+    limitedBy: "courses",
+    courses: "D",
+    note: "12/28 colleges (43%) — coverage D",
+  },
+  {
+    slug: "mi",
+    composite: "D",
+    limitedBy: "courses",
+    courses: "D",
+    transfers: "A",
+    note: "12/31 colleges but transfers are A (146K mappings, 5 unis)",
+  },
+  {
+    slug: "tx",
+    composite: "D",
+    limitedBy: "courses",
+    courses: "D",
+    transfers: "A",
+    note: "21/59 colleges but transfers A (186K, 43 unis from TCCNS)",
+  },
+  {
+    slug: "va",
+    composite: "D",
+    limitedBy: "transfers",
+    transfers: "D",
+    courses: "A",
+    note: "23/23 colleges + 15K transfer data, but no transfer scraper wired — will go stale",
+  },
+  {
+    slug: "ca",
+    composite: "F",
+    limitedBy: "transfers",
+    transfers: "F",
+    note: "117 colleges with no transfer data and no documented ceiling — F",
+  },
+  {
+    slug: "wv",
+    composite: "F",
+    courses: "F",
+    transfers: "F",
+    note: "1/9 colleges (11%) + no transfers — skeleton state",
+  },
+];
+
+interface AuditState {
+  slug: string;
+  grades: {
+    courses: { grade: string; reason: string };
+    prereqs: { grade: string; reason: string };
+    transfers: { grade: string; reason: string };
+    scorecard: { grade: string; reason: string };
+    config: { grade: string; reason: string };
+    composite: string;
+    limitedBy: string;
+    ceilingsApplied: Array<{ dimension: string; reason: string }>;
+  };
+}
+
+function runAudit(): AuditState[] {
+  const collector = path.join(
+    process.cwd(),
+    ".claude/skills/state-audit/scripts/collect-audit-data.ts",
+  );
+  const json = execSync(`npx tsx ${collector}`, {
+    encoding: "utf-8",
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return JSON.parse(json);
+}
+
+function main() {
+  console.log("Running state-audit grade snapshot test…\n");
+  const audit = runAudit();
+  const bySlug = new Map(audit.map((s) => [s.slug, s]));
+
+  let pass = 0;
+  let fail = 0;
+  const failures: string[] = [];
+
+  for (const exp of EXPECTATIONS) {
+    const state = bySlug.get(exp.slug);
+    if (!state) {
+      fail++;
+      failures.push(`${exp.slug}: not found in audit output`);
+      continue;
+    }
+    const g = state.grades;
+    const checks: Array<[string, string | undefined, string]> = [
+      ["composite", exp.composite, g.composite],
+      ["limitedBy", exp.limitedBy, g.limitedBy],
+      ["courses", exp.courses, g.courses.grade],
+      ["prereqs", exp.prereqs, g.prereqs.grade],
+      ["transfers", exp.transfers, g.transfers.grade],
+      ["scorecard", exp.scorecard, g.scorecard.grade],
+      ["config", exp.config, g.config.grade],
+    ];
+    const errs: string[] = [];
+    for (const [field, expected, actual] of checks) {
+      if (expected !== undefined && expected !== actual) {
+        errs.push(`${field}: expected ${expected}, got ${actual}`);
+      }
+    }
+    if (exp.ceilingsDimensions) {
+      const appliedDims = new Set(g.ceilingsApplied.map((c) => c.dimension));
+      for (const dim of exp.ceilingsDimensions) {
+        if (!appliedDims.has(dim)) {
+          errs.push(`ceilings: expected ${dim} exemption, none applied`);
+        }
+      }
+    }
+    if (errs.length === 0) {
+      pass++;
+      console.log(`  ✓ ${exp.slug.padEnd(4)} ${g.composite} (${g.limitedBy}) — ${exp.note}`);
+    } else {
+      fail++;
+      failures.push(`  ✗ ${exp.slug}: ${errs.join("; ")} (note: ${exp.note})`);
+    }
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed (${EXPECTATIONS.length} total)`);
+  if (failures.length > 0) {
+    console.log("\nFailures:");
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## What changes for someone using the audit

Running `/state-audit` now produces a per-state grade *breakdown* instead of one opaque letter. Each state's output has five dimension grades (courses, prereqs, transfers, scorecard, config), a composite grade (= worst dimension), and a `limitedBy` field naming exactly which dimension produced the composite. The next fix is always obvious: \"VA composite D, limited by transfers: data exists but scraper not wired\" tells you what to do.

The rubric also finally honors `StateConfig.documentedCeilings`. NH's transfers dimension correctly caps at B (instead of dropping to C) because NH documents \"UNH and Plymouth State publish no public articulation database\" as a hard ceiling. Previously the rubric ignored the field entirely.

**Old distribution:** 25 states bunched at B — useless signal.
**New distribution:** 9A / 5B / 6C / 6D / 9F — real gradient, real priorities.

Notable grade movements (post-IL/TX/OH/MI work):
- VA: B → D (transfers exist but scraper not wired — will go stale)
- OH: B → D (5/22 course coverage now visible as the binding constraint)
- NC/KY/GA/NY/TN: → A (fully wired, full coverage)
- NH: → B with `ceilingsApplied: [transfers]` recorded
- CA: → F (117 colleges, no transfer data, no documented ceiling)

## Technical

Grading moved from Claude-interpreted prose (`SKILL.md` lines 46-81) into TypeScript in `collect-audit-data.ts`. Each `AuditResult` now has a `grades` block:

```jsonc
\"grades\": {
  \"courses\":   { \"grade\": \"A\", \"reason\": \"full coverage (23/23), terms clean\" },
  \"transfers\": { \"grade\": \"D\", \"reason\": \"data exists (15483) but scraper not wired — will go stale\" },
  ...
  \"composite\": \"D\",
  \"limitedBy\": \"transfers\",
  \"ceilingsApplied\": []
}
```

Ceiling rules: `documentedCeilings.transfers` caps the transfers dimension at B floor (not below), same for `scorecard`. `documentedCeilings.courseColleges[]` is removed from the course coverage denominator. The capped dimension can still earn A on its own merits — the ceiling only prevents drops below B.

Per-dim thresholds are encoded in code and summarized as a table in SKILL.md. Snapshot tests in `grade-snapshot.test.ts` lock down expected grades for 11 representative states (flagship-A, ceiling-capped-B, thin-transfers-C, course-gap-D, not-wired-D, skeleton-F).

The collector's grading is now deterministic (same data → same grades every run) and reproducible. The prose section of SKILL.md shifts from \"apply these rules\" to \"interpret these grades\" — meaningfully less work for Claude per audit invocation.

## Test plan

- [x] Snapshot test passes: \`npx tsx .claude/skills/state-audit/scripts/grade-snapshot.test.ts\` → 11/11 ✓
- [x] Full audit produces \`grades\` block on every state
- [x] NH transfers correctly capped at B with reason in \`ceilingsApplied\`
- [x] IL (no ceiling) has empty \`ceilingsApplied\`
- [x] Project-wide typecheck clean
- [ ] Re-invoke \`/state-audit\` after merge and confirm the output is meaningfully more useful for prioritization

🤖 Generated with [Claude Code](https://claude.com/claude-code)