### PR TITLE
chore: bump scheduled-scrape.yml to refresh dispatch cache

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -1,4 +1,5 @@
 name: Scheduled scrape (unified)
+
 # Unified scheduled-scrape workflow (issue #59, PR 2; per-state PRs in
 # issue #169). Replaces the VA-only weekly-scrape-va.yml exemplar (#58).
 # Reads StateConfig.scrapers to build its matrix, so adding a state to


### PR DESCRIPTION
## What changes for someone using the site
Nothing user-visible. This is a one-line whitespace bump to `.github/workflows/scheduled-scrape.yml` so that GitHub Actions re-parses the workflow's `on:` triggers.

## Why
Manual dispatches (`gh workflow run scheduled-scrape.yml -f datatype=transfers`) are returning HTTP 422: *"Workflow does not have 'workflow_dispatch' trigger"* — even though the trigger is present in the file on main. Actions' cached view of the workflow is stale.

Same fix as commit e4d4884 ("chore: bump workflow file to refresh GitHub dispatch cache") from earlier today.

## After merge
I'll dispatch `scheduled-scrape.yml` with `datatype=transfers` to fire the 9 never-run transfers scrapers (ar, az, hi, il, ky, mi, nv, oh, tx) along with the rest of the registry's transfers jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)