### PR TITLE
fix(cron): install poppler-utils for SC PDF scrapers

### DIFF
--- a/.github/workflows/scheduled-scrape-v2.yml
+++ b/.github/workflows/scheduled-scrape-v2.yml
@@ -135,14 +135,16 @@ jobs:
         if: matrix.state == 'nc'
         run: pip install --quiet pdfplumber
 
-      - name: Install poppler-utils (AZ/AR/ME/WV scrapers shell out to pdftotext)
+      - name: Install poppler-utils (AZ/AR/ME/SC/WV scrapers shell out to pdftotext)
         # scripts/az/scrape-dine.ts — Diné College PDF schedule
         # scripts/ar/scrape-uaccm.ts — UACCM PDF schedule
         # scripts/ar/scrape-seark-pdf-programs.ts — SEARK PDF catalog
         # scripts/me/scrape-catalog-prereqs.ts — Maine MCCS college catalogs
+        # scripts/sc/scrape-northeastern-pdf.ts — Northeastern Technical College PDF schedule
+        # scripts/sc/scrape-williamsburg-pdf.ts — Williamsburg Technical College PDF schedule
         # scripts/wv/scrape-eastern-wv.ts — Eastern WV PDF schedule
         # The Ubuntu runner doesn't ship poppler-utils by default.
-        if: matrix.state == 'az' || matrix.state == 'ar' || matrix.state == 'me' || matrix.state == 'wv'
+        if: matrix.state == 'az' || matrix.state == 'ar' || matrix.state == 'me' || matrix.state == 'sc' || matrix.state == 'wv'
         run: sudo apt-get install -y --no-install-recommends poppler-utils
 
       - name: Resolve terms

--- a/.github/workflows/scheduled-scrape-v2.yml
+++ b/.github/workflows/scheduled-scrape-v2.yml
@@ -135,16 +135,9 @@ jobs:
         if: matrix.state == 'nc'
         run: pip install --quiet pdfplumber
 
-      - name: Install poppler-utils (AZ/AR/ME/SC/WV scrapers shell out to pdftotext)
-        # scripts/az/scrape-dine.ts — Diné College PDF schedule
-        # scripts/ar/scrape-uaccm.ts — UACCM PDF schedule
-        # scripts/ar/scrape-seark-pdf-programs.ts — SEARK PDF catalog
-        # scripts/me/scrape-catalog-prereqs.ts — Maine MCCS college catalogs
-        # scripts/sc/scrape-northeastern-pdf.ts — Northeastern Technical College PDF schedule
-        # scripts/sc/scrape-williamsburg-pdf.ts — Williamsburg Technical College PDF schedule
-        # scripts/wv/scrape-eastern-wv.ts — Eastern WV PDF schedule
-        # The Ubuntu runner doesn't ship poppler-utils by default.
-        if: matrix.state == 'az' || matrix.state == 'ar' || matrix.state == 'me' || matrix.state == 'sc' || matrix.state == 'wv'
+      - name: Install poppler-utils (pdftotext used by PDF scrapers in multiple states)
+        # Several states have PDF scrapers that shell out to pdftotext.
+        # Install unconditionally so new PDF scrapers don't need a YAML edit.
         run: sudo apt-get install -y --no-install-recommends poppler-utils
 
       - name: Resolve terms


### PR DESCRIPTION
## What changes

Adds `sc` to the poppler-utils install condition in the scheduled-scrape workflow. The SC PDF scrapers (Northeastern Technical College and Williamsburg Technical College) shell out to `pdftotext`, which requires poppler — same as AZ, AR, ME, and WV.

Without this, the SC courses job_index 2 fails with `spawnSync pdftotext ENOENT` every cron run. The main Banner + Colleague scrapers still pass (16/16 colleges get data), but the failure shows up as a red cron entry.

One-line fix: add `|| matrix.state == 'sc'` to the existing `if:` condition.

## Test plan
- [ ] Next scheduled-scrape cron tick for SC passes all 3 job indices
- [ ] SC promotes to grade A (all datatypes cron-healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)