### PR TITLE
tx: add Del Mar (Colleague) + 2x prereq coverage from catalog re-aggregate

### DIFF
--- a/data/tx/prereqs.json
+++ b/data/tx/prereqs.json
@@ -23,6 +23,12 @@
       "ABDR 2357"
     ]
   },
+  "ABDR 2041": {
+    "text": "ABDR 1331, 1419.",
+    "courses": [
+      "ABDR 1331"
+    ]
+  },
   "ABDR 2357": {
     "text": "ABDR 1315 and ABDR 1331 and ABDR 1419 and ABDR 1315 and ABDR 1331 and ABDR 1419",
     "courses": [
@@ -44,6 +50,12 @@
     "courses": [
       "ACCT 2301",
       "ACNT 1303"
+    ]
+  },
+  "ACCT 2402": {
+    "text": "ACCT 2401) Students will earn an A, B, C, D, F, or W. This course is an introduction to the fundamental concepts of managerial accounting appropriate for all organizations. Students will study information from the entity's accounting system relevant to decisions made by internal managers, as distinguished from information relevant to users who are external to the company. The emphasis is on the id",
+    "courses": [
+      "ACCT 2401"
     ]
   },
   "ACNT 1304": {
@@ -78,12 +90,48 @@
       "ACNT 1303"
     ]
   },
+  "ACNT 1347": {
+    "text": "ACNT 1331 or permission of instructor. Assessment Levels: R2, E2, M2. 52.1601",
+    "courses": [
+      "ACNT 1331"
+    ]
+  },
   "ACNT 2332": {
     "text": "ACNT 1303 and ACNT 1304 and COSC 1301",
     "courses": [
       "ACNT 1303",
       "ACNT 1304",
       "COSC 1301"
+    ]
+  },
+  "AERM 1210": {
+    "text": "AERM 1315 and AERM 1303 and AERM 1208 and AERM 1205 and AERM 1314",
+    "courses": [
+      "AERM 1315",
+      "AERM 1303",
+      "AERM 1208",
+      "AERM 1205",
+      "AERM 1314"
+    ]
+  },
+  "AERM 1344": {
+    "text": "AERM 1351 and AERM 1240 and AERM 2341 and AERM 1356 and AERM 1352",
+    "courses": [
+      "AERM 1351",
+      "AERM 1240",
+      "AERM 2341",
+      "AERM 1356",
+      "AERM 1352"
+    ]
+  },
+  "AERM 1352": {
+    "text": "AERM 2233 and AERM 1241 and AERM 1354 and AERM 2231 and AERM 1243",
+    "courses": [
+      "AERM 2233",
+      "AERM 1241",
+      "AERM 1354",
+      "AERM 2231",
+      "AERM 1243"
     ]
   },
   "ARCE 1315": {
@@ -93,9 +141,48 @@
     ]
   },
   "ARCE 1352": {
-    "text": "DFTG 1309 (min C)",
+    "text": "ARCH 2312, DFTG 1305. Assessment Levels: R2, E1, M2. 04.0901",
     "courses": [
-      "DFTG 1309"
+      "ARCH 2312",
+      "DFTG 1305"
+    ]
+  },
+  "ARCE 2344": {
+    "text": "ARCH 2312 or CNBT 1311. Assessment level: R2, E1, M3.",
+    "courses": [
+      "ARCH 2312",
+      "CNBT 1311"
+    ]
+  },
+  "ARCE 2352": {
+    "text": "ARCH 2312 Assessment Levels: R2, E1, M1. 04.0901",
+    "courses": [
+      "ARCH 2312"
+    ]
+  },
+  "ARCH 1304": {
+    "text": "ARCH 1303 and 1307. Corequisite: ARCH 1308. Assessment Levels: R2, E2, M2. 04.0201.5402",
+    "courses": [
+      "ARCH 1303",
+      "ARCH 1308"
+    ]
+  },
+  "ARCH 1315": {
+    "text": "DFTG 2319. Assessment Levels: R2, E1, M2. 15.1303.5211",
+    "courses": [
+      "DFTG 2319"
+    ]
+  },
+  "ARCH 2375": {
+    "text": "ARCH 2312. Assessment Levels: R2, E1, M3. 15.0101",
+    "courses": [
+      "ARCH 2312"
+    ]
+  },
+  "ARCH 2604": {
+    "text": "ARCH 2603. Assessment Levels: R3, E3, M3. 04.0201.5402",
+    "courses": [
+      "ARCH 2603"
     ]
   },
   "ARTC 1349": {
@@ -120,6 +207,18 @@
       "ARTC 2305"
     ]
   },
+  "ARTS 109N": {
+    "text": "ARTS 108N or have previous knowledge in balloon twisting. Balloons will be provided. A hand pump is recommended for the class.",
+    "courses": [
+      "ARTS 108N"
+    ]
+  },
+  "ARTS 1304": {
+    "text": "ARTS 1303. Assessment Levels: R3, E3, M1. 50.0703",
+    "courses": [
+      "ARTS 1303"
+    ]
+  },
   "ARTS 1312": {
     "text": "ARTS 1311",
     "courses": [
@@ -132,10 +231,22 @@
       "ARTS 1316"
     ]
   },
+  "ARTS 2057N": {
+    "text": "ARTS 2356 or permission of the instructor.",
+    "courses": [
+      "ARTS 2356"
+    ]
+  },
   "ARTS 2317": {
     "text": "ARTS 2316",
     "courses": [
       "ARTS 2316"
+    ]
+  },
+  "ARTS 2323": {
+    "text": "ARTS 1316. Assessment Levels: R1, E1, M0. 50.0705",
+    "courses": [
+      "ARTS 1316"
     ]
   },
   "ARTS 2347": {
@@ -144,10 +255,54 @@
       "ARTS 2346"
     ]
   },
+  "ARTV 1302": {
+    "text": "DFTG 2319. 10.0304",
+    "courses": [
+      "DFTG 2319"
+    ]
+  },
+  "ARTV 2351": {
+    "text": "ARTV 1345",
+    "courses": [
+      "ARTV 1345"
+    ]
+  },
+  "ATRM 1371": {
+    "text": "ELPT 1311. Assessment Levels: R3, E2, M3. 15.0406",
+    "courses": [
+      "ELPT 1311"
+    ]
+  },
+  "ATRM 1372": {
+    "text": "ELMT 1301, ELPT 1311. Assessment Levels: R2, E2, M2. 15.0406",
+    "courses": [
+      "ELMT 1301",
+      "ELPT 1311"
+    ]
+  },
   "AUMT 1306": {
     "text": "AUMT 1419",
     "courses": [
       "AUMT 1419"
+    ]
+  },
+  "AUMT 1316": {
+    "text": "AUMT 1305 and AUMT 1310 and AUMT 2317 and AUMT 2337 and AUMT 2288",
+    "courses": [
+      "AUMT 1305",
+      "AUMT 1310",
+      "AUMT 2317",
+      "AUMT 2337",
+      "AUMT 2288"
+    ]
+  },
+  "AUMT 1319": {
+    "text": "AUMT 1316 and AUMT 2325 and AUMT 2313 and AUMT 2328",
+    "courses": [
+      "AUMT 1316",
+      "AUMT 2325",
+      "AUMT 2313",
+      "AUMT 2328"
     ]
   },
   "AUMT 1345": {
@@ -170,6 +325,12 @@
       "AUMT 1306"
     ]
   },
+  "AUMT 2288": {
+    "text": "AUMT 1307",
+    "courses": [
+      "AUMT 1307"
+    ]
+  },
   "AUMT 2325": {
     "text": "AUMT 1407",
     "courses": [
@@ -183,10 +344,29 @@
       "AUMT 1407"
     ]
   },
+  "AUMT 2413": {
+    "text": "AUMT 1405. 47.0604",
+    "courses": [
+      "AUMT 1405"
+    ]
+  },
+  "AUMT 2417": {
+    "text": "AUMT 1407 and AUMT 1319. 47.0604",
+    "courses": [
+      "AUMT 1407",
+      "AUMT 1319"
+    ]
+  },
   "AUMT 2421": {
     "text": "AUMT 1407",
     "courses": [
       "AUMT 1407"
+    ]
+  },
+  "AUMT 2425": {
+    "text": "AUMT 2421. 47.0604",
+    "courses": [
+      "AUMT 2421"
     ]
   },
   "BIOL 1106": {
@@ -243,6 +423,15 @@
       "MATH 1314"
     ]
   },
+  "BIOL 1415": {
+    "text": "BIOL 1414, MATH 1314, BIOL 1406, CHEM 1411(or concurrent enrollment). Assessment Levels: R3, E3, M3. 26.1201",
+    "courses": [
+      "BIOL 1414",
+      "MATH 1314",
+      "BIOL 1406",
+      "CHEM 1411"
+    ]
+  },
   "BIOL 2101": {
     "text": "(BRDG) Developmental Reading 0372 (min DC) or (BWRT) Developmental Writing 0372 (min DC) or INRW 0173 (min S) and INRW 0373 (min DC) or ENGL 1301 (min C) or ENGL 1301 (min TC)",
     "courses": [
@@ -273,6 +462,12 @@
       "BIOL 2301",
       "BIOL 2101",
       "BIOL 2401"
+    ]
+  },
+  "BIOL 2306": {
+    "text": "BIOL 1309 or 1407. Assessment Levels: R3, E3, M2. 3.0103",
+    "courses": [
+      "BIOL 1309"
     ]
   },
   "BIOL 2316": {
@@ -314,6 +509,48 @@
       "CHEM 1411"
     ]
   },
+  "BITC 1403": {
+    "text": "BIOL 1414. Assessment Levels: R3, E3, M3. 41.0101",
+    "courses": [
+      "BIOL 1414"
+    ]
+  },
+  "BITC 1491": {
+    "text": "BIOL 1414, BIOL 1415. Assessment Levels: R3, E3, M3. 41.0101",
+    "courses": [
+      "BIOL 1414",
+      "BIOL 1415"
+    ]
+  },
+  "BITC 2350": {
+    "text": "BITC 1311.",
+    "courses": [
+      "BITC 1311"
+    ]
+  },
+  "BITC 2411": {
+    "text": "BIOL 1415 or Departmental approval. Assessment Levels: R3, E3, M3. 41.0101",
+    "courses": [
+      "BIOL 1415"
+    ]
+  },
+  "BITC 2431": {
+    "text": "BIOL 1414 or Departmental Approval. Assessment Levels: R3, E3, M3. 41.0101",
+    "courses": [
+      "BIOL 1414"
+    ]
+  },
+  "BITC 2441": {
+    "text": "BIOL1406, BIOL 1415 or Departmental approval. Assessment Levels: R3, E3, M3. 41.0101",
+    "courses": [
+      "BIOL 1406",
+      "BIOL 1415"
+    ]
+  },
+  "BITC 2486": {
+    "text": "Assigned by the College. Assessment Levels: R3, E3, M3. 41.0101",
+    "courses": []
+  },
   "BUSI 1301": {
     "text": "ENGL 0302 (min C) or ENGL 0327 (min C)",
     "courses": [
@@ -348,6 +585,12 @@
       "CDEC 1313"
     ]
   },
+  "CDEC 2265": {
+    "text": "CDEC 2326",
+    "courses": [
+      "CDEC 2326"
+    ]
+  },
   "CDEC 2326": {
     "text": "TECA 1311 or CDEC 1311",
     "courses": [
@@ -368,6 +611,18 @@
       "CDEC 2340"
     ]
   },
+  "CDEC 2387": {
+    "text": "CDEC 1356, 1358, or 2307 or instructor approval. Assessment Levels: R1, E1, M0. 19.0709",
+    "courses": [
+      "CDEC 1356"
+    ]
+  },
+  "CDEC 2388": {
+    "text": "CDEC 2387. Assessment Levels: R1, E1, M0. 19.0709",
+    "courses": [
+      "CDEC 2387"
+    ]
+  },
   "CETT 1405": {
     "text": "CETT 1403 (min C)",
     "courses": [
@@ -384,6 +639,24 @@
     "text": "CETT 1405 (min C)",
     "courses": [
       "CETT 1405"
+    ]
+  },
+  "CHEF 1310": {
+    "text": "CHEF 1301, 1305. Assessment Levels: R1, E1, M1. 12.0503",
+    "courses": [
+      "CHEF 1301"
+    ]
+  },
+  "CHEF 1314": {
+    "text": "CHEF 1301, 1305, 2302. Assessment Levels: R1, E1, M1. 12.0503",
+    "courses": [
+      "CHEF 1301"
+    ]
+  },
+  "CHEF 2302": {
+    "text": "CHEF 1301, 1305, 1310. Assessment Levels: R1, E1, M1. 12.0503",
+    "courses": [
+      "CHEF 1301"
     ]
   },
   "CHEF 2331": {
@@ -415,10 +688,11 @@
     ]
   },
   "CHEM 1307": {
-    "text": "CHEM 1311 (min D) or CHEM 1306 (min D)",
+    "text": "CHEM 1305, CHEM 1406 or CHEM 1411, or have permission of the Department Chairperson. Assessment Levels: R3, E3, M2. 40.0501",
     "courses": [
-      "CHEM 1311",
-      "CHEM 1306"
+      "CHEM 1305",
+      "CHEM 1406",
+      "CHEM 1411"
     ]
   },
   "CHEM 1311": {
@@ -437,6 +711,12 @@
       "CHEM 1109"
     ]
   },
+  "CHEM 1407": {
+    "text": "CHEM 1405 or 1406, or permission of the department chairperson. Assessment Levels: R3, E3, M2. 40.0501",
+    "courses": [
+      "CHEM 1405"
+    ]
+  },
   "CHEM 1411": {
     "text": "MATH 1314 or CHEM 1405",
     "courses": [
@@ -452,16 +732,116 @@
       "CHEM 1411"
     ]
   },
+  "CHEM 2123": {
+    "text": "Registration for CHEM 2323 or permission of instructor and department chair. Assessment Levels: R3, E3, M3. 40.0504",
+    "courses": [
+      "CHEM 2323"
+    ]
+  },
+  "CHEM 2125": {
+    "text": "Registration for CHEM 2325 or permission of instructor and department chair. Assessment Levels: R3, E3, M3. 40.0504",
+    "courses": [
+      "CHEM 2325"
+    ]
+  },
+  "CHEM 2323": {
+    "text": "CHEM 1412 and registration for CHEM 2123 or permission of instructor and department chair. Assessment Levels: R3, E3, M3. 40.0504",
+    "courses": [
+      "CHEM 1412",
+      "CHEM 2123"
+    ]
+  },
   "CHEM 2423": {
     "text": "CHEM 1412",
     "courses": [
       "CHEM 1412"
     ]
   },
+  "CJLE 1506": {
+    "text": "approval of department advisor. 43.0107",
+    "courses": []
+  },
+  "CJLE 1518": {
+    "text": "approval of department advisor. 43.0107",
+    "courses": []
+  },
+  "CJLE 1524": {
+    "text": "approval of department advisor. 43.0107",
+    "courses": []
+  },
   "CJSA 2332": {
     "text": "CJSA 1308",
     "courses": [
       "CJSA 1308"
+    ]
+  },
+  "CJSA 2489": {
+    "text": "CJLE 1506, CJLE 1512, CJLE 1518, CJLE 1524. 43.0104.",
+    "courses": [
+      "CJLE 1506",
+      "CJLE 1512",
+      "CJLE 1518",
+      "CJLE 1524"
+    ]
+  },
+  "CNBT 1342": {
+    "text": "ARCH 2312 or CNBT 1311. Assessment Levels: R2, E2, M1. 15.1001.",
+    "courses": [
+      "ARCH 2312",
+      "CNBT 1311"
+    ]
+  },
+  "CNBT 1346": {
+    "text": "ARCH 2312 or CNBT 1311. Assessment Levels: R2, E1, M2. 15.1001",
+    "courses": [
+      "ARCH 2312",
+      "CNBT 1311"
+    ]
+  },
+  "CNBT 2266": {
+    "text": "CNBT 1359, CNBT 1346, CNBT 2342.0 Assessment Levels: R2, E1, M22. 15.1001",
+    "courses": [
+      "CNBT 1359",
+      "CNBT 1346",
+      "CNBT 2342"
+    ]
+  },
+  "CNBT 2305": {
+    "text": "CNBT 1300, CNBT 1311, and CNBT 2342. Assessment Levels: R2, E2, M2. 15.1001",
+    "courses": [
+      "CNBT 1300",
+      "CNBT 1311",
+      "CNBT 2342"
+    ]
+  },
+  "CNBT 2317": {
+    "text": "ARCH 2312 or CNBT 1311. Assessment Levels: R2, E2, M2. 15.1001",
+    "courses": [
+      "ARCH 2312",
+      "CNBT 1311"
+    ]
+  },
+  "CNBT 2342": {
+    "text": "ARCH 2312 or CNBT 1311. Assessment Levels: R2, E1, M2. 15.1001",
+    "courses": [
+      "ARCH 2312",
+      "CNBT 1311"
+    ]
+  },
+  "CNBT 2344": {
+    "text": "CNBT 2342. Assessment Levels: R2, E2, M2. 15.1001.",
+    "courses": [
+      "CNBT 2342"
+    ]
+  },
+  "CNBT 2370": {
+    "text": "CNBT 1300, CNBT 1311, CNBT 1346, CNBT 1359, and CNBT 2342. Assessment Levels: R2, E2, M2. 15.1001",
+    "courses": [
+      "CNBT 1300",
+      "CNBT 1311",
+      "CNBT 1346",
+      "CNBT 1359",
+      "CNBT 2342"
     ]
   },
   "CNSE 1371": {
@@ -478,6 +858,39 @@
       "ARTV 1371"
     ]
   },
