### PR TITLE
fix(build): cap Supabase query concurrency to keep pgbouncer pool healthy

### DIFF
--- a/lib/__tests__/concurrency.test.ts
+++ b/lib/__tests__/concurrency.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { runPooled } from "../concurrency";
+
+describe("runPooled", () => {
+  it("returns results in input order regardless of completion order", async () => {
+    const tasks = [
+      () => new Promise<number>((r) => setTimeout(() => r(1), 30)),
+      () => new Promise<number>((r) => setTimeout(() => r(2), 5)),
+      () => new Promise<number>((r) => setTimeout(() => r(3), 20)),
+      () => new Promise<number>((r) => setTimeout(() => r(4), 10)),
+    ];
+    expect(await runPooled(tasks, 2)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("respects the concurrency limit", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 20 }, () => async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return 1;
+    });
+    await runPooled(tasks, 3);
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(0);
+  });
+
+  it("handles an empty task list", async () => {
+    expect(await runPooled([], 5)).toEqual([]);
+  });
+
+  it("doesn't spawn more workers than tasks", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 2 }, () => async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return 1;
+    });
+    await runPooled(tasks, 100);
+    expect(peak).toBe(2);
+  });
+
+  it("clamps limit to at least 1 even when passed 0 or negative", async () => {
+    const tasks = [
+      () => Promise.resolve("a"),
+      () => Promise.resolve("b"),
+    ];
+    expect(await runPooled(tasks, 0)).toEqual(["a", "b"]);
+    expect(await runPooled(tasks, -3)).toEqual(["a", "b"]);
+  });
+});

--- a/lib/concurrency.ts
+++ b/lib/concurrency.ts
@@ -1,0 +1,33 @@
+/**
+ * Concurrency-bounded task runner.
+ *
+ * Why this exists: several places in the data layer (`loadAllCourses`,
+ * `buildTransferLookupForCourses`) fan out to dozens of parallel Supabase
+ * queries via `Promise.all`. During `next build`, with multiple worker
+ * processes each running these calls simultaneously, the unbounded
+ * parallelism saturated Supabase's pgbouncer pool and surfaced as
+ * "Timed out acquiring connection from connection pool" errors that
+ * killed the production build (commit 8391a60, 2026-05-27). Capping each
+ * call to a small concurrency limit trades a tiny wall-clock cost for
+ * build resilience.
+ *
+ * Each task is a thunk — `() => Promise<T>` — so the work only starts
+ * when a worker picks it up, not at array-construction time.
+ */
+export async function runPooled<T>(
+  tasks: Array<() => Promise<T>>,
+  limit: number,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+  const workerCount = Math.min(Math.max(1, limit), tasks.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i]();
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -1,5 +1,6 @@
 import type { CourseSection } from "./types";
 import { supabase } from "./supabase";
+import { runPooled } from "./concurrency";
 
 // ---------------------------------------------------------------------------
 // In-memory cache (server-side, survives across requests in dev/prod)
@@ -299,7 +300,12 @@ export function getUniqueSubjects(courses: CourseSection[]): string[] {
 
 /**
  * Load all courses from all colleges for a given term from Supabase.
- * Uses parallel pagination for speed.
+ *
+ * Internally paginates with bounded concurrency — large states (NJ ~50k rows,
+ * VA ~30k) fan out to 30+ pages, and during `next build` the unbounded
+ * parallelism saturated Supabase's connection pool when multiple pages were
+ * built simultaneously. The cap below trades a small wall-clock cost (sequential
+ * batches of 5 instead of all-at-once) for build resilience.
  */
 export async function loadAllCourses(
   term: string,
@@ -315,32 +321,35 @@ export async function loadAllCourses(
 
     if (countErr || !count || count === 0) return [];
 
-    // Fetch all pages in parallel (much faster than sequential)
     const PAGE_SIZE = 1000;
     const pages = Math.ceil(count / PAGE_SIZE);
-    const promises: Promise<CourseSection[]>[] = [];
 
+    // Build one thunk per page. Each is a closure that performs the actual
+    // Supabase call when invoked — runPooled only starts a thunk when there's
+    // a free slot under the concurrency cap.
+    const tasks: Array<() => Promise<CourseSection[]>> = [];
     for (let i = 0; i < pages; i++) {
       const start = i * PAGE_SIZE;
       const end = start + PAGE_SIZE - 1;
-      promises.push(
-        (async () => {
-          const { data, error } = await supabase
-            .from("courses")
-            .select("*")
-            .eq("term", term)
-            .eq("state", state)
-            .range(start, end);
-          if (error) {
-            console.error(`loadAllCourses page ${i} error:`, error.message);
-            return [];
-          }
-          return (data || []).map(mapRow);
-        })()
-      );
+      tasks.push(async () => {
+        const { data, error } = await supabase
+          .from("courses")
+          .select("*")
+          .eq("term", term)
+          .eq("state", state)
+          .range(start, end);
+        if (error) {
+          console.error(`loadAllCourses page ${i} error:`, error.message);
+          return [];
+        }
+        return (data || []).map(mapRow);
+      });
     }
 
-    const results = await Promise.all(promises);
+    // Concurrency cap of 5 per call. With 3 build workers each running one
+    // loadAllCourses at a time, peak Supabase connections per state is ~15
+    // — well under any pgbouncer pool size in use here.
+    const results = await runPooled(tasks, 5);
     return results.flat();
   });
 }

--- a/lib/transfer-scoped.ts
+++ b/lib/transfer-scoped.ts
@@ -8,6 +8,7 @@
 // loads the entire state catalog (5.7 MB VA, 51 MB NJ/MD).
 
 import { supabase } from "./supabase";
+import { runPooled } from "./concurrency";
 
 // ---------------------------------------------------------------------------
 // In-memory TTL cache + inflight dedup (same pattern as lib/courses.ts)
@@ -143,8 +144,13 @@ export async function buildTransferLookupForCourses(
       }
     }
 
