### PR TITLE
fix(nj/transfer): iterate A-Z to capture full alphabet (was A-only)

### DIFF
--- a/scripts/nj/scrape-transfer.ts
+++ b/scripts/nj/scrape-transfer.ts
@@ -554,68 +554,70 @@ async function scrapeCC(
   const sessionId = await setupSession(ccCode, artId);
   await sleep(300);
 
-  // Step 3: Start from the first course
-  const firstCourseHtml = await retryFetch(
-    `${BASE_URL}/crs-srch.cgi?${sessionId}`,
-    `first-course(${ccCode})`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: `CRSID=A&LUp=Go&SI=${ccCode}&RI=All&From_where=precs.cgi`,
-    },
-  );
-
-  if (!firstCourseHtml) {
-    console.log("    Empty response for first course, skipping");
-    return [];
-  }
-
+  // Step 3+4: NJTransfer's `Next` link only walks within the starting-letter
+  // bucket — once we reach the last A-prefixed course, the Next link points
+  // back to the first A course (or disappears), so a single `CRSID=A` search
+  // followed by Next-iteration captures A-prefix data only. To get full
+  // alphabet coverage we restart the search at each letter A–Z.
   const allMappings: TransferMapping[] = [];
   let courseCount = 0;
   const seenCourses = new Set<string>();
+  const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
-  // Parse first course
-  let result = parseCourseEquivalencyPage(firstCourseHtml, ccCode);
-  if (result.ccCourseId) {
+  for (const letter of LETTERS) {
+    if (courseCount >= courseLimit) break;
+
+    const firstCourseHtml = await retryFetch(
+      `${BASE_URL}/crs-srch.cgi?${sessionId}`,
+      `first-course(${ccCode}, ${letter})`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: `CRSID=${letter}&LUp=Go&SI=${ccCode}&RI=All&From_where=precs.cgi`,
+      },
+    );
+
+    if (!firstCourseHtml) continue;
+
+    let result = parseCourseEquivalencyPage(firstCourseHtml, ccCode);
+
+    // Skip if no course was found for this letter or NJTransfer fell through
+    // to a course we've already captured under an earlier letter.
+    if (!result.ccCourseId || seenCourses.has(result.ccCourseId)) continue;
+
     seenCourses.add(result.ccCourseId);
     allMappings.push(...result.mappings);
     courseCount++;
-  }
 
-  // Step 4: Follow Next links
-  while (result.nextUrl && courseCount < courseLimit) {
-    await sleep(DELAY_MS);
+    // Iterate within this letter bucket via Next links
+    while (result.nextUrl && courseCount < courseLimit) {
+      await sleep(DELAY_MS);
 
-    const html = await retryFetch(
-      result.nextUrl,
-      `next-course(${ccCode}, #${courseCount})`,
-    );
-
-    if (!html) break;
-
-    result = parseCourseEquivalencyPage(html, ccCode);
-
-    // Detect loop (we've come back to a course we've seen)
-    if (result.ccCourseId && seenCourses.has(result.ccCourseId)) {
-      console.log(
-        `    Reached end of course list after ${courseCount} courses (loop detected at ${result.ccCourseId})`,
+      const html = await retryFetch(
+        result.nextUrl,
+        `next-course(${ccCode}, ${letter}, #${courseCount})`,
       );
-      break;
-    }
 
-    if (result.ccCourseId) {
-      seenCourses.add(result.ccCourseId);
-      allMappings.push(...result.mappings);
-      courseCount++;
+      if (!html) break;
 
-      if (courseCount % 50 === 0) {
-        console.log(
-          `    ${courseCount} courses processed (${allMappings.length} mappings so far)...`,
-        );
+      result = parseCourseEquivalencyPage(html, ccCode);
+
+      // End of bucket: Next link looped back to a course we've already seen
+      if (result.ccCourseId && seenCourses.has(result.ccCourseId)) break;
+
+      if (result.ccCourseId) {
+        seenCourses.add(result.ccCourseId);
+        allMappings.push(...result.mappings);
+        courseCount++;
+
+        if (courseCount % 50 === 0) {
+          console.log(
+            `    ${courseCount} courses processed (${allMappings.length} mappings so far)...`,
+          );
+        }
+      } else {
+        break;
       }
-    } else {
-      // Empty page — likely hit the end
-      break;
     }
   }
 


### PR DESCRIPTION
## What changes for someone using the site

**\`/nj/transfer\` will get ~2.5× more transfer mappings on the next cron tick.** Today the page can only answer questions about courses with codes starting in A (Accounting, Art, Arts, Automotive, etc.). After this lands and the cron runs, students searching for Biology (BIO), Chemistry (CHEM), English (ENGL), History (HIST), Mathematics (MAT), Psychology (PSY) and every other subject will see their transfer equivalencies.

This is a silent prior gap — the page renders fine, just with no data for the queried subject. Users assumed "no equivalency" when the reality was "the scraper never captured this letter."

## What was wrong

\`scripts/nj/scrape-transfer.ts\` hard-coded \`CRSID=A\` as its starting query (line 564), then followed NJTransfer.org's "Next course" link until a loop-back was detected. The problem: the Next link only walks within one starting-letter bucket — once we reach the last A-prefixed course, the link points back to the first A course. The scraper detected the loop and stopped, never reaching B–Z.

Result on main today: 68,357 transfer mappings for NJ, **all starting with A**. The 2026-05-25 cron pulled 102,105 mappings — still all A.

## The fix

Wrap the existing iteration in an outer for-loop over the alphabet. Restart the search at each letter with a fresh \`CRSID=<letter>\` POST, then walk Next links within that letter's bucket. A shared \`seenCourses\` set deduplicates if NJTransfer ever returns the same course under multiple letters.

## Verified locally

Ran with a test variant (\`LETTERS=BCD\`, \`--cc=BE --limit=10\`) and captured:

\`\`\`
BIO 101 "GENERAL BIOLOGY I" → Berkeley College S
BIO 101 "GENERAL BIOLOGY I" → Bloomfield College of Montclair State University B
BIO 101 "GENERAL BIOLOGY I" → Caldwell University B
BIO 101 "GENERAL BIOLOGY I" → Centenary University B
BIO 101 "GENERAL BIOLOGY I" → DeVry University B
BIO 101 "GENERAL BIOLOGY I" → Drew University B
\`\`\`

Real B-prefix data the previous code couldn't reach.

## Cost

One extra POST per CC per empty letter (cheap — server returns immediately when CRSID matches nothing). Full A–Z coverage will lift NJ from ~100k to ~250k+ mappings on the next cron tick, based on average alphabetic density across other state articulation sources.

## Verification after merge

1. Wait for next transfers cron tick (Wed/Sat 10:00 UTC), or manually dispatch \`scheduled-scrape-v2.yml -f datatype=transfers\`.
2. Check that the resulting NJ scrape has full A–Z coverage:
   \`\`\`
   jq '[.[].cc_prefix[0:1]] | unique | sort | join("")' data/nj/transfer-equiv.json
   \`\`\`
   Expected: \`ABCDEFGHIJKLMNOPRSTUVW\` (or similar broad coverage), not just \`A\`.
3. On prod, load \`/nj/transfer\`, pick RVCC + Rutgers SAS, search for \`BIO 101\` — should now return a mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)