+  "COMM 2305": {
+    "text": "COMM 1307, ENGL 1302 with minimum grades of \"C.\" Assessment Levels: R3, E3, M1. 09.0401",
+    "courses": [
+      "COMM 1307",
+      "ENGL 1302"
+    ]
+  },
+  "COMM 2315": {
+    "text": "COMM 2311 Media Writing. Assessment Levels: R3, E3, M1. 09.0101",
+    "courses": [
+      "COMM 2311"
+    ]
+  },
+  "COMM 2324": {
+    "text": "COMM 1336 and 1337 for a television internship for Digital Media and Radio/Television majors, COMM 2303 for a radio internship for Radio/Television majors with minimum average of \"C\" and permission of instructor. Assessment Levels: R1, E1, M0. 09.0101",
+    "courses": [
+      "COMM 1336",
+      "COMM 2303"
+    ]
+  },
+  "COMM 2339": {
+    "text": "ENGL 1301, 1302. Assessment Levels: R3, E3, M1. 09.0402",
+    "courses": [
+      "ENGL 1301"
+    ]
+  },
+  "COSC 1337": {
+    "text": "ITSE 1359 and MATH 1342. Assessment Levels: R3, E1, M1. 11.0201",
+    "courses": [
+      "ITSE 1359",
+      "MATH 1342"
+    ]
+  },
   "COSC 1436": {
     "text": "COSC 1301 or MATH 1314 or MATH 1414 or MATH 2412",
     "courses": [
@@ -488,15 +901,35 @@
     ]
   },
   "COSC 1437": {
-    "text": "COSC 1436",
+    "text": "COSC 1436 and MATH 1316. Assessment Levels: R3, E1, M1. 11.0201",
     "courses": [
-      "COSC 1436"
+      "COSC 1436",
+      "MATH 1316"
+    ]
+  },
+  "COSC 2325": {
+    "text": "COSC 1436 or ENGR 2304 , and ENGT 1407 or ENGR 2406. Open to Electrical Engineering majors or by permission of the Chair. Assessment Levels: R3, E2, M3. 11.0201",
+    "courses": [
+      "COSC 1436",
+      "ENGR 2304",
+      "ENGT 1407",
+      "ENGR 2406"
+    ]
+  },
+  "COSC 2425": {
+    "text": "COSC 1436 or ITSE 1402; and COSC 1437 or ITSE 2431 or permission of the instructor. Assessment Levels: R3, E1, M1. 11.0201",
+    "courses": [
+      "COSC 1436",
+      "ITSE 1402",
+      "COSC 1437",
+      "ITSE 2431"
     ]
   },
   "COSC 2436": {
-    "text": "COSC 1437",
+    "text": "COSC 1437. Pre/Corequisite: MATH 2305. Assessment Levels: R3, E1, M1. 11.0201",
     "courses": [
-      "COSC 1437"
+      "COSC 1437",
+      "MATH 2305"
     ]
   },
   "CPMT 2380": {
@@ -526,6 +959,36 @@
     "courses": [
       "ENGL 0302",
       "ENGL 0327"
+    ]
+  },
+  "CRIJ 2314": {
+    "text": "CRIJ 1301. Assessment Levels: R3, E3, M1. 43.0104",
+    "courses": [
+      "CRIJ 1301"
+    ]
+  },
+  "CRIJ 2323": {
+    "text": "CRIJ 1301. Assessment Levels: R3, E3, M1. 43.0104",
+    "courses": [
+      "CRIJ 1301"
+    ]
+  },
+  "CRTR 1242": {
+    "text": "CRTR 1241. Assessment Levels: R1, E1, M1. 22.0303",
+    "courses": [
+      "CRTR 1241"
+    ]
+  },
+  "CRTR 1348": {
+    "text": "CRTR 1241 or concurrent enrollment. Assessment Levels: R1, E1, M1. 22.0303",
+    "courses": [
+      "CRTR 1241"
+    ]
+  },
+  "CRTR 2343": {
+    "text": "CRTR 2301 and 2310 or concurrent enrollment. Assessment Levels: R1, E1, M1. 22.0303",
+    "courses": [
+      "CRTR 2301"
     ]
   },
   "CSME 1405": {
@@ -568,6 +1031,18 @@
       "CSME 2441"
     ]
   },
+  "CSME 2310": {
+    "text": "CSME 1248, 1354, 1453, 2401. 12.0407",
+    "courses": [
+      "CSME 1248"
+    ]
+  },
+  "CSME 2337": {
+    "text": "CSME 1248, 1354, 1453, 2401. 12.0401",
+    "courses": [
+      "CSME 1248"
+    ]
+  },
   "CSME 2401": {
     "text": "CSME 1453 and CSME 2439 and CSME 2441 and CSME 1453 and CSME 2439 and CSME 2441",
     "courses": [
@@ -599,6 +1074,32 @@
       "CSME 1445"
     ]
   },
+  "CTEC 1349": {
+    "text": "SCIT 1414. Assessment Levels: R3, E3, M3. 41.0301",
+    "courses": [
+      "SCIT 1414"
+    ]
+  },
+  "CTEC 1441": {
+    "text": "SCIT 1543 or consent of instructor. Assessment Levels: R3, E2, M3. 41.0301",
+    "courses": [
+      "SCIT 1543"
+    ]
+  },
+  "CTEC 2286": {
+    "text": "CTEC 2431. Assessment Levels: R3, E3, M3. 41.0301",
+    "courses": [
+      "CTEC 2431"
+    ]
+  },
+  "CTEC 2445": {
+    "text": "PTAC 1332, PTAC 1354, and PTAC 2420. 41.0301",
+    "courses": [
+      "PTAC 1332",
+      "PTAC 1354",
+      "PTAC 2420"
+    ]
+  },
   "CTEC 2545": {
     "text": "PTAC 2438 (min C) and PTAC 2314 (min C)",
     "courses": [
@@ -612,6 +1113,18 @@
       "PTAC 2438"
     ]
   },
+  "CTEC 441": {
+    "text": "SCIT 1543 or consent of instructor. Assessment Levels: R3, E2, M3. 41.0301",
+    "courses": [
+      "SCIT 1543"
+    ]
+  },
+  "CVOP 1381": {
+    "text": "DEMR 1427. Assessment Levels: R1, E1, M0. 49.0205",
+    "courses": [
+      "DEMR 1427"
+    ]
+  },
   "DAAC 1164": {
     "text": "DAAC 1304 (min C) or DAAC 1304 (min CT) and DAAC 1311 (min C) or DAAC 1311 (min CT) and DAAC 1317 (min C) or DAAC 1317 (min CT)",
     "courses": [
@@ -620,10 +1133,42 @@
       "DAAC 1317"
     ]
   },
+  "DAAC 1166": {
+    "text": "DAAC 1311, 2354 and approval of Human Services program director for assignment to specific practicum. Assessment Levels: R1, E1, M1. 51.1501",
+    "courses": [
+      "DAAC 1311"
+    ]
+  },
+  "DAAC 2341": {
+    "text": "DAAC 1319. Assessment Levels: R1, E1, M1. 51.1501",
+    "courses": [
+      "DAAC 1319"
+    ]
+  },
+  "DAAC 2343": {
+    "text": "DAAC 1311. Assessment Levels: R1, E1, M1. 51.1501",
+    "courses": [
+      "DAAC 1311"
+    ]
+  },
+  "DAAC 2363": {
+    "text": "DAAC 2354. Assessment Levels: R1, E1, M1. 51.1501",
+    "courses": [
+      "DAAC 2354"
+    ]
+  },
   "DEMR 1280": {
     "text": "DEMR 2412 (min C)",
     "courses": [
       "DEMR 2412"
+    ]
+  },
+  "DEMR 1306": {
+    "text": "DEMR 1329 and DEMR 1316 and DEMR 1321",
+    "courses": [
+      "DEMR 1329",
+      "DEMR 1316",
+      "DEMR 1321"
     ]
   },
   "DEMR 1313": {
@@ -636,6 +1181,12 @@
       "DEMR 2332",
       "DEMR 2334",
       "DEMR 2339"
+    ]
+  },
+  "DEMR 1447": {
+    "text": "DEMR 1416. 47.0605.",
+    "courses": [
+      "DEMR 1416"
     ]
   },
   "DEMR 2332": {
@@ -672,6 +1223,18 @@
       "DEMR 1313",
       "DEMR 2332",
       "DEMR 2334"
+    ]
+  },
+  "DEMR 2435": {
+    "text": "DEMR 1416. 47.0605",
+    "courses": [
+      "DEMR 1416"
+    ]
+  },
+  "DEMR 2470": {
+    "text": "DEMR 2332. Assessment Levels: R1, E1, M0. 47.0605",
+    "courses": [
+      "DEMR 2332"
     ]
   },
   "DFTG 1345": {
@@ -731,9 +1294,10 @@
     ]
   },
   "DFTG 2332": {
-    "text": "DFTG 2319 (min C)",
+    "text": "DFTG 2319, DFTG 1305. 15.1302",
     "courses": [
-      "DFTG 2319"
+      "DFTG 2319",
+      "DFTG 1305"
     ]
   },
   "DFTG 2338": {
@@ -756,6 +1320,12 @@
       "DFTG 2323"
     ]
   },
+  "DFTG 2371": {
+    "text": "DFTG 2370. 15.1302",
+    "courses": [
+      "DFTG 2370"
+    ]
+  },
   "DFTG 2380": {
     "text": "DFTG 2323 (min C) and DFTG 2332 (min C)",
     "courses": [
@@ -763,10 +1333,32 @@
       "DFTG 2332"
     ]
   },
-  "DHYG 1207": {
-    "text": "DHYG 1227",
+  "DHYG 1162": {
+    "text": "DHYG 1235",
     "courses": [
-      "DHYG 1227"
+      "DHYG 1235"
+    ]
+  },
+  "DHYG 1201": {
+    "text": "DHYG 1304 and DHYG 1227 and DHYG 1431",
+    "courses": [
+      "DHYG 1304",
+      "DHYG 1227",
+      "DHYG 1431"
+    ]
+  },
+  "DHYG 1207": {
+    "text": "DHYG 1331",
+    "courses": [
+      "DHYG 1331"
+    ]
+  },
+  "DHYG 1211": {
+    "text": "DHYG 1227 and DHYG 2231 and DHYG 2260",
+    "courses": [
+      "DHYG 1227",
+      "DHYG 2231",
+      "DHYG 2260"
     ]
   },
   "DHYG 1215": {
@@ -778,10 +1370,18 @@
       "DHYG 1235"
     ]
   },
-  "DHYG 1227": {
-    "text": "DHYG 1301 (min C)",
+  "DHYG 1219": {
+    "text": "DHYG 1331",
     "courses": [
-      "DHYG 1301"
+      "DHYG 1331"
+    ]
+  },
+  "DHYG 1227": {
+    "text": "DHYG 1201 and DHYG 1304 and DHYG 1431",
+    "courses": [
+      "DHYG 1201",
+      "DHYG 1304",
+      "DHYG 1431"
     ]
   },
   "DHYG 1235": {
@@ -795,11 +1395,18 @@
       "DHYG 1215"
     ]
   },
-  "DHYG 1304": {
-    "text": "DHYG 1331 and DHYG 2201",
+  "DHYG 1261": {
+    "text": "DHYG 1431. Assessment Levels: R3, E2, M2. 51.0601",
     "courses": [
-      "DHYG 1331",
-      "DHYG 2201"
+      "DHYG 1431"
+    ]
+  },
+  "DHYG 1304": {
+    "text": "DHYG 1201 and DHYG 1227 and DHYG 1431",
+    "courses": [
+      "DHYG 1201",
+      "DHYG 1227",
+      "DHYG 1431"
     ]
   },
   "DHYG 1311": {
@@ -832,10 +1439,18 @@
       "DHYG 1207"
     ]
   },
-  "DHYG 1431": {
-    "text": "DHYG 1301 (min C)",
+  "DHYG 1360": {
+    "text": "DHYG 1235",
     "courses": [
-      "DHYG 1301"
+      "DHYG 1235"
+    ]
+  },
+  "DHYG 1431": {
+    "text": "DHYG 1201 and DHYG 1304 and DHYG 1227",
+    "courses": [
+      "DHYG 1201",
+      "DHYG 1304",
+      "DHYG 1227"
     ]
   },
   "DHYG 2201": {
@@ -844,6 +1459,20 @@
       "DHYG 1227",
       "DHYG 1331",
       "DHYG 1304"
+    ]
+  },
+  "DHYG 2231": {
+    "text": "DHYG 1211 and DHYG 2201",
+    "courses": [
+      "DHYG 1211",
+      "DHYG 2201"
+    ]
+  },
+  "DHYG 2260": {
+    "text": "DHYG 1211 and DHYG 1360",
+    "courses": [
+      "DHYG 1211",
+      "DHYG 1360"
     ]
   },
   "DHYG 2261": {
@@ -878,6 +1507,12 @@
       "DHYG 1239"
     ]
   },
+  "DHYG 2363": {
+    "text": "DHYG 2201, 2362. Assessment Levels: R3, E3, M2. 51.0602",
+    "courses": [
+      "DHYG 2201"
+    ]
+  },
   "DHYGL 1304": {
     "text": "DHYG 1301 and DHYG 1227",
     "courses": [
@@ -900,10 +1535,47 @@
       "DMSO 1351"
     ]
   },
+  "DMSO 1202": {
+    "text": "DMSO 1210",
+    "courses": [
+      "DMSO 1210"
+    ]
+  },
+  "DMSO 1210": {
+    "text": "DMSO 1441 and DMSO 1202 and DMSO 1260",
+    "courses": [
+      "DMSO 1441",
+      "DMSO 1202",
+      "DMSO 1260"
+    ]
+  },
+  "DMSO 1242": {
+    "text": "Acceptance to the Echocardiography OR Diagnostic Medical Sonography Program. Assessment Levels: R3, E3, M3.",
+    "courses": []
+  },
   "DMSO 1251": {
     "text": "MSOL 1251",
     "courses": [
       "MSOL 1251"
+    ]
+  },
+  "DMSO 1260": {
+    "text": "DMSO 1210",
+    "courses": [
+      "DMSO 1210"
+    ]
+  },
+  "DMSO 1266": {
+    "text": "DMSO 1360. Assessment Levels: R3, E3, M3. 51.091",
+    "courses": [
+      "DMSO 1360"
+    ]
+  },
+  "DMSO 1267": {
+    "text": "DMSO 2253 and DMSO 1266",
+    "courses": [
+      "DMSO 2253",
+      "DMSO 1266"
     ]
   },
   "DMSO 1341": {
@@ -925,10 +1597,30 @@
       "DMSO 1110"
     ]
   },
