### PR TITLE
fix(build): make schedule page dynamic to unblock TX build timeout

### DIFF
--- a/app/[state]/schedule/page.tsx
+++ b/app/[state]/schedule/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import ScheduleClient from "./ScheduleClient";
-import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getUniversities } from "@/lib/transfer";
 import { getAvailableTermsForDisplay } from "@/lib/terms";
@@ -9,9 +8,13 @@ type Props = {
   params: Promise<{ state: string }>;
 };
 
-export function generateStaticParams() {
-  return getAllStates().map((s) => ({ state: s.slug }));
-}
+// Schedule pages are noindex and fully client-driven — no SEO benefit from
+// static generation. At build time, large states (TX: 20k+ sections, 90MB
+// transfers) saturate the Supabase connection pool when multiple pages are
+// generated in parallel, causing statement timeouts that kill the entire
+// build. Force-dynamic avoids the build-time query load entirely; the page
+// renders on first request and is then edge-cached per Vercel's defaults.
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;


### PR DESCRIPTION
## What's broken

Vercel build fails on `/tx/schedule` after 3 retries — all 3 attempts hit the 60-second page generation timeout. The root cause is Texas's massive dataset (20k+ course sections, 90MB transfer data) overwhelming Supabase's connection pool when multiple build workers generate TX pages in parallel. Cascading `canceling statement due to statement timeout` errors ripple through `loadAllCourses` and `buildTransferLookupForCourses`.

## Fix

The schedule page is `noindex` and fully client-driven — the server component only passes config props (universities, terms, quick-add subjects). All heavy data loading happens client-side via API calls. Switching from `generateStaticParams` (36 states × build-time queries) to `force-dynamic` (render on first request) eliminates the build-time Supabase load entirely.

No user-visible change — the page still works exactly the same, just isn't pre-rendered at deploy time.

## Test plan
- [x] TypeScript check passes
- [ ] Vercel build succeeds
- [ ] Schedule page loads correctly for TX (`/tx/schedule`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)