### PR TITLE
fix(ci): re-indent triage email $text into run: block — unbreaks scheduled-scrape YAML

### DIFF
--- a/.github/workflows/scheduled-scrape-v2.yml
+++ b/.github/workflows/scheduled-scrape-v2.yml
@@ -542,15 +542,15 @@ jobs:
 
           text="Scraper Health Triage Alert
 
-${actionable} actionable finding(s) from the latest cron run:
-- Persistent-broken: ${broken}
-- Regressions: ${regressions}
-- Partial-coverage: ${partial}
+          ${actionable} actionable finding(s) from the latest cron run:
+          - Persistent-broken: ${broken}
+          - Regressions: ${regressions}
+          - Partial-coverage: ${partial}
 
-${summary}
+          ${summary}
 
-View full triage: ${issue_url}
-Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          View full triage: ${issue_url}
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           html="<div style=\"font-family: -apple-system, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;\">
           <h2 style=\"color: #0d9488;\">Scraper Health Triage</h2>


### PR DESCRIPTION
## What changes for someone using the site
Nothing user-visible. This restores the ability to manually dispatch scheduled scraper runs from the GitHub Actions UI / CLI.

## What's wrong (root cause)
The bash `text="..."` multi-line assignment in the "Email triage alert" step (added in PR #556) has continuation lines with zero leading indentation. That escaped the YAML `run: |` block scalar, and YAML tried to parse the continuation lines as top-level mapping keys. The line `View full triage: ${issue_url}` at line 552 specifically blew up the parser.

This is why every fix attempt today failed:

| PR | Approach | Result |
|---|---|---|
| #580 | Whitespace bump (same recipe as e4d4884) | Didn't help — YAML still broken |
| #581 | Rename `scheduled-scrape.yml` → `-v2.yml` to bust cache | New workflow record had same broken YAML |
| n/a | Disable/re-enable workflow via API | Touched `updated_at` but parser stayed broken |

`npx js-yaml .github/workflows/scheduled-scrape-v2.yml` confirms the parse error at line 552, col 17.

## What this PR does
Indents lines 545-553 to match the block's 10-space indent. YAML strips the common leading indent before handing the script to bash, so the shell sees the identical multi-line string content; only YAML's view changes.

## Verified
- `npx js-yaml .github/workflows/scheduled-scrape-v2.yml` → parses cleanly (no output).

## After merge
- The workflow record should re-parse with the correct `name: Scheduled scrape (unified)` instead of the file path.
- I'll dispatch `scheduled-scrape-v2.yml -f datatype=transfers` to fire the 9 never-run transfers scrapers (ar, az, hi, il, ky, mi, nv, oh, tx).
- The Wed 10:00 UTC cron should also start succeeding again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)