+  "DMSO 1441": {
+    "text": "DMSO 1210 and DMSO 1260",
+    "courses": [
+      "DMSO 1210",
+      "DMSO 1260"
+    ]
+  },
   "DMSO 2230": {
     "text": "DMSO 2341 (min C)",
     "courses": [
       "DMSO 2341"
+    ]
+  },
+  "DMSO 2242": {
+    "text": "DMSO 2366 and DMSO 2405",
+    "courses": [
+      "DMSO 2366",
+      "DMSO 2405"
+    ]
+  },
+  "DMSO 2253": {
+    "text": "DMSO 1267",
+    "courses": [
+      "DMSO 1267"
     ]
   },
   "DMSO 2305": {
@@ -941,6 +1633,22 @@
     "text": "DMSO 2405 (min C)",
     "courses": [
       "DMSO 2405"
+    ]
+  },
+  "DMSO 2361": {
+    "text": "DMSO 1380 and DMSO 1266. Assessment Levels: R3, E3, M3. 51.0901",
+    "courses": [
+      "DMSO 1380",
+      "DMSO 1266"
+    ]
+  },
+  "DMSO 2366": {
+    "text": "DMSO 2242 and DMSO 1260 and DMSO 1266 and DMSO 1267",
+    "courses": [
+      "DMSO 2242",
+      "DMSO 1260",
+      "DMSO 1266",
+      "DMSO 1267"
     ]
   },
   "DMSOL 1251": {
@@ -961,8 +1669,44 @@
       "DMSO 2305"
     ]
   },
+  "DNTA 1167": {
+    "text": "DNTA 1166. Assessment Levels: R1, E1, M1. 51.0601",
+    "courses": [
+      "DNTA 1166"
+    ]
+  },
+  "DNTA 1347": {
+    "text": "DNTA 1311. Assessment Levels: R1, E1, M1. 51.0601",
+    "courses": [
+      "DNTA 1311"
+    ]
+  },
+  "DNTA 2166": {
+    "text": "DNTA 1167. Assessment Levels: R1, E1, M1. 51.0601",
+    "courses": [
+      "DNTA 1167"
+    ]
+  },
+  "DNTA 2250": {
+    "text": "DNTA 1353. Assessment Levels: R1, E1, M1. 51.0601",
+    "courses": [
+      "DNTA 1353"
+    ]
+  },
+  "DNTA 2252": {
+    "text": "DNTA 1349. Assessment Levels: R1, E1, M1. 51.0601",
+    "courses": [
+      "DNTA 1349"
+    ]
+  },
   "DRAM 1121": {
     "text": "DRAM 1120",
+    "courses": [
+      "DRAM 1120"
+    ]
+  },
+  "DRAM 2121": {
+    "text": "DRAM 1120. Assessment Levels: R2, E2, M2. 50.0506",
     "courses": [
       "DRAM 1120"
     ]
@@ -997,10 +1741,26 @@
       "DSAE 1303"
     ]
   },
+  "DSVT 1200": {
+    "text": "DMSO 2242",
+    "courses": [
+      "DMSO 2242"
+    ]
+  },
   "DSVT 1260": {
     "text": "DSVT 2418",
     "courses": [
       "DSVT 2418"
+    ]
+  },
+  "DSVT 1300": {
+    "text": "Acceptance to program. Assessment Levels: R3, E3, M3. 51.091",
+    "courses": []
+  },
+  "DSVT 2200": {
+    "text": "DMSO 2305, 2353. Assessment Levels: R3, E3, M3. 51.091",
+    "courses": [
+      "DMSO 2305"
     ]
   },
   "DSVT 2330": {
@@ -1044,6 +1804,12 @@
       "CETT 1321"
     ]
   },
+  "ELMT 2339": {
+    "text": "ELMT 1301. Assessment Levels: R3, E2, M3. 15.0403",
+    "courses": [
+      "ELMT 1301"
+    ]
+  },
   "ELPT 1225": {
     "text": "ELPT 2225",
     "courses": [
@@ -1054,6 +1820,18 @@
     "text": "ELPT 1225",
     "courses": [
       "ELPT 1225"
+    ]
+  },
+  "EMSP 1147": {
+    "text": "EMSP 2330, 2434. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 2330"
+    ]
+  },
+  "EMSP 1149": {
+    "text": "EMSP 1355. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 1355"
     ]
   },
   "EMSP 1160": {
@@ -1081,11 +1859,48 @@
       "EMSP 1161"
     ]
   },
+  "EMSP 1356": {
+    "text": "EMSP 1501. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 1501"
+    ]
+  },
   "EMSP 1501": {
     "text": "EMSP 1160 and MSPL 1501",
     "courses": [
       "EMSP 1160",
       "MSPL 1501"
+    ]
+  },
+  "EMSP 2137": {
+    "text": "EMSP 2330 and 2434. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 2330"
+    ]
+  },
+  "EMSP 2143": {
+    "text": "Student must have completed semesters I, II and III.Corequisite:EMSP 2252/ EMSP 2263. Assessment Levels: R3, E3, M2. 51.0904",
+    "courses": [
+      "EMSP 2252",
+      "EMSP 2263"
+    ]
+  },
+  "EMSP 2165": {
+    "text": "EMSP 1338 and 1356. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 1338"
+    ]
+  },
+  "EMSP 2166": {
+    "text": "EMSP 1356, 2165 and 2206. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 1356"
+    ]
+  },
+  "EMSP 2167": {
+    "text": "EMSP 2166, 2330 and 2434. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 2166"
     ]
   },
   "EMSP 2205": {
@@ -1096,6 +1911,43 @@
       "EMSP 2444",
       "EMSP 2434",
       "EMSP 1162"
+    ]
+  },
+  "EMSP 2206": {
+    "text": "EMSP 1338, 1355 and 1356. Corequisite: EMSP 2205/ EMSP 2261. Assessment Levels: R2, E2, M2. Lecture/Lab/Credit Hrs: 1-4-2",
+    "courses": [
+      "EMSP 1338",
+      "EMSP 2205",
+      "EMSP 2261"
+    ]
+  },
+  "EMSP 2243": {
+    "text": "Student must have completed semesters I, II and III.Corequisite:EMSP 2252/ EMSP 2263. Assessment Levels: R2, E2, M2. 51.0904",
+    "courses": [
+      "EMSP 2252",
+      "EMSP 2263"
+    ]
+  },
+  "EMSP 2252": {
+    "text": "Student must have completed first, second, and third semesters of the Paramedic program.Corequisite: EMSP 2252/EMSP 2263. Assessment Levels: R3, E3, M2. 51.0904",
+    "courses": [
+      "EMSP 2252",
+      "EMSP 2263"
+    ]
+  },
+  "EMSP 2262": {
+    "text": "Student must have completed first and second semesters of the Paramedic program.Corequisite: EMSP 2444/EMSP 2434/EMSP 2330. Assessment Levels: R3, E3, M2. 51.0904",
+    "courses": [
+      "EMSP 2444",
+      "EMSP 2434",
+      "EMSP 2330"
+    ]
+  },
+  "EMSP 2263": {
+    "text": "Student must have completed first, second, and third semesters of the Paramedic program. Corequisite: EMSP 2252/EMSP 2243. Assessment Levels: R3, E3, M2. 51.0904",
+    "courses": [
+      "EMSP 2252",
+      "EMSP 2243"
     ]
   },
   "EMSP 2306": {
@@ -1126,6 +1978,24 @@
       "EMSP 2348",
       "EMSP 2444",
       "EMSP 1161"
+    ]
+  },
+  "EMSP 2444": {
+    "text": "Student must have completed their first and second semester. Corequisite: EMSP 2330/EMSP 2262, EMSP 1338 and 1356. Assessment Levels: R3, E3, M2. 51.0904",
+    "courses": [
+      "EMSP 2330",
+      "EMSP 2262",
+      "EMSP 1338"
+    ]
+  },
+  "EMSP 2461": {
+    "text": "See Advisor) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills, and concepts. Direct supervision is provided by the clinical professional. Lab fee.",
+    "courses": []
+  },
+  "EMSP 2462": {
+    "text": "EMSP 2444, 1355, and 2461) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills, and concepts. Direct supervision is provided by the clinical professional.",
+    "courses": [
+      "EMSP 2444"
     ]
   },
   "EMSPL 1338": {
@@ -1175,6 +2045,14 @@
     "text": "EMSP 2330",
     "courses": [
       "EMSP 2330"
+    ]
+  },
+  "ENER 1330": {
+    "text": "IEIR 1302 and INMT 1305 and IEIR 1304",
+    "courses": [
+      "IEIR 1302",
+      "INMT 1305",
+      "IEIR 1304"
     ]
   },
   "ENGL 1301": {
@@ -1312,6 +2190,13 @@
       "MATH 2415"
     ]
   },
+  "ENGR 2304": {
+    "text": "MATH 1314 with a minimum grade of \"B\" and MATH 1316 with a minimum grade of \"B\". Assessment Levels: R3, E3, M3. 11.0201",
+    "courses": [
+      "MATH 1314",
+      "MATH 1316"
+    ]
+  },
   "ENGR 2308": {
     "text": "MATH 2413 (min D)",
     "courses": [
@@ -1325,9 +2210,11 @@
     ]
   },
   "ENGR 2406": {
-    "text": "MATH 1314",
+    "text": "MATH 1314 and COSC 1436 or ENGR 2304. Assessment Levels: R3, E2, M3. 14.1001",
     "courses": [
-      "MATH 1314"
+      "MATH 1314",
+      "COSC 1436",
+      "ENGR 2304"
     ]
   },
   "EPCT 2335": {
@@ -1337,6 +2224,77 @@
       "MATH 1314",
       "(SCIT) Related Sciences 1494",
       "(SCIT) Related Sciences 1418"
+    ]
+  },
+  "ESOL 0305": {
+    "text": "CELT scores of 70. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0306": {
+    "text": "CELT scores of 70. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0311": {
+    "text": "CELT score of 0-12. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0313": {
+    "text": "CELT scores of 0-12. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0314": {
+    "text": "CELT scores of 0-12. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0314N": {
+    "text": "CELT scores of 37-69.",
+    "courses": []
+  },
+  "ESOL 0321N": {
+    "text": "CELT scores of 37-69.",
+    "courses": []
+  },
+  "ESOL 0322": {
+    "text": "ESOL 0312 or CELT scores of 13-25. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": [
+      "ESOL 0312"
+    ]
+  },
+  "ESOL 0324": {
+    "text": "ESOL 0314 or CELT scores of 13-25. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": [
+      "ESOL 0314"
+    ]
+  },
+  "ESOL 0341N": {
+    "text": "CELT scores of 37-69.",
+    "courses": []
+  },
+  "ESOL 0343": {
+    "text": "CELT scores of 37-69. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0344": {
+    "text": "CELT scores of 37-69. Assessment Levels: R1, E1, M0. 32.0108",
+    "courses": []
+  },
+  "ESOL 0408": {
+    "text": "READ 0305 and ENGL 0305/0306 or ESOL 0305/0306 or REM levels of R2 and E2. Assessment Levels: R2, E2, M0. 32.0108",
+    "courses": [
+      "READ 0305",
+      "ENGL 0305",
+      "ESOL 0305"
+    ]
+  },
+  "FIRS 1203": {
+    "text": "FIRS 1301 and FIRS 1407 and FIRS 1313 and FIRS 1319 and FIRS 1323 and FIRS 1329",
+    "courses": [
+      "FIRS 1301",
+      "FIRS 1407",
+      "FIRS 1313",
+      "FIRS 1319",
+      "FIRS 1323",
+      "FIRS 1329"
     ]
   },
   "FIRS 1301": {
@@ -1363,12 +2321,30 @@
       "FIRS 1407"
     ]
   },
+  "FIRS 1323": {
+    "text": "FIRS 1203",
+    "courses": [
+      "FIRS 1203"
+    ]
+  },
+  "FIRS 1329": {
+    "text": "FIRS 1203",
+    "courses": [
+      "FIRS 1203"
+    ]
+  },
   "FIRS 1407": {
     "text": "FIRS 1301 and FIRS 1313 and FIRS 1319 and FIRS 1301 and FIRS 1313 and FIRS 1319",
     "courses": [
       "FIRS 1301",
       "FIRS 1313",
       "FIRS 1319"
+    ]
+  },
+  "FIRT 2331": {
+    "text": "FIRT 2309) Students will earn an A, B, C, D, F, or W. Emphasis on the use of incident management in large scale command problems and other specialized fire problems.",
+    "courses": [
+      "FIRT 2309"
     ]
   },
   "FLMC 1304": {
@@ -1383,6 +2359,98 @@
       "MUSC 2427"
     ]
   },
+  "FREN 1012N": {
+    "text": "FREN 1411. Assessment Levels: R3, E3, M1.",
+    "courses": [
+      "FREN 1411"
+    ]
+  },
+  "FREN 1412": {
+    "text": "FREN 1411. Assessment Levels: R3, E3, M1. 16.0901",
+    "courses": [
+      "FREN 1411"
+    ]
+  },
+  "GAME 2319": {
+    "text": "GAME 1306",
+    "courses": [
+      "GAME 1306"
+    ]
+  },
+  "GEOL 1404": {
+    "text": "GEOL 1303 or permission of instructor. Assessment Levels: R3, E3, M2. 40.0601",
+    "courses": [
+      "GEOL 1303"
+    ]
+  },
+  "GERM 1412": {
+    "text": "GERM 1411. Assessment Levels: R3, E3, M1. 16.0501",
+    "courses": [
+      "GERM 1411"
+    ]
+  },
+  "GERM 2312": {
+    "text": "GERM 2311, satisfactory score on placement test or permission of instructor. Assessment Levels: R3, E3, M1. 16.0501",
+    "courses": [
+      "GERM 2311"
+    ]
+  },
+  "GISC 1191": {
+    "text": "GISC 2420, ENGR 1304 or DFTG 1309 and SRVY 2340. Assessment Levels: R1, E1, M1. 45.0702",
+    "courses": [
+      "GISC 2420",
+      "ENGR 1304",
+      "DFTG 1309",
+      "SRVY 2340"
+    ]
+  },
+  "GISC 1421": {
+    "text": "ITSC 1405. Prerequisites: GISC 1302 or 1311. 45.0702",
+    "courses": [
+      "ITSC 1405",
+      "GISC 1302"
+    ]
+  },
+  "GISC 1491": {
+    "text": "GISC 1302 or 1311 and 1421 or 2420; or permission of GIS advisor. 45.0702",
+    "courses": [
+      "GISC 1302"
+    ]
+  },
+  "GISC 2131": {
+    "text": "GISC 1311 or GISC 1302, 1421, 1491, 2301 and 2420 or permission of GIS advisor. 45.0702",
+    "courses": [
+      "GISC 1311",
+      "GISC 1302"
+    ]
+  },
+  "GISC 2301": {
+    "text": "GISC 1311, 1421, 2420 and one of the following GISC 1491 or 2435. 45.0702",
+    "courses": [
+      "GISC 1311",
+      "GISC 1491"
+    ]
+  },
+  "GISC 2335": {
+    "text": "ITSE 1402 or COSC 1436 or ITSE 1329 and/or permission of advisor. 45.0702",
+    "courses": [
+      "ITSE 1402",
+      "COSC 1436",
+      "ITSE 1329"
+    ]
+  },
+  "GISC 2420": {
+    "text": "GISC 1302 or 1311. 45.0702",
+    "courses": [
+      "GISC 1302"
+    ]
+  },
+  "GISC 2435": {
+    "text": "ITSE 1402 and/or permission of GIS advisor. Assessment Levels: R1, E1, M1. 45.0702",
+    "courses": [
+      "ITSE 1402"
+    ]
+  },
   "GOVT 2305": {
     "text": "READ 1072",
     "courses": [
@@ -1393,6 +2461,44 @@
     "text": "READ 1072",
     "courses": [
       "READ 1072"
+    ]
+  },
+  "HAMG 1340": {
+    "text": "HAMG 1321. Assessment Levels: R1, E1, M1. 52.0901",
+    "courses": [
+      "HAMG 1321"
+    ]
+  },
+  "HAMG 2281": {
+    "text": "HAMG 1313 and 1342. Assessment Levels: R2, E2, M2",
+    "courses": [
+      "HAMG 1313"
+    ]
+  },
+  "HART 1391": {
+    "text": "HART 2336 Assessment Levels: R1, E1, M0. 15.0501",
+    "courses": [
+      "HART 2336"
+    ]
+  },
+  "HART 1403": {
+    "text": "HART 1407. 15.0501",
+    "courses": [
+      "HART 1407"
+    ]
+  },
+  "HART 1441": {
+    "text": "HART 1403, MAIR 1449. 15.0501",
+    "courses": [
+      "HART 1403",
+      "MAIR 1449"
+    ]
+  },
+  "HART 1445": {
+    "text": "HART 1403, MAIR 1449. 15.0501",
+    "courses": [
+      "HART 1403",
+      "MAIR 1449"
     ]
   },
   "HART 2301": {
@@ -1422,6 +2528,19 @@
     "courses": [
       "HART 1341",
       "HART 1345"
+    ]
+  },
+  "HART 2434": {
+    "text": "HART 2431. R1, E1, M0 15.0501",
+    "courses": [
+      "HART 2431"
+    ]
+  },
+  "HART 2442": {
+    "text": "HART 1401 and HART 1407. Assessment Levels: R1, E1, M0. 15.0501",
+    "courses": [
+      "HART 1401",
+      "HART 1407"
     ]
   },
   "HART 2445": {
@@ -1466,6 +2585,22 @@
       "ENGL 0302"
     ]
   },
+  "HITT 1261": {
+    "text": "HPRS 2201, HITT 1205, HITT 1301, HITT 1349, HITT 1341, HITT 1353, HITT 1345, HITT 1191, HITT 1342, HITT 2335, ITSW 1307. Assessment Levels: R3, E3, M2. 51.0707",
+    "courses": [
+      "HPRS 2201",
+      "HITT 1205",
+      "HITT 1301",
+      "HITT 1349",
+      "HITT 1341",
+      "HITT 1353",
+      "HITT 1345",
+      "HITT 1191",
+      "HITT 1342",
+      "HITT 2335",
+      "ITSW 1307"
+    ]
+  },
   "HITT 1303": {
     "text": "HITT 1305 (min C) or HITT 1305 (min CT)",
     "courses": [
@@ -1479,6 +2614,33 @@
       "HITT 1301"
     ]
   },
+  "HITT 1341": {
+    "text": "HITT 1301, HITT 1305, HITT 1349, and BIOL 2404. Assessment Levels: R3, E3, M2. 51.0713",
+    "courses": [
+      "HITT 1301",
+      "HITT 1305",
+      "HITT 1349",
+      "BIOL 2404"
+    ]
+  },
+  "HITT 1345": {
+    "text": "HITT 1301. Assessment Levels: R3, E3, M2. 51.0707",
+    "courses": [
+      "HITT 1301"
+    ]
+  },
+  "HITT 1353": {
+    "text": "HITT 1301. Assessment Levels: R3, E3, M2. 51.0707",
+    "courses": [
+      "HITT 1301"
+    ]
+  },
+  "HITT 1355": {
+    "text": "HITT 1191, 1301, 1345, and 1353. Assessment Levels: R3, E3, M2. 51.0707",
+    "courses": [
+      "HITT 1191"
+    ]
+  },
   "HITT 2167": {
     "text": "HITT 2335 (min C) and HITT 1341 (min C)",
     "courses": [
@@ -1486,11 +2648,23 @@
       "HITT 1341"
     ]
   },
+  "HITT 2239": {
+    "text": "HITT 1191, 1301, 1341, 1342, 1345, 1353, and 2335. Assessment Levels: R3, E3, M2. 51.0707",
+    "courses": [
+      "HITT 1191"
+    ]
+  },
   "HITT 2246": {
     "text": "HITT 2335 (min C) and HITT 1341 (min C)",
     "courses": [
       "HITT 2335",
       "HITT 1341"
+    ]
+  },
+  "HITT 2260": {
+    "text": "HITT 1261. Assessment Levels: R3, E3, M2. 51.0707",
+    "courses": [
+      "HITT 1261"
     ]
   },
   "HITT 2330": {
@@ -1529,10 +2703,50 @@
       "HPRS 1470"
     ]
   },
+  "HPRS 2301": {
+    "text": "HITT 1301, 1305, and 1349. Must be taken concurrently with: HITT 1341, 1345, 1353 and POFI 1341. 51.000",
+    "courses": [
+      "HITT 1301",
+      "HITT 1341",
+      "POFI 1341"
+    ]
+  },
+  "IFWA 1318": {
+    "text": "CHEF 1301. 12.0508",
+    "courses": [
+      "CHEF 1301"
+    ]
+  },
+  "IMED 1191": {
+    "text": "ITSC 1405. 13.0501",
+    "courses": [
+      "ITSC 1405"
+    ]
+  },
+  "IMED 1341": {
+    "text": "IMED 1301 11.0801",
+    "courses": [
+      "IMED 1301"
+    ]
+  },
+  "IMED 2311": {
+    "text": "IMED 2305. Assessment Levels: R1, E1, M1. 11.0801",
+    "courses": [
+      "IMED 2305"
+    ]
+  },
   "IMED 2315": {
     "text": "IMED 1316",
     "courses": [
       "IMED 1316"
+    ]
+  },
+  "IMED 2415": {
+    "text": "IMED 1301 and 1316. Suggested prerequisites: ITSE 1402 and ITSC 1405. Assessment Levels: R1, E1, M1. 11.0801",
+    "courses": [
+      "IMED 1301",
+      "ITSE 1402",
+      "ITSC 1405"
     ]
   },
   "INCR 1442": {
@@ -1543,9 +2757,10 @@
     ]
   },
   "INEW 2334": {
-    "text": "ITSE 2313",
+    "text": "ITSE 1311 and ITSE 1302",
     "courses": [
-      "ITSE 2313"
+      "ITSE 1311",
+      "ITSE 1302"
     ]
   },
   "INMT 1343": {
@@ -1558,6 +2773,12 @@
     "text": "INMT 1343",
     "courses": [
       "INMT 1343"
+    ]
+  },
+  "INMT 1417": {
+    "text": "RBTC 1401. Assessment Levels: R3, E2, M3. 15.0613",
+    "courses": [
+      "RBTC 1401"
     ]
   },
   "INMT 2301": {
@@ -1584,9 +2805,23 @@
       "ENGL 1301"
     ]
   },
+  "INRW 0303": {
+    "text": "ENGL 1301",
+    "courses": [
+      "ENGL 1301"
+    ]
+  },
   "INRW 0399": {
     "text": "ENGL 1301",
     "courses": [
+      "ENGL 1301"
+    ]
+  },
+  "INRW 0408": {
+    "text": "READ0305 and ENGL0305/0306 or Rem levels of R2 and E2. Concurrent enrollment in ENGL 1301 required. Assessment Levels: R2, E2, M0. 32.0108",
+    "courses": [
+      "READ 0305",
+      "ENGL 0305",
       "ENGL 1301"
     ]
   },
@@ -1610,6 +2845,13 @@
       "CETT 1405"
     ]
   },
