### PR TITLE
fix(scrapers): widen post-callback narrowing in nimble-cms parser

### DIFF
--- a/scripts/lib/scrape-nimble-cms-programs.ts
+++ b/scripts/lib/scrape-nimble-cms-programs.ts
@@ -316,7 +316,12 @@ function parseProgramPage(
       }
     });
 
-    if (current && current.courses.length > 0) groups.push(current);
+    // The `as` cast defeats TS's post-callback narrowing of `current` to
+    // `null` (and thus `current && ...` to `never`). The reassignment
+    // inside .each() is invisible to flow analysis at this scope, so the
+    // declared type is the right one to use here.
+    const finalGroup = current as RequirementGroup | null;
+    if (finalGroup && finalGroup.courses.length > 0) groups.push(finalGroup);
   });
 
   if (groups.length === 0) return null;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this unblocks the Vercel prod build (still failing after the earlier banner-ssb hotfix landed). Same root cause shape: a TypeScript build error in a scraper that prevents \`npm run build\` from succeeding.

## Technical

After #578 landed, prod still failed on commit 999fa2c with:

\`\`\`
./scripts/lib/scrape-nimble-cms-programs.ts:319:28
Type error: Property 'courses' does not exist on type 'never'.
\`\`\`

The pattern at fault:

\`\`\`ts
let current: RequirementGroup | null = null;

\$table.find(\"tr\").each((_, tr) => {
  // ...
  current = { ... };          // reassigned inside callback
});

if (current && current.courses.length > 0) groups.push(current);  // line 319
\`\`\`

TypeScript's flow analysis can't see the callback's reassignment from the outer scope, so it keeps \`current\` narrowed to \`null\`. The \`current && ...\` truthiness check then removes \`null\`, leaving \`never\` — and the property access fails.

Fix: \`const finalGroup = current as RequirementGroup | null\` re-asserts the declared type and defeats the post-callback narrowing. Runtime behavior unchanged.

## Test plan

- [x] \`npx tsc --noEmit --skipLibCheck\` runs clean (no errors anywhere)
- [ ] Vercel deploy succeeds on the next push to main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)