### PR TITLE
feat(seo): data-grounded editorial paragraphs on state + college pages

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { getCurrentTerm } from "@/lib/terms";
 import CollegeScorecardSection from "./CollegeScorecardSection";
 import CollegeTermSection from "./CollegeTermSection";
+import CollegeContext from "@/components/CollegeContext";
 import TopProgramsSection from "./TopProgramsSection";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { getAllStates } from "@/lib/states/registry";
@@ -330,6 +331,26 @@ export default async function CollegeDetailPage(props: PageProps) {
           </div>
         </div>
       </section>
+
+      {/* At-a-glance — data-grounded editorial context paragraphs. Renders
+          nothing when fewer than 2 sentences qualify (sparse-data colleges),
+          so we don't get an empty heading. */}
+      <CollegeContext
+        state={state}
+        stateName={config.name}
+        systemName={config.systemName}
+        institution={institution}
+        sections={coursesByTerm[defaultTerm] ?? []}
+        term={defaultTerm}
+        seniorWaiver={
+          config.seniorWaiver
+            ? {
+                ageThreshold: config.seniorWaiver.ageThreshold,
+                legalCitation: config.seniorWaiver.legalCitation,
+              }
+            : null
+        }
+      />
 
       {/* COURSES — immediately after hero (courses-first layout) */}
       <CollegeTermSection

--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -4,7 +4,8 @@ import { notFound } from "next/navigation";
 import SearchForm from "@/components/SearchForm";
 import StartingSoonCallout from "@/components/StartingSoonCallout";
 import NotifyBanner from "@/components/NotifyBanner";
-import { getNextTerm } from "@/lib/terms";
+import StateContext from "@/components/StateContext";
+import { getCurrentTerm, getNextTerm } from "@/lib/terms";
 import { getAllStates, isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getArticlesByState, getStateTopicLinks, categoryLabel } from "@/lib/blog";
@@ -43,6 +44,10 @@ export default async function HomePage({ params }: Props) {
   if (!isValidState(state)) notFound();
   const config = requireStateConfig(state);
   const nextTerm = await getNextTerm(state);
+  // Used by <StateContext> to compute statewide insights against the current
+  // term's data — safe to fail through to no insights, since the renderer
+  // skips when fewer than 2 sentences qualify.
+  const currentTerm = await getCurrentTerm(state).catch(() => null);
   const stateArticles = getArticlesByState(state);
   const topicLinks = getStateTopicLinks(state);
   const siteUrl =
@@ -283,6 +288,24 @@ export default async function HomePage({ params }: Props) {
           </p>
         </div>
       </section>
+
+      {/* At-a-glance — data-grounded editorial paragraphs about the state's
+          CC system. Renders nothing when fewer than 2 sentences qualify. */}
+      <StateContext
+        state={state}
+        stateName={config.name}
+        systemName={config.systemName}
+        term={currentTerm}
+        seniorWaiver={
+          config.seniorWaiver
+            ? {
+                ageThreshold: config.seniorWaiver.ageThreshold,
+                legalCitation: config.seniorWaiver.legalCitation,
+                bannerDetail: config.seniorWaiver.bannerDetail,
+              }
+            : null
+        }
+      />
 
       {/* Browse by program — only when at least one program qualifies */}
       {programSlugs.length > 0 && (

--- a/components/CollegeContext.tsx
+++ b/components/CollegeContext.tsx
@@ -1,0 +1,50 @@
+/**
+ * CollegeContext — server-rendered editorial paragraphs above the college
+ * page's stat grid. Computes data-grounded prose from the page's already-
+ * loaded section data plus a few Supabase queries (transfers, ASSIST for CA).
+ *
+ * Returns null when fewer than 2 sentences qualify, so data-sparse colleges
+ * don't render an empty heading.
+ */
+
+import {
+  getCollegeInsights,
+  type GetCollegeInsightsArgs,
+} from "@/lib/college-insights";
+import { renderCollegeProse } from "@/lib/insights-prose";
+
+export default async function CollegeContext(
+  args: GetCollegeInsightsArgs,
+) {
+  let paragraphs: string[] = [];
+  try {
+    const insights = await getCollegeInsights(args);
+    paragraphs = renderCollegeProse(insights);
+  } catch (err) {
+    // Never let a context-rendering failure break the page. Log so the
+    // signal still surfaces in Vercel logs without taking down the route.
+    console.warn(
+      `CollegeContext failed for ${args.state}/${args.institution.id}:`,
+      err,
+    );
+    return null;
+  }
+
+  if (paragraphs.length === 0) return null;
+
+  return (
+    <section
+      aria-label={`About ${args.institution.name}`}
+      className="mt-2 mb-8 rounded-2xl border border-gray-200 dark:border-slate-700 bg-gray-50/50 dark:bg-slate-800/40 px-6 py-6"
+    >
+      <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-4">
+        at a glance
+      </div>
+      <div className="space-y-4 text-[15px] leading-relaxed text-gray-700 dark:text-slate-300">
+        {paragraphs.map((p, i) => (
+          <p key={i}>{p}</p>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/StateContext.tsx
+++ b/components/StateContext.tsx
@@ -1,0 +1,46 @@
+/**
+ * StateContext — server-rendered editorial paragraphs for the state landing
+ * page. Aggregates statewide section counts, top subjects, transfer
+ * destinations, ASSIST data (CA only), and Scorecard medians into 2–4
+ * paragraphs of natural prose.
+ *
+ * Returns null when fewer than 2 sentences qualify, so sparse states don't
+ * render an empty heading.
+ */
+
+import {
+  getStateInsights,
+  type GetStateInsightsArgs,
+} from "@/lib/state-insights";
+import { renderStateProse } from "@/lib/insights-prose";
+
+export default async function StateContext(args: GetStateInsightsArgs) {
+  let paragraphs: string[] = [];
+  try {
+    const insights = await getStateInsights(args);
+    paragraphs = renderStateProse(insights);
+  } catch (err) {
+    console.warn(`StateContext failed for ${args.state}:`, err);
+    return null;
+  }
+
+  if (paragraphs.length === 0) return null;
+
+  return (
+    <section
+      aria-label={`About community colleges in ${args.stateName}`}
+      className="py-12 px-4 sm:px-6 lg:px-8"
+    >
+      <div className="max-w-4xl mx-auto">
+        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-4">
+          {args.stateName.toLowerCase()} community colleges at a glance
+        </div>
+        <div className="space-y-4 text-[15px] leading-relaxed text-gray-700 dark:text-slate-300">
+          {paragraphs.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/__tests__/insights-prose.test.ts
+++ b/lib/__tests__/insights-prose.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import {
+  BANNED_PHRASES,
+  pickVariant,
+  renderCollegeProse,
+  renderStateProse,
+} from "../insights-prose";
+import type { CollegeInsights } from "../college-insights";
+import type { StateInsights } from "../state-insights";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makeCollegeInsights(
+  overrides: Partial<CollegeInsights> = {},
+): CollegeInsights {
+  return {
+    state: "va",
+    collegeId: "northern-virginia-community-college",
+    collegeName: "Northern Virginia Community College",
+    systemName: "VCCS",
+    term: "2026FA",
+    termSectionCount: 4250,
+    sectionRank: { position: 1, outOf: 23, value: 4250 },
+    topSubjects: [
+      { prefix: "ENG", sections: 280 },
+      { prefix: "BIO", sections: 220 },
+      { prefix: "MTH", sections: 195 },
+    ],
+    modeShares: {
+      inPerson: { pct: 55, statePct: 60, delta: -5 },
+      hybrid: { pct: 10, statePct: 8, delta: 2 },
+      online: { pct: 35, statePct: 22, delta: 13 },
+    },
+    lateStartCount: 320,
+    lateStartRank: { position: 2, outOf: 23, value: 320 },
+    topTransferDestinations: [
+      { university: "George Mason University", mappingCount: 482 },
+      { university: "Virginia Commonwealth University", mappingCount: 391 },
+      { university: "Old Dominion University", mappingCount: 277 },
+    ],
+    totalTransferMappings: 1150,
+    assistAgreementCount: null,
+    assistTopUniversities: [],
+    scorecard: {
+      tuition: 5680,
+      tuitionStateMedian: 5000,
+      earnings10yr: 42300,
+      earningsStateMedian: 38000,
+      retentionFullTime: 0.68,
+      pellRate: 0.41,
+      pellStateAvg: 0.39,
+    },
+    seniorWaiver: { ageThreshold: 60, legalCitation: "§23.1-901" },
+    primaryCity: "Annandale",
+    additionalCities: ["Alexandria", "Manassas"],
+    ...overrides,
+  };
+}
+
+function makeStateInsights(
+  overrides: Partial<StateInsights> = {},
+): StateInsights {
+  return {
+    state: "va",
+    stateName: "Virginia",
+    systemName: "VCCS",
+    term: "2026FA",
+    totalSections: 28400,
+    collegesWithData: 23,
+    totalColleges: 23,
+    largestCollege: {
+      collegeCode: "northern-virginia-community-college",
+      collegeName: "Northern Virginia Community College",
+      sectionCount: 4250,
+    },
+    smallestCollege: {
+      collegeCode: "eastern-shore-community-college",
+      collegeName: "Eastern Shore Community College",
+      sectionCount: 95,
+    },
+    topSubjects: [
+      { prefix: "ENG", sectionCount: 1820, collegesOffering: 23 },
+      { prefix: "MTH", sectionCount: 1640, collegesOffering: 23 },
+      { prefix: "BIO", sectionCount: 1310, collegesOffering: 23 },
+    ],
+    topTransferDestinations: [
+      { university: "Virginia Commonwealth University", mappingCount: 8200 },
+      { university: "George Mason University", mappingCount: 7100 },
+      { university: "Old Dominion University", mappingCount: 6800 },
+    ],
+    totalTransferMappings: 32_000,
+    assistAgreementCount: null,
+    assistTopPairs: [],
+    blogPostCount: 22,
+    seniorWaiver: {
+      ageThreshold: 60,
+      legalCitation: "§23.1-901",
+      bannerDetail: "Free for VA residents 60+",
+    },
+    scorecard: {
+      medianTuition: 5000,
+      medianNetPrice: 8200,
+      medianEarnings: 38000,
+      medianCompletion: 0.32,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Banned-phrase enforcement
+// ---------------------------------------------------------------------------
+
+describe("BANNED_PHRASES enforcement", () => {
+  function flatText(parts: string[]): string {
+    return parts.join(" ").toLowerCase();
+  }
+
+  it("contains no banned phrases in college prose for a full insight bundle", () => {
+    const text = flatText(renderCollegeProse(makeCollegeInsights()));
+    for (const phrase of BANNED_PHRASES) {
+      expect(text).not.toContain(phrase);
+    }
+  });
+
+  it("contains no banned phrases in state prose for a full insight bundle", () => {
+    const text = flatText(renderStateProse(makeStateInsights()));
+    for (const phrase of BANNED_PHRASES) {
+      expect(text).not.toContain(phrase);
+    }
+  });
+
+  it("contains no banned phrases across all 3 variants for the catalog-rank fact", () => {
+    // Render the same insights against 12 distinct college IDs to spread
+    // across all 3 variant pools and confirm none reach the banned list.
+    for (let i = 0; i < 12; i++) {
+      const insights = makeCollegeInsights({
+        collegeId: `synthetic-college-${i}`,
+      });
+      const text = flatText(renderCollegeProse(insights));
+      for (const phrase of BANNED_PHRASES) {
+        expect(text).not.toContain(phrase);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Skip-when-unremarkable behaviour
+// ---------------------------------------------------------------------------
+
+describe("renderCollegeProse skip rules", () => {
+  it("returns empty array when fewer than 2 sentences qualify", () => {
+    // Minimal insights — only section count, no rank, no subjects, no
+    // transfer data, no scorecard, no senior waiver.
+    const thin = makeCollegeInsights({
+      termSectionCount: null,
+      sectionRank: null,
+      topSubjects: [],
+      modeShares: { inPerson: null, hybrid: null, online: null },
+      lateStartCount: null,
+      lateStartRank: null,
+      topTransferDestinations: [],
+      totalTransferMappings: null,
+      assistAgreementCount: null,
+      assistTopUniversities: [],
+      scorecard: null,
+      seniorWaiver: null,
+    });
+    expect(renderCollegeProse(thin)).toEqual([]);
+  });
+
+  it("omits the online-mode sentence when delta vs state median is < 5pp", () => {
+    const median = makeCollegeInsights({
+      modeShares: {
+        inPerson: { pct: 58, statePct: 60, delta: -2 },
+        hybrid: { pct: 9, statePct: 8, delta: 1 },
+        online: { pct: 24, statePct: 22, delta: 2 },
+      },
+    });
+    const text = renderCollegeProse(median).join(" ").toLowerCase();
+    expect(text).not.toContain("online");
+  });
+
+  it("omits the late-start sentence when this college is in the bottom half by late-start count", () => {
+    const bottomHalf = makeCollegeInsights({
+      lateStartRank: { position: 20, outOf: 23, value: 12 },
+    });
+    const text = renderCollegeProse(bottomHalf).join(" ").toLowerCase();
+    expect(text).not.toContain("late-start");
+  });
+
+  it("omits the cost sentence when tuition is within $250 of the state median", () => {
+    const median = makeCollegeInsights({
+      scorecard: {
+        tuition: 5100,
+        tuitionStateMedian: 5000,
+        earnings10yr: 38500,
+        earningsStateMedian: 38000,
+        retentionFullTime: 0.7,
+        pellRate: 0.4,
+        pellStateAvg: 0.4,
+      },
+    });
+    const text = renderCollegeProse(median).join(" ").toLowerCase();
+    expect(text).not.toContain("scorecard");
+  });
+});
+
+describe("renderStateProse skip rules", () => {
+  it("returns empty array when nothing qualifies", () => {
+    const empty: StateInsights = {
+      state: "xx",
+      stateName: "Nowhere",
+      systemName: "NoSys",
+      term: null,
+      totalSections: null,
+      collegesWithData: 0,
+      totalColleges: 0,
+      largestCollege: null,
+      smallestCollege: null,
+      topSubjects: [],
+      topTransferDestinations: [],
+      totalTransferMappings: null,
+      assistAgreementCount: null,
+      assistTopPairs: [],
+      blogPostCount: 0,
+      seniorWaiver: null,
+      scorecard: null,
+    };
+    expect(renderStateProse(empty)).toEqual([]);
+  });
+
+  it("renders the largest college alone if smallest is missing or ranks too few", () => {
+    const sparse = makeStateInsights({ smallestCollege: null });
+    const text = renderStateProse(sparse).join(" ");
+    expect(text).toContain("Northern Virginia Community College");
+    expect(text).not.toContain("smallest");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Variant distribution
+// ---------------------------------------------------------------------------
+
+describe("pickVariant", () => {
+  it("distributes keys roughly evenly across N variants", () => {
+    const counts = [0, 0, 0];
+    for (let i = 0; i < 300; i++) {
+      const idx = pickVariant(`college-${i}:catalog`, 3);
+      counts[idx]++;
+    }
+    // Each bucket should be within ±25% of the expected 100.
+    for (const c of counts) {
+      expect(c).toBeGreaterThanOrEqual(75);
+      expect(c).toBeLessThanOrEqual(125);
+    }
+  });
+
+  it("is deterministic — same key always returns the same index", () => {
+    const a = pickVariant("northern-virginia-community-college:catalog", 3);
+    const b = pickVariant("northern-virginia-community-college:catalog", 3);
+    expect(a).toBe(b);
+  });
+
+  it("returns 0 when n <= 0", () => {
+    expect(pickVariant("anything", 0)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Cite-source-inline check
+// ---------------------------------------------------------------------------
+
+describe("source-citation phrasing", () => {
+  it("uses at least one inline source citation in a full college bundle", () => {
+    const text = renderCollegeProse(makeCollegeInsights()).join(" ");
+    const citationPatterns = [
+      /Federal College Scorecard data/i,
+      /federal College Scorecard/i,
+      /state transfer records/i,
+      /Across .*'s catalog this term/i,
+      /California ASSIST registry/i,
+    ];
+    const matched = citationPatterns.some((p) => p.test(text));
+    expect(matched).toBe(true);
+  });
+
+  it("uses at least one inline source citation in a full state bundle", () => {
+    const text = renderStateProse(makeStateInsights()).join(" ");
+    const citationPatterns = [
+      /Federal College Scorecard data/i,
+      /federal College Scorecard/i,
+      /state transfer records/i,
+      /California ASSIST registry/i,
+    ];
+    const matched = citationPatterns.some((p) => p.test(text));
+    expect(matched).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Per-page determinism across rebuilds
+// ---------------------------------------------------------------------------
+
+describe("per-page determinism", () => {
+  it("renders identical prose on two calls with the same insights", () => {
+    const a = renderCollegeProse(makeCollegeInsights());
+    const b = renderCollegeProse(makeCollegeInsights());
+    expect(a).toEqual(b);
+  });
+
+  it("renders different sentences for different college IDs (variant spread)", () => {
+    const a = renderCollegeProse(
+      makeCollegeInsights({ collegeId: "alpha-college" }),
+    );
+    const b = renderCollegeProse(
+      makeCollegeInsights({ collegeId: "zulu-college" }),
+    );
+    // At least one paragraph should differ between two arbitrarily-named
+    // colleges with the same numeric inputs.
+    const same = a.length === b.length && a.every((p, i) => p === b[i]);
+    expect(same).toBe(false);
+  });
+});

--- a/lib/college-insights.ts
+++ b/lib/college-insights.ts
@@ -20,6 +20,9 @@
  *  - Scorecard cost/earnings with state-median comparison
  */
 
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import type { CourseSection, Institution } from "@/lib/types";
 import { computeOfferingProfile } from "@/lib/college-stats";
 import {
@@ -141,11 +144,59 @@ interface StateRankings {
 
 const rankingsCache = new Map<string, Promise<StateRankings | null>>();
 
+// Disk cache lives in the OS temp dir so it's shared across the Next.js
+// build worker processes. During `next build` with 7 parallel workers, the
+// first worker to need rankings for a state pays the Supabase cost and
+// writes the result; every other worker — and every other page on the same
+// worker — reads it back as a synchronous JSON parse.
+//
+// The cache is keyed by state+term and includes a generation timestamp so
+// stale entries from prior builds expire automatically. Failures to read or
+// write the disk cache are non-fatal — we degrade to in-process caching.
+const DISK_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+function rankingsCachePath(state: string, term: string): string {
+  return path.join(os.tmpdir(), `cc-coursemap-rankings-${state}-${term}.json`);
+}
+interface DiskCacheEnvelope {
+  generatedAt: number;
+  data: StateRankings | null;
+}
+function readDiskRankings(
+  state: string,
+  term: string,
+): StateRankings | null | undefined {
+  const file = rankingsCachePath(state, term);
+  try {
+    if (!fs.existsSync(file)) return undefined;
+    const raw = fs.readFileSync(file, "utf-8");
+    const envelope = JSON.parse(raw) as DiskCacheEnvelope;
+    if (Date.now() - envelope.generatedAt > DISK_CACHE_TTL_MS) return undefined;
+    return envelope.data;
+  } catch {
+    return undefined;
+  }
+}
+function writeDiskRankings(
+  state: string,
+  term: string,
+  data: StateRankings | null,
+): void {
+  const file = rankingsCachePath(state, term);
+  try {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ generatedAt: Date.now(), data } satisfies DiskCacheEnvelope),
+    );
+  } catch {
+    // Disk cache is best-effort — keep going.
+  }
+}
+
 /**
  * Build per-college section/late-start rankings + state-median mode shares
  * for the given state/term. Loads all state courses once and caches the
- * result for the duration of the process — fine for ISR builds since each
- * page rebuild gets a fresh process.
+ * result twice: in-process (this worker) and on disk under the OS temp dir
+ * (shared across all workers in the same `next build` run).
  *
  * Returns null when the state has no course data for the term.
  */
@@ -157,9 +208,21 @@ export async function getStateRankings(
   const existing = rankingsCache.get(key);
   if (existing) return existing;
 
+  // Cross-worker disk cache — synchronous read so we don't even create the
+  // Supabase request when another worker has already computed this state.
+  const fromDisk = readDiskRankings(state, term);
+  if (fromDisk !== undefined) {
+    const resolved = Promise.resolve(fromDisk);
+    rankingsCache.set(key, resolved);
+    return resolved;
+  }
+
   const promise = (async (): Promise<StateRankings | null> => {
     const sections = await loadAllCourses(term, state);
-    if (sections.length === 0) return null;
+    if (sections.length === 0) {
+      writeDiskRankings(state, term, null);
+      return null;
+    }
 
     // Group sections by college_code.
     const byCollege = new Map<string, CourseSection[]>();
@@ -211,7 +274,7 @@ export async function getStateRankings(
         : sorted[mid];
     };
 
-    return {
+    const result: StateRankings = {
       sectionRanks: sectionCounts,
       lateStartRanks: lateStartCounts,
       modeMedians: {
@@ -220,6 +283,8 @@ export async function getStateRankings(
         online: med(modeRows.map((r) => r.online)),
       },
     };
+    writeDiskRankings(state, term, result);
+    return result;
   })();
 
   rankingsCache.set(key, promise);
@@ -232,9 +297,54 @@ export async function getStateRankings(
 
 const transferDestCache = new Map<string, Promise<TransferDestination[]>>();
 
+function transferCachePath(state: string, ccSlug: string): string {
+  return path.join(
+    os.tmpdir(),
+    `cc-coursemap-xferdest-${state}-${ccSlug}.json`,
+  );
+}
+interface TransferCacheEnvelope {
+  generatedAt: number;
+  data: TransferDestination[];
+}
+function readDiskTransferDest(
+  state: string,
+  ccSlug: string,
+): TransferDestination[] | undefined {
+  try {
+    const file = transferCachePath(state, ccSlug);
+    if (!fs.existsSync(file)) return undefined;
+    const envelope = JSON.parse(
+      fs.readFileSync(file, "utf-8"),
+    ) as TransferCacheEnvelope;
+    if (Date.now() - envelope.generatedAt > DISK_CACHE_TTL_MS) return undefined;
+    return envelope.data;
+  } catch {
+    return undefined;
+  }
+}
+function writeDiskTransferDest(
+  state: string,
+  ccSlug: string,
+  data: TransferDestination[],
+): void {
+  try {
+    fs.writeFileSync(
+      transferCachePath(state, ccSlug),
+      JSON.stringify({
+        generatedAt: Date.now(),
+        data,
+      } satisfies TransferCacheEnvelope),
+    );
+  } catch {
+    // best-effort
+  }
+}
+
 /**
  * Top receiving universities for a given CC's course catalog, ordered by
- * mapping count desc. Limited to top 10.
+ * mapping count desc. Limited to top 10. Disk-cached per (state, college)
+ * under the OS temp dir for cross-worker reuse during `next build`.
  *
  * `subjectPrefixes` scopes the aggregation so we don't pull the full state
  * catalog. Pass the prefixes the college actually offers.
@@ -245,6 +355,13 @@ async function loadTopTransferDestinations(
   subjectPrefixes: string[],
 ): Promise<TransferDestination[]> {
   if (subjectPrefixes.length === 0) return [];
+
+  // Disk-cache key is per (state, ccSlug) — we accept slightly stale subject
+  // mixes (a course added between builds) in exchange for sharing the file
+  // across workers. Subject lists change slowly enough that the top-3
+  // destinations are stable.
+  const fromDisk = readDiskTransferDest(state, ccSlug);
+  if (fromDisk !== undefined) return fromDisk;
 
   const key = `${state}:${ccSlug}:${[...subjectPrefixes].sort().join("|")}`;
   const existing = transferDestCache.get(key);
@@ -274,10 +391,12 @@ async function loadTopTransferDestinations(
       tally.set(u, (tally.get(u) ?? 0) + 1);
     }
 
-    return Array.from(tally.entries())
+    const out = Array.from(tally.entries())
       .map(([university, mappingCount]) => ({ university, mappingCount }))
       .sort((a, b) => b.mappingCount - a.mappingCount)
       .slice(0, 10);
+    writeDiskTransferDest(state, ccSlug, out);
+    return out;
   })();
 
   transferDestCache.set(key, promise);

--- a/lib/college-insights.ts
+++ b/lib/college-insights.ts
@@ -1,0 +1,558 @@
+/**
+ * Per-college insight bundler. Returns a fact bag the prose renderer (in
+ * `lib/insights-prose.ts`) turns into editorial paragraphs on the college
+ * detail page.
+ *
+ * Every field on `CollegeInsights` is optional and present only when the
+ * underlying data is non-null. The renderer's job is to skip facts that are
+ * missing or unremarkable — so this bundler should never fabricate values to
+ * fill gaps. Better to render shorter prose on data-poor colleges than
+ * templated padding.
+ *
+ * What we layer on top of existing utilities:
+ *  - `computeOfferingProfile` (lib/college-stats) → mode mix, top subjects,
+ *    late-start count
+ *  - Per-college rank within the state for section count + late-start count
+ *    + online share (computed from state-wide section data, cached)
+ *  - Mode-mix deltas vs. state median percentages
+ *  - Top transfer-destination universities from the `transfers` table
+ *  - ASSIST agreement counts for CA colleges only (Phase 3 data)
+ *  - Scorecard cost/earnings with state-median comparison
+ */
+
+import type { CourseSection, Institution } from "@/lib/types";
+import { computeOfferingProfile } from "@/lib/college-stats";
+import {
+  getScorecard,
+  getStateAggregates,
+  type ScorecardRecord,
+  type StateScorecardAggregates,
+} from "@/lib/scorecard";
+import { loadAllCourses } from "@/lib/courses";
+import { supabase } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Public shape
+// ---------------------------------------------------------------------------
+
+export interface CollegeRank {
+  /** 1 = largest in the state. */
+  position: number;
+  /** Total colleges in the state with data for the same metric. */
+  outOf: number;
+  /** This college's value. */
+  value: number;
+}
+
+export interface ModeShare {
+  /** Percentage of sections in this mode at this college (0–100). */
+  pct: number;
+  /** State median percentage for the same mode (0–100). */
+  statePct: number;
+  /** `pct - statePct`, positive if college is above the state median. */
+  delta: number;
+}
+
+export interface TransferDestination {
+  university: string;
+  /** Total course→university equivalencies this CC has with the university. */
+  mappingCount: number;
+}
+
+export interface ScorecardContext {
+  /** Median in-state tuition at this college, $. */
+  tuition: number | null;
+  /** State-median in-state tuition for context. */
+  tuitionStateMedian: number | null;
+  /** Median 10-yr-after-entry earnings, $. */
+  earnings10yr: number | null;
+  /** State-median 10-yr earnings for context. */
+  earningsStateMedian: number | null;
+  /** First-year retention rate (full-time), 0–1. */
+  retentionFullTime: number | null;
+  /** Share of students receiving Pell grants, 0–1. */
+  pellRate: number | null;
+  /** State-average Pell rate. */
+  pellStateAvg: number | null;
+}
+
+export interface CollegeInsights {
+  state: string;
+  collegeId: string;
+  collegeName: string;
+  systemName: string;
+
+  /** Most-recent term's offering profile (sections, modes, top subjects). */
+  term: string;
+  termSectionCount: number | null;
+
+  /** Rank within the state by total sections offered this term. */
+  sectionRank: CollegeRank | null;
+
+  /** Top 3 subjects this term, with state-rank context if available. */
+  topSubjects: Array<{ prefix: string; sections: number }>;
+
+  /** Mode mix vs. state median for this term. */
+  modeShares: {
+    inPerson: ModeShare | null;
+    hybrid: ModeShare | null;
+    online: ModeShare | null;
+  };
+
+  /** Number of late-start sections (>14 days after earliest term start). */
+  lateStartCount: number | null;
+  /** Rank within state for late-start density. */
+  lateStartRank: CollegeRank | null;
+
+  /** Top 3 receiving universities by mapping count (from `transfers` table). */
+  topTransferDestinations: TransferDestination[];
+
+  /** Total transfer mappings on file for this college. */
+  totalTransferMappings: number | null;
+
+  /** CA-only: number of ASSIST agreements (CC → uni → major triples). */
+  assistAgreementCount: number | null;
+  /** CA-only: top 3 receiving universities by agreement count. */
+  assistTopUniversities: Array<{ slug: string; name: string; count: number }>;
+
+  /** Scorecard cost/earnings context vs. state. */
+  scorecard: ScorecardContext | null;
+
+  /** Has a senior tuition waiver (from state config). */
+  seniorWaiver: { ageThreshold: number; legalCitation: string } | null;
+
+  /** Campus locations (cities) — surfaces "near [city]" prose. */
+  primaryCity: string | null;
+  additionalCities: string[];
+}
+
+// ---------------------------------------------------------------------------
+// State-wide ranking cache
+// ---------------------------------------------------------------------------
+
+interface StateRankings {
+  /** Per-college section count, sorted desc. */
+  sectionRanks: Array<{ collegeCode: string; count: number }>;
+  /** Per-college late-start count, sorted desc. */
+  lateStartRanks: Array<{ collegeCode: string; count: number }>;
+  /** State-median mode percentages across colleges with ≥ 25 sections. */
+  modeMedians: { inPerson: number; hybrid: number; online: number };
+}
+
+const rankingsCache = new Map<string, Promise<StateRankings | null>>();
+
+/**
+ * Build per-college section/late-start rankings + state-median mode shares
+ * for the given state/term. Loads all state courses once and caches the
+ * result for the duration of the process — fine for ISR builds since each
+ * page rebuild gets a fresh process.
+ *
+ * Returns null when the state has no course data for the term.
+ */
+export async function getStateRankings(
+  state: string,
+  term: string,
+): Promise<StateRankings | null> {
+  const key = `${state}:${term}`;
+  const existing = rankingsCache.get(key);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<StateRankings | null> => {
+    const sections = await loadAllCourses(term, state);
+    if (sections.length === 0) return null;
+
+    // Group sections by college_code.
+    const byCollege = new Map<string, CourseSection[]>();
+    for (const s of sections) {
+      const list = byCollege.get(s.college_code);
+      if (list) list.push(s);
+      else byCollege.set(s.college_code, [s]);
+    }
+
+    const sectionCounts: Array<{ collegeCode: string; count: number }> = [];
+    const lateStartCounts: Array<{ collegeCode: string; count: number }> = [];
+    const modeRows: Array<{
+      inPerson: number;
+      hybrid: number;
+      online: number;
+    }> = [];
+
+    for (const [collegeCode, list] of byCollege) {
+      sectionCounts.push({ collegeCode, count: list.length });
+
+      const profile = computeOfferingProfile(list);
+      if (profile) {
+        lateStartCounts.push({
+          collegeCode,
+          count: profile.lateStartCount,
+        });
+        if (list.length >= 25) {
+          modeRows.push({
+            inPerson: profile.modes.modePcts["in-person"] ?? 0,
+            hybrid: profile.modes.modePcts["hybrid"] ?? 0,
+            // Combine `online` + `zoom` — both are remote synchronous-or-not.
+            online:
+              (profile.modes.modePcts["online"] ?? 0) +
+              (profile.modes.modePcts["zoom"] ?? 0),
+          });
+        }
+      }
+    }
+
+    sectionCounts.sort((a, b) => b.count - a.count);
+    lateStartCounts.sort((a, b) => b.count - a.count);
+
+    const med = (xs: number[]): number => {
+      if (xs.length === 0) return 0;
+      const sorted = [...xs].sort((a, b) => a - b);
+      const mid = Math.floor(sorted.length / 2);
+      return sorted.length % 2 === 0
+        ? (sorted[mid - 1] + sorted[mid]) / 2
+        : sorted[mid];
+    };
+
+    return {
+      sectionRanks: sectionCounts,
+      lateStartRanks: lateStartCounts,
+      modeMedians: {
+        inPerson: med(modeRows.map((r) => r.inPerson)),
+        hybrid: med(modeRows.map((r) => r.hybrid)),
+        online: med(modeRows.map((r) => r.online)),
+      },
+    };
+  })();
+
+  rankingsCache.set(key, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Transfer destination aggregation (Supabase)
+// ---------------------------------------------------------------------------
+
+const transferDestCache = new Map<string, Promise<TransferDestination[]>>();
+
+/**
+ * Top receiving universities for a given CC's course catalog, ordered by
+ * mapping count desc. Limited to top 10.
+ *
+ * `subjectPrefixes` scopes the aggregation so we don't pull the full state
+ * catalog. Pass the prefixes the college actually offers.
+ */
+async function loadTopTransferDestinations(
+  state: string,
+  ccSlug: string,
+  subjectPrefixes: string[],
+): Promise<TransferDestination[]> {
+  if (subjectPrefixes.length === 0) return [];
+
+  const key = `${state}:${ccSlug}:${[...subjectPrefixes].sort().join("|")}`;
+  const existing = transferDestCache.get(key);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<TransferDestination[]> => {
+    const { data, error } = await supabase
+      .from("transfers")
+      .select("university, univ_course")
+      .eq("state", state)
+      .in("cc_prefix", subjectPrefixes);
+
+    if (error) {
+      console.warn(
+        `loadTopTransferDestinations error for ${state}/${ccSlug}:`,
+        error.message,
+      );
+      return [];
+    }
+
+    const tally = new Map<string, number>();
+    for (const row of data ?? []) {
+      // Skip combo-credit placeholders like "**** ****".
+      if (row.univ_course && row.univ_course.includes("*")) continue;
+      const u = row.university;
+      if (!u) continue;
+      tally.set(u, (tally.get(u) ?? 0) + 1);
+    }
+
+    return Array.from(tally.entries())
+      .map(([university, mappingCount]) => ({ university, mappingCount }))
+      .sort((a, b) => b.mappingCount - a.mappingCount)
+      .slice(0, 10);
+  })();
+
+  transferDestCache.set(key, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// ASSIST aggregation (CA only)
+// ---------------------------------------------------------------------------
+
+const assistCache = new Map<
+  string,
+  Promise<{
+    count: number;
+    topUniversities: Array<{ slug: string; name: string; count: number }>;
+  }>
+>();
+
+async function loadAssistContext(
+  ccSlug: string,
+): Promise<{
+  count: number;
+  topUniversities: Array<{ slug: string; name: string; count: number }>;
+}> {
+  const existing = assistCache.get(ccSlug);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    const { data, error } = await supabase
+      .from("assist_agreements")
+      .select(
+        "receiving_institution_slug, receiving_institution_name, major_slug",
+      )
+      .eq("state", "ca")
+      .eq("cc_slug", ccSlug);
+
+    if (error) {
+      console.warn(`loadAssistContext error for ${ccSlug}:`, error.message);
+      return { count: 0, topUniversities: [] };
+    }
+    const rows = data ?? [];
+    if (rows.length === 0) return { count: 0, topUniversities: [] };
+
+    const byUni = new Map<string, { name: string; count: number }>();
+    for (const r of rows) {
+      const slug = r.receiving_institution_slug as string;
+      const name = r.receiving_institution_name as string;
+      if (!slug || !name) continue;
+      const entry = byUni.get(slug);
+      if (entry) entry.count += 1;
+      else byUni.set(slug, { name, count: 1 });
+    }
+    const topUniversities = Array.from(byUni.entries())
+      .map(([slug, v]) => ({ slug, name: v.name, count: v.count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 3);
+    return { count: rows.length, topUniversities };
+  })();
+
+  assistCache.set(ccSlug, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Main bundler
+// ---------------------------------------------------------------------------
+
+export interface GetCollegeInsightsArgs {
+  state: string;
+  /** Full state name, e.g. "Virginia". */
+  stateName: string;
+  /** State CC-system short name, e.g. "VCCS". */
+  systemName: string;
+  institution: Institution;
+  /** Section list for the rendered term — usually the page's `defaultTerm`. */
+  sections: CourseSection[];
+  /** The term these sections belong to (used for cross-college ranking). */
+  term: string;
+  /** Optional senior waiver from state config; surfaces in prose if present. */
+  seniorWaiver: { ageThreshold: number; legalCitation: string } | null;
+}
+
+/**
+ * Build the per-college insight bundle. Pulls in:
+ *  - The college's own section profile (synchronous, in-memory)
+ *  - State-wide rankings (cached)
+ *  - Transfer destinations (Supabase, cached)
+ *  - ASSIST counts for CA only (Supabase, cached)
+ *  - Scorecard context (from local data files)
+ *
+ * Failures in any branch degrade gracefully — the field comes back null and
+ * the prose renderer omits the corresponding sentence.
+ */
+export async function getCollegeInsights(
+  args: GetCollegeInsightsArgs,
+): Promise<CollegeInsights> {
+  const {
+    state,
+    institution,
+    sections,
+    term,
+    seniorWaiver,
+    systemName,
+  } = args;
+  const collegeId = institution.id;
+  const collegeCode = institution.college_slug;
+  const collegeName = institution.name;
+
+  // 1) This college's offering profile (fast, in-memory).
+  const profile = computeOfferingProfile(sections);
+  const termSectionCount = profile?.total ?? null;
+  const topSubjects = profile?.topSubjects.slice(0, 3) ?? [];
+  const lateStartCount = profile?.lateStartCount ?? null;
+
+  // Resolve subject prefixes for transfer destination aggregation.
+  const subjectPrefixes = Array.from(
+    new Set(sections.map((s) => s.course_prefix).filter(Boolean)),
+  );
+
+  // 2-5) Fan out the slow branches in parallel.
+  const [rankings, destinations, assistContext, scorecardRecord, stateAgg] =
+    await Promise.all([
+      getStateRankings(state, term).catch(() => null),
+      loadTopTransferDestinations(state, collegeCode, subjectPrefixes).catch(
+        () => [] as TransferDestination[],
+      ),
+      // ASSIST data only exists for CA at this time.
+      state === "ca"
+        ? loadAssistContext(collegeCode).catch(() => ({
+            count: 0,
+            topUniversities: [] as Array<{
+              slug: string;
+              name: string;
+              count: number;
+            }>,
+          }))
+        : Promise.resolve({
+            count: 0,
+            topUniversities: [] as Array<{
+              slug: string;
+              name: string;
+              count: number;
+            }>,
+          }),
+      Promise.resolve(getScorecard(state, collegeId)),
+      Promise.resolve(getStateAggregates(state)),
+    ]);
+
+  // Compute ranks once we have state-wide rankings.
+  const sectionRank = computeRank(
+    rankings?.sectionRanks ?? [],
+    collegeCode,
+  );
+  const lateStartRank = computeRank(
+    rankings?.lateStartRanks ?? [],
+    collegeCode,
+  );
+
+  // Mode shares vs. state median (only when state median is meaningful and
+  // this college has enough sections to compute a stable share).
+  const modeShares = computeModeShares(profile, rankings);
+
+  const scorecard = buildScorecardContext(scorecardRecord, stateAgg);
+
+  // Campus → cities (use distinct campus names as a cheap city proxy when no
+  // separate city field exists). Some configs store the campus name as
+  // "Annandale" already; for those we expose them as the "city" surface.
+  const cityList = uniqueCities(institution);
+  const primaryCity = cityList[0] ?? null;
+  const additionalCities = cityList.slice(1, 4);
+
+  return {
+    state,
+    collegeId,
+    collegeName,
+    systemName,
+    term,
+    termSectionCount,
+    sectionRank,
+    topSubjects,
+    modeShares,
+    lateStartCount,
+    lateStartRank,
+    topTransferDestinations: destinations.slice(0, 3),
+    totalTransferMappings: destinations.length === 0
+      ? null
+      : destinations.reduce((a, b) => a + b.mappingCount, 0),
+    assistAgreementCount: assistContext.count > 0 ? assistContext.count : null,
+    assistTopUniversities: assistContext.topUniversities,
+    scorecard,
+    seniorWaiver,
+    primaryCity,
+    additionalCities,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function computeRank(
+  list: Array<{ collegeCode: string; count: number }>,
+  collegeCode: string,
+): CollegeRank | null {
+  if (list.length === 0) return null;
+  const idx = list.findIndex((e) => e.collegeCode === collegeCode);
+  if (idx === -1) return null;
+  return {
+    position: idx + 1,
+    outOf: list.length,
+    value: list[idx].count,
+  };
+}
+
+function computeModeShares(
+  profile: ReturnType<typeof computeOfferingProfile>,
+  rankings: StateRankings | null,
+): CollegeInsights["modeShares"] {
+  if (!profile || profile.total < 25) {
+    return { inPerson: null, hybrid: null, online: null };
+  }
+  const meds = rankings?.modeMedians;
+  if (!meds) return { inPerson: null, hybrid: null, online: null };
+
+  const inPersonPct = profile.modes.modePcts["in-person"] ?? 0;
+  const hybridPct = profile.modes.modePcts["hybrid"] ?? 0;
+  const onlinePct =
+    (profile.modes.modePcts["online"] ?? 0) +
+    (profile.modes.modePcts["zoom"] ?? 0);
+
+  return {
+    inPerson: {
+      pct: inPersonPct,
+      statePct: meds.inPerson,
+      delta: inPersonPct - meds.inPerson,
+    },
+    hybrid: {
+      pct: hybridPct,
+      statePct: meds.hybrid,
+      delta: hybridPct - meds.hybrid,
+    },
+    online: {
+      pct: onlinePct,
+      statePct: meds.online,
+      delta: onlinePct - meds.online,
+    },
+  };
+}
+
+function buildScorecardContext(
+  record: ScorecardRecord | null,
+  agg: StateScorecardAggregates,
+): ScorecardContext | null {
+  if (!record) return null;
+  return {
+    tuition: record.cost.tuitionInState,
+    tuitionStateMedian: agg.medianTuitionInState,
+    earnings10yr: record.earnings.median10YrsAfterEntry,
+    earningsStateMedian: agg.medianEarnings,
+    retentionFullTime: record.completion.retentionRateFullTime,
+    pellRate: record.aid.pellGrantRate,
+    pellStateAvg: agg.avgPellRate,
+  };
+}
+
+function uniqueCities(institution: Institution): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const c of institution.campuses ?? []) {
+    const name = c.name?.trim();
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(name);
+  }
+  return out;
+}

--- a/lib/insights-prose.ts
+++ b/lib/insights-prose.ts
@@ -1,0 +1,414 @@
+/**
+ * Insights → prose renderer. Turns the structured fact bags from
+ * `college-insights.ts` and `state-insights.ts` into 2–4 paragraphs of
+ * editorial text per page.
+ *
+ * Design goals:
+ *
+ *  - **Never look AI-generic.** Every sentence cites a specific number
+ *    pulled from real data. Swapping the entity name makes the paragraph
+ *    factually wrong (which means search engines see genuinely unique
+ *    content across the corpus).
+ *  - **Variant pool.** Each fact has 3 sentence variants; the picker uses a
+ *    deterministic hash so the same page always renders the same sentence
+ *    (stable for indexing) but different pages spread across all variants.
+ *  - **Skip-when-unremarkable.** If a metric is missing OR within 5 percentage
+ *    points of the state median, the sentence is omitted. Median colleges
+ *    naturally render shorter content — the correct outcome.
+ *  - **Cite source inline.** Every sentence is prefixed with where its
+ *    numbers come from ("Federal College Scorecard data shows…",
+ *    "Across [college]'s catalog this term…", "According to state transfer
+ *    records…"). Reads like reporting, not assertion.
+ *  - **No banned words.** A test suite enforces a list of evaluative
+ *    adjectives that flag AI-generated prose ("robust", "diverse",
+ *    "comprehensive", "wide range of", "various", "many", etc.).
+ */
+
+import type { CollegeInsights } from "@/lib/college-insights";
+import type { StateInsights } from "@/lib/state-insights";
+import { subjectName } from "@/lib/subjects";
+
+// ---------------------------------------------------------------------------
+// Banned-phrase list (enforced at test time)
+// ---------------------------------------------------------------------------
+
+export const BANNED_PHRASES = [
+  "robust",
+  "diverse",
+  "comprehensive",
+  "wide range of",
+  "various",
+  "numerous",
+  "extensive",
+  "state-of-the-art",
+  "cutting-edge",
+  "world-class",
+  "top-notch",
+  "best-in-class",
+  "vibrant",
+  "rich array",
+];
+
+// ---------------------------------------------------------------------------
+// Deterministic variant picker
+// ---------------------------------------------------------------------------
+
+/**
+ * djb2 hash of a string → non-negative 32-bit int. Cheap and stable across
+ * runs (no Math.random, no Date.now).
+ */
+function hash(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h * 33) ^ s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+/** Pick one of `n` variants deterministically based on a stable key. */
+export function pickVariant(key: string, n: number): number {
+  if (n <= 0) return 0;
+  return hash(key) % n;
+}
+
+// ---------------------------------------------------------------------------
+// Number formatters
+// ---------------------------------------------------------------------------
+
+function roundToNearest(n: number, step: number): number {
+  return Math.round(n / step) * step;
+}
+
+function approxCount(n: number): string {
+  if (n < 50) return n.toLocaleString("en-US");
+  if (n < 200) return `around ${roundToNearest(n, 10).toLocaleString("en-US")}`;
+  if (n < 1000) return `around ${roundToNearest(n, 25).toLocaleString("en-US")}`;
+  if (n < 5000) return `around ${roundToNearest(n, 100).toLocaleString("en-US")}`;
+  return `around ${roundToNearest(n, 500).toLocaleString("en-US")}`;
+}
+
+function pct(n: number): string {
+  return `${Math.round(n)}%`;
+}
+
+function dollar(n: number): string {
+  return `$${Math.round(n).toLocaleString("en-US")}`;
+}
+
+function ordinal(n: number): string {
+  // 1st, 2nd, 3rd, 4th… handling teens correctly.
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: list-join with Oxford comma
+// ---------------------------------------------------------------------------
+
+function joinList(items: string[]): string {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function subjectLabel(prefix: string): string {
+  // `subjectName` returns the prefix itself if no display name is known.
+  const name = subjectName(prefix);
+  return name === prefix ? prefix : `${name} (${prefix})`;
+}
+
+/**
+ * Form a noun phrase like "23 VCCS colleges" or "23 California Community
+ * Colleges schools" depending on whether the system name already ends in
+ * "Colleges" (e.g. "California Community Colleges"). Avoids the awkward
+ * "Colleges colleges" duplication when the system name is plural.
+ */
+function systemColleges(systemName: string, count: number): string {
+  const noun = /colleges$/i.test(systemName) ? "schools" : "colleges";
+  return `${count} ${systemName} ${noun}`;
+}
+
+/** Single-college form: "VCCS college" or "California Community Colleges school". */
+function systemCollegeSingular(systemName: string): string {
+  const noun = /colleges$/i.test(systemName) ? "school" : "college";
+  return `${systemName} ${noun}`;
+}
+
+// ---------------------------------------------------------------------------
+// COLLEGE PROSE
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the college insight bundle to 2–4 paragraphs. Returns an empty
+ * array when fewer than 2 sentences qualify — the caller should not render
+ * the section in that case.
+ */
+export function renderCollegeProse(insights: CollegeInsights): string[] {
+  const sentences: string[] = [];
+
+  // --- Catalog scale + state rank ---
+  if (insights.termSectionCount && insights.sectionRank) {
+    const sr = insights.sectionRank;
+    const key = `${insights.collegeId}:catalog`;
+    const variants = [
+      `Across ${insights.collegeName}'s catalog this term, ${approxCount(insights.termSectionCount)} course sections are listed — the ${ordinal(sr.position)}-largest catalog among the ${systemColleges(insights.systemName, sr.outOf)} with current data.`,
+      `${insights.collegeName} lists ${approxCount(insights.termSectionCount)} sections this term, putting it ${ordinal(sr.position)} of ${systemColleges(insights.systemName, sr.outOf)} by catalog size.`,
+      `Among ${systemColleges(insights.systemName, sr.outOf)} with current course data, ${insights.collegeName} ranks ${ordinal(sr.position)} by section count, with ${approxCount(insights.termSectionCount)} sections this term.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  } else if (insights.termSectionCount) {
+    // No rank context, but at least the section count is real.
+    const key = `${insights.collegeId}:catalog-norank`;
+    const variants = [
+      `${insights.collegeName} lists ${approxCount(insights.termSectionCount)} course sections this term.`,
+      `Across ${insights.collegeName}'s catalog this term, ${approxCount(insights.termSectionCount)} sections are scheduled.`,
+      `${approxCount(insights.termSectionCount)} sections appear on ${insights.collegeName}'s current schedule.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Top subjects ---
+  if (insights.topSubjects.length >= 2) {
+    const labels = insights.topSubjects.slice(0, 3).map((s) => subjectLabel(s.prefix));
+    const lead = insights.topSubjects[0];
+    const key = `${insights.collegeId}:subjects`;
+    const variants = [
+      `The largest department this term is ${subjectLabel(lead.prefix)} with ${approxCount(lead.sections)} sections, followed by ${joinList(labels.slice(1))}.`,
+      `By section count, ${insights.collegeName}'s top subjects this term are ${joinList(labels)} — with ${subjectLabel(lead.prefix)} leading at ${approxCount(lead.sections)} sections.`,
+      `${joinList(labels)} are the most-offered subjects at ${insights.collegeName} this term, with ${subjectLabel(lead.prefix)} the largest at ${approxCount(lead.sections)} sections.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Online mode share (only when notably above or below state median) ---
+  const online = insights.modeShares.online;
+  if (online && Math.abs(online.delta) >= 5) {
+    const key = `${insights.collegeId}:online`;
+    const direction = online.delta > 0 ? "above" : "below";
+    const variants = [
+      `Across the catalog, ${pct(online.pct)} of sections are online — ${direction} the ${insights.systemName} median of ${pct(online.statePct)}.`,
+      `${pct(online.pct)} of ${insights.collegeName}'s sections this term run online, ${direction} the state-system median of ${pct(online.statePct)}.`,
+      `Online sections make up ${pct(online.pct)} of the schedule at ${insights.collegeName}, ${direction} the ${insights.systemName} median (${pct(online.statePct)}).`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Late-start density ---
+  if (
+    insights.lateStartCount != null &&
+    insights.lateStartCount >= 5 &&
+    insights.lateStartRank &&
+    insights.lateStartRank.position <= Math.ceil(insights.lateStartRank.outOf * 0.5)
+  ) {
+    const lsr = insights.lateStartRank;
+    const key = `${insights.collegeId}:latestart`;
+    const variants = [
+      `Late-start sections — those beginning more than two weeks after the term's earliest start date — number ${approxCount(insights.lateStartCount)} at ${insights.collegeName}, placing it ${ordinal(lsr.position)} of ${systemColleges(insights.systemName, lsr.outOf)} for late-start availability this term.`,
+      `${insights.collegeName} has ${approxCount(insights.lateStartCount)} late-start sections (more than two weeks past the earliest term start), ranking ${ordinal(lsr.position)} among ${systemColleges(insights.systemName, lsr.outOf)} for that availability.`,
+      `For students who missed the main registration window, ${insights.collegeName} offers ${approxCount(insights.lateStartCount)} late-start sections this term — ${ordinal(lsr.position)} of ${lsr.outOf} in the ${insights.systemName}.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Transfer destinations ---
+  if (insights.topTransferDestinations.length >= 2) {
+    const uniNames = insights.topTransferDestinations
+      .slice(0, 3)
+      .map((d) => d.university);
+    const lead = insights.topTransferDestinations[0];
+    const key = `${insights.collegeId}:transfer`;
+    const variants = [
+      `According to state transfer records, the receiving universities with the most course equivalencies from ${insights.collegeName} are ${joinList(uniNames)} — ${lead.university} alone accepts ${lead.mappingCount.toLocaleString("en-US")} of ${insights.collegeName}'s courses for credit.`,
+      `State transfer records show ${insights.collegeName}'s coursework articulates most often with ${joinList(uniNames)}, with ${lead.university} accepting ${lead.mappingCount.toLocaleString("en-US")} courses.`,
+      `For students planning to transfer, ${joinList(uniNames)} hold the most course equivalencies with ${insights.collegeName} per the state transfer registry — ${lead.university} leads with ${lead.mappingCount.toLocaleString("en-US")} accepted courses.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- ASSIST (CA only) ---
+  if (
+    insights.assistAgreementCount &&
+    insights.assistAgreementCount >= 3 &&
+    insights.assistTopUniversities.length >= 1
+  ) {
+    const lead = insights.assistTopUniversities[0];
+    const others = insights.assistTopUniversities
+      .slice(1)
+      .map((u) => `${u.name} (${u.count})`);
+    const key = `${insights.collegeId}:assist`;
+    const variants = [
+      `Per the California ASSIST registry, ${insights.collegeName} maintains ${insights.assistAgreementCount} major-specific articulation agreements with UC and CSU campuses — most with ${lead.name} (${lead.count})${others.length ? `, followed by ${joinList(others)}` : ""}.`,
+      `${insights.collegeName} has ${insights.assistAgreementCount} per-major articulation agreements on file with the California ASSIST registry; the deepest pipeline runs to ${lead.name} with ${lead.count} majors${others.length ? ` (${joinList(others)} round out the top three)` : ""}.`,
+      `Across the California ASSIST registry, ${insights.collegeName} maps to ${insights.assistAgreementCount} receiving-school majors — ${lead.name} accounts for ${lead.count}${others.length ? ` and ${joinList(others)} follow` : ""}.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Scorecard cost vs state median ---
+  const sc = insights.scorecard;
+  if (sc && sc.tuition != null && sc.tuitionStateMedian != null) {
+    const diff = sc.tuition - sc.tuitionStateMedian;
+    if (Math.abs(diff) >= 250) {
+      const direction = diff > 0 ? "above" : "below";
+      const key = `${insights.collegeId}:cost`;
+      const variants = [
+        `Federal College Scorecard data shows ${insights.collegeName}'s in-state tuition at ${dollar(sc.tuition)} per year — ${dollar(Math.abs(diff))} ${direction} the ${insights.systemName} median.`,
+        `In-state tuition at ${insights.collegeName} runs ${dollar(sc.tuition)} per year per federal College Scorecard data, ${direction} the ${insights.systemName} median by ${dollar(Math.abs(diff))}.`,
+        `According to the federal College Scorecard, ${insights.collegeName} charges in-state students ${dollar(sc.tuition)} a year — ${dollar(Math.abs(diff))} ${direction} the ${insights.systemName} median.`,
+      ];
+      sentences.push(variants[pickVariant(key, variants.length)]);
+    }
+  }
+
+  // --- Scorecard earnings ---
+  if (sc && sc.earnings10yr != null && sc.earningsStateMedian != null) {
+    const diff = sc.earnings10yr - sc.earningsStateMedian;
+    if (Math.abs(diff) >= 1500) {
+      const direction = diff > 0 ? "above" : "below";
+      const key = `${insights.collegeId}:earnings`;
+      const variants = [
+        `Federal data tracks former ${insights.collegeName} students earning a median of ${dollar(sc.earnings10yr)} ten years after enrollment — ${dollar(Math.abs(diff))} ${direction} the ${insights.systemName} median for that cohort window.`,
+        `Ten years after entry, former ${insights.collegeName} students earn a median of ${dollar(sc.earnings10yr)} per federal College Scorecard tracking — ${direction} the ${insights.systemName} median by ${dollar(Math.abs(diff))}.`,
+        `Per the federal College Scorecard, the ten-year-after-entry median earnings for ${insights.collegeName} alumni is ${dollar(sc.earnings10yr)}, ${dollar(Math.abs(diff))} ${direction} the ${insights.systemName} median.`,
+      ];
+      sentences.push(variants[pickVariant(key, variants.length)]);
+    }
+  }
+
+  // --- Senior waiver applicability ---
+  if (insights.seniorWaiver) {
+    const sw = insights.seniorWaiver;
+    const key = `${insights.collegeId}:senior`;
+    const variants = [
+      `Residents ${sw.ageThreshold} and older may attend ${insights.collegeName} tuition-free under ${sw.legalCitation}.`,
+      `Under ${sw.legalCitation}, ${insights.collegeName} waives tuition for in-state residents ${sw.ageThreshold} and older.`,
+      `${insights.collegeName} participates in the state senior tuition waiver — residents ${sw.ageThreshold}+ enroll without paying tuition, per ${sw.legalCitation}.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // Skip-when-thin: fewer than 2 sentences → caller should not render.
+  if (sentences.length < 2) return [];
+
+  // Pack into 2–3 paragraphs (3 sentences per paragraph max).
+  return groupIntoParagraphs(sentences, 3);
+}
+
+// ---------------------------------------------------------------------------
+// STATE PROSE
+// ---------------------------------------------------------------------------
+
+export function renderStateProse(insights: StateInsights): string[] {
+  const sentences: string[] = [];
+
+  // --- System scale ---
+  if (insights.totalSections != null && insights.collegesWithData > 0) {
+    const key = `${insights.state}:scale`;
+    const isPlural = insights.collegesWithData !== 1;
+    const variants = [
+      `Across the ${insights.systemName}, ${insights.collegesWithData} ${isPlural ? "colleges report" : "college reports"} ${approxCount(insights.totalSections)} course sections in the current term.`,
+      `The ${insights.systemName} runs ${approxCount(insights.totalSections)} course sections across ${insights.collegesWithData} ${isPlural ? "colleges" : "college"} this term.`,
+      `${systemColleges(insights.systemName, insights.collegesWithData)} ${isPlural ? "list" : "lists"} ${approxCount(insights.totalSections)} sections this term across their combined catalogs.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Largest/smallest ---
+  if (insights.largestCollege && insights.smallestCollege) {
+    const lg = insights.largestCollege;
+    const sm = insights.smallestCollege;
+    const key = `${insights.state}:range`;
+    const variants = [
+      `${lg.collegeName} runs the largest catalog this term at ${approxCount(lg.sectionCount)} sections, while ${sm.collegeName} runs the smallest at ${approxCount(sm.sectionCount)}.`,
+      `By section count, ${lg.collegeName} (${approxCount(lg.sectionCount)}) and ${sm.collegeName} (${approxCount(sm.sectionCount)}) anchor the size range across the ${insights.systemName} this term.`,
+      `Catalog sizes in the ${insights.systemName} range from ${approxCount(sm.sectionCount)} sections at ${sm.collegeName} to ${approxCount(lg.sectionCount)} at ${lg.collegeName}.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  } else if (insights.largestCollege) {
+    const lg = insights.largestCollege;
+    const key = `${insights.state}:largest`;
+    const variants = [
+      `${lg.collegeName} runs the largest catalog in the ${insights.systemName} this term at ${approxCount(lg.sectionCount)} sections.`,
+      `The largest catalog in the ${insights.systemName} this term belongs to ${lg.collegeName}, with ${approxCount(lg.sectionCount)} sections.`,
+      `By section count, ${lg.collegeName} leads the ${insights.systemName} this term with ${approxCount(lg.sectionCount)} sections.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Top subjects ---
+  if (insights.topSubjects.length >= 2) {
+    const labels = insights.topSubjects.map((s) => subjectLabel(s.prefix));
+    const lead = insights.topSubjects[0];
+    const key = `${insights.state}:subjects`;
+    const variants = [
+      `The most-offered subjects statewide are ${joinList(labels)} — ${subjectLabel(lead.prefix)} leads with ${approxCount(lead.sectionCount)} sections across ${lead.collegesOffering} colleges.`,
+      `${joinList(labels)} are the top subjects by section count across the ${insights.systemName}, with ${subjectLabel(lead.prefix)} the largest at ${approxCount(lead.sectionCount)} sections.`,
+      `By statewide section count, ${joinList(labels)} top the list — ${subjectLabel(lead.prefix)} alone runs ${approxCount(lead.sectionCount)} sections across ${lead.collegesOffering} colleges.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Transfer destinations ---
+  if (insights.topTransferDestinations.length >= 2) {
+    const uniNames = insights.topTransferDestinations.map((d) => d.university);
+    const lead = insights.topTransferDestinations[0];
+    const key = `${insights.state}:transfer`;
+    const variants = [
+      `According to state transfer records, the universities accepting the most ${insights.systemName} coursework are ${joinList(uniNames)} — ${lead.university} alone accepts ${lead.mappingCount.toLocaleString("en-US")} CC courses for credit.`,
+      `State transfer records show ${joinList(uniNames)} as the largest receivers of ${insights.systemName} transfer credit, with ${lead.university} leading at ${lead.mappingCount.toLocaleString("en-US")} accepted courses.`,
+      `For ${insights.systemName} students planning to transfer, ${joinList(uniNames)} hold the most course equivalencies on file — ${lead.university} leads with ${lead.mappingCount.toLocaleString("en-US")} accepted courses.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- ASSIST (CA only) ---
+  if (insights.assistAgreementCount && insights.assistTopPairs.length >= 1) {
+    const lead = insights.assistTopPairs[0];
+    const key = `${insights.state}:assist`;
+    const variants = [
+      `Per the California ASSIST registry, the ${insights.systemName} maintains ${approxCount(insights.assistAgreementCount)} per-major articulation agreements with UC and CSU campuses — the deepest single pipeline runs from ${lead.ccName} to ${lead.uniName} with ${lead.agreementCount} majors.`,
+      `The California ASSIST registry lists ${approxCount(insights.assistAgreementCount)} per-major agreements across the ${insights.systemName}, with the deepest CC-to-university pipeline being ${lead.ccName} → ${lead.uniName} (${lead.agreementCount} majors).`,
+      `Across the California ASSIST registry, ${insights.systemName} colleges hold ${approxCount(insights.assistAgreementCount)} major-specific articulation agreements — ${lead.ccName} → ${lead.uniName} is the deepest at ${lead.agreementCount} majors.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Senior waiver ---
+  if (insights.seniorWaiver) {
+    const sw = insights.seniorWaiver;
+    const key = `${insights.state}:senior`;
+    const variants = [
+      `${insights.stateName} residents ${sw.ageThreshold} and older may attend ${insights.systemName} colleges tuition-free under ${sw.legalCitation}.`,
+      `Under ${sw.legalCitation}, ${insights.stateName} waives tuition at ${insights.systemName} colleges for residents ${sw.ageThreshold} and older.`,
+      `The ${insights.systemName} participates in ${insights.stateName}'s senior tuition waiver — residents ${sw.ageThreshold}+ enroll without paying tuition, per ${sw.legalCitation}.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  // --- Scorecard medians ---
+  const sc = insights.scorecard;
+  if (sc && sc.medianTuition != null && sc.medianEarnings != null) {
+    const key = `${insights.state}:scorecard`;
+    const variants = [
+      `Federal College Scorecard data puts the ${insights.systemName} median in-state tuition at ${dollar(sc.medianTuition)} per year, with former students earning a median of ${dollar(sc.medianEarnings)} ten years after entry.`,
+      `Across the ${insights.systemName}, median in-state tuition is ${dollar(sc.medianTuition)} per year and median earnings ten years after enrollment are ${dollar(sc.medianEarnings)}, per the federal College Scorecard.`,
+      `Per federal College Scorecard data, ${insights.systemName} colleges charge a median ${dollar(sc.medianTuition)} in-state tuition annually; alumni earn a median ${dollar(sc.medianEarnings)} a decade after entry.`,
+    ];
+    sentences.push(variants[pickVariant(key, variants.length)]);
+  }
+
+  if (sentences.length < 2) return [];
+  return groupIntoParagraphs(sentences, 3);
+}
+
+// ---------------------------------------------------------------------------
+// Paragraph packing
+// ---------------------------------------------------------------------------
+
+function groupIntoParagraphs(sentences: string[], perPara: number): string[] {
+  const paras: string[] = [];
+  for (let i = 0; i < sentences.length; i += perPara) {
+    paras.push(sentences.slice(i, i + perPara).join(" "));
+  }
+  return paras;
+}

--- a/lib/state-insights.ts
+++ b/lib/state-insights.ts
@@ -1,0 +1,366 @@
+/**
+ * Per-state insight bundler. Returns a fact bag the prose renderer (in
+ * `lib/insights-prose.ts`) turns into editorial paragraphs on the state
+ * landing page.
+ *
+ * As with `college-insights`, every field is optional and present only when
+ * the underlying data is non-null. Sparse states should render shorter
+ * context blocks rather than padded ones.
+ */
+
+import { loadInstitutions } from "@/lib/institutions";
+import { getStateRankings } from "@/lib/college-insights";
+import { loadAllCourses } from "@/lib/courses";
+import { getStateAggregates, type StateScorecardAggregates } from "@/lib/scorecard";
+import { getArticlesByState } from "@/lib/blog";
+import { supabase } from "@/lib/supabase";
+import type { CourseSection } from "@/lib/types";
+
+export interface StateInsightCollegeRef {
+  collegeCode: string;
+  collegeName: string;
+  sectionCount: number;
+}
+
+export interface StateInsightSubject {
+  prefix: string;
+  sectionCount: number;
+  collegesOffering: number;
+}
+
+export interface StateInsightTransferDest {
+  university: string;
+  mappingCount: number;
+}
+
+export interface StateInsightAssistPair {
+  ccSlug: string;
+  ccName: string;
+  uniSlug: string;
+  uniName: string;
+  agreementCount: number;
+}
+
+export interface StateInsights {
+  state: string;
+  stateName: string;
+  systemName: string;
+
+  /** Term these insights summarize. */
+  term: string | null;
+
+  /** Total course sections statewide this term. */
+  totalSections: number | null;
+  /** Number of colleges with at least one section this term. */
+  collegesWithData: number;
+  /** Number of colleges in the state per registry, regardless of data. */
+  totalColleges: number;
+
+  largestCollege: StateInsightCollegeRef | null;
+  smallestCollege: StateInsightCollegeRef | null;
+  topSubjects: StateInsightSubject[];
+
+  topTransferDestinations: StateInsightTransferDest[];
+  totalTransferMappings: number | null;
+
+  /** CA-only: total ASSIST agreements for the state. */
+  assistAgreementCount: number | null;
+  /** CA-only: top 3 CC→Uni pairs by agreement count. */
+  assistTopPairs: StateInsightAssistPair[];
+
+  blogPostCount: number;
+
+  seniorWaiver: {
+    ageThreshold: number;
+    legalCitation: string;
+    bannerDetail: string;
+  } | null;
+
+  scorecard: {
+    medianTuition: number | null;
+    medianNetPrice: number | null;
+    medianEarnings: number | null;
+    medianCompletion: number | null;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Process-cached transfer + ASSIST aggregations (heavy queries)
+// ---------------------------------------------------------------------------
+
+const stateTransferCache = new Map<
+  string,
+  Promise<{ destinations: StateInsightTransferDest[]; total: number }>
+>();
+
+async function loadStateTransferDestinations(
+  state: string,
+): Promise<{ destinations: StateInsightTransferDest[]; total: number }> {
+  const existing = stateTransferCache.get(state);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    // We only need a destination tally, so request a thin projection. The
+    // table is keyed on (state, cc_prefix, cc_number, university); the read
+    // is sequential-on-state with a small projection, which Postgres handles
+    // comfortably for the per-state row counts we see in production.
+    const PAGE_SIZE = 1000;
+    const tally = new Map<string, number>();
+    let total = 0;
+    let from = 0;
+
+    while (true) {
+      const { data, error } = await supabase
+        .from("transfers")
+        .select("university, univ_course")
+        .eq("state", state)
+        .range(from, from + PAGE_SIZE - 1);
+      if (error) {
+        console.warn(
+          `loadStateTransferDestinations error for ${state}:`,
+          error.message,
+        );
+        break;
+      }
+      const rows = data ?? [];
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        if (row.univ_course && row.univ_course.includes("*")) continue;
+        const u = row.university;
+        if (!u) continue;
+        tally.set(u, (tally.get(u) ?? 0) + 1);
+        total += 1;
+      }
+      if (rows.length < PAGE_SIZE) break;
+      from += PAGE_SIZE;
+    }
+
+    const destinations = Array.from(tally.entries())
+      .map(([university, mappingCount]) => ({ university, mappingCount }))
+      .sort((a, b) => b.mappingCount - a.mappingCount)
+      .slice(0, 5);
+
+    return { destinations, total };
+  })();
+
+  stateTransferCache.set(state, promise);
+  return promise;
+}
+
+const stateAssistCache = new Map<
+  string,
+  Promise<{ count: number; topPairs: StateInsightAssistPair[] }>
+>();
+
+async function loadStateAssistContext(
+  state: string,
+): Promise<{ count: number; topPairs: StateInsightAssistPair[] }> {
+  const existing = stateAssistCache.get(state);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    const { data, error, count } = await supabase
+      .from("assist_agreements")
+      .select(
+        "cc_slug, cc_name, receiving_institution_slug, receiving_institution_name",
+        { count: "exact" },
+      )
+      .eq("state", state);
+
+    if (error) {
+      console.warn(`loadStateAssistContext error for ${state}:`, error.message);
+      return { count: 0, topPairs: [] as StateInsightAssistPair[] };
+    }
+    const rows = data ?? [];
+    if (rows.length === 0) {
+      return { count: 0, topPairs: [] as StateInsightAssistPair[] };
+    }
+
+    const pairTally = new Map<
+      string,
+      { ccSlug: string; ccName: string; uniSlug: string; uniName: string; count: number }
+    >();
+    for (const r of rows) {
+      const key = `${r.cc_slug}|${r.receiving_institution_slug}`;
+      const entry = pairTally.get(key);
+      if (entry) entry.count += 1;
+      else
+        pairTally.set(key, {
+          ccSlug: r.cc_slug as string,
+          ccName: r.cc_name as string,
+          uniSlug: r.receiving_institution_slug as string,
+          uniName: r.receiving_institution_name as string,
+          count: 1,
+        });
+    }
+    const topPairs = Array.from(pairTally.values())
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 3)
+      .map((p) => ({
+        ccSlug: p.ccSlug,
+        ccName: p.ccName,
+        uniSlug: p.uniSlug,
+        uniName: p.uniName,
+        agreementCount: p.count,
+      }));
+
+    return { count: count ?? rows.length, topPairs };
+  })();
+
+  stateAssistCache.set(state, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Top subjects statewide
+// ---------------------------------------------------------------------------
+
+function tallyTopSubjects(sections: CourseSection[]): StateInsightSubject[] {
+  const byPrefix = new Map<
+    string,
+    { sectionCount: number; colleges: Set<string> }
+  >();
+  for (const s of sections) {
+    const prefix = s.course_prefix;
+    if (!prefix) continue;
+    const entry = byPrefix.get(prefix);
+    if (entry) {
+      entry.sectionCount += 1;
+      entry.colleges.add(s.college_code);
+    } else {
+      byPrefix.set(prefix, {
+        sectionCount: 1,
+        colleges: new Set([s.college_code]),
+      });
+    }
+  }
+  return Array.from(byPrefix.entries())
+    .map(([prefix, v]) => ({
+      prefix,
+      sectionCount: v.sectionCount,
+      collegesOffering: v.colleges.size,
+    }))
+    .sort((a, b) => b.sectionCount - a.sectionCount)
+    .slice(0, 3);
+}
+
+// ---------------------------------------------------------------------------
+// Main bundler
+// ---------------------------------------------------------------------------
+
+export interface GetStateInsightsArgs {
+  state: string;
+  stateName: string;
+  systemName: string;
+  /** Most-recent term with data for the state. */
+  term: string | null;
+  seniorWaiver: {
+    ageThreshold: number;
+    legalCitation: string;
+    bannerDetail: string;
+  } | null;
+}
+
+export async function getStateInsights(
+  args: GetStateInsightsArgs,
+): Promise<StateInsights> {
+  const { state, stateName, systemName, term, seniorWaiver } = args;
+  const institutions = loadInstitutions(state);
+  const totalColleges = institutions.length;
+
+  const codeToName = new Map<string, string>();
+  for (const i of institutions) codeToName.set(i.college_slug, i.name);
+
+  // Fan out the heavy queries in parallel.
+  const [
+    rankings,
+    allSections,
+    transferAgg,
+    assistAgg,
+    scorecardAgg,
+  ] = await Promise.all([
+    term ? getStateRankings(state, term).catch(() => null) : Promise.resolve(null),
+    term
+      ? loadAllCourses(term, state).catch(() => [] as CourseSection[])
+      : Promise.resolve([] as CourseSection[]),
+    loadStateTransferDestinations(state).catch(() => ({
+      destinations: [] as StateInsightTransferDest[],
+      total: 0,
+    })),
+    state === "ca"
+      ? loadStateAssistContext(state).catch(() => ({
+          count: 0,
+          topPairs: [] as StateInsightAssistPair[],
+        }))
+      : Promise.resolve({ count: 0, topPairs: [] as StateInsightAssistPair[] }),
+    Promise.resolve(getStateAggregates(state)),
+  ]);
+
+  const totalSections = allSections.length || null;
+  const topSubjects = tallyTopSubjects(allSections);
+
+  let largestCollege: StateInsightCollegeRef | null = null;
+  let smallestCollege: StateInsightCollegeRef | null = null;
+  if (rankings && rankings.sectionRanks.length > 0) {
+    const head = rankings.sectionRanks[0];
+    const tail = rankings.sectionRanks[rankings.sectionRanks.length - 1];
+    largestCollege = head
+      ? {
+          collegeCode: head.collegeCode,
+          collegeName: codeToName.get(head.collegeCode) ?? head.collegeCode,
+          sectionCount: head.count,
+        }
+      : null;
+    // Only surface "smallest" if there are ≥ 3 colleges in the rankings —
+    // otherwise it's a meaningless callout.
+    smallestCollege =
+      rankings.sectionRanks.length >= 3 && tail
+        ? {
+            collegeCode: tail.collegeCode,
+            collegeName: codeToName.get(tail.collegeCode) ?? tail.collegeCode,
+            sectionCount: tail.count,
+          }
+        : null;
+  }
+
+  const blogPostCount = getArticlesByState(state).length;
+
+  return {
+    state,
+    stateName,
+    systemName,
+    term,
+    totalSections,
+    collegesWithData: rankings?.sectionRanks.length ?? 0,
+    totalColleges,
+    largestCollege,
+    smallestCollege,
+    topSubjects,
+    topTransferDestinations: transferAgg.destinations.slice(0, 3),
+    totalTransferMappings: transferAgg.total > 0 ? transferAgg.total : null,
+    assistAgreementCount: assistAgg.count > 0 ? assistAgg.count : null,
+    assistTopPairs: assistAgg.topPairs,
+    blogPostCount,
+    seniorWaiver,
+    scorecard: buildScorecardSummary(scorecardAgg),
+  };
+}
+
+function buildScorecardSummary(
+  agg: StateScorecardAggregates,
+): StateInsights["scorecard"] {
+  if (
+    agg.medianTuitionInState == null &&
+    agg.medianNetPrice == null &&
+    agg.medianEarnings == null &&
+    agg.medianCompletionRate == null
+  ) {
+    return null;
+  }
+  return {
+    medianTuition: agg.medianTuitionInState,
+    medianNetPrice: agg.medianNetPrice,
+    medianEarnings: agg.medianEarnings,
+    medianCompletion: agg.medianCompletionRate,
+  };
+}


### PR DESCRIPTION
## What changes for users

Every state landing page (`/[state]`) and college detail page (`/[state]/college/[id]`) now renders a short **"at a glance"** section with 2–4 paragraphs of natural prose. Each sentence cites a specific number — top subjects this term, late-start availability, where students transfer, how the college's mode mix compares to the state median, cost in context, ASSIST agreement counts for CA, senior waiver applicability.

A reviewer landing on `/va/college/northern-virginia-community-college` will see something like:

> Among 23 VCCS colleges with current course data, Northern Virginia Community College ranks 1st by section count, with around 4,300 sections this term. By section count, NVCC's top subjects this term are English (ENG), Biology (BIO), and Mathematics (MTH) — with English (ENG) leading at around 275 sections. Online sections make up 35% of the schedule at NVCC, above the VCCS median (22%).
>
> NVCC has around 325 late-start sections (more than two weeks past the earliest term start), ranking 2nd among 23 VCCS colleges. According to state transfer records, the receiving universities with the most course equivalencies from NVCC are George Mason University, Virginia Commonwealth University, and Old Dominion University — George Mason University alone accepts 482 of NVCC's courses for credit. Federal College Scorecard data shows NVCC's in-state tuition at \$5,680 per year — \$680 above the VCCS median.

Sparse-data colleges and states render shorter blocks or nothing at all (skip-when-unremarkable). Median-on-everything colleges don't get padded sentences — by design.

## Why

AdSense rejected the site for **"low value content."** The homepage, About, Privacy, Contact, and 127-post blog are already substantive — they're not the bottleneck. The bottleneck is the ~600 college detail pages and ~26 state pages, which are nearly all data widgets (stat grids, course tables, mode filters) with no editorial prose. Google's site-level quality classifier weights the whole corpus and reads templated data tables as thin.

The naive fix (LLM-templated paragraphs) reads identically across pages — exactly what Google's classifiers flag. This PR takes the opposite approach: every sentence is grounded in a specific number from data the page already loads, so swapping the college name makes the paragraph factually wrong. Search engines see genuinely unique content; readers get useful, specific context.

## Technical

**New libraries:**
- `lib/college-insights.ts` — wraps existing `computeOfferingProfile` (lib/college-stats) and layers per-state rank (section count, late-start density), mode-mix vs state median, top transfer destinations (Supabase aggregation on the existing `transfers` table), ASSIST agreement counts for CA colleges (Phase 3 data), and Scorecard context with state-median comparison.
- `lib/state-insights.ts` — largest/smallest college by section count, top 3 subjects statewide, top transfer destinations statewide, blog count, CA-only ASSIST totals + top CC→Uni pairs.
- `lib/insights-prose.ts` — sentence renderer. Each fact has 3 deterministically-picked variant templates (`hash(entityId + factKey) % 3`), so distribution is even across pages and the same page renders the same variant on every build (stable for SEO). Skip-when-unremarkable rules: 5pp threshold on percentages, \$250 on costs, \$1.5k on earnings, bottom-half exclusion on late-start density. Inline source citations on every sentence (\"Federal College Scorecard data shows…\", \"According to state transfer records…\", \"Per the California ASSIST registry…\"). Banned-phrase list (\"robust\", \"diverse\", \"comprehensive\", \"various\", \"many\", \"numerous\", \"state-of-the-art\", \"cutting-edge\", \"world-class\", \"vibrant\", \"rich array\") enforced at test time.

**New components:**
- `components/CollegeContext.tsx` and `components/StateContext.tsx` — server components that call the insights libs, render prose to JSX paragraphs, return null when fewer than 2 sentences qualify.

**Page wiring:**
- `app/[state]/college/[id]/page.tsx` — `<CollegeContext />` directly below the hero section, above the stat card grid (above-the-fold for crawl + readers).
- `app/[state]/page.tsx` — `<StateContext />` between \"What You Can Do\" and the conditional \"Browse by Program\" section.

**National rollout from day one.** No flag gating. Sparse-data states naturally render shorter context (or nothing) instead of templated padding — that's the correct behaviour.

## Tests

`lib/__tests__/insights-prose.test.ts` — 16 vitest cases covering:
- No banned phrase appears in any output across 12 distinct college fixtures
- Skip-when-unremarkable behaviour (median delta → sentence omitted, missing data → sentence omitted, too few qualifying sentences → empty array)
- Variant distribution within ±25% of expected 33% across 300 random keys
- Determinism (same insights → same prose on repeat calls)
- At least one inline source citation in a full college bundle and a full state bundle

All 16 pass locally.

## Files changed

| Path | Change |
|---|---|
| `lib/college-insights.ts` | New — per-college insight bundler |
| `lib/state-insights.ts` | New — per-state insight bundler |
| `lib/insights-prose.ts` | New — sentence renderer |
| `lib/__tests__/insights-prose.test.ts` | New — 16 unit tests |
| `components/CollegeContext.tsx` | New — server component |
| `components/StateContext.tsx` | New — server component |
| `app/[state]/college/[id]/page.tsx` | Insert `<CollegeContext />` below hero |
| `app/[state]/page.tsx` | Insert `<StateContext />` after \"What You Can Do\" |

## Test plan

- [ ] Local dev: \`npm run dev\`, load \`/va/college/northern-virginia-community-college\`, \`/ga/college/atlanta-technical-college\`, \`/nh\`, \`/ca/college/de-anza-college\` and confirm the at-a-glance section renders different, naturally-reading paragraphs per page
- [ ] CA's De Anza page should explicitly mention the California ASSIST registry and agreement count
- [ ] Confirm no \"low-value\" pages render an empty at-a-glance section (renderer returns null when fewer than 2 sentences qualify)
- [ ] Post-merge: wait 7 days for Google to recrawl, then re-request AdSense review and watch GSC for impression growth on long-tail queries (\"[college] transfer\", \"[college] online classes\", \"largest community college in [state]\")