+  "INTC 2230": {
+    "text": "INTC 1307 and INTC 1341. Assessment Levels: R1, E1, M1.",
+    "courses": [
+      "INTC 1307",
+      "INTC 1341"
+    ]
+  },
   "INTC 2336": {
     "text": "CETT 1303 (min C) and CETT 1325 (min C)",
     "courses": [
@@ -1624,16 +2866,40 @@
       "CETT 1405"
     ]
   },
+  "IRW 0320": {
+    "text": "ENGL 1301",
+    "courses": [
+      "ENGL 1301"
+    ]
+  },
+  "ITCC 1340": {
+    "text": "ITCC 1414. 11.1002.",
+    "courses": [
+      "ITCC 1414"
+    ]
+  },
   "ITCC 1344": {
-    "text": "ITCC 1314 (min C)",
+    "text": "ITCC 1314",
     "courses": [
       "ITCC 1314"
+    ]
+  },
+  "ITCC 2312": {
+    "text": "ITCC 1340. 11.1002.",
+    "courses": [
+      "ITCC 1340"
     ]
   },
   "ITCC 2320": {
     "text": "ITCC 1344 (min C)",
     "courses": [
       "ITCC 1344"
+    ]
+  },
+  "ITMT 2305": {
+    "text": "CPMT 1351",
+    "courses": [
+      "CPMT 1351"
     ]
   },
   "ITNW 1309": {
@@ -1649,6 +2915,12 @@
       "ITCC 1314"
     ]
   },
+  "ITNW 1351": {
+    "text": "CPMT 1349. Assessment Levels: R1,E1, M1. 11.1002",
+    "courses": [
+      "CPMT 1349"
+    ]
+  },
   "ITNW 1354": {
     "text": "ITSC 1325 and ITCC 1314",
     "courses": [
@@ -1656,8 +2928,28 @@
       "ITCC 1314"
     ]
   },
+  "ITNW 2332": {
+    "text": "ITSC 1358. Assessment Levels: R1, E1, M1. 11.0901",
+    "courses": [
+      "ITSC 1358"
+    ]
+  },
+  "ITNW 2435": {
+    "text": "ITNW 1354, 1425, ITSC 1358 ITCC 1401. Assessment Levels: R1, E1, M1. 11.0901",
+    "courses": [
+      "ITNW 1354",
+      "ITSC 1358",
+      "ITCC 1401"
+    ]
+  },
   "ITSC 1305": {
     "text": "ITSC 1301",
+    "courses": [
+      "ITSC 1301"
+    ]
+  },
+  "ITSC 1325": {
+    "text": "ITSC 1301. 47.0104",
     "courses": [
       "ITSC 1301"
     ]
@@ -1669,10 +2961,76 @@
       "ITNW 1308"
     ]
   },
+  "ITSE 1302": {
+    "text": "ITSE 1329",
+    "courses": [
+      "ITSE 1329"
+    ]
+  },
+  "ITSE 2302": {
+    "text": "COSC 1436, IMED 1316, or permission of department chair. 11.0801",
+    "courses": [
+      "COSC 1436",
+      "IMED 1316"
+    ]
+  },
+  "ITSE 2313": {
+    "text": "IMED 1301. 11.0801",
+    "courses": [
+      "IMED 1301"
+    ]
+  },
+  "ITSE 2317": {
+    "text": "COSC 1436 or ITSE 1359. R1, E1, M1. 11.0201",
+    "courses": [
+      "COSC 1436",
+      "ITSE 1359"
+    ]
+  },
+  "ITSE 2321": {
+    "text": "ITSE 1302",
+    "courses": [
+      "ITSE 1302"
+    ]
+  },
   "ITSE 2357": {
     "text": "ITSE 2321 (min C)",
     "courses": [
       "ITSE 2321"
+    ]
+  },
+  "ITSE 2402": {
+    "text": "IMED 1316. Assessment Levels: R1, E1, M1.",
+    "courses": [
+      "IMED 1316"
+    ]
+  },
+  "ITSE 2409": {
+    "text": "ITSE 1402 and ITSW 1407. Assessment Levels: R1, E1, M1.",
+    "courses": [
+      "ITSE 1402",
+      "ITSW 1407"
+    ]
+  },
+  "ITSE 2437": {
+    "text": "ITSE 1402 or COSC 1436 and ITSE 2431, or COSC 1437 or permission of the instructor. Assessment Levels: R1, E1, M1. 11.0201",
+    "courses": [
+      "ITSE 1402",
+      "COSC 1436",
+      "ITSE 2431",
+      "COSC 1437"
+    ]
+  },
+  "ITSW 2334": {
+    "text": "POFI 1349",
+    "courses": [
+      "POFI 1349"
+    ]
+  },
+  "ITSW 2337": {
+    "text": "ITSW 1307",
+    "courses": [
+      "ITSW 1307"
     ]
   },
   "ITSY 1342": {
@@ -1688,6 +3046,12 @@
       "ITSY 1342"
     ]
   },
+  "ITSY 2330": {
+    "text": "ITSY 2301. Assessment Levels: R1, E1, M1. 11.1003",
+    "courses": [
+      "ITSY 2301"
+    ]
+  },
   "ITSY 2341": {
     "text": "ITSY 2301",
     "courses": [
@@ -1698,6 +3062,24 @@
     "text": "ITSY 2301",
     "courses": [
       "ITSY 2301"
+    ]
+  },
+  "ITSY 2417": {
+    "text": "ITSY 2400. Assessment Levels: R1, E1, M1. 11.1003",
+    "courses": [
+      "ITSY 2400"
+    ]
+  },
+  "JAPN 2311": {
+    "text": "JAPN 1411 and 1412, satisfactory score on placement test, or approval of instructor. Assessment Levels: R3, E3, M1. 16.0302",
+    "courses": [
+      "JAPN 1411"
+    ]
+  },
+  "JAPN 2312": {
+    "text": "JAPN 2311, satisfactory score on placement test, or permission of instructor. Assessment Levels: R3, E3, M1. 16.0302",
+    "courses": [
+      "JAPN 2311"
     ]
   },
   "KINE 1115": {
@@ -1719,6 +3101,13 @@
       "LGLA 1342"
     ]
   },
+  "LGLA 1345": {
+    "text": "LGLA 1307 and LGLA 1401. Assessment Levels: R3, E3, M2. 22.0302",
+    "courses": [
+      "LGLA 1307",
+      "LGLA 1401"
+    ]
+  },
   "LGLA 1349": {
     "text": "LGLA 1303 and LGLA 1344",
     "courses": [
@@ -1733,10 +3122,29 @@
       "LGLA 1344"
     ]
   },
+  "LGLA 1401": {
+    "text": "LGLA 1307. Assessment Levels: R3, E3, M22. 22.0302",
+    "courses": [
+      "LGLA 1307"
+    ]
+  },
   "LGLA 2303": {
     "text": "LGLA 1307 (min C) or LGLA 1307 (min CT)",
     "courses": [
       "LGLA 1307"
+    ]
+  },
+  "LGLA 2305": {
+    "text": "LGLA 1307. Assessment Levels: R3, E3, M2. 22.0302",
+    "courses": [
+      "LGLA 1307"
+    ]
+  },
+  "LGLA 2307": {
+    "text": "LGLA 1304 and LGLA 1401 R3, E3, M2. 22.0302",
+    "courses": [
+      "LGLA 1304",
+      "LGLA 1401"
     ]
   },
   "LGLA 2309": {
@@ -1762,6 +3170,13 @@
       "LGLA 1344"
     ]
   },
+  "LGLA 2333": {
+    "text": "LGLA 1307 AND LGLA 1401. Assessment Levels: R3, E3, M2. 22.0302",
+    "courses": [
+      "LGLA 1307",
+      "LGLA 1401"
+    ]
+  },
   "LGLA 2388": {
     "text": "LGLA 1351 (min C) and LGLA 1401 (min C) and LGLA 2303 (min C) and LGLA 2313 (min C)",
     "courses": [
@@ -1776,6 +3191,14 @@
     "courses": [
       "LMGT 1319"
     ]
+  },
+  "LTCA 2310": {
+    "text": "Baccalaureate degree required to take the certificate courses. Assessment Levels: R3, E3, M3. 51.0702",
+    "courses": []
+  },
+  "LTCA 2488": {
+    "text": "Baccalaureate degree required to take the certificate courses. Assessment Levels: R3, E3, M3. 51.0702",
+    "courses": []
   },
   "MATH 0132": {
     "text": "MATH 1332",
@@ -1809,12 +3232,24 @@
       "MATH 1442"
     ]
   },
+  "MATH 0306": {
+    "text": "MATH 1332",
+    "courses": [
+      "MATH 1332"
+    ]
+  },
   "MATH 0314": {
     "text": "MATH 0435 and MATH 1314 and STSK 0305",
     "courses": [
       "MATH 0435",
       "MATH 1314",
       "STSK 0305"
+    ]
+  },
+  "MATH 0315": {
+    "text": "MATH 1314",
+    "courses": [
+      "MATH 1314"
     ]
   },
   "MATH 0324": {
@@ -1836,6 +3271,10 @@
       "MATH 1342"
     ]
   },
