### PR TITLE
Curate NM state-metadata entry (auto-add-state followup)

### DIFF
--- a/data/state-metadata.json
+++ b/data/state-metadata.json
@@ -224,6 +224,16 @@
         "bannerDetail": "New Jersey law allows residents aged 65+ to enroll in NJ community college credit courses tuition-free on a space-available basis."
       }
     },
+    "nm": {
+      "fullName": "New Mexico",
+      "fipsCode": "35",
+      "systemName": "NM Community Colleges",
+      "systemFullName": "New Mexico Community Colleges",
+      "systemUrl": "https://hed.nm.gov/",
+      "defaultZip": "87501",
+      "defaultZipCity": "Santa Fe",
+      "seniorWaiver": null
+    },
     "nv": {
       "fullName": "Nevada",
       "fipsCode": "32",


### PR DESCRIPTION
## What changes for users

Nothing visible. This is metadata plumbing.

## What changes technically

Adds the `nm` entry to `data/state-metadata.json` so the next time someone re-runs `auto-add-state nm` (or any registry-rebuilding script that reads this file), the bootstrap picks up the right `fullName` ("New Mexico"), `systemName`/`systemFullName`, `systemUrl` (NMHED), `defaultZip`/`defaultZipCity` (Santa Fe 87501), and `fipsCode` ("35") — instead of falling through to placeholder values like `"Nm"`.

`seniorWaiver` is left `null` (same pattern as Alabama and DC), pending verification of the NM senior tuition statute. NMSA § 21-1-4.6 is the likely citation but I didn't have a primary source open to confirm exact wording, so I left it unset rather than ship a guess.

### Side investigation (no code change)

While here, attempted to revisit Mesalands Community College — one of the colleges deferred in [#699](https://github.com/rohan-c0de/cc-coursemap/pull/699). The original recon flagged it as Jenzabar ICS behind a Fastly bot challenge. A Playwright probe showed that real chromium clears Fastly cleanly, but the `/ICS/*` endpoints return **real HTTP 404** from the Mesalands marketing-site CMS post-challenge — there is no Jenzabar portal at that domain. The original recon misread Fastly's 3 KB JS-challenge interstitial as a successful 200 page. Without a discoverable SIS subdomain for Mesalands, no Playwright tweak helps. Leaving Mesalands deferred. The attempted scraper was deleted (don't ship a 0-section scraper).

## Verification

- `jq '.states.nm' data/state-metadata.json` returns the new entry
- File still parses as valid JSON
- No registry/code edits; no scrapers added or removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
