### PR TITLE
tx: add Alvin, Vernon (Colleague) + Victoria (Banner SSB 9) scrapers

### DIFF
--- a/lib/states/tx/config.ts
+++ b/lib/states/tx/config.ts
@@ -113,6 +113,13 @@ const txConfig: StateConfig = {
         scripts: ["scripts/tx/scrape-howard.ts"],
         runner: "http",
       },
+      // Vernon College + Victoria College — two standalone Banner SSB 9
+      // instances with public guest access. Vernon serves SSB at the root
+      // domain (www.vernoncollege.edu) rather than the usual subdomain.
+      {
+        scripts: ["scripts/tx/scrape-banner-ssb.ts"],
+        runner: "http",
+      },
     ],
     transfers: [
       { scripts: ["scripts/tx/scrape-transfer-tccns.ts"], runner: "http" },

--- a/scripts/tx/scrape-banner-ssb.ts
+++ b/scripts/tx/scrape-banner-ssb.ts
@@ -1,0 +1,39 @@
+/**
+ * Texas — Banner SSB 9 scrape
+ *
+ * Thin wrapper around the shared Banner SSB 9 template for TX colleges
+ * with public Banner Self-Service Banner 9 instances. URL verified
+ * guest-open (HTTP 200, no redirect to login) on 2026-05-28:
+ *
+ *   victoria-college   → https://xe-stu.victoriacollege.edu
+ *
+ * (Vernon College was originally fingerprinted as Banner SSB at
+ * www.vernoncollege.edu/StudentRegistrationSsb/... — that path is actually
+ * the college website's custom 404 returning HTTP 200, not a real Banner
+ * endpoint. Vernon runs Ellucian Colleague Cloud at
+ * vernon-ss.colleague.elluciancloud.com, so it's handled by
+ * scripts/tx/scrape-colleague.ts instead.)
+ *
+ * The TX Alamo District scraper at scripts/tx/scrape-alamo.ts also uses the
+ * Banner SSB template but with a campus-description split — it's kept
+ * separate because its single Banner instance maps to 5 college slugs.
+ *
+ * Usage:
+ *   npx tsx scripts/tx/scrape-banner-ssb.ts
+ *   npx tsx scripts/tx/scrape-banner-ssb.ts --college vernon-college
+ */
+import { scrapeBannerSsbState } from "../lib/scrape-banner-ssb";
+
+async function main() {
+  await scrapeBannerSsbState({
+    state: "tx",
+    hosts: {
+      "victoria-college": "https://xe-stu.victoriacollege.edu",
+    },
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/tx/scrape-colleague.ts
+++ b/scripts/tx/scrape-colleague.ts
@@ -24,6 +24,16 @@ const HOSTS: Record<string, string> = {
   "galveston-college": "https://gcsis-ssprod.gc.edu",
   "mclennan-community-college": "https://mymcc.mclennan.edu",
   "texas-southmost-college": "https://selfservice.tsc.edu",
+  // TX Phase A — verified guest-open Colleague Self-Service hosts.
+  "alvin-community-college": "https://self-service.alvincollege.edu",
+  // Vernon was fingerprinted as Banner SSB but
+  // www.vernoncollege.edu/StudentRegistrationSsb is the website's 404 page
+  // served at HTTP 200, not a real Banner endpoint. The college's actual
+  // SIS is Ellucian Colleague Cloud.
+  "vernon-college": "https://vernon-ss.colleague.elluciancloud.com",
+  // Austin CCD's selfservice.austincc.edu is auth-gated
+  // (redirects /Student/Courses → /Account/Login). Deferred — needs an
+  // alternate guest endpoint or catalog-only import.
 };
 
 async function main() {


### PR DESCRIPTION
## What changes for someone using the site

Three more Texas community colleges show up in course search going forward — **Alvin Community College**, **Victoria College**, and **Vernon College**. Live counts from a local smoke test: Victoria publishes 1,142 sections across Fall 2026 + Summer 2026 (most with prerequisites), and Alvin publishes ~1,092 sections. Vernon will land on the next scheduled-scrape run. This moves TX from 22/59 colleges scraped (37%) to 25/59 (42%), as Phase A of a larger coverage push.

Nothing else in the UI changes. The colleges already had entries on the `/tx` college list; this PR makes their course data start populating instead of staying empty.

## What changes on the technical front

Two scrapers, three new colleges:

- **`scripts/tx/scrape-colleague.ts`** — extended with two more hosts driven by the shared Colleague Self-Service template (`scripts/lib/scrape-colleague.ts`):
  - `alvin-community-college` → `https://self-service.alvincollege.edu` (newly verified guest-open)
  - `vernon-college` → `https://vernon-ss.colleague.elluciancloud.com` (Vernon was originally fingerprinted as Banner SSB at `www.vernoncollege.edu/StudentRegistrationSsb/...` — that URL is actually the college website's custom 404 returned at HTTP 200, not a real Banner endpoint. Re-investigation found the real SIS is Ellucian Colleague Cloud.)
- **`scripts/tx/scrape-banner-ssb.ts`** (new) — thin wrapper around the shared Banner SSB 9 template (`scripts/lib/scrape-banner-ssb.ts`) for `victoria-college` at `xe-stu.victoriacollege.edu`.
- **`lib/states/tx/config.ts`** — declares the new Banner SSB scraper in `scrapers.courses` so the unified `scheduled-scrape.yml` matrix picks it up. The Colleague script is already declared, so the two new hosts come along for free.

## Known gaps deferred from Phase A

- **Austin Community College District** (Colleague) — `selfservice.austincc.edu/Student/Courses` redirects to `/Account/Login`. Auth-gated; needs an alternate guest endpoint or Acalog catalog-only import. Will revisit in a later phase.

## What's next (the rest of the plan)

This is **Phase A** of the TX coverage plan. Future PRs:
- **B** — Jenzabar sweep (Hill, NCTC, NETCC, Panola, Paris Jr, Ranger, Texarkana)
- **C** — Re-fingerprint the 7 "unknown"/9 "custom" colleges (El Paso, San Jac, Tyler Jr, Lee, Laredo, Angelina, Lamar-Orange + the custom set)
- **D** — Coursedog section template (Del Mar, Trinity Valley)
- **E** — Acalog catalog import (Dallas, Brazosport, Midland — for prereqs)
- **F** — Bespoke giants (Lone Star System, Collin CCD)

Targets: A+B ≈ 35/59 (C-tier), A–D ≈ 41/59 (B-), A–F ≈ 50+/59 (B+/A).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run check:scrapers` passes (35 states × 4 datatypes)
- [x] Local smoke: Victoria scraper writes 1,142 sections across 2 terms with prereqs
- [x] Local smoke: Alvin Colleague scraper writes 1,092 sections
- [ ] Next scheduled-scrape cron tick lands all three colleges as committed JSON in `data/tx/courses/`
- [ ] Post-merge: `curl communitycollegepath.com/api/tx/colleges/alvin-community-college/sections` returns rows after cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)