### PR TITLE
fix(db): covering index unblocks Vercel build (state/term/college_code)

### DIFF
--- a/supabase/migrations/015_state_term_college_covering_index.sql
+++ b/supabase/migrations/015_state_term_college_covering_index.sql
@@ -1,0 +1,39 @@
+-- ---------------------------------------------------------------------------
+-- 015_state_term_college_covering_index.sql
+--
+-- Fixes a production build failure where `npm run build` on Vercel was timing
+-- out generating `/[state]/page` for any state with ≥25k course rows (CA, NC,
+-- GA, VA, TX, MD, etc.). The failing query is `get_term_college_counts(p_state)`
+-- from migration 009:
+--
+--   SELECT term, COUNT(DISTINCT college_code) FROM courses
+--   WHERE state = p_state GROUP BY term ORDER BY term;
+--
+-- With only `idx_courses_state_term (state, term)`, Postgres did an Index Scan
+-- plus a heap fetch per row to read college_code. For CA's 93k rows that's
+-- ~800ms single-shot; under the 2000-page Vercel build's concurrent worker
+-- pressure each query stretched past the 60s statement_timeout, aborting the
+-- whole export.
+--
+-- This index adds college_code to the trailing position so the same query
+-- resolves as an Index Only Scan with zero heap fetches:
+--
+--   GroupAggregate (actual time=12.7..27.0 rows=7 loops=1)
+--     Index Only Scan using idx_courses_state_term_college (Heap Fetches: 0)
+--
+--   793 ms → 27 ms (29× speed-up on CA).
+--
+-- We keep idx_courses_state_term in place — narrower index still wins for
+-- queries that only filter on state+term without reading college_code, and the
+-- overhead of two indexes on the same leading column pair is trivial relative
+-- to the time we just won back.
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_courses_state_term_college
+  ON courses(state, term, college_code);
+
+-- Heap-fetch counts in the EXPLAIN above were initially high (35k) because
+-- recent imports had not yet been marked all-visible. Production was VACUUM
+-- ANALYZE'd as part of the rollout; subsequent fresh imports will lag the
+-- visibility map briefly until autovacuum catches up, which is fine — the
+-- query still uses the new index and degrades gracefully.


### PR DESCRIPTION
## What changes for someone using the site

Production deploys go through again. Right now `npm run build` on Vercel is aborting during the 2,000-page static export — every state-index page for CA, NC, GA, VA, MD, TX (and basically any state with ≥25k course rows) fails after 3 retries because the Supabase RPC behind them times out at the 60-second statement_timeout. Until this lands, no new merge can deploy.

## What changes on the technical front

The build's failure trace points at one query:

```sql
SELECT term, COUNT(DISTINCT college_code) FROM courses
WHERE state = $1 GROUP BY term ORDER BY term;
```

(defined as `get_term_college_counts(p_state)` in migration 009, called from `lib/terms.ts:70`)

Before this PR the only relevant index was `idx_courses_state_term (state, term)`. The planner uses it to filter, but `college_code` lives only in the heap — so 93k Index Scan + heap fetches for California. Single-shot ~800ms. Multiply by ~50 worker threads each generating ~40 state pages in parallel and the cluster's concurrent-connection pressure pushes individual statements past 60s. Build dies.

The new `(state, term, college_code)` index turns the same query into an **Index Only Scan with zero heap fetches**:

| State | Rows | Before | After |
|---|---:|---:|---:|
| CA | 93,694 | 793 ms | **27 ms** |
| NC | 85,881 | (similar) | (similar) |

EXPLAIN (ANALYZE) before / after:

```
-- Before
GroupAggregate  (actual time=662..793 rows=7)
  Index Scan using idx_courses_state_term  (actual time=1..718 rows=93694)
  Buffers: shared hit=2515 read=2096

-- After
GroupAggregate  (actual time=12..27 rows=7)
  Index Only Scan using idx_courses_state_term_college  (Heap Fetches: 0)
  Buffers: shared hit=89
```

The narrower `idx_courses_state_term` stays in place — still preferred by the planner for queries that only filter on state+term without needing college_code.

## Production already mitigated

I applied this migration directly to the production cluster via the Supabase MCP and ran `VACUUM (ANALYZE) courses` to clear visibility-map staleness from this week's imports (CCC, HCC, IECC, IL Colleague, Eastern WV, the cron-merged scrapes). The live cluster is already on the fast path. This PR is the source-of-truth tracking — future fresh databases (preview branches, local dev, restore-from-scratch) will pick the same index up at migration time.

The migration is idempotent (`CREATE INDEX IF NOT EXISTS`), so re-running on prod is safe.

## Test plan

- [x] EXPLAIN ANALYZE before/after on production CA (largest state) — 29× speedup, 0 heap fetches
- [x] Migration applied to production via Supabase MCP
- [x] `VACUUM (ANALYZE) courses` run to refresh visibility map
- [ ] After merge: next Vercel build should complete `/[state]/page` generation in seconds instead of timing out

## Why this happened now, not earlier

The courses table grew significantly this session — CCC + HCC + IECC + IL Colleague + Eastern WV + concurrent cron scrapes added ~30k rows. Before today, single-shot RPC latency was probably well under the contention threshold. Above ~50k rows per state the heap-fetch path becomes the limiting factor under concurrent build pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)