+  "MATH 0371": {
+    "text": "TSIA2 Math score of 936 - 945 32.0104",
+    "courses": []
+  },
   "MATH 0421": {
     "text": "NCBM 0110",
     "courses": [
@@ -1843,9 +3282,9 @@
     ]
   },
   "MATH 1314": {
-    "text": "NCBM 0124",
+    "text": "MATH 0314",
     "courses": [
-      "NCBM 0124"
+      "MATH 0314"
     ]
   },
   "MATH 1316": {
@@ -1857,9 +3296,9 @@
     ]
   },
   "MATH 1324": {
-    "text": "MATH 0332 (min C)",
+    "text": "MATH 0324",
     "courses": [
-      "MATH 0332"
+      "MATH 0324"
     ]
   },
   "MATH 1325": {
@@ -1872,9 +3311,9 @@
     ]
   },
   "MATH 1332": {
-    "text": "NCBM 0132",
+    "text": "MATH 0332",
     "courses": [
-      "NCBM 0132"
+      "MATH 0332"
     ]
   },
   "MATH 1342": {
@@ -1903,10 +3342,27 @@
       "MATH 1350"
     ]
   },
+  "MATH 2305": {
+    "text": "MATH 2413 - Calculus I. Assessment Levels: R3, E3, M3. 27.0101.5819.",
+    "courses": [
+      "MATH 2413"
+    ]
+  },
+  "MATH 2312": {
+    "text": "Two years of high school algebra and one-half year trigonometry or the equivalent. Assessment Levels: R3, E1, M3. 27.0101",
+    "courses": []
+  },
   "MATH 2318": {
     "text": "MATH 2414",
     "courses": [
       "MATH 2414"
+    ]
+  },
+  "MATH 2320": {
+    "text": "MATH 2414, MATH 2415 (recommended) with a grade of \"C\" or above in both courses. Assessment Levels: R3, E1, M3. 27.0101",
+    "courses": [
+      "MATH 2414",
+      "MATH 2415"
     ]
   },
   "MATH 2412": {
@@ -1941,6 +3397,47 @@
       "MCHN 1338"
     ]
   },
+  "MCHN 2341": {
+    "text": "MCHN 2345 and MCHN 1372 and MCHN 2372",
+    "courses": [
+      "MCHN 2345",
+      "MCHN 1372",
+      "MCHN 2372"
+    ]
+  },
+  "MDCA 1254": {
+    "text": "MDCA 1417) Students will earn an A, B, C, D, F, or W. A preparation for one of the National Commission for Certifying Agencies NCCA recognized credentialing exams. Lab fee.",
+    "courses": [
+      "MDCA 1417"
+    ]
+  },
+  "MLAB 1127": {
+    "text": "MLAB 1201 and MLAB 1415",
+    "courses": [
+      "MLAB 1201",
+      "MLAB 1415"
+    ]
+  },
+  "MLAB 1231": {
+    "text": "MLAB 2434 and MLAB 2266 and MLAB 2401",
+    "courses": [
+      "MLAB 2434",
+      "MLAB 2266",
+      "MLAB 2401"
+    ]
+  },
+  "MLAB 2338": {
+    "text": "MLAB 2232",
+    "courses": [
+      "MLAB 2232"
+    ]
+  },
+  "MLAB 2434": {
+    "text": "MLAB 1211",
+    "courses": [
+      "MLAB 1211"
+    ]
+  },
   "MRKG 2470": {
     "text": "MRKG 1372 (min C)",
     "courses": [
@@ -1957,6 +3454,48 @@
     "text": "MRKG 1472 (min C)",
     "courses": [
       "MRKG 1472"
+    ]
+  },
+  "MSCI 2371": {
+    "text": "MSCI 1171 and 1172 or with permission of ROTC department. Assessment Levels: R3, E2, M1.\"",
+    "courses": [
+      "MSCI 1171"
+    ]
+  },
+  "MSCI 2372": {
+    "text": "MSCI 1171, 1172 and 2371 or with permission of ROTC department. Assessment Levels: R3, E2, M1.\"",
+    "courses": [
+      "MSCI 1171"
+    ]
+  },
+  "MUEN 1152": {
+    "text": "Instructor's approval. Assessment Levels: R1, E1, M1. 50.0908",
+    "courses": []
+  },
+  "MUEN 1153": {
+    "text": "By audition) Students will earn an A, B, C, D, F, or W. A select choral ensemble specializing in the performance of jazz and popular literature. Public appearances are scheduled throughout the academic year. Lab fee.",
+    "courses": []
+  },
+  "MUEN 1154": {
+    "text": "By audition) Students will earn an A, B, C, D, F, or W. A select choral ensemble specializing in the performance of jazz and popular literature. Public appearances are scheduled throughout the academic year. Lab fee.",
+    "courses": []
+  },
+  "MUEN 2151": {
+    "text": "By audition) Students will earn an A, B, C, D, F, or W. A selective choral group specializing in the performance of major works from all periods. Public appearances scheduled throughout the academic year. Lab fee.",
+    "courses": []
+  },
+  "MUEN 2152": {
+    "text": "By audition) Students will earn an A, B, C, D, F, or W. A selective choral group specializing in the performance of major works from all periods. Public appearances scheduled throughout the academic year. Lab fee.",
+    "courses": []
+  },
+  "MUEN 2154": {
+    "text": "By audition) Students will earn an A, B, C, D, F, or W. A select choral ensemble specializing in the performance of jazz and popular literature. Public appearances are scheduled throughout the academic year. Lab fee.",
+    "courses": []
+  },
+  "MUSC 1213": {
+    "text": "MUSI 1301 or instructor approval. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 1301"
     ]
   },
   "MUSC 1321": {
@@ -2003,6 +3542,13 @@
     "text": "MUSC 1313",
     "courses": [
       "MUSC 1313"
+    ]
+  },
+  "MUSC 2327": {
+    "text": "MUSC 1327 (MUSC 1331 recommended). Assessment Levels: R2, E2, M2. 10.0203",
+    "courses": [
+      "MUSC 1327",
+      "MUSC 1331"
     ]
   },
   "MUSC 2347": {
@@ -2084,6 +3630,13 @@
       "MUSI 1303"
     ]
   },
+  "MUSI 1116": {
+    "text": "MUSI 1303 and MUSI 1183 with grade \"C\" or above. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 1303",
+      "MUSI 1183"
+    ]
+  },
   "MUSI 1117": {
     "text": "MUSI 1312",
     "courses": [
@@ -2094,6 +3647,31 @@
     "text": "MUSI 1303",
     "courses": [
       "MUSI 1303"
+    ]
+  },
+  "MUSI 1182": {
+    "text": "MUSI 1181 with a grade of at least \"C\" or consent of instructor. Assessment Levels: R1, E1, M1. 50.0907",
+    "courses": [
+      "MUSI 1181"
+    ]
+  },
+  "MUSI 1211": {
+    "text": "Placement exam or MUSI 1301. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 1301"
+    ]
+  },
+  "MUSI 1212": {
+    "text": "completion of MUSI 1211 with a grade of \"C\" or above. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 1211"
+    ]
+  },
+  "MUSI 1217": {
+    "text": "Completion of MUSI 1211 and 1216 with a grade of \"C\" or above and enrollment in or successful completion of MUSI 1212. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 1211",
+      "MUSI 1212"
     ]
   },
   "MUSI 1311": {
@@ -2110,9 +3688,16 @@
     ]
   },
   "MUSI 2116": {
-    "text": "MUSI 1117",
+    "text": "Completion of MUSI 1312 and MUSI 1117 with a grade of \"C\" or above. Assessment Levels: R1, E1, M1. 50.0904",
     "courses": [
+      "MUSI 1312",
       "MUSI 1117"
+    ]
+  },
+  "MUSI 2117": {
+    "text": "Completion of MUSI 2311 and 2116 with a grade of \"C\" or above. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 2311"
     ]
   },
   "MUSI 2181": {
@@ -2121,11 +3706,43 @@
       "MUSI 1182"
     ]
   },
+  "MUSI 2212": {
+    "text": "Completion of MUSI 2211 with a grade of \"C\" or above. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 2211"
+    ]
+  },
+  "MUSI 2216": {
+    "text": "Completion of MUSI 1212 and MUSI 1217 with a grade of \"C\" or above and enrollment in or successful completion of MUSI 2211. Assessment Levels: R1, E1, M1. 50.0904",
+    "courses": [
+      "MUSI 1212",
+      "MUSI 1217",
+      "MUSI 2211"
+    ]
+  },
   "MUSI 2311": {
     "text": "MUSI 1312 and MUSI 1071",
     "courses": [
       "MUSI 1312",
       "MUSI 1071"
+    ]
+  },
+  "MUSI 2312": {
+    "text": "MUSI 2311 and 2116 with grades of C or higher) Students will earn an A, B, C, D, F, or W. Continuation of advanced chromaticism and survey of analytical and compositional procedures in post-tonal music. Optional correlated study at the keyboard.",
+    "courses": [
+      "MUSI 2311"
+    ]
+  },
+  "MUSP 1101": {
+    "text": "MUSI 1212. Assessment Levels: R1, El, MI. 50.0903",
+    "courses": [
+      "MUSI 1212"
+    ]
+  },
+  "MUSP 2159": {
+    "text": "MUSI 1212. Assessment Levels: R1, E1, Ml. 50.0903",
+    "courses": [
+      "MUSI 1212"
     ]
   },
   "NCBM 0110": {
@@ -2164,6 +3781,206 @@
       "ENGL 1301"
     ]
   },
+  "NDTE 2474": {
+    "text": "NDTE 2473. Assessment Levels: R1, E1, M0. 48.0508",
+    "courses": [
+      "NDTE 2473"
+    ]
+  },
+  "NMTT 1167": {
+    "text": "NMTT 1166 and approval of the NMT program director for assignment of specific clinical location. Assessment Levels: R3, E3, M3. 51.0905",
+    "courses": [
+      "NMTT 1166"
+    ]
+  },
+  "NMTT 1201": {
+    "text": "Admission to the NMT program. Assessment Levels: R3, E3, M3. 51.0905",
+    "courses": []
+  },
+  "NMTT 1266": {
+    "text": "NMTT 1311 and SCIT 1320",
+    "courses": [
+      "NMTT 1311",
+      "SCIT 1320"
+    ]
+  },
+  "NMTT 1301": {
+    "text": "Admission to the Nuclear Medicine Technology Program. Assessment Levels: R3, E3, M3.",
+    "courses": []
+  },
+  "NMTT 1309": {
+    "text": "NMTT 1313 or approval of NMT program director. Assessment Levels: R3, E3, M3. 51.0905",
+    "courses": [
+      "NMTT 1313"
+    ]
+  },
+  "NMTT 1313": {
+    "text": "Admission to the Nuclear Medicine Technology Program. Assessment Levels: R3, E3, M3. 51.0905",
+    "courses": []
+  },
+  "NMTT 2201": {
+    "text": "CHEM 1406 or its equivalent, or instructor's permission. Assessment Levels: R3, E3, M3. 51.0905",
+    "courses": [
+      "CHEM 1406"
+    ]
+  },
+  "NMTT 2209": {
+    "text": "NMTT 1309",
+    "courses": [
+      "NMTT 1309"
+    ]
+  },
+  "NMTT 2233": {
+    "text": "NMTT 2209 (min C)",
+    "courses": [
+      "NMTT 2209"
+    ]
+  },
+  "NMTT 2235": {
+    "text": "All NMTT courses or approval of the NMT program director. Assessment Levels: R3, E3, M3 51.0905",
+    "courses": []
+  },
+  "NMTT 2266": {
+    "text": "NMTT 2209",
+    "courses": [
+      "NMTT 2209"
+    ]
+  },
+  "NMTT 2313": {
+    "text": "NMTT 2209, BIOL 2401, 2402. Assessment Levels: R3, E3, M3.. 51.0905",
+    "courses": [
+      "NMTT 2209",
+      "BIOL 2401"
+    ]
+  },
+  "NMTT 2366": {
+    "text": "NMTT 1367 and approval of the NMT program director for assignment of specific clinical location. Assessment Levels: R3, E3, M3. 51.0905",
+    "courses": [
+      "NMTT 1367"
+    ]
+  },
+  "NURA 1160": {
+    "text": "See health occupations advisor) Students will earn an A, B, C, D, F, or W. A health related work-based learning experience that enables the student to apply specialized occupational theory skills and concepts. Direct supervision is provided by the clinical professional. Lab fee $87 includes professional liability insurance and drug screening.",
+    "courses": []
+  },
+  "NURS 3301": {
+    "text": "Acceptance into the RN-to-BSN Program) Students will earn an A, B, C, D, F, or W. This course focuses on the registered nurse's synthesis of nursing knowledge and skills to perform a comprehensive health assessment of individuals across the lifespan. Requires computer/web access. Lab fee.",
+    "courses": []
+  },
+  "NURS 3313": {
+    "text": "NURS 3350, NURS 3351, NURS 3301, NURS 3353. Corequisites: NURS 4355. Assessment Levels: R3, E3, M3. 51.3801.",
+    "courses": [
+      "NURS 3350",
+      "NURS 3351",
+      "NURS 3301",
+      "NURS 3353",
+      "NURS 4355"
+    ]
+  },
+  "NURS 3350": {
+    "text": "Admit to RN to BSN program track. Corequisites: NURS 3301. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "NURS 3301"
+    ]
+  },
+  "NURS 3351": {
+    "text": "NURS 3350, NURS 3301, NURS 4314 and NURS 3326) Students will earn an A, B, C, D, F, or W. Scholarly exchange prepares the baccalaureate nurse to understand the language of research and the scientific process through evaluation of quantitative, qualitative, and mixed method research methodology as a foundation for evidence-based practice in the healthcare setting. This course will investigate resea",
+    "courses": [
+      "NURS 3350",
+      "NURS 3301",
+      "NURS 4314",
+      "NURS 3326"
+    ]
+  },
+  "NURS 3353": {
+    "text": "Admit to RN to BSN program, NURS 3301 and NURS 3350. Corequisites: NURS 3351. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "NURS 3301",
+      "NURS 3350",
+      "NURS 3351"
+    ]
+  },
+  "NURS 4160": {
+    "text": "NURS 3350, NURS 3351, NURS 3301, NURS 3353, NURS 3313, NURS 4355. Co-requisite: NURS 4326. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "NURS 3350",
+      "NURS 3351",
+      "NURS 3301",
+      "NURS 3353",
+      "NURS 3313",
+      "NURS 4355",
+      "NURS 4326"
+    ]
+  },
+  "NURS 4161": {
+    "text": "NURS 3350, NURS 3351, NURS 3301, NURS 3353, NURS 3313, NURS 4355 NURS 4326 NURS 4160. Co-requesites: NURS 4457, NURS 4353. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "NURS 3350",
+      "NURS 3351",
+      "NURS 3301",
+      "NURS 3353",
+      "NURS 3313",
+      "NURS 4355",
+      "NURS 4326",
+      "NURS 4160",
+      "NURS 4457",
+      "NURS 4353"
+    ]
+  },
+  "NURS 4314": {
+    "text": "Acceptance into the RN-to-BSN Program) Students will earn an A, B, C, D, F, or W. This course examines the theoretical and conceptual bases of nursing to encourage the student to critique, evaluate and utilize appropriate nursing theory within their own practice. Focus will be on a variety of theories from nursing. Requires computer/web access.",
+    "courses": []
+  },
+  "NURS 4326": {
+    "text": "NURS 3350, NURS 3351, NURS 3301, NURS 3353, NURS 3313, NURS 4355. Co-requisites: NURS 4160. Assessment Levels: R3, E3, M3. 51.3801.",
+    "courses": [
+      "NURS 3350",
+      "NURS 3351",
+      "NURS 3301",
+      "NURS 3353",
+      "NURS 3313",
+      "NURS 4355",
+      "NURS 4160"
+    ]
+  },
+  "NURS 4354": {
+    "text": "NURS 3350, NURS 3351, NURS 3301, NURS 3353, NURS 3313, NURS 4355, NURS 4326, NURS 4160. Co-requisites: NURS 4457, NURS 4161. Assessment Levels: R3, E3, M3. 51.3801.",
+    "courses": [
+      "NURS 3350",
+      "NURS 3351",
+      "NURS 3301",
+      "NURS 3353",
+      "NURS 3313",
+      "NURS 4355",
+      "NURS 4326",
+      "NURS 4160",
+      "NURS 4457",
+      "NURS 4161"
+    ]
+  },
+  "NURS 4355": {
+    "text": "NURS 3350, NURS 3351, NURS 3301, NURS 3353. Co-requisites: NURS 3313. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "NURS 3350",
+      "NURS 3351",
+      "NURS 3301",
+      "NURS 3353",
+      "NURS 3313"
+    ]
+  },
+  "NURS 4457": {
+    "text": "Prerequisites: NURS 3350, NURS 3301, NURS 4314 and NURS 3326) Students will earn an A, B, C, D, F, or W. This course explores leadership and management theories, resource allocation, the nurse as a change agent, member of the profession, communication, and quality improvement in the healthcare setting. Lab fee includes RN-to-BSN HESI mobility test and leb fee.",
+    "courses": [
+      "NURS 3350",
+      "NURS 3301",
+      "NURS 4314",
+      "NURS 3326"
+    ]
+  },
+  "OSHT 2388": {
+    "text": "Permission of instructor. Assessment Levels: R1, E1, M1. 15.0701",
+    "courses": []
+  },
   "OTHA 1162": {
     "text": "OTHA 1341 and OTHA 1315 and OTHA 1161",
     "courses": [
@@ -2172,10 +3989,66 @@
       "OTHA 1161"
     ]
   },
