### PR TITLE
fix(api): rename URL-encoded articulation route dirs + Next 16 async params

### DIFF
--- a/app/api/[state]/articulation/[major]/route.ts
+++ b/app/api/[state]/articulation/[major]/route.ts
@@ -14,10 +14,11 @@ export const revalidate = 86400; // 1 day
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { state: string; major: string } }
+  { params }: { params: Promise<{ state: string; major: string }> }
 ) {
-  const state = params.state.toLowerCase();
-  const majorSlug = params.major.toLowerCase();
+  const { state: stateParam, major: majorParam } = await params;
+  const state = stateParam.toLowerCase();
+  const majorSlug = majorParam.toLowerCase();
   const cc = request.nextUrl.searchParams.get("cc");
   const university = request.nextUrl.searchParams.get("university");
 

--- a/app/api/[state]/articulation/route.ts
+++ b/app/api/[state]/articulation/route.ts
@@ -19,9 +19,10 @@ export const revalidate = 86400; // 1 day
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { state: string } }
+  { params }: { params: Promise<{ state: string }> }
 ) {
-  const state = params.state.toLowerCase();
+  const { state: stateParam } = await params;
+  const state = stateParam.toLowerCase();
   const cc = request.nextUrl.searchParams.get("cc");
   const university = request.nextUrl.searchParams.get("university");
 


### PR DESCRIPTION
## What changes for someone using the site

Unblocks Vercel deploys. The current build (after the OOM fix in #593 cleared) is failing on a TypeScript error in two API route files that were created with broken directory names AND a pre-Next-16 params signature. Fixing those lets PRs #588 (transfer data), #590 (NJ scraper), and #591 (TX transfer perf) finally ship to prod.

Once this lands and Vercel finishes deploying:
- \`/tx/transfer\` should drop from ~15s to a few seconds
- The articulation API endpoints at \`/api/[state]/articulation\` and \`/api/[state]/articulation/[major]\` will actually be reachable (they're currently 404 because the dirs are URL-encoded)

## What was wrong

PR #592 (CA articulation import) created the articulation API routes in directories named \`app/api/%5Bstate%5D/articulation/%5Bmajor%5D/\` — URL-encoded brackets instead of literal \`[state]\` and \`[major]\`. Next.js route matching uses literal brackets, so these routes have been silently dead since #592 merged.

Separately, the handlers used the pre-Next-15 params shape (\`params: { state: string }\`) instead of Next 16's required \`params: Promise<{ state: string }>\`. Next's typecheck flagged this once the OOM fix (#593) cleared the build memory ceiling and the build could actually progress to typechecking the route layer.

## The fix

- \`git mv\` both files from \`%5B...\`-named dirs to literal \`[...]\`-named dirs (the file diff shows as renames with a tiny patch, both >93% similar).
- Update both handlers to type \`params\` as a Promise and \`await\` it before destructuring.

## Verified

\`npx tsc --noEmit\` shows no errors in the moved route files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)