-    const chunkResults = await Promise.all(
-      queries.map(async ({ prefix, numbers }) => {
+    // Concurrency-cap the per-prefix queries — large colleges fan out to
+    // 20+ subject prefixes, and `next build` runs this on many pages in
+    // parallel. Unbounded Promise.all here was a major contributor to
+    // pgbouncer connection-pool exhaustion during deploy. Cap of 5 keeps
+    // peak connections per call modest while staying fast in practice.
+    const chunkResults = await runPooled(
+      queries.map(({ prefix, numbers }) => async () => {
         const { data, error } = await supabase
           .from("transfers")
           .select(
@@ -158,7 +164,8 @@ export async function buildTransferLookupForCourses(
           return [] as TransferRow[];
         }
         return (data ?? []) as TransferRow[];
-      })
+      }),
+      5
     );
 
     return rowsToLookup(chunkResults.flat());


### PR DESCRIPTION
## What changes for users

Nothing visible. This is a build-stability fix: it stops the deploys that were failing with \`Timed out acquiring connection from connection pool\` errors during \`next build\`. With this in, every state and college page that was failing to render will now reach production.

## Why

The 2026-05-27 production build failed on \`/[state]/courses/page\` for \`/ga/courses\` and \`/tn/courses\` with:

\`\`\`
buildTransferLookupForCourses error: Timed out acquiring connection from connection pool
Failed to build /[state]/courses/page: /ga/courses (attempt 1 of 3) because it took more than 60 seconds
\`\`\`

Root cause: \`loadAllCourses\` and \`buildTransferLookupForCourses\` both fan out to dozens of parallel Supabase queries via unbounded \`Promise.all\`. For a large state, one call already hits 30+ concurrent queries; with 3 Vercel build workers each running these in parallel across many pages, that saturated Supabase's pgbouncer pool and queries started timing out.

This predates the insights work in #620 — the same \"Timed out acquiring connection\" warnings appeared in prior deploys. The pre-existing fragility just hadn't yet been the proximate cause of a deploy failure.

## Technical

New \`lib/concurrency.ts → runPooled(tasks, limit)\` — small thunk-based pool runner. Each task is a \`() => Promise<T>\` so work only starts when a worker slot frees up.

Applied with a cap of 5 to two unbounded fan-outs:
- \`loadAllCourses\` (lib/courses.ts) — internal paginated catalog load
- \`buildTransferLookupForCourses\` (lib/transfer-scoped.ts) — per-prefix transfer queries

**Impact:** peak concurrent Supabase connections per call drops from ~30 to 5. With 3 build workers, peak per state drops from ~90 to ~15 — well under pgbouncer's pool ceiling. Wall-clock cost is small because Supabase round-trips are fast and the throttle only kicks in past 5 paginated chunks.

## Tests

\`lib/__tests__/concurrency.test.ts\` — 5 unit tests covering:
- Results returned in input order regardless of completion order
- Peak concurrency never exceeds the limit
- Empty input handled
- Worker count clamped to the smaller of (limit, task count)
- Defensive handling of limit ≤ 0 (treated as 1)

All passing locally (21/21 across both new and pre-existing prose tests).

## Test plan

- [ ] Merge → watch Vercel rebuild of main → confirm it completes without timeout errors
- [ ] Spot-check \`/ga/courses\` and \`/tn/courses\` (the two pages that failed last deploy) render in production