+  "OTHA 1211": {
+    "text": "OTHA 1309, 1405, and 2301. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1309"
+    ]
+  },
+  "OTHA 1241": {
+    "text": "OTHA 1305 and OTHA 1309 and OTHA 1415",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1309",
+      "OTHA 1415"
+    ]
+  },
+  "OTHA 1262": {
+    "text": "OTHA 1211, 1309, 1319, 1405, 2301, 2309. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1211"
+    ]
+  },
+  "OTHA 1309": {
+    "text": "BIOL 2404 and ENGL 1301. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "BIOL 2404",
+      "ENGL 1301"
+    ]
+  },
+  "OTHA 1315": {
+    "text": "OTHA 1211, 1309, 1319, 1405, 2301, and 2309; and must be taken concurrently with OTHA 1262 and 2302. Assessment Level: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1211",
+      "OTHA 1262"
+    ]
+  },
   "OTHA 1415": {
     "text": "OTHA 1309",
     "courses": [
       "OTHA 1309"
+    ]
+  },
+  "OTHA 1419": {
+    "text": "OTHA 1253 and OTHA 2335 and OTHA 2405",
+    "courses": [
+      "OTHA 1253",
+      "OTHA 2335",
+      "OTHA 2405"
+    ]
+  },
+  "OTHA 2230": {
+    "text": "OTHA 1211, 1262, 1309, 1315, 1319, 1405, 2235, 2301, 2302, 2309, 2331, and 2360. Corequisite: OTHA 2466.. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1211",
+      "OTHA 2466"
+    ]
+  },
+  "OTHA 2231": {
+    "text": "OTHA 1211, 1262, 1309, 1315, 1319, 1405, 2301, 2302, and 2309. Corequisite: OTHA 2235 and 2360. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1211",
+      "OTHA 2235"
     ]
   },
   "OTHA 2235": {
@@ -2201,12 +4074,33 @@
       "OTHA 2304"
     ]
   },
+  "OTHA 2309": {
+    "text": "OTHA 1309, 1405, and 2301. Corequisites: OTHA 1211 and 1319. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1309",
+      "OTHA 1211"
+    ]
+  },
+  "OTHA 2331": {
+    "text": "OTHA 1211, 1262, 1309, 1315, 1319, 1405, 2301, 2302, and 2309. Corequisite: OTHA 2235 and 2360. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1211",
+      "OTHA 2235"
+    ]
+  },
   "OTHA 2405": {
     "text": "OTHA 1319 and OTHA 2209 and OTHA 2304",
     "courses": [
       "OTHA 1319",
       "OTHA 2209",
       "OTHA 2304"
+    ]
+  },
+  "OTHA 2466": {
+    "text": "OTHA 1211, 1262, 1309, 1315, 1319, 1405, 2235, 2301, 2302, 2309, 2331, 2360. Corequisite: OTHA 2330. Assessment Levels: R2, E2, M2. 51.0803",
+    "courses": [
+      "OTHA 1211",
+      "OTHA 2330"
     ]
   },
   "PHIL 1301": {
@@ -2230,6 +4124,38 @@
       "ENGL 1301"
     ]
   },
+  "PHRA 1243": {
+    "text": "PHRA 1202, 1201, 1205, 1309, 1313, 1349) Students will earn an A, B, C, D, F, or W. A review of major topics covered on the national Pharmacy Technician Certification Examination (PTCE). Lab fee $193 includes skills lab fee, practice certification exam and national certification fee.",
+    "courses": [
+      "PHRA 1202"
+    ]
+  },
+  "PHRA 1305": {
+    "text": "PHRA 1267, 1304, 1345, and 1441. Must be taken concurrently with: PHRA 1243. Assessment Levels: R3, E3, M3. 51.0805",
+    "courses": [
+      "PHRA 1267",
+      "PHRA 1243"
+    ]
+  },
+  "PHRA 1306": {
+    "text": "PHRA 1267, 1304, 1309, 1345, and 1441. Must be taken concurrently with PHRA 2266. Assessment Levels: R3, E3, M3. 51.0805",
+    "courses": [
+      "PHRA 1267",
+      "PHRA 2266"
+    ]
+  },
+  "PHYS 1305": {
+    "text": "MATH 0373 or equivalent. Assessment Levels: R3, E1, M3. 40.0201",
+    "courses": [
+      "MATH 0373"
+    ]
+  },
+  "PHYS 1310": {
+    "text": "MATH 1314 and 1316 or permission of instructor. Assessment Levels: R3, E1, M3. 40.0201",
+    "courses": [
+      "MATH 1314"
+    ]
+  },
   "PHYS 1401": {
     "text": "MATH 1314 or MATH 1316 or MATH 2312 or MATH 2412",
     "courses": [
@@ -2240,8 +4166,10 @@
     ]
   },
   "PHYS 1402": {
-    "text": "PHYS 1401",
+    "text": "MATH 1314 and MATH 1316 with a minimum grade of \"C\" or above and PHYS 1401. Assessment Levels: R3, E1, M3. 40.0201",
     "courses": [
+      "MATH 1314",
+      "MATH 1316",
       "PHYS 1401"
     ]
   },
@@ -2252,9 +4180,10 @@
     ]
   },
   "PHYS 2425": {
-    "text": "MATH 2413",
+    "text": "MATH 2413 Corequisite: MATH 2414. Assessment Levels: R3, E1, M3. 40.0801",
     "courses": [
-      "MATH 2413"
+      "MATH 2413",
+      "MATH 2414"
     ]
   },
   "PHYS 2426": {
@@ -2264,12 +4193,52 @@
       "MATH 2414"
     ]
   },
+  "PLAB 1163": {
+    "text": "PLAB 1223",
+    "courses": [
+      "PLAB 1223"
+    ]
+  },
+  "PLAB 1323": {
+    "text": "See health occupations advisor) Students will earn an A, B, C, D, F, or W. Skill development in the performance of a variety of blood collection methods using proper techniques and standard precautions. Includes vacuum collection devices, syringes, capillary skin puncture, butterfly needles and blood culture, and specimen collection on adults, children and infants. Emphasis on infection prevention",
+    "courses": []
+  },
+  "PMHS 1166": {
+    "text": "DAAC 1311, 1314, 2354 and approval of Human Services program director for assignment to specific practicum. Assessment Levels: R1, E1, M1. 51.1502",
+    "courses": [
+      "DAAC 1311"
+    ]
+  },
+  "PMHS 2166": {
+    "text": "DAAC 1311, 2354, PMHS 1166, approval of Human Services program director for assignment to specific practicum. Assessment Levels: R1, E1, M1. 51.1502",
+    "courses": [
+      "DAAC 1311",
+      "PMHS 1166"
+    ]
+  },
+  "POFI 1349": {
+    "text": "BUSG 1404 or ITSW 1404",
+    "courses": [
+      "BUSG 1404",
+      "ITSW 1404"
+    ]
+  },
+  "POFI 2301": {
+    "text": "Keyboarding proficiency of 35 words per minute and knowledge of keyboarding procedures and formatting. 52.0407",
+    "courses": []
+  },
   "POFI 2401": {
     "text": "POFT 1329 or POFT 1301 or COSC 1401",
     "courses": [
       "POFT 1329",
       "POFT 1301",
       "COSC 1401"
+    ]
+  },
+  "POFM 1300": {
+    "text": "MDCA 1313) Students will earn an A, B, C, D, F, or W. Presentation and application of basic coding rules, principles, guidelines and conventions utilizing various coding systems.",
+    "courses": [
+      "MDCA 1313"
     ]
   },
   "POFM 2386": {
@@ -2279,6 +4248,12 @@
       "POFT 2312",
       "HITT 1305",
       "HITT 1313"
+    ]
+  },
+  "POFT 1291": {
+    "text": "POFI 1349",
+    "courses": [
+      "POFI 1349"
     ]
   },
   "PSGT 1310": {
@@ -2299,6 +4274,55 @@
       "PSGT 2411",
       "RSPT 1237",
       "PSGT 1310"
+    ]
+  },
+  "PSTR 1305": {
+    "text": "CHEF 1301, 1305, PSTR 1301. Assessment Levels: R1, E1, M1. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1306": {
+    "text": "CHEF 1301, 1305; PSTR 1301, 2431. Assessment Levels: R1, E1, M1. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1310": {
+    "text": "CHEF 1301, 1305; PSTR 1301. Assessment Levels: R1, E1, M1. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1391": {
+    "text": "CHEF 1301, 1305; PSTR 1301, 2431. Assessment Levels: R1, E1, M1. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1440": {
+    "text": "CHEF 1301, 1305; PSTR 1301, 2431. Assessment Levels: R2, E2, M2. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1442": {
+    "text": "CHEF 1301, 1305 PSTR 1301,1305, 2431. Assessment Levels: R1, E1, M1. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 2301": {
+    "text": "CHEF 1301, 1305; PSTR 1301, 2431. 12.0501",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301"
     ]
   },
   "PSYC 2301": {
@@ -2345,12 +4369,24 @@
       "PSYC 2301"
     ]
   },
+  "PTAC 1332": {
+    "text": "PTAC 1302",
+    "courses": [
+      "PTAC 1302"
+    ]
+  },
   "PTAC 1354": {
     "text": "PTAC 2420 (min C) and PHYS 1305 (min C) and PHYS 1105 (min C)",
     "courses": [
       "PTAC 2420",
       "PHYS 1305",
       "PHYS 1105"
+    ]
+  },
+  "PTAC 1410": {
+    "text": "PTAC 1302. 41.0301",
+    "courses": [
+      "PTAC 1302"
     ]
   },
   "PTAC 2314": {
@@ -2384,6 +4420,43 @@
       "PTAC 2336"
     ]
   },
+  "PTHA 1201": {
+    "text": "PTHA 1405 and PTHA 1413",
+    "courses": [
+      "PTHA 1405",
+      "PTHA 1413"
+    ]
+  },
+  "PTHA 1405": {
+    "text": "PTHA 1201",
+    "courses": [
+      "PTHA 1201"
+    ]
+  },
+  "PTHA 1431": {
+    "text": "PTHA 1321. Assessment Levels: R3, E3, M3.",
+    "courses": [
+      "PTHA 1321"
+    ]
+  },
+  "PTHA 2205": {
+    "text": "PTHA 1201, 1321, 1413, 1431, 2509. Assessment Levels: R3, E3, M3. 51.0806",
+    "courses": [
+      "PTHA 1201"
+    ]
+  },
+  "PTHA 2266": {
+    "text": "PTHA 1201, 1321, 1413, 1431, 2509. Assessment Levels: R3, E3, M3. 51.0806",
+    "courses": [
+      "PTHA 1201"
+    ]
+  },
+  "PTHA 2301": {
+    "text": "PTHA 1260",
+    "courses": [
+      "PTHA 1260"
+    ]
+  },
   "PTHA 2339": {
     "text": "PTHA 2435",
     "courses": [
@@ -2405,6 +4478,85 @@
       "PTHA 2535"
     ]
   },
+  "PTHA 2431": {
+    "text": "PTHA 1260 and PTHA 1301 and PTHA 1405 and PTHA 1413 and PTHA 1431 and PTHA 2301 and PTHA 2409 and PTHA 1321 and PTHA 2435",
+    "courses": [
+      "PTHA 1260",
+      "PTHA 1301",
+      "PTHA 1405",
+      "PTHA 1413",
+      "PTHA 1431",
+      "PTHA 2301",
+      "PTHA 2409",
+      "PTHA 1321",
+      "PTHA 2435"
+    ]
+  },
+  "PTHA 2435": {
+    "text": "PTHA 1201, 1321, 1413, 1431, 2509. Assessment Levels: R3, E3, M3. 51.0806",
+    "courses": [
+      "PTHA 1201"
+    ]
+  },
+  "PTHA 2509": {
+    "text": "PTHA 1201, 1305, 1413. Assessment Levels: R3, E3, M3. 51.0806",
+    "courses": [
+      "PTHA 1201"
+    ]
+  },
+  "RADR 1201": {
+    "text": "RADR 1266",
+    "courses": [
+      "RADR 1266"
+    ]
+  },
+  "RADR 1202": {
+    "text": "RADR 1267 and RADR 2166",
+    "courses": [
+      "RADR 1267",
+      "RADR 2166"
+    ]
+  },
+  "RADR 1203": {
+    "text": "RADR 1266",
+    "courses": [
+      "RADR 1266"
+    ]
+  },
+  "RADR 1213": {
+    "text": "RADR 1311, 2309. Assessment Levels: R3, E3, M3. 51.0911",
+    "courses": [
+      "RADR 1311"
+    ]
+  },
+  "RADR 1260": {
+    "text": "RADR 1309 and HPRS 1106, 1204. Assessment Levels: R3, E3, M3.",
+    "courses": [
+      "RADR 1309",
+      "HPRS 1106"
+    ]
+  },
+  "RADR 1261": {
+    "text": "RADR 1309. Assessment Levels: R3, E3, M3.",
+    "courses": [
+      "RADR 1309"
+    ]
+  },
+  "RADR 1266": {
+    "text": "RADR 1201 and RADR 1203 and RADR 2313 and RADR 1411",
+    "courses": [
+      "RADR 1201",
+      "RADR 1203",
+      "RADR 2313",
+      "RADR 1411"
+    ]
+  },
+  "RADR 1311": {
+    "text": "RADR 1266",
+    "courses": [
+      "RADR 1266"
+    ]
+  },
   "RADR 1313": {
     "text": "RADR 1309 (min C)",
     "courses": [
@@ -2417,16 +4569,91 @@
       "RADR 1309"
     ]
   },
-  "RADR 2305": {
-    "text": "RADR 1313 (min C)RADR 1313 (min C)",
+  "RADR 2117": {
+    "text": "RADR 1261. 12-week summer session. Assessment Levels: R3, E3, M3. 51.0911",
     "courses": [
-      "RADR 1313"
+      "RADR 1261"
+    ]
+  },
+  "RADR 2166": {
+    "text": "RADR 1202",
+    "courses": [
+      "RADR 1202"
+    ]
+  },
+  "RADR 2213": {
+    "text": "RADR 2361. Assessment Levels: R3, E3, M3. 51.0911",
+    "courses": [
+      "RADR 2361"
+    ]
+  },
+  "RADR 2217": {
+    "text": "RADR 1202 and RADR 2305 and RADR 2309 and RADR 2366",
+    "courses": [
+      "RADR 1202",
+      "RADR 2305",
+      "RADR 2309",
+      "RADR 2366"
+    ]
+  },
+  "RADR 2235": {
+    "text": "RADR 2362. Assessment Levels: R3, E3, M3.",
+    "courses": [
+      "RADR 2362"
+    ]
+  },
+  "RADR 2305": {
+    "text": "RADR 2217",
+    "courses": [
+      "RADR 2217"
+    ]
+  },
+  "RADR 2309": {
+    "text": "RADR 2217",
+    "courses": [
+      "RADR 2217"
+    ]
+  },
+  "RADR 2313": {
+    "text": "RADR 1266",
+    "courses": [
+      "RADR 1266"
     ]
   },
   "RADR 2333": {
     "text": "RADR 2401 (min C)",
     "courses": [
       "RADR 2401"
+    ]
+  },
+  "RADR 2335": {
+    "text": "RADR 2361. Assessment Levels: R3, E3, M3. 51.0911",
+    "courses": [
+      "RADR 2361"
+    ]
+  },
+  "RADR 2362": {
+    "text": "RADR 1261 and 2361. Assessment Levels: R3, E3, M3. 51.0911",
+    "courses": [
+      "RADR 1261"
+    ]
+  },
+  "RADR 2366": {
+    "text": "RADR 2217",
+    "courses": [
+      "RADR 2217"
+    ]
+  },
+  "RADR 2401": {
+    "text": "RADR 1266",
+    "courses": [
+      "RADR 1266"
+    ]
+  },
+  "RADT 1371": {
+    "text": "RADT 2366",
+    "courses": [
+      "RADT 2366"
     ]
   },
   "RBTC 1401": {
@@ -2508,15 +4735,62 @@
       "RNSG 1201"
     ]
   },
-  "RNSG 1137": {
-    "text": "BIOL 2402 (min C) or BIOL 2402 (min CT) and RNSG 1118 (min C) or RNSG 1118 (min CT) and RNSG 1228 (min C) or RNSG 1228 (min CT) and RNSG 1260 (min C) or RNSG 1260 (min CT) and RNSG 1424 (min C) or RNSG 1424 (min CT)",
+  "RNSG 1118": {
+    "text": "Admission to Nursing Program, BIOL 2401, 2402, ENGL 1301 and PSYC 2301. Corequisites/Concurrent: SPCH 1311, or 1315, or 1321, RNSG 1125 and 1324. Assessment Levels: R3, E3, M3. 51.3801",
     "courses": [
-      "BIOL 2402",
-      "RNSG 1118",
-      "RNSG 1228",
-      "RNSG 1260",
-      "RNSG 1424"
+      "BIOL 2401",
+      "ENGL 1301",
+      "PSYC 2301",
+      "SPCH 1311",
+      "RNSG 1125"
     ]
+  },
+  "RNSG 1125": {
+    "text": "RNSG 1433",
+    "courses": [
+      "RNSG 1433"
+    ]
+  },
+  "RNSG 1126": {
+    "text": "RNSG 1125, 1128, 1161, 1216 and 1430. Corequisites/Concurrent: BIOL 2420 and SPCH 1311, 1315 or 1321, RNSG 1533 and 2362. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "RNSG 1125",
+      "BIOL 2420",
+      "SPCH 1311",
+      "RNSG 1533"
+    ]
+  },
+  "RNSG 1128": {
+    "text": "Admission to Nursing Program, BIOL 2401, 2402, ENGL 1301 and PSYC 2301. Corequisites/Concurrent: RNSG 1125, 1161, 1216, and 1430. For LVN to RN Transition Students: Corequisite/Concurrent: RNSG 1118, 1324. Assessment Levels: R3, E3, M3 51.3801",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301",
+      "PSYC 2301",
+      "RNSG 1125",
+      "RNSG 1118"
+    ]
+  },
+  "RNSG 1137": {
+    "text": "BIOL 2420, SPCH 1311, 1315 or 1321 and RNSG 1126, 1533 and 2362. Prerequisites for the LVN to RN Transition Students: RNSG 1118, 1128 and 1324. Corequisites/Concurrent: PHIL 2306, RNSG 1538 and 2363. Corequisites/Concurrent for LVN to RN Transition Students: BIOL 2420, PHIL 2306, RNSG 1262 and 1538. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "BIOL 2420",
+      "SPCH 1311",
+      "RNSG 1126",
+      "RNSG 1118",
+      "PHIL 2306",
+      "RNSG 1538",
+      "RNSG 1262"
+    ]
+  },
+  "RNSG 1161": {
+    "text": "RNSG 1216",
+    "courses": [
+      "RNSG 1216"
+    ]
+  },
+  "RNSG 1163": {
+    "text": "Acceptance into the Transition Nursing Program) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills and concepts. Direct supervision is provided by the clinical professional. Lab fee includes drug screening and lab fee. Requires computer/web access.",
+    "courses": []
   },
   "RNSG 1201": {
     "text": "BIOL 2401 and BIOL 2402 and BIOL 2420",
@@ -2530,6 +4804,21 @@
     "text": "RNSG 1360",
     "courses": [
       "RNSG 1360"
+    ]
+  },
+  "RNSG 1216": {
+    "text": "Admission to Nursing Program, BIOL 2401, 2402, ENGL 1301 and PSYC 2301. Corequisites/Concurrent: RNSG 1125, 1128, 1161, and 1430. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301",
+      "PSYC 2301",
+      "RNSG 1125"
+    ]
+  },
+  "RNSG 1218": {
+    "text": "RNSG 1424",
+    "courses": [
+      "RNSG 1424"
     ]
   },
   "RNSG 1251": {
@@ -2546,6 +4835,16 @@
       "BIOL 2101"
     ]
   },
