### PR TITLE
fix(cron): install poppler-utils for Maine prereqs scraper

### DIFF
--- a/.github/workflows/scheduled-scrape-v2.yml
+++ b/.github/workflows/scheduled-scrape-v2.yml
@@ -135,13 +135,14 @@ jobs:
         if: matrix.state == 'nc'
         run: pip install --quiet pdfplumber
 
-      - name: Install poppler-utils (AZ/AR/WV scrapers shell out to pdftotext)
+      - name: Install poppler-utils (AZ/AR/ME/WV scrapers shell out to pdftotext)
         # scripts/az/scrape-dine.ts — Diné College PDF schedule
         # scripts/ar/scrape-uaccm.ts — UACCM PDF schedule
         # scripts/ar/scrape-seark-pdf-programs.ts — SEARK PDF catalog
+        # scripts/me/scrape-catalog-prereqs.ts — Maine MCCS college catalogs
         # scripts/wv/scrape-eastern-wv.ts — Eastern WV PDF schedule
         # The Ubuntu runner doesn't ship poppler-utils by default.
-        if: matrix.state == 'az' || matrix.state == 'ar' || matrix.state == 'wv'
+        if: matrix.state == 'az' || matrix.state == 'ar' || matrix.state == 'me' || matrix.state == 'wv'
         run: sudo apt-get install -y --no-install-recommends poppler-utils
 
       - name: Resolve terms


### PR DESCRIPTION
## Summary

Maine's prerequisite scraper (`scripts/me/scrape-catalog-prereqs.ts`) extracts prerequisites from college PDFs using `pdftotext` from the poppler-utils package. The GitHub Actions runner doesn't have this installed by default, causing the scraper to fail silently in cron and output empty data.

This fix adds Maine to the conditional step that installs poppler-utils, alongside existing states (AZ, AR, WV) that already have this dependency. Now the prerqs cron job (Sun 07:00 UTC) will successfully extract text from Maine college catalogs and populate `data/me/prereqs.json` with 948+ prerequisites.

**Impact:** Moves Maine from B+ to A grade by enabling complete prerequisite data.

## Test plan

- [x] Manually verified that Maine's prereq scraper produces 948 entries when run locally
- [x] Identified root cause: missing `pdftotext` in cron environment
- [x] Added Maine to poppler-utils install step (matching AZ/AR/WV pattern)
- [ ] Next: wait for Sun 07:00 UTC cron run or manually trigger workflow with `workflow_dispatch`
- [ ] Verify: check that data/me/prereqs.json has non-empty content after cron runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)