### PR TITLE
perf: sparse SSG for /[state]/college/[id] — pre-render top-10 traffic states

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -14,7 +14,7 @@ import CollegeTermSection from "./CollegeTermSection";
 import CollegeContext from "@/components/CollegeContext";
 import TopProgramsSection from "./TopProgramsSection";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
-import { getAllStates } from "@/lib/states/registry";
+import { getPrerenderStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getTopInstructors } from "@/lib/instructors";
 import { computeOfferingProfile } from "@/lib/college-stats";
@@ -74,13 +74,25 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   };
 }
 
-// Force HTTP 404 (not a cached 200 soft-404) for any (state, college-id) pair
-// not in `loadInstitutions`. `generateStaticParams` already enumerates every
-// valid pair at build time, so this is zero extra build cost. See #337.
-export const dynamicParams = false;
+// Sparse SSG (#702): pre-render only the colleges whose state config sets
+// `prerenderAtBuild: true`. Everything else renders on demand via ISR
+// (24h `revalidate` below) on the first visit and serves from the CDN
+// thereafter.
+//
+// Invalid (state, id) pairs still return a true HTTP 404 because the page
+// body calls `notFound()` after the in-memory `institutions.find()` miss.
+// Switching `dynamicParams` to `true` does not weaken the 404 guarantee
+// the previous `false` setting offered; it only lets Next.js reach the
+// page handler before bailing. The handler is a synchronous array lookup,
+// so the per-invalid-request CPU cost is negligible.
+//
+// State priority is set on each StateConfig rather than hardcoded here —
+// see CLAUDE.md invariant #1. To promote a state into the build-time
+// tier, set `prerenderAtBuild: true` in `lib/states/{slug}/config.ts`.
+export const dynamicParams = true;
 
 export function generateStaticParams() {
-  return getAllStates().flatMap((config) =>
+  return getPrerenderStates().flatMap((config) =>
     loadInstitutions(config.slug).map((i) => ({ state: config.slug, id: i.id }))
   );
 }

--- a/lib/states/ct/config.ts
+++ b/lib/states/ct/config.ts
@@ -21,6 +21,7 @@ const ctConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENG 101", "MAT 137", "BIO 111", "PSY 111", "HIS 101", "SOC 101"],
   defaultZip: "06103",
   defaultZipCity: "Hartford",

--- a/lib/states/de/config.ts
+++ b/lib/states/de/config.ts
@@ -21,6 +21,7 @@ const deConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENG 111", "MAT 153", "BIO 120", "HIS 111", "PSY 121", "ECO 251"],
   defaultZip: "19901",
   defaultZipCity: "Dover",

--- a/lib/states/ga/config.ts
+++ b/lib/states/ga/config.ts
@@ -47,6 +47,7 @@ const gaConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENGL 1101", "MATH 1111", "HIST 2111", "BIOL 1111", "PSYC 1101", "ECON 2105"],
   defaultZip: "30303",
   defaultZipCity: "Atlanta",

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -28,6 +28,7 @@ const maConfig: StateConfig = {
   // the ones whose scheduling systems are SSO-gated (Massasoit, Cape Cod,
   // QCC, Roxbury, MassBay).
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENG 101", "MAT 128", "BIO 110", "PSY 101", "HIS 101", "SOC 101"],
   defaultZip: "02108",
   defaultZipCity: "Boston",

--- a/lib/states/md/config.ts
+++ b/lib/states/md/config.ts
@@ -62,6 +62,7 @@ const mdConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENGL 101", "MATH 135", "BIOL 101", "HIST 101", "PSYC 101", "ECON 201"],
   defaultZip: "21202",
   defaultZipCity: "Baltimore",

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -26,6 +26,7 @@ const meConfig: StateConfig = {
   // is retained manual-only for out-of-state use if the in-state rule
   // is ever relaxed.
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENG 101", "MAT 101", "BIO 101", "PSY 101", "HIS 101", "SOC 101"],
   defaultZip: "04101",
   defaultZipCity: "Portland",

--- a/lib/states/nc/config.ts
+++ b/lib/states/nc/config.ts
@@ -73,6 +73,7 @@ const ncConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENG 111", "MAT 171", "BIO 111", "HIS 111", "PSY 150", "ECO 251"],
   defaultZip: "27601",
   defaultZipCity: "Raleigh",

--- a/lib/states/nh/config.ts
+++ b/lib/states/nh/config.ts
@@ -27,6 +27,7 @@ const nhConfig: StateConfig = {
   // Keene as a destination. Accepting that limited coverage rather
   // than hide real data behind the flag.
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENGL 101", "MATH 120", "BIOL 105", "PSYC 101", "HIST 101", "SOCI 101"],
   defaultZip: "03101",
   defaultZipCity: "Manchester",

--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -128,6 +128,19 @@ export interface StateConfig {
      *  or descriptive prose pages with no structured curriculum. */
     programs?: string;
   };
+  /**
+   * Build-time SSG priority. When true, this state's per-college pages
+   * (and any other route opting into the same flag) are pre-rendered at
+   * build time. When false/undefined, pages render on demand via ISR
+   * on the first visit and cache for the route's `revalidate` window.
+   *
+   * Tier this against actual Search Console traffic, not population —
+   * see #702 for the analysis. Promote a state when its `/[state]/college/`
+   * clicks consistently land in the top quartile across 90-day windows.
+   * Demoting is fine too if a previously hot state's traffic drops; the
+   * route remains functional under ISR.
+   */
+  prerenderAtBuild?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -266,4 +279,17 @@ export function hasPrereqsCoverage(slug: string): boolean {
 export function hasProgramsCoverage(slug: string): boolean {
   const cfg = configs[slug];
   return (cfg?.scrapers?.programs ?? []).length > 0;
+}
+
+/**
+ * Returns the slugs whose pages should be pre-rendered at build time
+ * (`prerenderAtBuild: true` in the StateConfig). All other states' pages
+ * defer to ISR-on-demand rendering.
+ *
+ * Tracked separately from `getAllStates()` so build-time iteration
+ * (`generateStaticParams`) doesn't have to re-check the flag at every
+ * call site. See #702 for the SSG-priority rationale.
+ */
+export function getPrerenderStates(): StateConfig[] {
+  return ALL_CONFIGS.filter((c) => c.prerenderAtBuild === true);
 }

--- a/lib/states/sc/config.ts
+++ b/lib/states/sc/config.ts
@@ -47,6 +47,7 @@ const scConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   popularCourses: ["ENG 101", "MAT 110", "BIO 101", "HIS 101", "PSY 201", "ECO 210"],
   defaultZip: "29201",
   defaultZipCity: "Columbia",

--- a/lib/states/tn/config.ts
+++ b/lib/states/tn/config.ts
@@ -41,6 +41,7 @@ const tnConfig: StateConfig = {
   },
 
   transferSupported: true,
+  prerenderAtBuild: true, // High Search Console traffic; pre-render at build (#702)
   // Transfer data sourced from UTK's public transfer course equivalency tool
   // at bannerssb.utk.edu (10k+ mappings across all 13 TBR CCs). Additional
   // universities (APSU, MTSU, etc.) are added incrementally by running


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible. This is a build-time optimization: the per-college page on the live site (e.g. `/ga/college/abac`) renders identically for every user. Invalid college URLs (`/wa/college/notreal`) still return a proper HTTP 404 the same way they did before.

What changes under the hood is **how many pages the deploy pre-renders**. Today every deploy pre-renders 691 college pages (every college in every state). After this lands, deploys pre-render only the 155 colleges in the top-10 highest-traffic states; the other 536 college pages render on the first visit and cache via the existing 24-hour ISR window. First visitor pays a one-time render cost, everyone within 24 hours hits the CDN.

## What changes on the technical front

Backed by Google Search Console data: looking at the last 90 days of `/[state]/college/*` clicks across all 38 states, **10 states drive ~95% of traffic**:

| State | 90d clicks | Colleges |
|---|---:|---:|
| ga | 457 | 22 |
| nc | 230 | 58 |
| tn | 196 | 12 |
| sc | 135 | 16 |
| ct | 130 | 1 |
| md | 93 | 16 |
| ma | 92 | 15 |
| de | 44 | 1 |
| nh | 43 | 7 |
| me | 28 | 7 |
| **Total** | **1,448** | **155** |

The other 28 states share fewer than 80 clicks combined across the same window — and most are recently added (CA, FL, IL, MI, OH, TX), still indexing.

The mechanism:
- Added `prerenderAtBuild?: boolean` to `StateConfig` and exported `getPrerenderStates()` from the registry. Avoids hardcoding a state list inside a component (CLAUDE.md invariant #1).
- The 10 listed configs got `prerenderAtBuild: true,` with a tracking comment pointing here.
- `app/[state]/college/[id]/page.tsx` flipped from `dynamicParams = false` (universe pre-rendered) to `dynamicParams = true` + a narrowed `generateStaticParams` that only iterates `getPrerenderStates()`.

## Why 404 behavior doesn't change

The previous comment said `dynamicParams = false` was chosen specifically to return real HTTP 404s (not 200+not-found-UI). On a closer read, **the page handler at line 95 already calls `notFound()` after the `institutions.find()` miss** — so the 404 was double-protected. Switching `dynamicParams` to `true` only lets Next.js reach the page handler before bailing; the handler then calls `notFound()` for invalid pairs and you get the same real 404. The per-invalid-request cost is a synchronous in-memory array lookup (microseconds).

## Why this matters

A local `next build` against current main this session was at **minute 9 with 657 of 1,960 static pages rendered**, with workers timing out on Supabase fetches for `/ma/college/bhcc/courses/eng`, `/ca/college/citrus-college`, and similar. The per-page `buildTransferLookupForCourses` call fans out to 5-concurrent Supabase queries; with 7 build workers running in parallel that's up to 35 concurrent connections against pgbouncer, and the supabase-js fetch wrapper hits its 60-second cap per page.

Vercel doesn't currently fail because its build environment handles the connection-pool pressure better than my laptop, but each new state grows the build linearly. With 38 states today and aiming for 50, the math gets worse fast. Cutting `/[state]/college/[id]` from the build-time set removes 536 pages from this contention pattern.

Estimated effects:
- Build-time pre-renders for this route: 691 → 155 (-77.5%)
- buildTransferLookupForCourses calls at build time: -536 × ~5 Supabase queries each ≈ -2,680 build-time queries
- ISR cost at runtime: first-visit render per long-tail college page, then cached 24h

Routes not changed: `[state]/college/[id]/courses/[prefix]` is already sparse SSG (top-3 colleges × 6 subjects per state). `[state]/course/[code]`, `[state]/subject/[prefix]`, `[state]/program/[slug]`, `[state]/college/[id]/programs`, and `[state]/college/[id]/instructor/[slug]` already return `[]` from generateStaticParams — pure ISR.

## How to promote/demote a state

`prerenderAtBuild` is a per-state boolean in the StateConfig. Tier this against actual Search Console traffic (90d `/[state]/college/` clicks); promote when a state lands consistently in the top quartile, demote if its traffic drops. The route remains functional under ISR for any state regardless.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run check:scrapers` passes (37 states accounted for)
- [ ] Vercel preview deploy renders `/ga/college/abac` instantly (CDN hit, was pre-rendered)
- [ ] Vercel preview deploy renders `/ca/college/de-anza` on first visit (ISR render), then CDN-cached
- [ ] `/wa/college/notreal` still returns HTTP 404 on the preview deploy
- [ ] Production build log shows reduced "Generating static pages" total

🤖 Generated with [Claude Code](https://claude.com/claude-code)