+  "RNSG 1324": {
+    "text": "Admission to Nursing Program BIOL 2401, 2402, ENGL 1301 and PSYC 2301. For LVN to RN Transition Students: SPCH 1311 or 1315 or 1321, RNSG 1118 and 1125. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301",
+      "PSYC 2301",
+      "SPCH 1311",
+      "RNSG 1118"
+    ]
+  },
   "RNSG 1360": {
     "text": "RNSG 1205",
     "courses": [
@@ -2557,6 +4856,29 @@
     "courses": [
       "BIOL 2401",
       "BIOL 2402"
+    ]
+  },
+  "RNSG 1424": {
+    "text": "RNSG 2261 and RNSG 1218",
+    "courses": [
+      "RNSG 2261",
+      "RNSG 1218"
+    ]
+  },
+  "RNSG 1430": {
+    "text": "Admission to Nursing Program, BIOL 2401, 2402, ENGL 1301 and PSYC 2301. Corequisites/Concurrent: RNSG 1125, 1128, 1161, and 1216. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301",
+      "PSYC 2301",
+      "RNSG 1125"
+    ]
+  },
+  "RNSG 1438": {
+    "text": "RNSG 2363 and RNSG 1433",
+    "courses": [
+      "RNSG 2363",
+      "RNSG 1433"
     ]
   },
   "RNSG 1441": {
@@ -2580,6 +4902,15 @@
     "courses": [
       "RNSG 1441",
       "RNSG 2213"
+    ]
+  },
+  "RNSG 1533": {
+    "text": "RNSG 1125, 1128, 1161, 1216, and 1430. Corequisites/Concurrent: BIOL 2420, RNSG 1126 and 2362, SPCH 1311 or 1315 or 1321. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "RNSG 1125",
+      "BIOL 2420",
+      "RNSG 1126",
+      "SPCH 1311"
     ]
   },
   "RNSG 1538": {
@@ -2624,6 +4955,27 @@
       "RNSG 1163"
     ]
   },
+  "RNSG 2261": {
+    "text": "RNSG 1424",
+    "courses": [
+      "RNSG 1424"
+    ]
+  },
+  "RNSG 2262": {
+    "text": "RNSG 1433",
+    "courses": [
+      "RNSG 1433"
+    ]
+  },
+  "RNSG 2360": {
+    "text": "PHIL 2306, RNSG 1137, 1538 and 2363. Prerequisites for LVN to RN Transition Students: BIOL 2420, PHIL 2306, RNSG 1137, 1262, and 1538. Concurrent: RNSG 2138 and 2539 Assessment Levels: R3, E3, M3. 51.1601",
+    "courses": [
+      "PHIL 2306",
+      "RNSG 1137",
+      "BIOL 2420",
+      "RNSG 2138"
+    ]
+  },
   "RNSG 2361": {
     "text": "RNSG 1424 (min C) or RNSG 1424 (min CT) and RNSG 1260 (min C) or RNSG 1260 (min CT) and RNSG 1228 (min C) or RNSG 1228 (min CT) and RNSG 1118 (min C) or RNSG 1118 (min CT) and BIOL 2402 (min C) or BIOL 2402 (min CT)",
     "courses": [
@@ -2635,13 +4987,27 @@
     ]
   },
   "RNSG 2362": {
-    "text": "BIOL 2420 (min C) or BIOL 2420 (min CT) and RNSG 1137 (min C) or RNSG 1137 (min CT) and RNSG 1260 (min C) or RNSG 1260 (min CT) and RNSG 1538 (min C) or RNSG 1538 (min CT) and RNSG 2361 (min C) or RNSG 2361 (min CT)",
+    "text": "RNSG 1125, RNSG 1128, RNSG 1161, RNSG 1216, and RNSG 1430. Corequisites/Concurrent:BIOL 2420, RNSG 1126, RNSG 1533 and SPCH 1311 or SPCH 1315 or SPCH 1321. Assessment Levels: R3, E3, M3. 51.3801",
     "courses": [
+      "RNSG 1125",
+      "RNSG 1128",
+      "RNSG 1161",
+      "RNSG 1216",
+      "RNSG 1430",
       "BIOL 2420",
-      "RNSG 1137",
-      "RNSG 1260",
-      "RNSG 1538",
-      "RNSG 2361"
+      "RNSG 1126",
+      "RNSG 1533",
+      "SPCH 1311",
+      "SPCH 1315",
+      "SPCH 1321"
+    ]
+  },
+  "RNSG 2363": {
+    "text": "RNSG 1126, 1533 and 2362. Corequisites/Concurrent: PHIL 2306, RNSG 1137 and 1538. Assessment Levels: R3, E3, M3. 51.3801",
+    "courses": [
+      "RNSG 1126",
+      "PHIL 2306",
+      "RNSG 1137"
     ]
   },
   "RNSG 2432": {
@@ -2677,6 +5043,15 @@
       "RNSG 2361"
     ]
   },
+  "RSPT 1166": {
+    "text": "RSPT 1101 and RSPT 1225 and RSPT 1340 and RSPT 1410",
+    "courses": [
+      "RSPT 1101",
+      "RSPT 1225",
+      "RSPT 1340",
+      "RSPT 1410"
+    ]
+  },
   "RSPT 1237": {
     "text": "PSGT 1360 and PSGT 2411 and PSGT 2205 and PSGT 2561 and PSGT 1310",
     "courses": [
@@ -2687,10 +5062,56 @@
       "PSGT 1310"
     ]
   },
+  "RSPT 1261": {
+    "text": "RSPT 1213, 1260, 1310. Assessment Levels: R3, E3, M3. 51.0908",
+    "courses": [
+      "RSPT 1213"
+    ]
+  },
+  "RSPT 2161": {
+    "text": "RSPT 1260, 1261. Assessment Levels: R3, E3, M3. 51.0908",
+    "courses": [
+      "RSPT 1260"
+    ]
+  },
+  "RSPT 2166": {
+    "text": "RSPT 1167 and RSPT 2243 and RSPT 2314",
+    "courses": [
+      "RSPT 1167",
+      "RSPT 2243",
+      "RSPT 2314"
+    ]
+  },
+  "RSPT 2210": {
+    "text": "RSPT 1213, 1260, 1310. Assessment Levels: R3, E3, M3. 51.0908",
+    "courses": [
+      "RSPT 1213"
+    ]
+  },
+  "RSPT 2260": {
+    "text": "RSPT 1260, 1261, 2161. Assessment Levels: R3, E3, M3. 51.0908",
+    "courses": [
+      "RSPT 1260"
+    ]
+  },
+  "RSPT 2266": {
+    "text": "RSPT 2310 and RSPT 2353 and RSPT 2358",
+    "courses": [
+      "RSPT 2310",
+      "RSPT 2353",
+      "RSPT 2358"
+    ]
+  },
   "RSPT 2314": {
     "text": "RSPT 1411",
     "courses": [
       "RSPT 1411"
+    ]
+  },
+  "RSPT 2353": {
+    "text": "RSPT 2161, 2314. Assessment Levels: R3, E3, M3. 51.0908",
+    "courses": [
+      "RSPT 2161"
     ]
   },
   "RSPT 2361": {
@@ -2699,10 +5120,105 @@
       "RSPT 2560"
     ]
   },
+  "RSPT 53": {
+    "text": "RSPT 2161, 2314. Assessment Levels: R3, E3, M3. 51.0908",
+    "courses": [
+      "RSPT 2161"
+    ]
+  },
+  "SCIT 2401": {
+    "text": "CHEM 1407 or SCIT 1415 and CTEC 1206 or CHEM 1412. Assessment Levels: R3, E3, M2. 40.0504",
+    "courses": [
+      "CHEM 1407",
+      "SCIT 1415",
+      "CTEC 1206",
+      "CHEM 1412"
+    ]
+  },
+  "SGNL 1302": {
+    "text": "SGNL 1301 or instructor approval. Assessment Levels: R1, E1, M1. 16.1603",
+    "courses": [
+      "SGNL 1301"
+    ]
+  },
   "SGNL 1402": {
     "text": "SGNL 1401",
     "courses": [
       "SGNL 1401"
+    ]
+  },
+  "SLNG 1211": {
+    "text": "SGNL 1302 or instructor approval. Assessment Levels: R2, E2, M1. 16.1603",
+    "courses": [
+      "SGNL 1302"
+    ]
+  },
+  "SLNG 1307": {
+    "text": "SGNL 1301, 1302; ENGL 1301. Assessment Levels: R3, E3, M1. 16.1603",
+    "courses": [
+      "SGNL 1301",
+      "ENGL 1301"
+    ]
+  },
+  "SLNG 1321": {
+    "text": "SGNL 1301 or instructor approval. Assessment Levels: R3, E2, M1. 16.1603",
+    "courses": [
+      "SGNL 1301"
+    ]
+  },
+  "SLNG 1347": {
+    "text": "SGNL 1302 or instructor approval. Assessment Levels: R3, E3, M1. 16.1603",
+    "courses": [
+      "SGNL 1302"
+    ]
+  },
+  "SLNG 1444": {
+    "text": "SGNL 1302 or instructor approval. Assessment Levels: R2, E2, M1. 16.1603",
+    "courses": [
+      "SGNL 1302"
+    ]
+  },
+  "SLNG 2286": {
+    "text": "SLNG 2431, 2434. Assessment Levels: R3, E3, M3. 16.1603",
+    "courses": [
+      "SLNG 2431"
+    ]
+  },
+  "SLNG 2287": {
+    "text": "SLNG 2286 or instructor approval. Assessment Levels: R3, E3, M3. 16.1603",
+    "courses": [
+      "SLNG 2286"
+    ]
+  },
+  "SLNG 2302": {
+    "text": "SLNG 2301. Assessment Levels: R3, E3, M2.",
+    "courses": [
+      "SLNG 2301"
+    ]
+  },
+  "SLNG 2334": {
+    "text": "SLNG 1345 or instructor approval. Assessment Levels: R3, E3, M1.",
+    "courses": [
+      "SLNG 1345"
+    ]
+  },
+  "SLNG 2401": {
+    "text": "SGNL 1301, 1302; ENGL 1301. Assessment Levels: R3, E3, M2. 16.1603",
+    "courses": [
+      "SGNL 1301",
+      "ENGL 1301"
+    ]
+  },
+  "SLNG 2402": {
+    "text": "SLNG 2401. Assessment Levels: R3, E3, M2. 16.1603",
+    "courses": [
+      "SLNG 2401"
+    ]
+  },
+  "SLNG 2434": {
+    "text": "SLNG 1445 or instructor approval. Assessment Levels: R3, E3, M1. 16.1603",
+    "courses": [
+      "SLNG 1445"
     ]
   },
   "SOCW 2362": {
@@ -2711,10 +5227,22 @@
       "SOCI 1301"
     ]
   },
+  "SOCW 2389": {
+    "text": "SOCW 2361. Assement levels: R3, E3, M1. 44.0701",
+    "courses": [
+      "SOCW 2361"
+    ]
+  },
   "SPAN 1412": {
     "text": "SPAN 1411",
     "courses": [
       "SPAN 1411"
+    ]
+  },
+  "SPAN 2": {
+    "text": "SPAN 2311 or satisfactory score on departmental oral proficiency test. Assessment Levels: R3, E3, M1. 16.0905",
+    "courses": [
+      "SPAN 2311"
     ]
   },
   "SPAN 2311": {
@@ -2740,12 +5268,26 @@
       "HITT 1305"
     ]
   },
+  "SRGT 1441": {
+    "text": "SRGT 1405 and SRGT 1409. Assessment Levels: R3, E3, M1. 51.0909",
+    "courses": [
+      "SRGT 1405",
+      "SRGT 1409"
+    ]
+  },
   "SRGT 1442": {
     "text": "SRGT 1405 (min C) or SRGT 1405 (min CT) and SRGT 1409 (min C) or SRGT 1409 (min CT) and SRGT 1541 (min C) or SRGT 1541 (min CT)",
     "courses": [
       "SRGT 1405",
       "SRGT 1409",
       "SRGT 1541"
+    ]
+  },
+  "SRGT 1460": {
+    "text": "SRGT 1405 and SRGT 1409. Assessment Levels: R3, E3, M1. 51.0909",
+    "courses": [
+      "SRGT 1405",
+      "SRGT 1409"
     ]
   },
   "SRGT 1462": {
@@ -2755,6 +5297,13 @@
       "SRGT 1409",
       "SRGT 1360",
       "SRGT 1541",
+      "SRGT 1461"
+    ]
+  },
+  "SRGT 1505": {
+    "text": "SRGT 1409 and SRGT 1461",
+    "courses": [
+      "SRGT 1409",
       "SRGT 1461"
     ]
   },
@@ -2774,10 +5323,52 @@
       "SRGT 1541"
     ]
   },
+  "SRGT 2461": {
+    "text": "SRGT 1405, 1409 and 1260) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills and concepts. Direct supervision is provided by the clinical professional. Lab fee.",
+    "courses": [
+      "SRGT 1405"
+    ]
+  },
+  "SRGT 2462": {
+    "text": "SRGT 1405, 1409 and 1260) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills and concepts. Direct supervision is provided by the clinical professional. Lab fee.",
+    "courses": [
+      "SRGT 1405"
+    ]
+  },
   "TECA 1354": {
     "text": "CDEC 1166",
     "courses": [
       "CDEC 1166"
+    ]
+  },
+  "TRVM 2301": {
+    "text": "CHEF 1301, CHEF 1305, HAMG 1321, HAMG 1340, and HAMG 1313 REM Levels: R2, E2, M1.",
+    "courses": [
+      "CHEF 1301",
+      "CHEF 1305",
+      "HAMG 1321",
+      "HAMG 1340",
+      "HAMG 1313"
+    ]
+  },
+  "VNSG 1119": {
+    "text": "VNSG 1119 and VNSG 1230 and VNSG 1234 and VNSG 1432 and VNSG 2460",
+    "courses": [
+      "VNSG 1119",
+      "VNSG 1230",
+      "VNSG 1234",
+      "VNSG 1432",
+      "VNSG 2460"
+    ]
+  },
+  "VNSG 1122": {
+    "text": "Acceptance into the Vocational Nursing Program) Students will earn an A, B, C, D, F, or W. Introduction to the nursing profession and its responsibilities. Includes legal and ethical issues in nursing practice. Concepts related to the physical, emotional and psychosocial self-care of the learner/professional. Lab fee.",
+    "courses": []
+  },
+  "VNSG 1201": {
+    "text": "VNSG 1230",
+    "courses": [
+      "VNSG 1230"
     ]
   },
   "VNSG 1204": {
@@ -2787,23 +5378,80 @@
       "NURA 1301"
     ]
   },
-  "VNSG 1230": {
-    "text": "VNSG 1261 (min C) or VNSG 1261 (min CT) and VNSG 1204 (min C) or VNSG 1204 (min CT) and VNSG 1234 (min C) or VNSG 1234 (min CT) and VNSG 1409 (min C) or VNSG 1409 (min CT) and VNSG 1462 (min C) or VNSG 1462 (min CT) and VNSG 1400 (min C) or VNSG 1400 (min CT)",
+  "VNSG 1219": {
+    "text": "RNSG 1126, 1533, and 2362. Assessment Levels: R3, E3, M3. 51.3901",
     "courses": [
-      "VNSG 1261",
-      "VNSG 1204",
+      "RNSG 1126"
+    ]
+  },
+  "VNSG 1227": {
+    "text": "VNSG 1423",
+    "courses": [
+      "VNSG 1423"
+    ]
+  },
+  "VNSG 1230": {
+    "text": "VNSG 1423 and VNSG 1234 and VNSG 1409 and VNSG 1261 and VNSG 2410 and VNSG 2163 and VNSG 1201",
+    "courses": [
+      "VNSG 1423",
       "VNSG 1234",
       "VNSG 1409",
-      "VNSG 1462",
-      "VNSG 1400"
+      "VNSG 1261",
+      "VNSG 2410",
+      "VNSG 2163",
+      "VNSG 1201"
+    ]
+  },
+  "VNSG 1231": {
+    "text": "VNSG 1236 and VNSG 1261 and VNSG 1329",
+    "courses": [
+      "VNSG 1236",
+      "VNSG 1261",
+      "VNSG 1329"
     ]
   },
   "VNSG 1234": {
-    "text": "VNSG 1261 (min C) and VNSG 1204 (min C) and VNSG 1400 (min C)",
+    "text": "VNSG 1119 and VNSG 1230 and VNSG 1234 and VNSG 1432 and VNSG 2460",
     "courses": [
+      "VNSG 1119",
+      "VNSG 1230",
+      "VNSG 1234",
+      "VNSG 1432",
+      "VNSG 2460"
+    ]
+  },
+  "VNSG 1236": {
+    "text": "VNSG 1231 and VNSG 1261 and VNSG 1329",
+    "courses": [
+      "VNSG 1231",
       "VNSG 1261",
-      "VNSG 1204",
-      "VNSG 1400"
+      "VNSG 1329"
+    ]
+  },
+  "VNSG 1260": {
+    "text": "VNSG 1423",
+    "courses": [
+      "VNSG 1423"
+    ]
+  },
+  "VNSG 1261": {
+    "text": "VNSG 1231 and VNSG 1236 and VNSG 1329",
+    "courses": [
+      "VNSG 1231",
+      "VNSG 1236",
+      "VNSG 1329"
+    ]
+  },
+  "VNSG 1262": {
+    "text": "See advisor) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills and concepts. Direct supervision is provided by the clinical professional. A preceptorship at the end of the semester provides a capstone experience and allows the student to integrate technical skills, nursing concepts, a",
+    "courses": []
+  },
+  "VNSG 1329": {
+    "text": "VNSG 1231 and VNSG 1236 and VNSG 1261",
+    "courses": [
+      "VNSG 1231",
+      "VNSG 1236",
+      "VNSG 1261"
     ]
   },
   "VNSG 1330": {
@@ -2813,12 +5461,47 @@
       "VNSG 1460"
     ]
   },
+  "VNSG 1331": {
+    "text": "VNSG 1423",
+    "courses": [
+      "VNSG 1423"
+    ]
+  },
+  "VNSG 1400": {
+    "text": "VNSG 1423",
+    "courses": [
+      "VNSG 1423"
+    ]
+  },
   "VNSG 1409": {
     "text": "VNSG 1204 (min C) and VNSG 1261 (min C) and VNSG 1400 (min C)",
     "courses": [
       "VNSG 1204",
       "VNSG 1261",
       "VNSG 1400"
+    ]
+  },
+  "VNSG 1423": {
+    "text": "VNSG 1204 and VNSG 1331 and VNSG 1227 and VNSG 1400 and VNSG 1260 and BIOL 2401 and HITT 1205 or BIOL 2402",
+    "courses": [
+      "VNSG 1204",
+      "VNSG 1331",
+      "VNSG 1227",
+      "VNSG 1400",
+      "VNSG 1260",
+      "BIOL 2401",
+      "HITT 1205",
+      "BIOL 2402"
+    ]
+  },
+  "VNSG 1432": {
+    "text": "VNSG 1119 and VNSG 1230 and VNSG 1234 and VNSG 1432 and VNSG 2460",
+    "courses": [
+      "VNSG 1119",
+      "VNSG 1230",
+      "VNSG 1234",
+      "VNSG 1432",
+      "VNSG 2460"
     ]
   },
   "VNSG 1460": {
@@ -2847,11 +5530,27 @@
       "VNSG 1462"
     ]
   },
+  "VNSG 1472": {
+    "text": "Acceptance into the Vocational Nursing Program) Students will earn an A, B, C, D, F, or W. Introduction to basic nursing skills. Emphasis on utilization of the nursing process and related scientific principles. Lab fee.",
+    "courses": []
+  },
   "VNSG 1509": {
     "text": "VNSG 1423 and VNSG 1460",
     "courses": [
       "VNSG 1423",
       "VNSG 1460"
+    ]
+  },
+  "VNSG 2163": {
+    "text": "VNSG 1230",
+    "courses": [
+      "VNSG 1230"
+    ]
+  },
+  "VNSG 2214": {
+    "text": "VNSG 1231, 1122, 1400, 1472, 2473, and 1160) Students will earn an A, B, C, D, F, or W. Application of nursing skills to meet complex patient needs utilizing the nursing process and related scientific principles. Lab fee.",
+    "courses": [
+      "VNSG 1231"
     ]
   },
   "VNSG 2331": {
@@ -2870,6 +5569,41 @@
       "VNSG 1400",
       "VNSG 1409",
       "VNSG 1462"
+    ]
+  },
+  "VNSG 2460": {
+    "text": "VNSG 1119 and VNSG 1230 and VNSG 1234 and VNSG 1432 and VNSG 2460",
+    "courses": [
+      "VNSG 1119",
+      "VNSG 1230",
+      "VNSG 1234",
+      "VNSG 1432",
+      "VNSG 2460"
+    ]
+  },
+  "VNSG 2473": {
+    "text": "Acceptance into the Vocatiional Nursing Program) Students will earn an A, B, C, D, F, or W. Continuation of application of advanced nursing skills to meet patient needs utilizing the nursing process and related scientific principles. Lab fee.",
+    "courses": []
+  },
+  "WLDG 1371": {
+    "text": "WLDG 1370 (min C)",
+    "courses": [
+      "WLDG 1370"
+    ]
+  },
+  "WLDG 1375": {
+    "text": "WLDG 1371 (min C)",
+    "courses": [
+      "WLDG 1371"
+    ]
+  },
+  "WLDG 1377": {
+    "text": "WLDG 1376 and WLDG 2377 and WLDG 1317 and WLDG 2372",
+    "courses": [
+      "WLDG 1376",
+      "WLDG 2377",
+      "WLDG 1317",
+      "WLDG 2372"
     ]
   },
   "WLDG 1412": {
@@ -2920,6 +5654,18 @@
       "WLDG 2451",
       "WLDG 2435",
       "WLDG 2453"
+    ]
+  },
+  "WLDG 1457": {
+    "text": "WLDG 1428",
+    "courses": [
+      "WLDG 1428"
+    ]
+  },
+  "WLDG 2372": {
+    "text": "WLDG 1317 (min C)",
+    "courses": [
+      "WLDG 1317"
     ]
   },
   "WLDG 2406": {

--- a/scripts/tx/scrape-colleague.ts
+++ b/scripts/tx/scrape-colleague.ts
@@ -31,6 +31,11 @@ const HOSTS: Record<string, string> = {
   // served at HTTP 200, not a real Banner endpoint. The college's actual
   // SIS is Ellucian Colleague Cloud.
   "vernon-college": "https://vernon-ss.colleague.elluciancloud.com",
+  // TX Phase D — Del Mar's actual SIS turned out to be Colleague at
+  // colss-prod.ec.delmar.edu (Phase C had treated Del Mar as Coursedog-
+  // only because that's where its catalog lives; the live class schedule
+  // is a separate Colleague host the fingerprinter never probed).
+  "del-mar-college": "https://colss-prod.ec.delmar.edu",
   // Austin CCD's selfservice.austincc.edu is auth-gated
   // (redirects /Student/Courses → /Account/Login). Deferred — needs an
   // alternate guest endpoint or catalog-only import.


### PR DESCRIPTION
## What changes for someone using the site

Two improvements ship together here:

1. **Del Mar College** starts showing live class sections in TX course search. Phase A–C had treated Del Mar as catalog-only because its Coursedog catalog is what came up in fingerprinting, but the actual class schedule lives on a separate Colleague Self-Service host the fingerprinter never probed. 31/59 → 32/59 colleges with live sections.

2. **The semester planner's prerequisite chain doubles in coverage for TX.** `prereqs.json` jumps from 416 to 831 unique courses — meaning ~415 more TX courses will resolve their "you must take X first" arrows immediately, especially for courses unique to the catalog-only colleges (HCC, Trinity Valley, Del Mar).

## What changes on the technical front

- **`scripts/tx/scrape-colleague.ts`** — extended with `del-mar-college` at `https://colss-prod.ec.delmar.edu`. The shared Colleague template works as-is; no template change needed. URL verified guest-open (HTTP 200, no redirect).

- **`data/tx/prereqs.json`** — re-aggregated. The big finding: the existing aggregator at `scripts/lib/aggregate-prereqs.ts` *already* merges `data/{state}/coursedog-catalog/*.json` into the prereq output (that generalization landed earlier for FL). But no one had re-run the aggregator since Del Mar (2,923 courses) and Trinity Valley (906 courses) coursedog-catalog dumps were committed, so 651 catalog-sourced prereqs were sitting on disk unused. One `npx tsx scripts/lib/aggregate-prereqs.ts tx` invocation collects them.

  - Breakdown after merge:
    - 1,910 / 50,901 sections across 22 colleges contributed prereqs
    - 651 / 4,720 catalog courses across 3 Coursedog colleges (HCC + Del Mar + TVCC) contributed prereqs
    - Deduped union: **831 unique courses** (up from 416)

## Phase D scope correction

Phase D was originally planned as "build a Coursedog section scraper for Del Mar + TVCC." That turned out to rest on a misconception — Coursedog is a curriculum/catalog platform, not a sections one (the existing `scripts/lib/scrape-coursedog.ts` docstring spells this out: "Coursedog colleges typically run their actual class registration on Banner / Colleague / PeopleSoft, with Coursedog providing the published course-catalog metadata only").

Probing each college's actual class registration produced:
- **Del Mar** → Colleague at `colss-prod.ec.delmar.edu` ✅ (shipped)
- **Trinity Valley** → `mycardinalconnect.tvcc.edu` behind a Cloudflare JS challenge → deferred (needs Playwright to pass challenge, then probably login behind it)

## What's next (the rest of the TX plan)

- **C.2 (deferred from this session)** — Lone Star College System (~93k students). PS Classic `COMMUNITY_ACCESS.CLASS_SEARCH.GBL` with embedded guest credentials. Investigation completed but `SUBJECT_SRCH` dropdown won't commit through Playwright `selectOption`; needs deeper debugging with browser devtools open. Own focused PR.
- **E** — Acalog catalog ingest for prereq coverage (Brazosport, Midland, Dallas from Phase A defer; plus Tyler Jr, Lamar State Orange, Wharton County, San Jacinto, Grayson from Phase C catalog-only bucket). Same pattern as today's catalog merge: each Acalog → coursedog-catalog/-style dump → re-aggregate.
- **F** — Bespoke Playwright sweep of the 8 deferred-investigation colleges (El Paso, Cisco, Clarendon, Frank Phillips, Western TX, Hill, Ranger, NETCC) + Lone Star.

Cumulative targets after merge: A+B+C+D ≈ 32/59 (54%). Through E: ≈ 32/59 sections (Acalog has no sections) but prereqs likely climb past 1,500. Through F: 40+/59 sections, prereqs 2,000+.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run check:scrapers` passes (40 states × 4 datatypes)
- [x] Del Mar Colleague URL verified guest-open via `curl -L`
- [x] Aggregator re-run: 416 → 831 unique prereq entries
- [ ] Next scheduled-scrape cron tick lands Del Mar sections in `data/tx/courses/del-mar-college/`
- [ ] Post-merge: `curl communitycollegepath.com/api/tx/colleges/del-mar-college/sections` returns rows after cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)