### PR TITLE
tx: ingest 6 Acalog catalogs for prereqs (831 → 2,162, +1,331 new)

### DIFF
--- a/data/tx/prereqs.json
+++ b/data/tx/prereqs.json
@@ -23,10 +23,28 @@
       "ABDR 2357"
     ]
   },
+  "ABDR 1455": {
+    "text": "Required : ABDR 1419",
+    "courses": [
+      "ABDR 1419"
+    ]
+  },
+  "ABDR 1458": {
+    "text": "Required : ABDR 1431",
+    "courses": [
+      "ABDR 1431"
+    ]
+  },
   "ABDR 2041": {
     "text": "ABDR 1331, 1419.",
     "courses": [
       "ABDR 1331"
+    ]
+  },
+  "ABDR 2353": {
+    "text": "Required : ABDR 1431",
+    "courses": [
+      "ABDR 1431"
     ]
   },
   "ABDR 2357": {
@@ -35,6 +53,20 @@
       "ABDR 1315",
       "ABDR 1331",
       "ABDR 1419"
+    ]
+  },
+  "ABDR 2537": {
+    "text": "Required : ABDR 1419 , ABDR 1455",
+    "courses": [
+      "ABDR 1419",
+      "ABDR 1455"
+    ]
+  },
+  "ABDR 2541": {
+    "text": "Required : ABDR 1419 , ABDR 1455",
+    "courses": [
+      "ABDR 1419",
+      "ABDR 1455"
     ]
   },
   "ACCT 2301": {
@@ -58,6 +90,19 @@
       "ACCT 2401"
     ]
   },
+  "ACNT 1278": {
+    "text": "Recommended : ACNT 1277 or equivalent",
+    "courses": [
+      "ACNT 1277"
+    ]
+  },
+  "ACNT 1279": {
+    "text": "Recommended : ACNT 1277 or equivalent and ACNT 1278 or equivalent",
+    "courses": [
+      "ACNT 1277",
+      "ACNT 1278"
+    ]
+  },
   "ACNT 1304": {
     "text": "ACNT 1303",
     "courses": [
@@ -78,6 +123,12 @@
       "ACNT 1303"
     ]
   },
+  "ACNT 1313": {
+    "text": "Recommended : ACCT 2301",
+    "courses": [
+      "ACCT 2301"
+    ]
+  },
   "ACNT 1329": {
     "text": "ACNT 1303",
     "courses": [
@@ -96,6 +147,81 @@
       "ACNT 1331"
     ]
   },
+  "ACNT 1373": {
+    "text": "Recommended : ACCT 2301",
+    "courses": [
+      "ACCT 2301"
+    ]
+  },
+  "ACNT 1374": {
+    "text": "Recommended : ACNT 1373 or equivalent",
+    "courses": [
+      "ACNT 1373"
+    ]
+  },
+  "ACNT 1375": {
+    "text": "Recommended : ACCT 2301",
+    "courses": [
+      "ACCT 2301"
+    ]
+  },
+  "ACNT 1377": {
+    "text": "Recommended : ACCT 2301",
+    "courses": [
+      "ACCT 2301"
+    ]
+  },
+  "ACNT 1380": {
+    "text": "Recommended : Instructor approval",
+    "courses": []
+  },
+  "ACNT 1411": {
+    "text": "ACNT 1303",
+    "courses": [
+      "ACNT 1303"
+    ]
+  },
+  "ACNT 1429": {
+    "text": "ACNT 1303",
+    "courses": [
+      "ACNT 1303"
+    ]
+  },
+  "ACNT 2302": {
+    "text": "Recommended : ACCT 2301 , ACCT 2302 , ACNT 1311 , and ACNT 1313",
+    "courses": [
+      "ACCT 2301",
+      "ACCT 2302",
+      "ACNT 1311",
+      "ACNT 1313"
+    ]
+  },
+  "ACNT 2303": {
+    "text": "Required : ACCT 2301 . This course is cross-listed as ACNT 2403. The student may register for either ACNT 2303 or ACNT 2403 but may receive credit for only one of the two",
+    "courses": [
+      "ACCT 2301",
+      "ACNT 2403"
+    ]
+  },
+  "ACNT 2304": {
+    "text": "Required : ACNT 2303 . This course is cross-listed as ACNT 2404. The student may register for either ACNT 2304 or ACNT 2404 but may receive credit for only one of the two",
+    "courses": [
+      "ACNT 2303",
+      "ACNT 2404"
+    ]
+  },
+  "ACNT 2309": {
+    "text": "Recommended : ACCT 2302",
+    "courses": [
+      "ACCT 2302"
+    ]
+  },
+  "ACNT 2311": {
+    "text": "Recommended : ACCT 2302",
+    "courses": [
+      "ACCT 2302"
+    ]
+  },
   "ACNT 2332": {
     "text": "ACNT 1303 and ACNT 1304 and COSC 1301",
     "courses": [
@@ -103,6 +229,35 @@
       "ACNT 1304",
       "COSC 1301"
     ]
+  },
+  "ACNT 2336": {
+    "text": "ACCT 2301",
+    "courses": [
+      "ACCT 2301"
+    ]
+  },
+  "ACNT 2377": {
+    "text": "Recommended : ACNT 1377",
+    "courses": [
+      "ACNT 1377"
+    ]
+  },
+  "ACNT 2378": {
+    "text": "Recommended : ACNT 1374 (or equivalent) or concurrent enrollment in ACNT 1374",
+    "courses": [
+      "ACNT 1374"
+    ]
+  },
+  "ACNT 2379": {
+    "text": "Recommended: ACNT 1373 and ACNT 1374",
+    "courses": [
+      "ACNT 1373",
+      "ACNT 1374"
+    ]
+  },
+  "ACNT 2380": {
+    "text": "Recommended : Instructor approval",
+    "courses": []
   },
   "AERM 1210": {
     "text": "AERM 1315 and AERM 1303 and AERM 1208 and AERM 1205 and AERM 1314",
@@ -114,6 +269,30 @@
       "AERM 1314"
     ]
   },
+  "AERM 1241": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1243": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1247": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1253": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1254": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1340": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
   "AERM 1344": {
     "text": "AERM 1351 and AERM 1240 and AERM 2341 and AERM 1356 and AERM 1352",
     "courses": [
@@ -124,6 +303,18 @@
       "AERM 1352"
     ]
   },
+  "AERM 1345": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1349": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1350": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
   "AERM 1352": {
     "text": "AERM 2233 and AERM 1241 and AERM 1354 and AERM 2231 and AERM 1243",
     "courses": [
@@ -133,6 +324,58 @@
       "AERM 2231",
       "AERM 1243"
     ]
+  },
+  "AERM 1357": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1444": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1452": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 1456": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 2233": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 2351": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 2352": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AERM 2447": {
+    "text": "General Courses. Course scheduling information",
+    "courses": []
+  },
+  "AGRI 2330": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
+  },
+  "ANTH 2302": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
+  "ANTH 2346": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
+  "ANTH 2351": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
+  "ANTH 2401": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
   },
   "ARCE 1315": {
     "text": "DFTG 1309 (min C)",
@@ -167,6 +410,12 @@
       "ARCH 1308"
     ]
   },
+  "ARCH 1308": {
+    "text": "Required : ARCH 1307 . Background Search Required: No",
+    "courses": [
+      "ARCH 1307"
+    ]
+  },
   "ARCH 1315": {
     "text": "DFTG 2319. Assessment Levels: R2, E1, M2. 15.1303.5211",
     "courses": [
@@ -179,10 +428,23 @@
       "ARCH 2312"
     ]
   },
+  "ARCH 2603": {
+    "text": "Required : ARCH 1304 and ARCH 1308 . Background Search Required: No",
+    "courses": [
+      "ARCH 1304",
+      "ARCH 1308"
+    ]
+  },
   "ARCH 2604": {
     "text": "ARCH 2603. Assessment Levels: R3, E3, M3. 04.0201.5402",
     "courses": [
       "ARCH 2603"
+    ]
+  },
+  "ARTC 1313": {
+    "text": "Recommended: ARTC 1302 . Background Search Required: No",
+    "courses": [
+      "ARTC 1302"
     ]
   },
   "ARTC 1349": {
@@ -193,10 +455,34 @@
       "IMED 1316"
     ]
   },
+  "ARTC 1359": {
+    "text": "IMED 1301 with a grade of “C” or better",
+    "courses": [
+      "IMED 1301"
+    ]
+  },
+  "ARTC 2301": {
+    "text": "ARTC 1321 with a grade of “C” or better",
+    "courses": [
+      "ARTC 1321"
+    ]
+  },
   "ARTC 2305": {
     "text": "ARTC 1302 (min C)",
     "courses": [
       "ARTC 1302"
+    ]
+  },
+  "ARTC 2311": {
+    "text": "Recommended : Credit or concurrent enrollment in ENGL 1301 , or demonstrated competence approved by the instructor. Background Search Required: No",
+    "courses": [
+      "ENGL 1301"
+    ]
+  },
+  "ARTC 2313": {
+    "text": "Required : ARTC 1313",
+    "courses": [
+      "ARTC 1313"
     ]
   },
   "ARTC 2333": {
@@ -207,11 +493,37 @@
       "ARTC 2305"
     ]
   },
+  "ARTC 2335": {
+    "text": "Recommended : Advanced standing or instructor approval. This course is cross-listed as ARTC 2435. The student may register for either ARTC 2335 or ARTC 2435 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "ARTC 2435"
+    ]
+  },
+  "ARTC 2347": {
+    "text": "Recommended : ARTC 1317",
+    "courses": [
+      "ARTC 1317"
+    ]
+  },
+  "ARTC 2348": {
+    "text": "ARTC 1313 with a grade of “C” or better",
+    "courses": [
+      "ARTC 1313"
+    ]
+  },
+  "ARTC 2388": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. Background Search Required: No",
+    "courses": []
+  },
   "ARTS 109N": {
     "text": "ARTS 108N or have previous knowledge in balloon twisting. Balloons will be provided. A hand pump is recommended for the class.",
     "courses": [
       "ARTS 108N"
     ]
+  },
+  "ARTS 1303": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
   },
   "ARTS 1304": {
     "text": "ARTS 1303. Assessment Levels: R3, E3, M1. 50.0703",
@@ -219,11 +531,19 @@
       "ARTS 1303"
     ]
   },
+  "ARTS 1311": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
+  },
   "ARTS 1312": {
     "text": "ARTS 1311",
     "courses": [
       "ARTS 1311"
     ]
+  },
+  "ARTS 1316": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
   },
   "ARTS 1317": {
     "text": "ARTS 1316 (min D) or ARTS 1316 (min DT)",
@@ -235,6 +555,28 @@
     "text": "ARTS 2356 or permission of the instructor.",
     "courses": [
       "ARTS 2356"
+    ]
+  },
+  "ARTS 2311": {
+    "text": "Any two studio art courses",
+    "courses": []
+  },
+  "ARTS 2313": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
+    ]
+  },
+  "ARTS 2316": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
     ]
   },
   "ARTS 2317": {
@@ -249,16 +591,102 @@
       "ARTS 1316"
     ]
   },
+  "ARTS 2326": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
+    ]
+  },
+  "ARTS 2333": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
+    ]
+  },
+  "ARTS 2341": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
+    ]
+  },
+  "ARTS 2346": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
+    ]
+  },
   "ARTS 2347": {
     "text": "ARTS 2346",
     "courses": [
       "ARTS 2346"
     ]
   },
+  "ARTS 2348": {
+    "text": "Recommended : For Art Majors – ARTS 1311 and ARTS 1316 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1316"
+    ]
+  },
+  "ARTS 2356": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . This course is cross-listed as COMM 1318 . The student may register for either ARTS 2356 or COMM 1318 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317",
+      "COMM 1318"
+    ]
+  },
+  "ARTS 2357": {
+    "text": "ARTS 2356 or approval of the division chair",
+    "courses": [
+      "ARTS 2356"
+    ]
+  },
+  "ARTS 2366": {
+    "text": "Recommended : For Art Majors – ARTS 1311 , ARTS 1312 , ARTS 1316 , and ARTS 1317 . Background Search Required: No",
+    "courses": [
+      "ARTS 1311",
+      "ARTS 1312",
+      "ARTS 1316",
+      "ARTS 1317"
+    ]
+  },
+  "ARTT 1391": {
+    "text": "ARTC 2301 with a grade of “C” or better",
+    "courses": [
+      "ARTC 2301"
+    ]
+  },
   "ARTV 1302": {
     "text": "DFTG 2319. 10.0304",
     "courses": [
       "DFTG 2319"
+    ]
+  },
+  "ARTV 1341": {
+    "text": "ARTV 2345 with a grade of “C” or better",
+    "courses": [
+      "ARTV 2345"
+    ]
+  },
+  "ARTV 2345": {
+    "text": "ARTV 1345 with a grade of “C” or better",
+    "courses": [
+      "ARTV 1345"
     ]
   },
   "ARTV 2351": {
@@ -280,10 +708,36 @@
       "ELPT 1311"
     ]
   },
+  "AUMT 1257": {
+    "text": "AUMT 1305 and AUMT 1407 with a grade of “C” or better",
+    "courses": [
+      "AUMT 1305",
+      "AUMT 1407"
+    ]
+  },
+  "AUMT 1281": {
+    "text": "Required : Instructor approval required. This course is cross-listed as AUMT 1381 . The student may register for either AUMT 1281 or AUMT 1381 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "AUMT 1381"
+    ]
+  },
   "AUMT 1306": {
     "text": "AUMT 1419",
     "courses": [
       "AUMT 1419"
+    ]
+  },
+  "AUMT 1307": {
+    "text": "Required : AUMT 1305 taken previously. Background Search Required: No",
+    "courses": [
+      "AUMT 1305"
+    ]
+  },
+  "AUMT 1310": {
+    "text": "Required : AUMT 1305 , AUMT 1307 taken previously. Background Search Required: No",
+    "courses": [
+      "AUMT 1305",
+      "AUMT 1307"
     ]
   },
   "AUMT 1316": {
@@ -318,6 +772,36 @@
       "AUMT 1407"
     ]
   },
+  "AUMT 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "AUMT 1381": {
+    "text": "AUMT 1380 and approval of the division chair",
+    "courses": [
+      "AUMT 1380"
+    ]
+  },
+  "AUMT 1391": {
+    "text": "Required : AUMT 1305 , AUMT 1307 taken previously. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "AUMT 1305",
+      "AUMT 1307"
+    ]
+  },
+  "AUMT 1407": {
+    "text": "Credit for or concurrent enrollment in AUMT 1301",
+    "courses": [
+      "AUMT 1301"
+    ]
+  },
+  "AUMT 1416": {
+    "text": "AUMT 1305 and AUMT 1407 with a grade of “C” or better",
+    "courses": [
+      "AUMT 1305",
+      "AUMT 1407"
+    ]
+  },
   "AUMT 1419": {
     "text": "AUMT 1407 and AUMT 1306",
     "courses": [
@@ -325,9 +809,62 @@
       "AUMT 1306"
     ]
   },
+  "AUMT 1491": {
+    "text": "Required : AUMT 2317 taken previously. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "AUMT 2317"
+    ]
+  },
+  "AUMT 2280": {
+    "text": "Recommended : Completion of at least two AUMT courses and Automotive Department approval. This course is cross-listed as AUMT 2380 . The student may register for either AUMT 2280 or AUMT 2380 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "AUMT 2380"
+    ]
+  },
+  "AUMT 2281": {
+    "text": "Recommended : Completion of at least two AUMT courses and Automotive Department approval. This course is cross-listed as AUMT 2381 . The student may register for either AUMT 2281 or AUMT 2381 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "AUMT 2381"
+    ]
+  },
   "AUMT 2288": {
     "text": "AUMT 1307",
     "courses": [
+      "AUMT 1307"
+    ]
+  },
+  "AUMT 2301": {
+    "text": "Certificate in Automotive Technology and must be TSI satisfied",
+    "courses": []
+  },
+  "AUMT 2307": {
+    "text": "Required : Instructor approval required. Background Search Required: No",
+    "courses": []
+  },
+  "AUMT 2311": {
+    "text": "Required : AUMT 1305 , AUMT 1307 . Background Search Required: No",
+    "courses": [
+      "AUMT 1305",
+      "AUMT 1307"
+    ]
+  },
+  "AUMT 2313": {
+    "text": "Required : AUMT 1305 taken previously. Background Search Required: No",
+    "courses": [
+      "AUMT 1305"
+    ]
+  },
+  "AUMT 2317": {
+    "text": "Required : AUMT 1307 , AUMT 1319 . Background Search Required: No",
+    "courses": [
+      "AUMT 1307",
+      "AUMT 1319"
+    ]
+  },
+  "AUMT 2321": {
+    "text": "Required : AUMT 1305 , AUMT 1307 taken previously. Background Search Required: No",
+    "courses": [
+      "AUMT 1305",
       "AUMT 1307"
     ]
   },
@@ -337,11 +874,72 @@
       "AUMT 1407"
     ]
   },
+  "AUMT 2328": {
+    "text": "Required : Instructor approval required. Background Search Required: No",
+    "courses": []
+  },
+  "AUMT 2332": {
+    "text": "Required : AUMT 2325 taken previously. Background Search Required: No",
+    "courses": [
+      "AUMT 2325"
+    ]
+  },
+  "AUMT 2334": {
+    "text": "Required : AUMT 2317 taken previously. Background Search Required: No",
+    "courses": [
+      "AUMT 2317"
+    ]
+  },
+  "AUMT 2337": {
+    "text": "AUMT 1307 or instructor approval. Course scheduling information",
+    "courses": [
+      "AUMT 1307"
+    ]
+  },
+  "AUMT 2357": {
+    "text": "AUMT 1305 , AUMT 1407 , AUMT 1419 , AUMT 2321 , AUMT 2417 , AUMT 2434 , AUMT 1345 , AUMT 1257 , AUMT 1310 , AUMT 1416 , AUMT 2413 and AUMT 2425 with a grade of “C” or better",
+    "courses": [
+      "AUMT 1257",
+      "AUMT 1305",
+      "AUMT 1310",
+      "AUMT 1345",
+      "AUMT 1407",
+      "AUMT 1416",
+      "AUMT 1419",
+      "AUMT 2321",
+      "AUMT 2413",
+      "AUMT 2417",
+      "AUMT 2425",
+      "AUMT 2434"
+    ]
+  },
   "AUMT 2366": {
     "text": "AUMT 1301 or AUMT 1407",
     "courses": [
       "AUMT 1301",
       "AUMT 1407"
+    ]
+  },
+  "AUMT 2367": {
+    "text": "Required : Instructor approval required",
+    "courses": []
+  },
+  "AUMT 2380": {
+    "text": "AUMT 1381 and approval of the division chair",
+    "courses": [
+      "AUMT 1381"
+    ]
+  },
+  "AUMT 2381": {
+    "text": "Required : Instructor approval required. This course is cross-listed as AUMT 2281 . The student may register for either AUMT 2381 or AUMT 2281 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "AUMT 2281"
+    ]
+  },
+  "AUMT 2402": {
+    "text": "Required : AUMT 2317 . Background Search Required: No",
+    "courses": [
+      "AUMT 2317"
     ]
   },
   "AUMT 2413": {
@@ -367,6 +965,19 @@
     "text": "AUMT 2421. 47.0604",
     "courses": [
       "AUMT 2421"
+    ]
+  },
+  "AUMT 2434": {
+    "text": "AUMT 1407 and AUMT 2317",
+    "courses": [
+      "AUMT 1407",
+      "AUMT 2317"
+    ]
+  },
+  "AUMT 2437": {
+    "text": "AUMT 1407",
+    "courses": [
+      "AUMT 1407"
     ]
   },
   "BIOL 1106": {
@@ -423,6 +1034,24 @@
       "MATH 1314"
     ]
   },
+  "BIOL 1408": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "BIOL 1409": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "BIOL 1411": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "BIOL 1413": {
+    "text": "Suggested: MATH 1314",
+    "courses": [
+      "MATH 1314"
+    ]
+  },
   "BIOL 1415": {
     "text": "BIOL 1414, MATH 1314, BIOL 1406, CHEM 1411(or concurrent enrollment). Assessment Levels: R3, E3, M3. 26.1201",
     "courses": [
@@ -448,6 +1077,26 @@
       "BIOL 2301",
       "BIOL 2101",
       "BIOL 2401"
+    ]
+  },
+  "BIOL 2106": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR and in Mathematics. Course scheduling information",
+    "courses": []
+  },
+  "BIOL 2120": {
+    "text": "Successful completion of BIOL 2101 , as well as successful completion of, or concurrent enrollment in, BIOL 2320",
+    "courses": [
+      "BIOL 2101",
+      "BIOL 2320"
+    ]
+  },
+  "BIOL 2289": {
+    "text": "BIOL 1406 and BIOL 1407 or BIOL 2401 and BIOL 2402 . Course scheduling information",
+    "courses": [
+      "BIOL 1406",
+      "BIOL 1407",
+      "BIOL 2401",
+      "BIOL 2402"
     ]
   },
   "BIOL 2301": {
@@ -495,6 +1144,20 @@
     "text": "BIOL 2401",
     "courses": [
       "BIOL 2401"
+    ]
+  },
+  "BIOL 2404": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR and in Mathematics. Course scheduling information",
+    "courses": []
+  },
+  "BIOL 2406": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "BIOL 2416": {
+    "text": "Required : BIOL 1406 . Background Search Required: No",
+    "courses": [
+      "BIOL 1406"
     ]
   },
   "BIOL 2420": {
@@ -551,11 +1214,71 @@
     "text": "Assigned by the College. Assessment Levels: R3, E3, M3. 41.0101",
     "courses": []
   },
+  "BMGT 1192": {
+    "text": "Approval of the Division Chair",
+    "courses": []
+  },
+  "BMGT 1297": {
+    "text": "Approval of the Division Chair",
+    "courses": []
+  },
+  "BMGT 1382": {
+    "text": "Recommended: Students should have professional work experience and/or should have completed at least 9 credit hours of business coursework as prerequisites. This capstone course is part of the Business and Management Degree Pathway. Background Search Required: No",
+    "courses": []
+  },
+  "BMGT 1391": {
+    "text": "Approval of the Division Chair",
+    "courses": []
+  },
+  "BMGT 1392": {
+    "text": "Approval of the Division Chair",
+    "courses": []
+  },
+  "BMGT 2341": {
+    "text": "BUSI 1301 Business Principles",
+    "courses": [
+      "BUSI 1301"
+    ]
+  },
+  "BMGT 2382": {
+    "text": "Recommended: Students should have professional work experience and/or should have completed at least 9 credit hours of business coursework as prerequisites. This capstone course is part of the Business and Management Degree Pathway",
+    "courses": []
+  },
+  "BUSG 1166": {
+    "text": "This course is part of the Entrepreneurship Degree Pathway. Students should have business ownership experience",
+    "courses": []
+  },
+  "BUSG 1391": {
+    "text": "12 hours of business-related courses. This course may be repeated for additional credit using a different topic. Course scheduling information",
+    "courses": []
+  },
+  "BUSG 2166": {
+    "text": "This course is part of the Entrepreneurship Degree Pathway. Students should have business ownership experience",
+    "courses": []
+  },
+  "BUSG 2309": {
+    "text": "Suggested: ACCT 2301 and BUSI 1301",
+    "courses": [
+      "ACCT 2301",
+      "BUSI 1301"
+    ]
+  },
   "BUSI 1301": {
     "text": "ENGL 0302 (min C) or ENGL 0327 (min C)",
     "courses": [
       "ENGL 0302",
       "ENGL 0327"
+    ]
+  },
+  "BUSI 2301": {
+    "text": "Recommended : High school coursework in U.S. history and government, or equivalent. Background Search Required: No",
+    "courses": []
+  },
+  "BUSI 2304": {
+    "text": "TSI ELAR (Reading and Writing) requirement met and POFT 1301 or ENGL 1301",
+    "courses": [
+      "ENGL 1301",
+      "POFT 1301"
     ]
   },
   "BUSI 2305": {
@@ -567,17 +1290,63 @@
       "BCIS 1405"
     ]
   },
+  "CDEC 1164": {
+    "text": "Must have a GPA of 2.0 or higher and Division Chair approval",
+    "courses": []
+  },
   "CDEC 1166": {
     "text": "TECA 1354",
     "courses": [
       "TECA 1354"
     ]
   },
+  "CDEC 1303": {
+    "text": "Criminal history check",
+    "courses": []
+  },
+  "CDEC 1311": {
+    "text": "Criminal history check",
+    "courses": []
+  },
   "CDEC 1313": {
     "text": "CDEC 2166",
     "courses": [
       "CDEC 2166"
     ]
+  },
+  "CDEC 1318": {
+    "text": "Criminal history check",
+    "courses": []
+  },
+  "CDEC 1321": {
+    "text": "Must be able to pass a criminal history check",
+    "courses": []
+  },
+  "CDEC 1341": {
+    "text": "Required : Meet with your assigned School of Education Senior Success Coach for enrollment and course requirements",
+    "courses": []
+  },
+  "CDEC 1354": {
+    "text": "Criminal history check",
+    "courses": []
+  },
+  "CDEC 1380": {
+    "text": "Completion of at least 3 hours of CDEC courses or approval of the division chair",
+    "courses": []
+  },
+  "CDEC 1381": {
+    "text": "CDEC 1380 or approval of the division chair",
+    "courses": [
+      "CDEC 1380"
+    ]
+  },
+  "CDEC 1394": {
+    "text": "Permission by Director required to enroll. Course scheduling information",
+    "courses": []
+  },
+  "CDEC 1413": {
+    "text": "Recommended : A previous CDEC course or instructor approval",
+    "courses": []
   },
   "CDEC 2166": {
     "text": "CDEC 1313",
@@ -590,6 +1359,26 @@
     "courses": [
       "CDEC 2326"
     ]
+  },
+  "CDEC 2286": {
+    "text": "Must be in final semester; must have a GPA of 2.0 or higher; and have Division Chair approval",
+    "courses": []
+  },
+  "CDEC 2289": {
+    "text": "Recommended : Concurrent enrollment with CDEC 2336",
+    "courses": [
+      "CDEC 2336"
+    ]
+  },
+  "CDEC 2307": {
+    "text": "CDEC 1313",
+    "courses": [
+      "CDEC 1313"
+    ]
+  },
+  "CDEC 2315": {
+    "text": "Sophomore standing and Division Chair approval",
+    "courses": []
   },
   "CDEC 2326": {
     "text": "TECA 1311 or CDEC 1311",
@@ -604,11 +1393,39 @@
       "CDEC 2326"
     ]
   },
+  "CDEC 2336": {
+    "text": "Recommended : CDEC 2326 and CDEC 2328 . DREA 0093 or English as a Second Language (ESOL) 0044 or have met the Texas Success Initiative (TSI) standard in Reading",
+    "courses": [
+      "CDEC 2326",
+      "CDEC 2328",
+      "DREA 0093"
+    ]
+  },
   "CDEC 2340": {
     "text": "CDEC 1359 and CDEC 2340",
     "courses": [
       "CDEC 1359",
       "CDEC 2340"
+    ]
+  },
+  "CDEC 2366": {
+    "text": "Basic skills certificate or AAS majors only. Course scheduling information",
+    "courses": []
+  },
+  "CDEC 2380": {
+    "text": "CDEC 1380 and CDEC 1381 or approval of the division chair",
+    "courses": [
+      "CDEC 1380",
+      "CDEC 1381"
+    ]
+  },
+  "CDEC 2384": {
+    "text": "CDEC 1311 , CDEC 1313 , CDEC 1319 , and CDEC 2326 with a grade of “C” or better",
+    "courses": [
+      "CDEC 1311",
+      "CDEC 1313",
+      "CDEC 1319",
+      "CDEC 2326"
     ]
   },
   "CDEC 2387": {
@@ -623,10 +1440,44 @@
       "CDEC 2387"
     ]
   },
+  "CETT 1325": {
+    "text": "IEIR 1304 with a grade of “C” or better",
+    "courses": [
+      "IEIR 1304"
+    ]
+  },
+  "CETT 1341": {
+    "text": "CETT 1429",
+    "courses": [
+      "CETT 1429"
+    ]
+  },
+  "CETT 1345": {
+    "text": "CETT 1331 or ELMT 1301",
+    "courses": [
+      "CETT 1331",
+      "ELMT 1301"
+    ]
+  },
   "CETT 1405": {
     "text": "CETT 1403 (min C)",
     "courses": [
       "CETT 1403"
+    ]
+  },
+  "CETT 1407": {
+    "text": "Required : ELPT 1455 and ELPT 2419 . Background Search Required: No",
+    "courses": [
+      "ELPT 1455",
+      "ELPT 2419"
+    ]
+  },
+  "CETT 1409": {
+    "text": "Credit for or concurrent enrollment in ENER 1350 or PTAC 1302 or INMT 1305",
+    "courses": [
+      "ENER 1350",
+      "INMT 1305",
+      "PTAC 1302"
     ]
   },
   "CETT 1415": {
@@ -635,10 +1486,82 @@
       "CETT 1405"
     ]
   },
+  "CETT 1429": {
+    "text": "Required : CETT 1405 . This course is cross-listed as CETT 1329. The student may register for either CETT 1429 or CETT 1329 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "CETT 1329",
+      "CETT 1405"
+    ]
+  },
   "CETT 1441": {
     "text": "CETT 1405 (min C)",
     "courses": [
       "CETT 1405"
+    ]
+  },
+  "CETT 1449": {
+    "text": "Recommended : CETT 1429 . Background Search Required: No",
+    "courses": [
+      "CETT 1429"
+    ]
+  },
+  "CETT 1457": {
+    "text": "Required : CETT 1429 . Background Search Required: No",
+    "courses": [
+      "CETT 1429"
+    ]
+  },
+  "CETT 2280": {
+    "text": "Required : Faculty Approval prior to registration. Background Search Required: No",
+    "courses": []
+  },
+  "CETT 2281": {
+    "text": "Required : Faculty Approval prior to registration. Background Search Required: No",
+    "courses": []
+  },
+  "CETT 2337": {
+    "text": "Recommended : CETT 1425 . Background Search Required: No",
+    "courses": [
+      "CETT 1425"
+    ]
+  },
+  "CETT 2349": {
+    "text": "Electronics major expecting completion of all Electronics courses in the current semester",
+    "courses": []
+  },
+  "CETT 2380": {
+    "text": "12 semester credit hours. This course may be repeated if topics and learning outcomes vary. Course scheduling information",
+    "courses": []
+  },
+  "CETT 2433": {
+    "text": "Recommended : CETT 1429 . Background Search Required: No",
+    "courses": [
+      "CETT 1429"
+    ]
+  },
+  "CETT 2435": {
+    "text": "Recommended : CETT 1445. Background Search Required: No",
+    "courses": [
+      "CETT 1445"
+    ]
+  },
+  "CETT 2480": {
+    "text": "Required : Faculty Approval prior to registration. Background Search Required: No",
+    "courses": []
+  },
+  "CETT 2481": {
+    "text": "Required : Faculty Approval prior to registration. Background Search Required: No",
+    "courses": []
+  },
+  "CHEF 1005": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "CHEF 1302": {
+    "text": "Required: CHEF 1301 and CHEF 1305 with a “C” or better",
+    "courses": [
+      "CHEF 1301",
+      "CHEF 1305"
     ]
   },
   "CHEF 1310": {
@@ -653,6 +1576,28 @@
       "CHEF 1301"
     ]
   },
+  "CHEF 1441": {
+    "text": "Required : CHEF 2331 with a “C” or better and a minimum of a food handler’s certificate, preferred ServSafe Food Manager Certificate or the Texas Food Guard Certification. Failure to comply will result in student being dropped from this course",
+    "courses": [
+      "CHEF 2331"
+    ]
+  },
+  "CHEF 1445": {
+    "text": "Required : CHEF 2331 with a “C” or better and a minimum of a food handler’s certificate, preferred ServSafe Food Manager Certificate or the Texas Food Guard Certification. Failure to comply will result in student being dropped from this course",
+    "courses": [
+      "CHEF 2331"
+    ]
+  },
+  "CHEF 2001": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "CHEF 2301": {
+    "text": "IFWA 2441 with a grade of “C” or better",
+    "courses": [
+      "IFWA 2441"
+    ]
+  },
   "CHEF 2302": {
     "text": "CHEF 1301, 1305, 1310. Assessment Levels: R1, E1, M1. 12.0503",
     "courses": [
@@ -664,6 +1609,20 @@
     "courses": [
       "CHEF 1301",
       "CHEF 1305"
+    ]
+  },
+  "CHEF 2341": {
+    "text": "Recommended : CHEF 2331 or PSTR 2331 and CHEF 1305 with a “C” or better and a minimum of a food handler’s certificate, preferred ServSafe Food Manager Certificate or the Texas Food Guard Certification",
+    "courses": [
+      "CHEF 1305",
+      "CHEF 2331",
+      "PSTR 2331"
+    ]
+  },
+  "CHEM 1105": {
+    "text": "Successful completion of, or concurrent enrollment in, CHEM 1305",
+    "courses": [
+      "CHEM 1305"
     ]
   },
   "CHEM 1107": {
@@ -711,10 +1670,20 @@
       "CHEM 1109"
     ]
   },
+  "CHEM 1405": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR and in Mathematics. Course scheduling information",
+    "courses": []
+  },
   "CHEM 1407": {
     "text": "CHEM 1405 or 1406, or permission of the department chairperson. Assessment Levels: R3, E3, M2. 40.0501",
     "courses": [
       "CHEM 1405"
+    ]
+  },
+  "CHEM 1409": {
+    "text": "Required : MATH 1314 College Algebra . High school chemistry or equivalent preparation",
+    "courses": [
+      "MATH 1314"
     ]
   },
   "CHEM 1411": {
@@ -751,10 +1720,36 @@
       "CHEM 2123"
     ]
   },
+  "CHEM 2325": {
+    "text": "A grade of C or better in CHEM 2323",
+    "courses": [
+      "CHEM 2323"
+    ]
+  },
+  "CHEM 2389": {
+    "text": "Required : CHEM 1412 with a minimum grade of “C.”",
+    "courses": [
+      "CHEM 1412"
+    ]
+  },
   "CHEM 2423": {
     "text": "CHEM 1412",
     "courses": [
       "CHEM 1412"
+    ]
+  },
+  "CHEM 2425": {
+    "text": "Required : CHEM 2423 with a minimum grade of “C.” Background Search Required: No",
+    "courses": [
+      "CHEM 2423"
+    ]
+  },
+  "CHLT 2166": {
+    "text": "CHLT 1309 ; PSYT 1329 ; concurrent enrollment in DAAC 1317 ; and Division Chair approval",
+    "courses": [
+      "CHLT 1309",
+      "DAAC 1317",
+      "PSYT 1329"
     ]
   },
   "CJLE 1506": {
@@ -768,6 +1763,33 @@
   "CJLE 1524": {
     "text": "approval of department advisor. 43.0107",
     "courses": []
+  },
+  "CJSA 1393": {
+    "text": "CJSA 1308 , CJSA 2323 and CRIJ 2314 with a grade of “C” or better",
+    "courses": [
+      "CJSA 1308",
+      "CJSA 2323",
+      "CRIJ 2314"
+    ]
+  },
+  "CJSA 1401": {
+    "text": "Required: CJSA 1400 . Background Search Required: No",
+    "courses": [
+      "CJSA 1400"
+    ]
+  },
+  "CJSA 1472": {
+    "text": "Required: CJSA 1471 . Background Search Required: No",
+    "courses": [
+      "CJSA 1471"
+    ]
+  },
+  "CJSA 2323": {
+    "text": "CJSA 1308 and CRIJ 2314 with a grade of “C” or better",
+    "courses": [
+      "CJSA 1308",
+      "CRIJ 2314"
+    ]
   },
   "CJSA 2332": {
     "text": "CJSA 1308",
@@ -784,10 +1806,27 @@
       "CJLE 1524"
     ]
   },
+  "CNBT 1280": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "CNBT 1281": {
+    "text": "CNBT 1280 OR CNBT 1380 and approval of the division chair",
+    "courses": [
+      "CNBT 1280",
+      "CNBT 1380"
+    ]
+  },
   "CNBT 1342": {
     "text": "ARCH 2312 or CNBT 1311. Assessment Levels: R2, E2, M1. 15.1001.",
     "courses": [
       "ARCH 2312",
+      "CNBT 1311"
+    ]
+  },
+  "CNBT 1344": {
+    "text": "Required : CNBT 1311",
+    "courses": [
       "CNBT 1311"
     ]
   },
@@ -796,6 +1835,32 @@
     "courses": [
       "ARCH 2312",
       "CNBT 1311"
+    ]
+  },
+  "CNBT 1359": {
+    "text": "POFI 1301 or ITSC 1301 or BCIS 1305 or approval of the division chair",
+    "courses": [
+      "BCIS 1305",
+      "ITSC 1301",
+      "POFI 1301"
+    ]
+  },
+  "CNBT 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "CNBT 1381": {
+    "text": "CNBT 1380 and approval of the division chair",
+    "courses": [
+      "CNBT 1380"
+    ]
+  },
+  "CNBT 1446": {
+    "text": "POFI 1301 or ITSC 1301 or BCIS 1305 or approval of the division chair",
+    "courses": [
+      "BCIS 1305",
+      "ITSC 1301",
+      "POFI 1301"
     ]
   },
   "CNBT 2266": {
@@ -814,11 +1879,35 @@
       "CNBT 2342"
     ]
   },
+  "CNBT 2310": {
+    "text": "Recommended : Concurrent with CNBT 2342",
+    "courses": [
+      "CNBT 2342"
+    ]
+  },
+  "CNBT 2315": {
+    "text": "Required : CNBT 1346",
+    "courses": [
+      "CNBT 1346"
+    ]
+  },
   "CNBT 2317": {
     "text": "ARCH 2312 or CNBT 1311. Assessment Levels: R2, E2, M2. 15.1001",
     "courses": [
       "ARCH 2312",
       "CNBT 1311"
+    ]
+  },
+  "CNBT 2335": {
+    "text": "CNBT 1359",
+    "courses": [
+      "CNBT 1359"
+    ]
+  },
+  "CNBT 2337": {
+    "text": "CNBT 1346 or approval of the division chair",
+    "courses": [
+      "CNBT 1346"
     ]
   },
   "CNBT 2342": {
@@ -834,6 +1923,10 @@
       "CNBT 2342"
     ]
   },
+  "CNBT 2366": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
   "CNBT 2370": {
     "text": "CNBT 1300, CNBT 1311, CNBT 1346, CNBT 1359, and CNBT 2342. Assessment Levels: R2, E2, M2. 15.1001",
     "courses": [
@@ -844,10 +1937,33 @@
       "CNBT 2342"
     ]
   },
+  "CNBT 2380": {
+    "text": "CNBT 1381 and approval of the division chair",
+    "courses": [
+      "CNBT 1381"
+    ]
+  },
   "CNSE 1371": {
     "text": "HYDR 1301 (min C)",
     "courses": [
       "HYDR 1301"
+    ]
+  },
+  "COMM 1307": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
+  "COMM 1317": {
+    "text": "Required : COMM 1316 . Background Search Required: No",
+    "courses": [
+      "COMM 1316"
+    ]
+  },
+  "COMM 1319": {
+    "text": "Recommended : COMM 1318 . This course is cross-listed as ARTS 2357 . The student may register for either COMM 1319 or ARTS 2357 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "ARTS 2357",
+      "COMM 1318"
     ]
   },
   "COMM 1337": {
@@ -864,6 +1980,10 @@
       "COMM 1307",
       "ENGL 1302"
     ]
+  },
+  "COMM 2311": {
+    "text": "Recommended : Typing ability",
+    "courses": []
   },
   "COMM 2315": {
     "text": "COMM 2311 Media Writing. Assessment Levels: R3, E3, M1. 09.0101",
@@ -883,6 +2003,10 @@
     "courses": [
       "ENGL 1301"
     ]
+  },
+  "COMM 2389": {
+    "text": "Consent of Department Chair",
+    "courses": []
   },
   "COSC 1337": {
     "text": "ITSE 1359 and MATH 1342. Assessment Levels: R3, E1, M1. 11.0201",
@@ -916,6 +2040,12 @@
       "ENGR 2406"
     ]
   },
+  "COSC 2336": {
+    "text": "COSC 1437 or instructor permission. Course scheduling information",
+    "courses": [
+      "COSC 1437"
+    ]
+  },
   "COSC 2425": {
     "text": "COSC 1436 or ITSE 1402; and COSC 1437 or ITSE 2431 or permission of the instructor. Assessment Levels: R3, E1, M1. 11.0201",
     "courses": [
@@ -932,6 +2062,24 @@
       "MATH 2305"
     ]
   },
+  "CPMT 1345": {
+    "text": "ITSC 1325 or instructor approval. Course scheduling information",
+    "courses": [
+      "ITSC 1325"
+    ]
+  },
+  "CPMT 1351": {
+    "text": "ITSC 1325 or instructor approval. Course scheduling information",
+    "courses": [
+      "ITSC 1325"
+    ]
+  },
+  "CPMT 1449": {
+    "text": "Recommended : CETT 1403 . Background Search Required: No",
+    "courses": [
+      "CETT 1403"
+    ]
+  },
   "CPMT 2380": {
     "text": "CPMT 1351 (min C) and CPMT 2333 (min C) and ITCC 1310 (min C) and ITNW 1313 (min C)",
     "courses": [
@@ -941,11 +2089,25 @@
       "ITNW 1313"
     ]
   },
+  "CPMT 2445": {
+    "text": "Recommended : CETT 1429 . Background Search Required: No",
+    "courses": [
+      "CETT 1429"
+    ]
+  },
   "CRIJ 1301": {
     "text": "ENGL 0302 (min C)",
     "courses": [
       "ENGL 0302"
     ]
+  },
+  "CRIJ 1306": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
+  },
+  "CRIJ 1307": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
   },
   "CRIJ 1310": {
     "text": "ENGL 0302 (min C) or ENGL 0327 (min C)",
@@ -953,6 +2115,10 @@
       "ENGL 0302",
       "ENGL 0327"
     ]
+  },
+  "CRIJ 2301": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
   },
   "CRIJ 2313": {
     "text": "ENGL 0302 (min C) or ENGL 0327 (min C)",
@@ -973,6 +2139,10 @@
       "CRIJ 1301"
     ]
   },
+  "CRIJ 2328": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
+  },
   "CRTR 1242": {
     "text": "CRTR 1241. Assessment Levels: R1, E1, M1. 22.0303",
     "courses": [
@@ -985,11 +2155,47 @@
       "CRTR 1241"
     ]
   },
+  "CRTR 2206": {
+    "text": "Suggested: CRTR 1404",
+    "courses": [
+      "CRTR 1404"
+    ]
+  },
+  "CRTR 2303": {
+    "text": "Suggested: CRTR 2401",
+    "courses": [
+      "CRTR 2401"
+    ]
+  },
+  "CRTR 2335": {
+    "text": "Suggested: CRTR 2303",
+    "courses": [
+      "CRTR 2303"
+    ]
+  },
   "CRTR 2343": {
     "text": "CRTR 2301 and 2310 or concurrent enrollment. Assessment Levels: R1, E1, M1. 22.0303",
     "courses": [
       "CRTR 2301"
     ]
+  },
+  "CRTR 2401": {
+    "text": "Suggested: CRTR 1406",
+    "courses": [
+      "CRTR 1406"
+    ]
+  },
+  "CSIS 3352": {
+    "text": "Python programming familiarity",
+    "courses": []
+  },
+  "CSME 1248": {
+    "text": "Open only to students admitted to the Cosmetology program",
+    "courses": []
+  },
+  "CSME 1401": {
+    "text": "Open only to students admitted to the Cosmetology program",
+    "courses": []
   },
   "CSME 1405": {
     "text": "CSME 1410 and CSME 1443 and CSME 1447 and CSME 1410 and CSME 1443 and CSME 1447",
@@ -1007,6 +2213,10 @@
       "CSME 1447"
     ]
   },
+  "CSME 1431": {
+    "text": "Open only to students admitted to the Cosmetology program",
+    "courses": []
+  },
   "CSME 1443": {
     "text": "CSME 1410 and CSME 1405 and CSME 1447 and CSME 1405 and CSME 1410 and CSME 1447",
     "courses": [
@@ -1023,6 +2233,10 @@
       "CSME 1443"
     ]
   },
+  "CSME 1451": {
+    "text": "Open only to students admitted to the Cosmetology program",
+    "courses": []
+  },
   "CSME 1453": {
     "text": "CSME 2401 and CSME 2439 and CSME 2441 and CSME 2401 and CSME 2439 and CSME 2441",
     "courses": [
@@ -1030,6 +2244,10 @@
       "CSME 2439",
       "CSME 2441"
     ]
+  },
+  "CSME 2202": {
+    "text": "Open only to students admitted to the Cosmetology program",
+    "courses": []
   },
   "CSME 2310": {
     "text": "CSME 1248, 1354, 1453, 2401. 12.0407",
@@ -1080,16 +2298,77 @@
       "SCIT 1414"
     ]
   },
+  "CTEC 1380": {
+    "text": "Process Op Co-op - Completion of or concurrent enrollment in PTAC 2420 , PTAC 1308 and a 2.7 GPA or approval of the division chair. Lab Tech Co-op - Completion of or concurrent enrollment in CTEC 1441 and a 2.7 GPA or approval of the division chair",
+    "courses": [
+      "CTEC 1441",
+      "PTAC 1308",
+      "PTAC 2420"
+    ]
+  },
+  "CTEC 1381": {
+    "text": "CTEC 1380 and a 2. 7 GPA or approval of the division chair",
+    "courses": [
+      "CTEC 1380"
+    ]
+  },
+  "CTEC 1391": {
+    "text": "Grade of C or better in PTAC 1354 OR PTAC 2386",
+    "courses": [
+      "PTAC 1354",
+      "PTAC 2386"
+    ]
+  },
+  "CTEC 1401": {
+    "text": "Credit for or concurrent enrollment in MATH 1314",
+    "courses": [
+      "MATH 1314"
+    ]
+  },
   "CTEC 1441": {
     "text": "SCIT 1543 or consent of instructor. Assessment Levels: R3, E2, M3. 41.0301",
     "courses": [
       "SCIT 1543"
     ]
   },
+  "CTEC 1480": {
+    "text": "Credit for or concurrent enrollment in PTAC 2420 and assignment by the Program Director and Co-op employer",
+    "courses": [
+      "PTAC 2420"
+    ]
+  },
+  "CTEC 2250": {
+    "text": "Completion of or concurrent enrollment in PTAC 2438 and PTAC 2446",
+    "courses": [
+      "PTAC 2438",
+      "PTAC 2446"
+    ]
+  },
+  "CTEC 2271": {
+    "text": "Grade of C or better in PTAC 1354 OR PTAC 2386 AND completion of OR concurrent enrollment in PTAC 2438 AND PTAC 2446",
+    "courses": [
+      "PTAC 1354",
+      "PTAC 2386",
+      "PTAC 2438",
+      "PTAC 2446"
+    ]
+  },
   "CTEC 2286": {
     "text": "CTEC 2431. Assessment Levels: R3, E3, M3. 41.0301",
     "courses": [
       "CTEC 2431"
+    ]
+  },
+  "CTEC 2380": {
+    "text": "CTEC 1381 and a 2. 7 GPA or approval of the division chair",
+    "courses": [
+      "CTEC 1381"
+    ]
+  },
+  "CTEC 2431": {
+    "text": "A grade of C or better in CTEC 1441",
+    "courses": [
+      "CTEC 1441"
     ]
   },
   "CTEC 2445": {
@@ -1099,6 +2378,10 @@
       "PTAC 1354",
       "PTAC 2420"
     ]
+  },
+  "CTEC 2480": {
+    "text": "Enrollment in Process Technology program, sophomore standing, 30 completed semester hours in program and departmental approval",
+    "courses": []
   },
   "CTEC 2545": {
     "text": "PTAC 2438 (min C) and PTAC 2314 (min C)",
@@ -1119,11 +2402,75 @@
       "SCIT 1543"
     ]
   },
+  "CTMT 1391": {
+    "text": "Recommended : CTMT 2332 , RADR 2240 , CTMT 2336 , CTMT 2364 , and ARRT registered in radiography or registry eligible, or instructor permission. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information . Background Search Required: Yes",
+    "courses": [
+      "CTMT 2332",
+      "CTMT 2336",
+      "CTMT 2364",
+      "RADR 2240"
+    ]
+  },
+  "CTMT 2267": {
+    "text": "Recommended : CTMT 2332 , RADR 2240 , CTMT 2336 , CTMT 2364 , and ARRT registered in radiography or registry eligible, or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "CTMT 2332",
+      "CTMT 2336",
+      "CTMT 2364",
+      "RADR 2240"
+    ]
+  },
+  "CTMT 2332": {
+    "text": "Recommended : ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": []
+  },
+  "CTMT 2336": {
+    "text": "Recommended : CTMT 2332 , RADR 2240 , and ARRT registered in radiography or registry eligible, or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "CTMT 2332",
+      "RADR 2240"
+    ]
+  },
+  "CTMT 2364": {
+    "text": "Recommended : CTMT 2332 , RADR 2240 and ARRT registered in radiography or registry eligible, or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "CTMT 2332",
+      "RADR 2240"
+    ]
+  },
   "CVOP 1381": {
     "text": "DEMR 1427. Assessment Levels: R1, E1, M0. 49.0205",
     "courses": [
       "DEMR 1427"
     ]
+  },
+  "CVTT 1110": {
+    "text": "Recommended : A grade of “C” or better in all CVTT and support courses. Background Search Required: Yes",
+    "courses": []
+  },
+  "CVTT 1153": {
+    "text": "Recommended : A grade of “C” or better in all CVTT and support courses. Background Search Required: No",
+    "courses": []
+  },
+  "CVTT 1304": {
+    "text": "Recommended : Admission to the Invasive Cardiovascular Technology program with Health Occupations Core Curriculum or prior degree in Health Sciences. Background Search Required: Yes",
+    "courses": []
+  },
+  "CVTT 1313": {
+    "text": "Recommended : Admission to the Invasive Cardiovascular Technology program with Health Occupations Core Curriculum or prior degree in Health Sciences. Background Search Required: Yes",
+    "courses": []
+  },
+  "CVTT 1340": {
+    "text": "Recommended : A grade of “C” or better in all CVTT and support courses. Background Search Required: Yes",
+    "courses": []
+  },
+  "CVTT 1350": {
+    "text": "Recommended : A grade of “C” or better in all CVTT and support courses. Background Search Required: Yes",
+    "courses": []
+  },
+  "CVTT 1471": {
+    "text": "Recommended : A grade of “C” or better in all previous CVTT and support courses. Background Search Required: Yes",
+    "courses": []
   },
   "DAAC 1164": {
     "text": "DAAC 1304 (min C) or DAAC 1304 (min CT) and DAAC 1311 (min C) or DAAC 1311 (min CT) and DAAC 1317 (min C) or DAAC 1317 (min CT)",
@@ -1139,6 +2486,31 @@
       "DAAC 1311"
     ]
   },
+  "DAAC 1317": {
+    "text": "DAAC 1311 with a grade of “C” or better",
+    "courses": [
+      "DAAC 1311"
+    ]
+  },
+  "DAAC 2166": {
+    "text": "DAAC 1311 . Course scheduling information",
+    "courses": [
+      "DAAC 1311"
+    ]
+  },
+  "DAAC 2167": {
+    "text": "DAAC 2166 . Corequisite(s): DAAC 2271 . Course scheduling information",
+    "courses": [
+      "DAAC 2166",
+      "DAAC 2271"
+    ]
+  },
+  "DAAC 2307": {
+    "text": "DAAC 1319 . Course scheduling information",
+    "courses": [
+      "DAAC 1319"
+    ]
+  },
   "DAAC 2341": {
     "text": "DAAC 1319. Assessment Levels: R1, E1, M1. 51.1501",
     "courses": [
@@ -1151,10 +2523,38 @@
       "DAAC 1311"
     ]
   },
+  "DAAC 2354": {
+    "text": "DAAC 2341 or instructor approval. The lab portion of this course is mandatory and requires three hours of lab participation per week. Course scheduling information",
+    "courses": [
+      "DAAC 2341"
+    ]
+  },
   "DAAC 2363": {
     "text": "DAAC 2354. Assessment Levels: R1, E1, M1. 51.1501",
     "courses": [
       "DAAC 2354"
+    ]
+  },
+  "DAAC 2367": {
+    "text": "Completion of all program-required coursework through the third semester of classes with a grade of “C” or better and approval by the department chair after evaluation of the student’s degree audit",
+    "courses": []
+  },
+  "DANC 1301": {
+    "text": "Required : DANC 1201 . Background Search Required: No",
+    "courses": [
+      "DANC 1201"
+    ]
+  },
+  "DANC 2241": {
+    "text": "DANC 1241 with a grade of “C” or better",
+    "courses": [
+      "DANC 1241"
+    ]
+  },
+  "DANC 2245": {
+    "text": "DANC 1245 with a grade of “C” or better",
+    "courses": [
+      "DANC 1245"
     ]
   },
   "DEMR 1280": {
@@ -1163,12 +2563,24 @@
       "DEMR 2412"
     ]
   },
+  "DEMR 1305": {
+    "text": "Required : DEMR 1301 . Background Search Required: No",
+    "courses": [
+      "DEMR 1301"
+    ]
+  },
   "DEMR 1306": {
     "text": "DEMR 1329 and DEMR 1316 and DEMR 1321",
     "courses": [
       "DEMR 1329",
       "DEMR 1316",
       "DEMR 1321"
+    ]
+  },
+  "DEMR 1310": {
+    "text": "DEMR 1329 or instructor approval. Course scheduling information",
+    "courses": [
+      "DEMR 1329"
     ]
   },
   "DEMR 1313": {
@@ -1183,10 +2595,64 @@
       "DEMR 2339"
     ]
   },
+  "DEMR 1317": {
+    "text": "Required : DEMR 1305 . Background Search Required: No",
+    "courses": [
+      "DEMR 1305"
+    ]
+  },
+  "DEMR 1321": {
+    "text": "Required : DEMR 1305 . Background Search Required: No",
+    "courses": [
+      "DEMR 1305"
+    ]
+  },
+  "DEMR 1323": {
+    "text": "Required : DEMR 1305 . Background Search Required: No",
+    "courses": [
+      "DEMR 1305"
+    ]
+  },
+  "DEMR 1327": {
+    "text": "DEMR 1329 or instructor approval. Course scheduling information",
+    "courses": [
+      "DEMR 1329"
+    ]
+  },
+  "DEMR 1330": {
+    "text": "Required : DEMR 1305 . Background Search Required: No",
+    "courses": [
+      "DEMR 1305"
+    ]
+  },
+  "DEMR 1342": {
+    "text": "DEMR 1329 . Course scheduling information",
+    "courses": [
+      "DEMR 1329"
+    ]
+  },
+  "DEMR 1380": {
+    "text": "DEMR 1329 . Course scheduling information",
+    "courses": [
+      "DEMR 1329"
+    ]
+  },
   "DEMR 1447": {
     "text": "DEMR 1416. 47.0605.",
     "courses": [
       "DEMR 1416"
+    ]
+  },
+  "DEMR 2312": {
+    "text": "DEMR 1310 . Course scheduling information",
+    "courses": [
+      "DEMR 1310"
+    ]
+  },
+  "DEMR 2331": {
+    "text": "Required : DEMR 1305 . Background Search Required: No",
+    "courses": [
+      "DEMR 1305"
     ]
   },
   "DEMR 2332": {
@@ -1213,6 +2679,12 @@
       "DEMR 2339"
     ]
   },
+  "DEMR 2335": {
+    "text": "DEMR 1316 or instructor approval. Course scheduling information",
+    "courses": [
+      "DEMR 1316"
+    ]
+  },
   "DEMR 2339": {
     "text": "DEMR 1306 and DEMR 1310 and DEMR 1317 and DEMR 1342 and DEMR 1313 or DEMR 2332 or DEMR 2334 and DEMR 1313 and DEMR 2332 and DEMR 2334",
     "courses": [
@@ -1237,10 +2709,84 @@
       "DEMR 2332"
     ]
   },
+  "DFTG 1302": {
+    "text": "DFTG 2340 . (Fall semester only) Course scheduling information",
+    "courses": [
+      "DFTG 2340"
+    ]
+  },
+  "DFTG 1315": {
+    "text": "Introductory. Background Search Required: No",
+    "courses": []
+  },
+  "DFTG 1317": {
+    "text": "DFTG 1305 and DFTG 1309 or approval of the division chair",
+    "courses": [
+      "DFTG 1305",
+      "DFTG 1309"
+    ]
+  },
+  "DFTG 1330": {
+    "text": "DFTG 1305 AND DFTG 1309",
+    "courses": [
+      "DFTG 1305",
+      "DFTG 1309"
+    ]
+  },
+  "DFTG 1333": {
+    "text": "DFTG 1305",
+    "courses": [
+      "DFTG 1305"
+    ]
+  },
+  "DFTG 1341": {
+    "text": "DFTG 1302 . Course scheduling information",
+    "courses": [
+      "DFTG 1302"
+    ]
+  },
   "DFTG 1345": {
     "text": "DFTG 1305",
     "courses": [
       "DFTG 1305"
+    ]
+  },
+  "DFTG 1358": {
+    "text": "DFTG 1305 and DFTG 1309 or approval of the division chair",
+    "courses": [
+      "DFTG 1305",
+      "DFTG 1309"
+    ]
+  },
+  "DFTG 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "DFTG 1381": {
+    "text": "DFTG 1380 and approval of the division chair",
+    "courses": [
+      "DFTG 1380"
+    ]
+  },
+  "DFTG 1413": {
+    "text": "Required : WLDG 1313 , WLDG 1417",
+    "courses": [
+      "WLDG 1313",
+      "WLDG 1417"
+    ]
+  },
+  "DFTG 1417": {
+    "text": "DFTG 1405 and credit for or concurrent enrollment in DFTG 2319",
+    "courses": [
+      "DFTG 1405",
+      "DFTG 2319"
+    ]
+  },
+  "DFTG 1430": {
+    "text": "DFTG 1405 and DFTG 1409",
+    "courses": [
+      "DFTG 1405",
+      "DFTG 1409"
     ]
   },
   "DFTG 2300": {
@@ -1255,6 +2801,12 @@
       "DFTG 1305"
     ]
   },
+  "DFTG 2306": {
+    "text": "DFTG 2340",
+    "courses": [
+      "DFTG 2340"
+    ]
+  },
   "DFTG 2307": {
     "text": "DFTG 1309 (min C)",
     "courses": [
@@ -1267,11 +2819,24 @@
       "DFTG 1309"
     ]
   },
+  "DFTG 2312": {
+    "text": "DFTG 1309 or DFTG 1409 . Background Search Required: No",
+    "courses": [
+      "DFTG 1309",
+      "DFTG 1409"
+    ]
+  },
   "DFTG 2319": {
     "text": "DFTG 1305 and ENGR 1304",
     "courses": [
       "DFTG 1305",
       "ENGR 1304"
+    ]
+  },
+  "DFTG 2321": {
+    "text": "DFTG 1305 . Course scheduling information",
+    "courses": [
+      "DFTG 1305"
     ]
   },
   "DFTG 2323": {
@@ -1298,6 +2863,13 @@
     "courses": [
       "DFTG 2319",
       "DFTG 1305"
+    ]
+  },
+  "DFTG 2335": {
+    "text": "Recommended : DFTG 1309 . This course is cross-listed as DFTG 2435 . The student may register for either DFTG 2335 or DFTG 2435 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "DFTG 1309",
+      "DFTG 2435"
     ]
   },
   "DFTG 2338": {
@@ -1333,10 +2905,68 @@
       "DFTG 2332"
     ]
   },
+  "DFTG 2381": {
+    "text": "Approval of Dean and concurrent enrollment in a Drafting-related course. Course scheduling information",
+    "courses": []
+  },
+  "DFTG 2406": {
+    "text": "DFTG 2319 and MATH 1316",
+    "courses": [
+      "DFTG 2319",
+      "MATH 1316"
+    ]
+  },
+  "DFTG 2407": {
+    "text": "DFTG 2319 and MATH 1316",
+    "courses": [
+      "DFTG 2319",
+      "MATH 1316"
+    ]
+  },
+  "DFTG 2419": {
+    "text": "Recommended : Basic Computer-Aided Drafting or the approval of the instructor. This course is cross-listed as DFTG 2319 . The student may register for either DFTG 2319 or DFTG 2419 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "DFTG 2319"
+    ]
+  },
+  "DFTG 2423": {
+    "text": "DFTG 2319 and MATH 1316",
+    "courses": [
+      "DFTG 2319",
+      "MATH 1316"
+    ]
+  },
+  "DFTG 2431": {
+    "text": "Recommended : DFTG 1417 . Background Search Required: No",
+    "courses": [
+      "DFTG 1417"
+    ]
+  },
+  "DFTG 2432": {
+    "text": "Required : DFTG 2419 or equivalent (course substitution to be approved by a CAD faculty member). This course is cross-listed as DFTG 2332 . The student may register for either DFTG 2332 or DFTG 2432 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "DFTG 2332",
+      "DFTG 2419"
+    ]
+  },
+  "DFTG 2435": {
+    "text": "Required : DFTG 2419 or equivalent (course substitution to be approved by a CAD faculty member). This course is cross-listed as DFTG 2335 . The student may register for either DFTG 2335 or DFTG 2435 but may receive credit for only one of the two Background Search Required: No",
+    "courses": [
+      "DFTG 2335",
+      "DFTG 2419"
+    ]
+  },
   "DHYG 1162": {
     "text": "DHYG 1235",
     "courses": [
       "DHYG 1235"
+    ]
+  },
+  "DHYG 1170": {
+    "text": "Required: DHYG 1235 and DHYG 1301",
+    "courses": [
+      "DHYG 1235",
+      "DHYG 1301"
     ]
   },
   "DHYG 1201": {
@@ -1395,11 +3025,23 @@
       "DHYG 1215"
     ]
   },
+  "DHYG 1239": {
+    "text": "Required : DHYG 1301 , DHYG 1304 , DHYG 1431",
+    "courses": [
+      "DHYG 1301",
+      "DHYG 1304",
+      "DHYG 1431"
+    ]
+  },
   "DHYG 1261": {
     "text": "DHYG 1431. Assessment Levels: R3, E2, M2. 51.0601",
     "courses": [
       "DHYG 1431"
     ]
+  },
+  "DHYG 1301": {
+    "text": "Required : Acceptance into the Dental Hygiene Program. Background Search Required: No",
+    "courses": []
   },
   "DHYG 1304": {
     "text": "DHYG 1201 and DHYG 1227 and DHYG 1431",
@@ -1417,6 +3059,12 @@
       "DHYG 1304",
       "DHYG 1227",
       "DHYG 1235"
+    ]
+  },
+  "DHYG 1315": {
+    "text": "Required : DHYG 1219 . Background Search Required: No",
+    "courses": [
+      "DHYG 1219"
     ]
   },
   "DHYG 1331": {
@@ -1451,6 +3099,21 @@
       "DHYG 1201",
       "DHYG 1304",
       "DHYG 1227"
+    ]
+  },
+  "DHYG 2102": {
+    "text": "DHYG 1315 with a grade of “C” or higher",
+    "courses": [
+      "DHYG 1315"
+    ]
+  },
+  "DHYG 2153": {
+    "text": "Required : DHYG 1311 , DHYG 1315 , DHYG 2231 , and DHYG 2362 . Background Search Required: No",
+    "courses": [
+      "DHYG 1311",
+      "DHYG 1315",
+      "DHYG 2231",
+      "DHYG 2362"
     ]
   },
   "DHYG 2201": {
@@ -1507,10 +3170,64 @@
       "DHYG 1239"
     ]
   },
+  "DHYG 2362": {
+    "text": "Required : DHYG 1431 and DHYG 1261 . Background Search Required: No",
+    "courses": [
+      "DHYG 1261",
+      "DHYG 1431"
+    ]
+  },
   "DHYG 2363": {
     "text": "DHYG 2201, 2362. Assessment Levels: R3, E3, M2. 51.0602",
     "courses": [
       "DHYG 2201"
+    ]
+  },
+  "DHYG 3300": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 3310": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 3320": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 3330": {
+    "text": "MATH 1342 with a grade of “C” or better",
+    "courses": [
+      "MATH 1342"
+    ]
+  },
+  "DHYG 4220": {
+    "text": "DHYG 3330 with a grade of “C” or better",
+    "courses": [
+      "DHYG 3330"
+    ]
+  },
+  "DHYG 4300": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 4350": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 4360": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 4380": {
+    "text": "Acceptance in program",
+    "courses": []
+  },
+  "DHYG 4430": {
+    "text": "DHYG 3320 and DHYG 3330 with a grade of “C” or better",
+    "courses": [
+      "DHYG 3320",
+      "DHYG 3330"
     ]
   },
   "DHYGL 1304": {
@@ -1528,12 +3245,104 @@
       "DHYG 1331"
     ]
   },
+  "DIRW 0115": {
+    "text": "Required : The successful completion of DIRW 0305 or DWRI 0305 or DREA 0305 or an appropriate TSI test score",
+    "courses": [
+      "DIRW 0305",
+      "DREA 0305",
+      "DWRI 0305"
+    ]
+  },
+  "DIRW 0305": {
+    "text": "Required : An appropriate assessment test score. Background Search Required: No",
+    "courses": []
+  },
+  "DIRW 0310": {
+    "text": "Required : The successful completion of DIRW 0305 or DWRI 0305 or DREA 0305 or an appropriate assessment test score. Background Search Required: No",
+    "courses": [
+      "DIRW 0305",
+      "DREA 0305",
+      "DWRI 0305"
+    ]
+  },
+  "DIRW 0315": {
+    "text": "Required : The successful completion of DIRW 0305 or DWRI 0305 or DREA 0305 or an appropriate TSI test score",
+    "courses": [
+      "DIRW 0305",
+      "DREA 0305",
+      "DWRI 0305"
+    ]
+  },
+  "DITA 1029": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "DITA 1032": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "DITA 1033": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "DITA 1036": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "DMAT 0115": {
+    "text": "Required : An appropriate assessment test score or DMAT 0305",
+    "courses": [
+      "DMAT 0305"
+    ]
+  },
+  "DMAT 0117": {
+    "text": "Required : An appropriate assessment test score",
+    "courses": []
+  },
+  "DMAT 0305": {
+    "text": "Required : An appropriate assessment test score. Background Search Required: No",
+    "courses": []
+  },
+  "DMAT 0307": {
+    "text": "Required : An appropriate assessment test score. Background Search Required: No",
+    "courses": []
+  },
+  "DMAT 0310": {
+    "text": "Required : An appropriate assessment test score or DMAT 0305 . Background Search Required: No",
+    "courses": [
+      "DMAT 0305"
+    ]
+  },
+  "DMAT 0314": {
+    "text": "Required : An appropriate assessment test score or DMAT 0305",
+    "courses": [
+      "DMAT 0305"
+    ]
+  },
+  "DMAT 0324": {
+    "text": "Required : An appropriate assessment test score or DMAT 0305",
+    "courses": [
+      "DMAT 0305"
+    ]
+  },
+  "DMAT 0332": {
+    "text": "Required : An appropriate assessment test score",
+    "courses": []
+  },
+  "DMAT 0342": {
+    "text": "Required : An appropriate assessment test score",
+    "courses": []
+  },
   "DMSO 1101": {
     "text": "DMSO 1110 (min C) and DMSO 1351 (min C)",
     "courses": [
       "DMSO 1110",
       "DMSO 1351"
     ]
+  },
+  "DMSO 1110": {
+    "text": "Admission into the program. Course scheduling information",
+    "courses": []
   },
   "DMSO 1202": {
     "text": "DMSO 1210",
@@ -1578,6 +3387,10 @@
       "DMSO 1266"
     ]
   },
+  "DMSO 1302": {
+    "text": "Admission into the program. Course scheduling information",
+    "courses": []
+  },
   "DMSO 1341": {
     "text": "DMSO 1110 (min C) and DMSO 1251 (min C)",
     "courses": [
@@ -1597,11 +3410,29 @@
       "DMSO 1110"
     ]
   },
+  "DMSO 1366": {
+    "text": "Recommended : HPRS 1204 or documented completion of coursework through Prior Learning Assessment in basic health profession skills. Admission to the Diagnostic Medical Sonography Program. Completion of all previous support and DMSO program courses. Grade of 70 or better in all previous sonography courses. Grade of 80 or better is required in practicum courses. Background Search Required: Yes",
+    "courses": [
+      "HPRS 1204"
+    ]
+  },
+  "DMSO 1367": {
+    "text": "Recommended : HPRS 2210 or documented completion of coursework through Prior Learning Assessment in advanced health profession skills. Admission to the Diagnostic Medical Sonography Program. Completion of all previous support and DMSO program courses. Grade of 70 or better in all previous sonography courses. Grade of 80 or better is required in practicum courses. Background Search Required: Yes",
+    "courses": [
+      "HPRS 2210"
+    ]
+  },
   "DMSO 1441": {
     "text": "DMSO 1210 and DMSO 1260",
     "courses": [
       "DMSO 1210",
       "DMSO 1260"
+    ]
+  },
+  "DMSO 2130": {
+    "text": "Recommended : HPRS 2231 or documented completion of coursework through Prior Learning Assessment in general health professions management. Admission to the Diagnostic Medical Sonography Program. Completion of all previous support and DMSO program courses. Grade of 70 or better in all previous sonography courses. Grade of 80 or better is required in practicum courses. Background Search Required: Yes",
+    "courses": [
+      "HPRS 2231"
     ]
   },
   "DMSO 2230": {
@@ -1623,17 +3454,37 @@
       "DMSO 1267"
     ]
   },
+  "DMSO 2266": {
+    "text": "DMSO 1267 . Course scheduling information",
+    "courses": [
+      "DMSO 1267"
+    ]
+  },
+  "DMSO 2267": {
+    "text": "DMSO 2266 . Course scheduling information",
+    "courses": [
+      "DMSO 2266"
+    ]
+  },
   "DMSO 2305": {
     "text": "MSOL 2305",
     "courses": [
       "MSOL 2305"
     ]
   },
+  "DMSO 2341": {
+    "text": "Recommended : Admission to the Diagnostic Medical Sonography Program. Completion of all previous support and DMSO program courses. Grade of 70 or better in all previous sonography courses. Grade of 80 or better is required in practicum courses. Background Search Required: Yes",
+    "courses": []
+  },
   "DMSO 2342": {
     "text": "DMSO 2405 (min C)",
     "courses": [
       "DMSO 2405"
     ]
+  },
+  "DMSO 2343": {
+    "text": "Recommended : Admission to either the Diagnostic Medical Sonography Program or the Cardiac Sonography Program. Background Search Required: Yes",
+    "courses": []
   },
   "DMSO 2361": {
     "text": "DMSO 1380 and DMSO 1266. Assessment Levels: R3, E3, M3. 51.0901",
@@ -1650,6 +3501,10 @@
       "DMSO 1266",
       "DMSO 1267"
     ]
+  },
+  "DMSO 2405": {
+    "text": "Recommended : Admission to the Diagnostic Medical Sonography Program. Completion of all previous support and DMSO program courses. Grade of 70 or better in all previous sonography courses. Grade of 80 or better is required in practicum courses. Background Search Required: Yes",
+    "courses": []
   },
   "DMSOL 1251": {
     "text": "DMSO 1251",
@@ -1669,14 +3524,127 @@
       "DMSO 2305"
     ]
   },
+  "DMTH 0300": {
+    "text": "Appropriate math placement score. Corequisite: NCBM 0101 Corequisite: NCBM 0101 CP",
+    "courses": [
+      "NCBM 0101"
+    ]
+  },
+  "DMTH 0301": {
+    "text": "Appropriate placement scores",
+    "courses": []
+  },
+  "DMTH 0311": {
+    "text": "Appropriate placement scores",
+    "courses": []
+  },
+  "DNTA 1113": {
+    "text": "Acceptance into Certified Dental Assisting program",
+    "courses": []
+  },
   "DNTA 1167": {
     "text": "DNTA 1166. Assessment Levels: R1, E1, M1. 51.0601",
     "courses": [
       "DNTA 1166"
     ]
   },
+  "DNTA 1241": {
+    "text": "Suggested: DNTA 1401 . Corequisite: DNTA 1245 , DNTA 1249 , DNTA 1251 , DNTA 1353 , and DNTA 1660",
+    "courses": [
+      "DNTA 1245",
+      "DNTA 1249",
+      "DNTA 1251",
+      "DNTA 1353",
+      "DNTA 1401",
+      "DNTA 1660"
+    ]
+  },
+  "DNTA 1245": {
+    "text": "DNTA 1311 , DNTA 1301 , DNTA 1415 , DNTA 1113 and DNTA 1305 with a grade of “C” or better",
+    "courses": [
+      "DNTA 1113",
+      "DNTA 1301",
+      "DNTA 1305",
+      "DNTA 1311",
+      "DNTA 1415"
+    ]
+  },
+  "DNTA 1249": {
+    "text": "DNTA 1311 , DNTA 1301 , DNTA 1415 , DNTA 1113 and DNTA 1305 with a grade of “C” or better",
+    "courses": [
+      "DNTA 1113",
+      "DNTA 1301",
+      "DNTA 1305",
+      "DNTA 1311",
+      "DNTA 1415"
+    ]
+  },
+  "DNTA 1251": {
+    "text": "DNTA 1249 , DNTA 1245 , DNTA 2250 , DNTA 1341 , DNTA 1266 , and DNTA 1347 with a grade of “C” or better",
+    "courses": [
+      "DNTA 1245",
+      "DNTA 1249",
+      "DNTA 1266",
+      "DNTA 1341",
+      "DNTA 1347",
+      "DNTA 2250"
+    ]
+  },
+  "DNTA 1266": {
+    "text": "DNTA 1311 , DNTA 1301 , DNTA 1415 , DNTA 1113 and DNTA 1305 with a grade of “C” or better",
+    "courses": [
+      "DNTA 1113",
+      "DNTA 1301",
+      "DNTA 1305",
+      "DNTA 1311",
+      "DNTA 1415"
+    ]
+  },
+  "DNTA 1301": {
+    "text": "Acceptance into Certified Dental Assisting program",
+    "courses": []
+  },
+  "DNTA 1305": {
+    "text": "Acceptance into Certified Dental Assisting program",
+    "courses": []
+  },
+  "DNTA 1311": {
+    "text": "Acceptance into Certified Dental Assisting program",
+    "courses": []
+  },
+  "DNTA 1341": {
+    "text": "DNTA 1311 , DNTA 1301 , DNTA 1415 , DNTA 1113 and DNTA 1305 with a grade of “C” or better",
+    "courses": [
+      "DNTA 1113",
+      "DNTA 1301",
+      "DNTA 1305",
+      "DNTA 1311",
+      "DNTA 1415"
+    ]
+  },
   "DNTA 1347": {
     "text": "DNTA 1311. Assessment Levels: R1, E1, M1. 51.0601",
+    "courses": [
+      "DNTA 1311"
+    ]
+  },
+  "DNTA 1353": {
+    "text": "Suggested: DNTA 1315 Corequisite: DNTA 1241 , DNTA 1245 , DNTA 1249 , DNTA 1251 , and DNTA 1660",
+    "courses": [
+      "DNTA 1241",
+      "DNTA 1245",
+      "DNTA 1249",
+      "DNTA 1251",
+      "DNTA 1315",
+      "DNTA 1660"
+    ]
+  },
+  "DNTA 1415": {
+    "text": "Acceptance into Certified Dental Assisting program",
+    "courses": []
+  },
+  "DNTA 1447": {
+    "text": "Suggested: DNTA 1311",
     "courses": [
       "DNTA 1311"
     ]
@@ -1699,10 +3667,37 @@
       "DNTA 1349"
     ]
   },
+  "DNTA 2266": {
+    "text": "DNTA 1249 , DNTA 1245 , DNTA 2250 , DNTA 1341 , DNTA 1266 and DNTA 1347 with a grade of “C” or better",
+    "courses": [
+      "DNTA 1245",
+      "DNTA 1249",
+      "DNTA 1266",
+      "DNTA 1341",
+      "DNTA 1347",
+      "DNTA 2250"
+    ]
+  },
   "DRAM 1121": {
     "text": "DRAM 1120",
     "courses": [
       "DRAM 1120"
+    ]
+  },
+  "DRAM 1351": {
+    "text": "Division Chair approval",
+    "courses": []
+  },
+  "DRAM 1352": {
+    "text": "DRAM 1351 or approval of the division chair",
+    "courses": [
+      "DRAM 1351"
+    ]
+  },
+  "DRAM 2120": {
+    "text": "DRAM 1121",
+    "courses": [
+      "DRAM 1121"
     ]
   },
   "DRAM 2121": {
@@ -1711,10 +3706,158 @@
       "DRAM 1120"
     ]
   },
+  "DRAM 2331": {
+    "text": "Recommended: DRAM 1330 or demonstrated competence approved by the instructor. Background Search Required: No",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRAM 2355": {
+    "text": "TSI ELAR (Reading and Writing) requirement met and DRAM 1310",
+    "courses": [
+      "DRAM 1310"
+    ]
+  },
+  "DRAM 2361": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "DRAM 2389": {
+    "text": "DRAM 1310 OR DRAM 2366 OR instructor approval",
+    "courses": [
+      "DRAM 1310",
+      "DRAM 2366"
+    ]
+  },
+  "DREA 0305": {
+    "text": "Required : An appropriate assessment test score. Background Search Required: No",
+    "courses": []
+  },
+  "DRTE 1270": {
+    "text": "DRAM 1330 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRTE 1271": {
+    "text": "DRAM 1330 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRTE 1272": {
+    "text": "DRAM 1330 and DRAM 2331 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331"
+    ]
+  },
+  "DRTE 1273": {
+    "text": "DRAM 1330 and DRAM 2331 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331"
+    ]
+  },
+  "DRTE 1370": {
+    "text": "DRAM 1330 and DRAM 2331 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331"
+    ]
+  },
+  "DRTE 1371": {
+    "text": "DRAM 1330 and DRAM 2331 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331"
+    ]
+  },
+  "DRTE 1372": {
+    "text": "DRAM 1330 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRTE 1374": {
+    "text": "DRAM 1330 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRTE 1375": {
+    "text": "DRAM 1330 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRTE 1376": {
+    "text": "DRAM 1330 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330"
+    ]
+  },
+  "DRTE 1377": {
+    "text": "DRAM 1330 and DRAM 2331 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331"
+    ]
+  },
+  "DRTE 1378": {
+    "text": "DRAM 1330 and DRAM 2331 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331"
+    ]
+  },
+  "DRTE 2170": {
+    "text": "DRAM 1330 , DRAM 2331 and DRTE 1370 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331",
+      "DRTE 1370"
+    ]
+  },
+  "DRTE 2270": {
+    "text": "DRAM 1330 , DRAM 2331 and DRTE 1370 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1330",
+      "DRAM 2331",
+      "DRTE 1370"
+    ]
+  },
+  "DRTE 2370": {
+    "text": "DRAM 1330 , DRAM 1120 and DRTE 1376 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1120",
+      "DRAM 1330",
+      "DRTE 1376"
+    ]
+  },
+  "DRTE 2371": {
+    "text": "DRAM 1330 , DRAM 1120 , DRAM 2331 and DRTE 1378 . Courses may also be taken as corequisites",
+    "courses": [
+      "DRAM 1120",
+      "DRAM 1330",
+      "DRAM 2331",
+      "DRTE 1378"
+    ]
+  },
+  "DSAE 1270": {
+    "text": "Recommended : Admission to the program. Current American Heart Association, Class C Basic Life Support certification",
+    "courses": []
+  },
   "DSAE 1303": {
     "text": "SAEL 1303",
     "courses": [
       "SAEL 1303"
+    ]
+  },
+  "DSAE 2303": {
+    "text": "Required: BIOL 2401",
+    "courses": [
+      "BIOL 2401"
     ]
   },
   "DSAE 2335": {
@@ -1741,6 +3884,12 @@
       "DSAE 1303"
     ]
   },
+  "DSAI 2375": {
+    "text": "DSAI 1371",
+    "courses": [
+      "DSAI 1371"
+    ]
+  },
   "DSVT 1200": {
     "text": "DMSO 2242",
     "courses": [
@@ -1753,6 +3902,12 @@
       "DSVT 2418"
     ]
   },
+  "DSVT 1265": {
+    "text": "DSVT 1264 . Course scheduling information",
+    "courses": [
+      "DSVT 1264"
+    ]
+  },
   "DSVT 1300": {
     "text": "Acceptance to program. Assessment Levels: R3, E3, M3. 51.091",
     "courses": []
@@ -1763,11 +3918,25 @@
       "DMSO 2305"
     ]
   },
+  "DSVT 2300": {
+    "text": "DSVT 1300 . Course scheduling information",
+    "courses": [
+      "DSVT 1300"
+    ]
+  },
   "DSVT 2330": {
     "text": "SVTL 2330",
     "courses": [
       "SVTL 2330"
     ]
+  },
+  "DSVT 2367": {
+    "text": "Recommended : Admission to the Diagnostic Medical Sonography Program. Completion of all previous support and DMSO program courses. Grade of 70 or better in all previous sonography courses. Grade of 80 or better is required in practicum courses. Background Search Required: Yes",
+    "courses": []
+  },
+  "DWRI 0305": {
+    "text": "Required : An appropriate assessment test score. Background Search Required: No",
+    "courses": []
   },
   "ECON 2301": {
     "text": "ENGL 0327 (min C) or ENGL 0302 (min C)",
@@ -1783,6 +3952,122 @@
       "ENGL 0302"
     ]
   },
+  "EDEC 3301": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. A successful background check is required to spend time in early childcare centers. Background Search Required: Yes",
+    "courses": []
+  },
+  "EDEC 3302": {
+    "text": "Required : EDEC 3301 . Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: Yes",
+    "courses": [
+      "EDEC 3301"
+    ]
+  },
+  "EDEC 3303": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required of consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDEC 3305": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDEC 3307": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDEC 3309": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDEC 3311": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDEL 3318": {
+    "text": "Required : “C” or better in MATH 1350 and MATH 1351 . Background Search Required: No",
+    "courses": [
+      "MATH 1350",
+      "MATH 1351"
+    ]
+  },
+  "EDEL 4301": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) are required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDEL 4302": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDEL 4303": {
+    "text": "Required : EDEL 3318 . Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": [
+      "EDEL 3318"
+    ]
+  },
+  "EDEL 4311": {
+    "text": "Required : EDEC 3302 . Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Approval from department to begin student teaching is required",
+    "courses": [
+      "EDEC 3302"
+    ]
+  },
+  "EDEL 4312": {
+    "text": "Required : EDEL 4311 . Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Approval from department to begin student teaching is required",
+    "courses": [
+      "EDEL 4311"
+    ]
+  },
+  "EDIT 3310": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDLL 3301": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDLL 3305": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDTP 3301": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDTP 3303": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Additional course specific prerequisites may apply. Background Search Required: No",
+    "courses": []
+  },
+  "EDTP 3305": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDTP 3307": {
+    "text": "Required : Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": []
+  },
+  "EDTP 4310": {
+    "text": "Required : EDLL 3305 . Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": [
+      "EDLL 3305"
+    ]
+  },
+  "EDTP 4315": {
+    "text": "Required : EDEL 4301 , 4302, 4303; EDLL 3305 . Concurrent enrollment and acceptance into the Educator Preparation Program (EPP) is required or consent of department dean. A minimum of a 2.75 GPA is required for all upper-level courses in the BAS (Bachelor of Applied Science) ECE (Early Childhood Education) program. Background Search Required: No",
+    "courses": [
+      "EDEL 4301",
+      "EDLL 3305"
+    ]
+  },
+  "EDUC 1100": {
+    "text": "TSI requirements not met",
+    "courses": []
+  },
+  "EDUC 1300": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300 or ENGL 1301 /NCBI 0300",
+    "courses": [
+      "ENGL 1301",
+      "INRW 0300",
+      "NCBI 0300"
+    ]
+  },
   "EDUC 1301": {
     "text": "EDUC 0000",
     "courses": [
@@ -1796,6 +4081,30 @@
       "EDUC 0000"
     ]
   },
+  "EECT 2339": {
+    "text": "CETT 1403 and CETT 1425",
+    "courses": [
+      "CETT 1403",
+      "CETT 1425"
+    ]
+  },
+  "ELMT 1301": {
+    "text": "ELMT 1380 or WLDG 1307 with a grade of “C” or better",
+    "courses": [
+      "ELMT 1380",
+      "WLDG 1307"
+    ]
+  },
+  "ELMT 1380": {
+    "text": "TECM 1303 , IEIR 1302 , IEIR 1304 , INCR 1302 and HYDR 1345 with a grade of “C” or better",
+    "courses": [
+      "HYDR 1345",
+      "IEIR 1302",
+      "IEIR 1304",
+      "INCR 1302",
+      "TECM 1303"
+    ]
+  },
   "ELMT 2333": {
     "text": "CETT 1409 (min C) and CETT 1315 (min C) and CETT 1321 (min C)",
     "courses": [
@@ -1804,10 +4113,56 @@
       "CETT 1321"
     ]
   },
+  "ELMT 2337": {
+    "text": "CETT 1302 or instructor permission. Course scheduling information",
+    "courses": [
+      "CETT 1302"
+    ]
+  },
   "ELMT 2339": {
     "text": "ELMT 1301. Assessment Levels: R3, E2, M3. 15.0403",
     "courses": [
       "ELMT 1301"
+    ]
+  },
+  "ELMT 2351": {
+    "text": "TECM 1303 with a grade of “C” or better",
+    "courses": [
+      "TECM 1303"
+    ]
+  },
+  "ELMT 2353": {
+    "text": "ELPT 2305 with a grade of “C” or better",
+    "courses": [
+      "ELPT 2305"
+    ]
+  },
+  "ELMT 2433": {
+    "text": "Recommended : CETT 1429 . Background Search Required: No",
+    "courses": [
+      "CETT 1429"
+    ]
+  },
+  "ELMT 2437": {
+    "text": "PTAC 1432",
+    "courses": [
+      "PTAC 1432"
+    ]
+  },
+  "ELMT 2441": {
+    "text": "CETT 1409 ; INTC 1350 ; and ELMT 2437",
+    "courses": [
+      "CETT 1409",
+      "ELMT 2437",
+      "INTC 1350"
+    ]
+  },
+  "ELMT 2452": {
+    "text": "CETT 1409 ; INTC 1350 ; and PTAC 2436",
+    "courses": [
+      "CETT 1409",
+      "INTC 1350",
+      "PTAC 2436"
     ]
   },
   "ELPT 1225": {
@@ -1816,10 +4171,145 @@
       "ELPT 2225"
     ]
   },
+  "ELPT 1329": {
+    "text": "Required : ELPT 1311 , ELPT 1321",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321"
+    ]
+  },
+  "ELPT 1341": {
+    "text": "Required : ELPT 1311 , ELPT 1321 This course is cross-listed as ELPT 1441 . The student may register for either ELPT 1341 or ELPT 1441 but may receive credit for only one of the two",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321",
+      "ELPT 1441"
+    ]
+  },
+  "ELPT 1345": {
+    "text": "Required : ELPT 1311 , ELPT 1321",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321"
+    ]
+  },
+  "ELPT 1380": {
+    "text": "Required : ELPT 1311 , ELPT 1321",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321"
+    ]
+  },
+  "ELPT 1391": {
+    "text": "Required : ELPT 1311 , ELPT 1321 This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321"
+    ]
+  },
+  "ELPT 1420": {
+    "text": "Required : ELPT 1419",
+    "courses": [
+      "ELPT 1419"
+    ]
+  },
+  "ELPT 1441": {
+    "text": "CETT 1402 with a grade of “C” or better",
+    "courses": [
+      "CETT 1402"
+    ]
+  },
   "ELPT 2225": {
     "text": "ELPT 1225",
     "courses": [
       "ELPT 1225"
+    ]
+  },
+  "ELPT 2305": {
+    "text": "IEIR 1304 (Electrical/Electronic Controls Technology/Power Plant Technology) or CETT 1402 (Industrial Maintenance Technology) with a grade of “C” or better",
+    "courses": [
+      "CETT 1402",
+      "IEIR 1304"
+    ]
+  },
+  "ELPT 2319": {
+    "text": "CETT 1325 (Electrical/Electronic Controls Technology) or CETT 1402 (Industrial Maintenance Technology) with a grade of “C” or better",
+    "courses": [
+      "CETT 1325",
+      "CETT 1402"
+    ]
+  },
+  "ELPT 2325": {
+    "text": "ELPT 1345 or Division Chair Approval",
+    "courses": [
+      "ELPT 1345"
+    ]
+  },
+  "ELPT 2347": {
+    "text": "ELPT 2319 with a grade of “C” or better",
+    "courses": [
+      "ELPT 2319"
+    ]
+  },
+  "ELPT 2419": {
+    "text": "Required : ELPT 1473",
+    "courses": [
+      "ELPT 1473"
+    ]
+  },
+  "ELPT 2437": {
+    "text": "Required : ELPT 1311 , ELPT 1321 , ELPT 1370 , ELPT 1325",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321",
+      "ELPT 1325",
+      "ELPT 1370"
+    ]
+  },
+  "ELPT 2443": {
+    "text": "Required : ELPT 1311 , ELPT 1321 , ELPT 1370 , ELPT 1325",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321",
+      "ELPT 1325",
+      "ELPT 1370"
+    ]
+  },
+  "ELPT 2455": {
+    "text": "Required : ELPT 2419",
+    "courses": [
+      "ELPT 2419"
+    ]
+  },
+  "ELTN 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "ELTN 1381": {
+    "text": "ELTN 1380 or approval of the division chair",
+    "courses": [
+      "ELTN 1380"
+    ]
+  },
+  "ELTN 2380": {
+    "text": "ELTN 1381 or approval of the division chair",
+    "courses": [
+      "ELTN 1381"
+    ]
+  },
+  "EMAP 2489": {
+    "text": "EMAP 1345 , EMAP 1400 , EMAP 1440 , EMAP 2300 , HMSY 1337 , HMSY 1338 , HMSY 1339 , HMSY 1340 , HMSY 1341 , and HMSY 1342",
+    "courses": [
+      "EMAP 1345",
+      "EMAP 1400",
+      "EMAP 1440",
+      "EMAP 2300",
+      "HMSY 1337",
+      "HMSY 1338",
+      "HMSY 1339",
+      "HMSY 1340",
+      "HMSY 1341",
+      "HMSY 1342"
     ]
   },
   "EMSP 1147": {
@@ -1839,6 +4329,34 @@
     "courses": [
       "EMSP 1501"
     ]
+  },
+  "EMSP 1164": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross",
+    "courses": []
+  },
+  "EMSP 1260": {
+    "text": "Concurrent enrollment in EMSP 1501",
+    "courses": [
+      "EMSP 1501"
+    ]
+  },
+  "EMSP 1261": {
+    "text": "Concurrent enrollment in EMSP 1355 , EMSP 1356 , and EMSP 1438",
+    "courses": [
+      "EMSP 1355",
+      "EMSP 1356",
+      "EMSP 1438"
+    ]
+  },
+  "EMSP 1291": {
+    "text": "EMSP 1501 or current EMT certification",
+    "courses": [
+      "EMSP 1501"
+    ]
+  },
+  "EMSP 1305": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross",
+    "courses": []
   },
   "EMSP 1338": {
     "text": "BIOL 2401 or BIOL 2404 or EMSP 1501 and EMSP 2306",
@@ -1865,6 +4383,26 @@
       "EMSP 1501"
     ]
   },
+  "EMSP 1370": {
+    "text": "Permission from Public Service Division required to enroll. Course scheduling information",
+    "courses": []
+  },
+  "EMSP 1391": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information . Background Search Required: Students will be required to submit to and pass a criminal background search and a drug screen as prescribed by the program and college. Failure to comply will result in the student being dropped from all EMSP courses",
+    "courses": []
+  },
+  "EMSP 1438": {
+    "text": "Concurrent enrollment in EMSP 1261 , EMSP 1355 , and EMSP 1356",
+    "courses": [
+      "EMSP 1261",
+      "EMSP 1355",
+      "EMSP 1356"
+    ]
+  },
+  "EMSP 1455": {
+    "text": "Admission to the program. Course scheduling information",
+    "courses": []
+  },
   "EMSP 1501": {
     "text": "EMSP 1160 and MSPL 1501",
     "courses": [
@@ -1884,6 +4422,16 @@
       "EMSP 2252",
       "EMSP 2263"
     ]
+  },
+  "EMSP 2161": {
+    "text": "EMSP 2360",
+    "courses": [
+      "EMSP 2360"
+    ]
+  },
+  "EMSP 2164": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross, (3) Certification by the Texas Department of State Health Services as an Emergency Medical Technician-Basic or higher",
+    "courses": []
   },
   "EMSP 2165": {
     "text": "EMSP 1338 and 1356. Assessment Levels: R2, E2, M2. 51.0904",
@@ -1921,6 +4469,10 @@
       "EMSP 2261"
     ]
   },
+  "EMSP 2237": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross, (3) Completion of Texas Department of State Health Services approved Emergency Medical Technician course or certification by the Texas Department of State Health Services or National Registry of EMT as an Emergency Medical Technician-Basic or higher",
+    "courses": []
+  },
   "EMSP 2243": {
     "text": "Student must have completed semesters I, II and III.Corequisite:EMSP 2252/ EMSP 2263. Assessment Levels: R2, E2, M2. 51.0904",
     "courses": [
@@ -1933,6 +4485,23 @@
     "courses": [
       "EMSP 2252",
       "EMSP 2263"
+    ]
+  },
+  "EMSP 2260": {
+    "text": "EMSP 1260 , EMSP 1338 , EMSP 1356 , and EMSP 2306 with a grade of “C” or better",
+    "courses": [
+      "EMSP 1260",
+      "EMSP 1338",
+      "EMSP 1356",
+      "EMSP 2306"
+    ]
+  },
+  "EMSP 2261": {
+    "text": "Current AEMT certification from the Texas Department of State Health Services or current AEMT certification from the National Registry or EMSP 1338 ; EMSP 1355 ; EMSP 1356 with a current EMT certification from the Texas Department of State Health Services",
+    "courses": [
+      "EMSP 1338",
+      "EMSP 1355",
+      "EMSP 1356"
     ]
   },
   "EMSP 2262": {
@@ -1949,6 +4518,37 @@
       "EMSP 2252",
       "EMSP 2243"
     ]
+  },
+  "EMSP 2264": {
+    "text": "Current EMT certification and EMSP 1338 ; EMSP 1355 ; EMSP 1356 or AEMT certification and EMSP 2305 ; EMSP 2306 ; EMSP 2330 ; EMSP 2434 ; EMSP 2444",
+    "courses": [
+      "EMSP 1338",
+      "EMSP 1355",
+      "EMSP 1356",
+      "EMSP 2305",
+      "EMSP 2306",
+      "EMSP 2330",
+      "EMSP 2434",
+      "EMSP 2444"
+    ]
+  },
+  "EMSP 2265": {
+    "text": "EMSP 2360",
+    "courses": [
+      "EMSP 2360"
+    ]
+  },
+  "EMSP 2266": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross, (3) Certification by the Texas Department of State Health Services as an Emergency Medical Technician-Basic or higher",
+    "courses": []
+  },
+  "EMSP 2300": {
+    "text": "Must be certified as EMT-Basic, Intermediate, Paramedic, or Licensed Paramedic",
+    "courses": []
+  },
+  "EMSP 2305": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross, (3) Completion of Texas Department of State Health Services approved Emergency Medical Technician course or certification by the Texas Department of State Health Services or National Registry of EMT as an Emergency Medical Technician-Basic or higher",
+    "courses": []
   },
   "EMSP 2306": {
     "text": "BIOL 2401 or BIOL 2404 or EMSP 1501 or EMSP 1160 and EMSP 1356 and EMSP 1338",
@@ -1969,6 +4569,10 @@
       "EMSP 2348",
       "EMSP 1355"
     ]
+  },
+  "EMSP 2430": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross, (3) Completion of Texas Department of State Health Services approved Emergency Medical Technician course or certification by the Texas Department of State Health Services or National Registry of EMT as an Emergency Medical Technician-Basic or higher",
+    "courses": []
   },
   "EMSP 2434": {
     "text": "EMSP 1438 and EMSP 1456 and EMSP 2348 and EMSP 2444 and EMSP 1161",
@@ -1997,6 +4601,14 @@
     "courses": [
       "EMSP 2444"
     ]
+  },
+  "EMSP 2471": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BLS (CPR) certification by the American Heart Association or American Red Cross",
+    "courses": []
+  },
+  "EMSP 2553": {
+    "text": "Required : (1) Admission into the Emergency Medical Services Program, (2) Current BCLS (CPR) certification by the American Heart Association or American Red Cross, (3) Current license as an RRT, PA, or RN",
+    "courses": []
   },
   "EMSPL 1338": {
     "text": "EMSP 1338",
@@ -2053,6 +4665,16 @@
       "IEIR 1302",
       "INMT 1305",
       "IEIR 1304"
+    ]
+  },
+  "ENER 1350": {
+    "text": "TSI Requirements met in Math",
+    "courses": []
+  },
+  "ENER 2325": {
+    "text": "INMT 1317 or instructor permission. Course scheduling information",
+    "courses": [
+      "INMT 1317"
     ]
   },
   "ENGL 1301": {
@@ -2160,6 +4782,18 @@
       "ENGL 1302"
     ]
   },
+  "ENGL 2389": {
+    "text": "ENGL 2307",
+    "courses": [
+      "ENGL 2307"
+    ]
+  },
+  "ENGR 1172": {
+    "text": "Required : MATH 2412 or the equivalent. Background Search Required: No",
+    "courses": [
+      "MATH 2412"
+    ]
+  },
   "ENGR 1201": {
     "text": "MATH 1314 or MATH 1414 or MATH 2412",
     "courses": [
@@ -2174,6 +4808,26 @@
       "MATH 1316",
       "TECM 1349",
       "MATH 2312"
+    ]
+  },
+  "ENGR 1307": {
+    "text": "Required : MATH 1316 and ENGR 1304 . Background Search Required: No",
+    "courses": [
+      "ENGR 1304",
+      "MATH 1316"
+    ]
+  },
+  "ENGR 2110": {
+    "text": "Required : ENGR 2304 or COSC 1436",
+    "courses": [
+      "COSC 1436",
+      "ENGR 2304"
+    ]
+  },
+  "ENGR 2300": {
+    "text": "Required : MATH 2414 . Background Search Required: No",
+    "courses": [
+      "MATH 2414"
     ]
   },
   "ENGR 2301": {
@@ -2197,16 +4851,58 @@
       "MATH 1316"
     ]
   },
+  "ENGR 2305": {
+    "text": "Required : MATH 2414 and PHYS 2426",
+    "courses": [
+      "MATH 2414",
+      "PHYS 2426"
+    ]
+  },
+  "ENGR 2306": {
+    "text": "Required : MATH 1314",
+    "courses": [
+      "MATH 1314"
+    ]
+  },
   "ENGR 2308": {
     "text": "MATH 2413 (min D)",
     "courses": [
       "MATH 2413"
     ]
   },
+  "ENGR 2310": {
+    "text": "Required : ENGR 2304 or COSC 1436",
+    "courses": [
+      "COSC 1436",
+      "ENGR 2304"
+    ]
+  },
   "ENGR 2332": {
     "text": "ENGR 2301",
     "courses": [
       "ENGR 2301"
+    ]
+  },
+  "ENGR 2333": {
+    "text": "Required : ENGR 1201 , CHEM 1412 , MATH 2414 and PHYS 2425 . Background Search Required: No",
+    "courses": [
+      "CHEM 1412",
+      "ENGR 1201",
+      "MATH 2414",
+      "PHYS 2425"
+    ]
+  },
+  "ENGR 2334": {
+    "text": "Required : MATH 2415 . Background Search Required: No",
+    "courses": [
+      "MATH 2415"
+    ]
+  },
+  "ENGR 2405": {
+    "text": "Required : MATH 2414 and PHYS 2426",
+    "courses": [
+      "MATH 2414",
+      "PHYS 2426"
     ]
   },
   "ENGR 2406": {
@@ -2217,6 +4913,107 @@
       "ENGR 2304"
     ]
   },
+  "ENGT 1401": {
+    "text": "Required : MATH 1314 or MATH 1414 . Background Search Required: No",
+    "courses": [
+      "MATH 1314",
+      "MATH 1414"
+    ]
+  },
+  "ENGT 1402": {
+    "text": "Required : ENGT 1401 and either MATH 1316 or MATH 2412 . Background Search Required: No",
+    "courses": [
+      "ENGT 1401",
+      "MATH 1316",
+      "MATH 2412"
+    ]
+  },
+  "ENGT 1407": {
+    "text": "Required : MATH 1314 or MATH 1414 . Background Search Required: No",
+    "courses": [
+      "MATH 1314",
+      "MATH 1414"
+    ]
+  },
+  "ENVR 1101": {
+    "text": "Successful completion of, or concurrent enrollment in ENVR 1301",
+    "courses": [
+      "ENVR 1301"
+    ]
+  },
+  "ENVR 1102": {
+    "text": "Successful completion of, or concurrent enrollment in ENVR 1302",
+    "courses": [
+      "ENVR 1302"
+    ]
+  },
+  "ENVR 1401": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR and in Mathematics. Course scheduling information",
+    "courses": []
+  },
+  "ENVR 1402": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR and in Mathematics. Course scheduling information",
+    "courses": []
+  },
+  "EPCT 1301": {
+    "text": "OSHT 1405",
+    "courses": [
+      "OSHT 1405"
+    ]
+  },
+  "EPCT 1305": {
+    "text": "EPCT 1311",
+    "courses": [
+      "EPCT 1311"
+    ]
+  },
+  "EPCT 1311": {
+    "text": "OSHT 1405",
+    "courses": [
+      "OSHT 1405"
+    ]
+  },
+  "EPCT 1344": {
+    "text": "EPCT 1441",
+    "courses": [
+      "EPCT 1441"
+    ]
+  },
+  "EPCT 1347": {
+    "text": "EPCT 1305 and EPCT 1311",
+    "courses": [
+      "EPCT 1305",
+      "EPCT 1311"
+    ]
+  },
+  "EPCT 1440": {
+    "text": "CHEM 1305 Introductory Chemistry",
+    "courses": [
+      "CHEM 1305"
+    ]
+  },
+  "EPCT 1441": {
+    "text": "OSHT 1301 OR OSHT 1405 OR OSHT 2309",
+    "courses": [
+      "OSHT 1301",
+      "OSHT 1405",
+      "OSHT 2309"
+    ]
+  },
+  "EPCT 2300": {
+    "text": "OSHT 2401 OSHA Regulations - General Industry",
+    "courses": [
+      "OSHT 2401"
+    ]
+  },
+  "EPCT 2333": {
+    "text": "EPCT 1311 , EPCT 1305 , and EPCT 1441",
+    "courses": [
+      "EPCT 1305",
+      "EPCT 1311",
+      "EPCT 1441"
+    ]
+  },
   "EPCT 2335": {
     "text": "MATH 1332 (min C) or MATH 1314 (min C) and (SCIT) Related Sciences 1494 (min C) or (SCIT) Related Sciences 1418 (min C)",
     "courses": [
@@ -2225,6 +5022,26 @@
       "(SCIT) Related Sciences 1494",
       "(SCIT) Related Sciences 1418"
     ]
+  },
+  "EPCT 2431": {
+    "text": "EPCT 1441",
+    "courses": [
+      "EPCT 1441"
+    ]
+  },
+  "EPCT 2459": {
+    "text": "EPCT 1311 Introduction to Environmental Science",
+    "courses": [
+      "EPCT 1311"
+    ]
+  },
+  "ESOL 0301": {
+    "text": "Appropriate scores on a TJC-approved placement test, or instructor approval",
+    "courses": []
+  },
+  "ESOL 0302": {
+    "text": "Appropriate scores on a TJC-approved placement test, or instructor approval",
+    "courses": []
   },
   "ESOL 0305": {
     "text": "CELT scores of 70. Assessment Levels: R1, E1, M0. 32.0108",
@@ -2286,6 +5103,10 @@
       "ESOL 0305"
     ]
   },
+  "FIRS 1103": {
+    "text": "Admission to program",
+    "courses": []
+  },
   "FIRS 1203": {
     "text": "FIRS 1301 and FIRS 1407 and FIRS 1313 and FIRS 1319 and FIRS 1323 and FIRS 1329",
     "courses": [
@@ -2341,11 +5162,31 @@
       "FIRS 1319"
     ]
   },
+  "FIRS 1433": {
+    "text": "Admission to program",
+    "courses": []
+  },
+  "FIRS 1507": {
+    "text": "Recommended : FIRS 1313 . Background Search Required: No",
+    "courses": [
+      "FIRS 1313"
+    ]
+  },
   "FIRT 2331": {
     "text": "FIRT 2309) Students will earn an A, B, C, D, F, or W. Emphasis on the use of incident management in large scale command problems and other specialized fire problems.",
     "courses": [
       "FIRT 2309"
     ]
+  },
+  "FIRT 2333": {
+    "text": "Recommended : FIRT 1303 . Background Search Required: No",
+    "courses": [
+      "FIRT 1303"
+    ]
+  },
+  "FIRT 2380": {
+    "text": "Assigned by College. This course may be repeated if topics and learning outcomes vary. Course scheduling information",
+    "courses": []
   },
   "FLMC 1304": {
     "text": "RTVB 1321 (min C)",
@@ -2371,10 +5212,318 @@
       "FREN 1411"
     ]
   },
+  "FREN 2311": {
+    "text": "One year of college French or two or more credits in high school French",
+    "courses": []
+  },
+  "FREN 2312": {
+    "text": "FREN 2311",
+    "courses": [
+      "FREN 2311"
+    ]
+  },
+  "FSHD 1332": {
+    "text": "Required : FSHD 1324 , FSHN 1325 , FSHN 1417 , FSHN 1418 . Background Search Required: No",
+    "courses": [
+      "FSHD 1324",
+      "FSHN 1325",
+      "FSHN 1417",
+      "FSHN 1418"
+    ]
+  },
+  "FSHD 1391": {
+    "text": "Required : FSHN 1418 , FSHN 1325 . This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "FSHN 1325",
+      "FSHN 1418"
+    ]
+  },
+  "FSHD 2241": {
+    "text": "Required : FSHN 1417 . Background Search Required: No",
+    "courses": [
+      "FSHN 1417"
+    ]
+  },
+  "FSHD 2288": {
+    "text": "Recommended : FSHD 1324 , FSHN 1417 , FSHN 1418 , FSHD 1311 , DRAM 1310 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "DRAM 1310",
+      "FSHD 1311",
+      "FSHD 1324",
+      "FSHN 1417",
+      "FSHN 1418"
+    ]
+  },
+  "FSHD 2305": {
+    "text": "Required : FSHN 1417 . Background Search Required: No",
+    "courses": [
+      "FSHN 1417"
+    ]
+  },
+  "FSHD 2343": {
+    "text": "Required : FSHN 1417 , FSHN 1418 , FSHD 1324 , FSHN 1325 , FSHN 1313 , FSHD 1311 , FSHD 1322 . Background Search Required: No",
+    "courses": [
+      "FSHD 1311",
+      "FSHD 1322",
+      "FSHD 1324",
+      "FSHN 1313",
+      "FSHN 1325",
+      "FSHN 1417",
+      "FSHN 1418"
+    ]
+  },
+  "FSHD 2344": {
+    "text": "Required : FSHD 2343 . Background Search Required: No",
+    "courses": [
+      "FSHD 2343"
+    ]
+  },
+  "FSHD 2388": {
+    "text": "Recommended : FSHD 1324 , FSHN 1417 , FSHN 1418 , FSHN 1123 with a “C” or better or approval of instructor. Background Search Required: No",
+    "courses": [
+      "FSHD 1324",
+      "FSHN 1123",
+      "FSHN 1417",
+      "FSHN 1418"
+    ]
+  },
+  "FSHN 1305": {
+    "text": "Recommended : FSHD 1324",
+    "courses": [
+      "FSHD 1324"
+    ]
+  },
+  "FSHN 1315": {
+    "text": "Required : FSHN 1417 , FSHD 1324 . Background Search Required: No",
+    "courses": [
+      "FSHD 1324",
+      "FSHN 1417"
+    ]
+  },
+  "FSHN 1325": {
+    "text": "Required : FSHD 1324 . Background Search Required: No",
+    "courses": [
+      "FSHD 1324"
+    ]
+  },
+  "FSHN 1382": {
+    "text": "Recommended : Completion of two courses in Fashion Marketing or demonstrated competence approved by the instructor. Background Search Required: No",
+    "courses": []
+  },
+  "FSHN 1418": {
+    "text": "Required : FSHN 1417 , FSHD 1324 . Background Search Required: No",
+    "courses": [
+      "FSHD 1324",
+      "FSHN 1417"
+    ]
+  },
+  "FSHN 2315": {
+    "text": "Required : FSHN 1417 , FSHN 1418 , FSHD 1324 , FSHN 1325 . Background Search Required: No",
+    "courses": [
+      "FSHD 1324",
+      "FSHN 1325",
+      "FSHN 1417",
+      "FSHN 1418"
+    ]
+  },
+  "FSHN 2370": {
+    "text": "Required : FSHD 1324 , FSHN 1325 , FSHN 2315 . Background Search Required: No",
+    "courses": [
+      "FSHD 1324",
+      "FSHN 1325",
+      "FSHN 2315"
+    ]
+  },
+  "FSHN 2382": {
+    "text": "Required : FSHN 1382 . Background Search Required: No",
+    "courses": [
+      "FSHN 1382"
+    ]
+  },
+  "FSHN 2432": {
+    "text": "Required : FSHN 1325 , FSHN 2315 . Background Search Required: No",
+    "courses": [
+      "FSHN 1325",
+      "FSHN 2315"
+    ]
+  },
+  "GAME 1304": {
+    "text": "Recommended : GAME 1303 . Background Search Required: No",
+    "courses": [
+      "GAME 1303"
+    ]
+  },
+  "GAME 1334": {
+    "text": "ARTC 2301 with a grade of “C” or better",
+    "courses": [
+      "ARTC 2301"
+    ]
+  },
+  "GAME 1343": {
+    "text": "Recommended : ITSE 1302 , ITSE 1307 , GAME 2302 or instructor approval",
+    "courses": [
+      "GAME 2302",
+      "ITSE 1302",
+      "ITSE 1307"
+    ]
+  },
+  "GAME 1353": {
+    "text": "Recommended : GAME 1343 , GAME 2302 , GAME 2342 , or instructor approval. Background Search Required: No",
+    "courses": [
+      "GAME 1343",
+      "GAME 2302",
+      "GAME 2342"
+    ]
+  },
+  "GAME 1359": {
+    "text": "Recommended : GAME 1343 or instructor approval",
+    "courses": [
+      "GAME 1343"
+    ]
+  },
+  "GAME 1373": {
+    "text": "Recommended : GAME 1303",
+    "courses": [
+      "GAME 1303"
+    ]
+  },
+  "GAME 1394": {
+    "text": "GAME 1303 with a grade of “C” or better",
+    "courses": [
+      "GAME 1303"
+    ]
+  },
+  "GAME 2302": {
+    "text": "Recommended : MATH 1314 and GAME 1359 or instructor approval. Background Search Required: No",
+    "courses": [
+      "GAME 1359",
+      "MATH 1314"
+    ]
+  },
+  "GAME 2308": {
+    "text": "GAME 2309 with a grade of “C” or better",
+    "courses": [
+      "GAME 2309"
+    ]
+  },
+  "GAME 2309": {
+    "text": "Recommended : GAME 1334 . Background Search Required: No",
+    "courses": [
+      "GAME 1334"
+    ]
+  },
   "GAME 2319": {
     "text": "GAME 1306",
     "courses": [
       "GAME 1306"
+    ]
+  },
+  "GAME 2332": {
+    "text": "Recommended : GAME 1303 . Background Search Required: No",
+    "courses": [
+      "GAME 1303"
+    ]
+  },
+  "GAME 2333": {
+    "text": "Recommended : GAME 1359 . Background Search Required: No",
+    "courses": [
+      "GAME 1359"
+    ]
+  },
+  "GAME 2334": {
+    "text": "Recommended : GAME 1303 or GAME 2332 . Background Search Required: No",
+    "courses": [
+      "GAME 1303",
+      "GAME 2332"
+    ]
+  },
+  "GAME 2336": {
+    "text": "Recommended : GAME 1303 . Background Search Required: No",
+    "courses": [
+      "GAME 1303"
+    ]
+  },
+  "GAME 2341": {
+    "text": "ITSE 1302 and GAME 1303 with a grade of “C” or better",
+    "courses": [
+      "GAME 1303",
+      "ITSE 1302"
+    ]
+  },
+  "GAME 2342": {
+    "text": "Recommended : COSC 1437 , ITSE 1302 , GAME 2302 , or instructor approval. Background Search Required: No",
+    "courses": [
+      "COSC 1437",
+      "GAME 2302",
+      "ITSE 1302"
+    ]
+  },
+  "GAME 2343": {
+    "text": "GAME 1353 with a grade of “C” or better or concurrent enrollment",
+    "courses": [
+      "GAME 1353"
+    ]
+  },
+  "GAME 2347": {
+    "text": "Recommended : GAME 1343 , GAME 2302 , GAME 2342 , or instructor approval. Background Search Required: No",
+    "courses": [
+      "GAME 1343",
+      "GAME 2302",
+      "GAME 2342"
+    ]
+  },
+  "GAME 2359": {
+    "text": "Recommended : GAME 1303 or GAME 2334 . Background Search Required: No",
+    "courses": [
+      "GAME 1303",
+      "GAME 2334"
+    ]
+  },
+  "GAME 2374": {
+    "text": "Recommended : GAME 1303 . Background Search Required: No",
+    "courses": [
+      "GAME 1303"
+    ]
+  },
+  "GAME 2387": {
+    "text": "(Recommended ) Instructor approval. Background Search Required: No",
+    "courses": []
+  },
+  "GEOG 1302": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "GEOG 1303": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "GEOL 1103": {
+    "text": "Credit for or concurrent enrollment in GEOL 1303",
+    "courses": [
+      "GEOL 1303"
+    ]
+  },
+  "GEOL 1104": {
+    "text": "Credit for or concurrent enrollment in GEOL 1304",
+    "courses": [
+      "GEOL 1304"
+    ]
+  },
+  "GEOL 1303": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
+  },
+  "GEOL 1304": {
+    "text": "TSI ELAR (Reading and Writing) requirement met; Credit for or concurrent enrollment in GEOL 1303",
+    "courses": [
+      "GEOL 1303"
+    ]
+  },
+  "GEOL 1402": {
+    "text": "Required : GEOL 1401 or GEOL 1403 . Background Search Required: No",
+    "courses": [
+      "GEOL 1401",
+      "GEOL 1403"
     ]
   },
   "GEOL 1404": {
@@ -2383,16 +5532,43 @@
       "GEOL 1303"
     ]
   },
+  "GEOL 1405": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR and in Mathematics. Course scheduling information",
+    "courses": []
+  },
+  "GEOL 2289": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "GEOL 2479": {
+    "text": "CHEM 1411 and GEOL 1403 . Course scheduling information",
+    "courses": [
+      "CHEM 1411",
+      "GEOL 1403"
+    ]
+  },
   "GERM 1412": {
     "text": "GERM 1411. Assessment Levels: R3, E3, M1. 16.0501",
     "courses": [
       "GERM 1411"
     ]
   },
+  "GERM 2311": {
+    "text": "GERM 1412 . Course scheduling information",
+    "courses": [
+      "GERM 1412"
+    ]
+  },
   "GERM 2312": {
     "text": "GERM 2311, satisfactory score on placement test or permission of instructor. Assessment Levels: R3, E3, M1. 16.0501",
     "courses": [
       "GERM 2311"
+    ]
+  },
+  "GERS 2366": {
+    "text": "Required: GERS 1301 Background Search Required: No",
+    "courses": [
+      "GERS 1301"
     ]
   },
   "GISC 1191": {
@@ -2451,6 +5627,14 @@
       "ITSE 1402"
     ]
   },
+  "GOVT 2107": {
+    "text": "Recommended : By permission only. Enrollment limited to students who have already completed a minimum of 6 SCH of GOVT courses but have not satisfied the statutory requirement for study of the federal and state constitutions. Ensures compliance with TEC §51.301. Background Search Required: No",
+    "courses": []
+  },
+  "GOVT 2304": {
+    "text": "Required : College level ready in Reading and Writing. Background Search Required: No",
+    "courses": []
+  },
   "GOVT 2305": {
     "text": "READ 1072",
     "courses": [
@@ -2461,6 +5645,23 @@
     "text": "READ 1072",
     "courses": [
       "READ 1072"
+    ]
+  },
+  "GOVT 2311": {
+    "text": "Required : College level ready in Reading and Writing. Background Search Required: No",
+    "courses": []
+  },
+  "GOVT 2389": {
+    "text": "GOVT 2305 and GOVT 2306 . Course scheduling information",
+    "courses": [
+      "GOVT 2305",
+      "GOVT 2306"
+    ]
+  },
+  "GRPH 1359": {
+    "text": "ARTC 1313 with a grade of “C” or better",
+    "courses": [
+      "ARTC 1313"
     ]
   },
   "HAMG 1340": {
@@ -2475,10 +5676,87 @@
       "HAMG 1313"
     ]
   },
+  "HAMG 2301": {
+    "text": "RSTO 1221 with grade of “C” or better",
+    "courses": [
+      "RSTO 1221"
+    ]
+  },
+  "HAMG 2307": {
+    "text": "Recommended : CHEF 1301 or PSTR 1301 or TRVM 1300 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "CHEF 1301",
+      "PSTR 1301",
+      "TRVM 1300"
+    ]
+  },
+  "HART 1281": {
+    "text": "HART 1380 and approval of the division chair",
+    "courses": [
+      "HART 1380"
+    ]
+  },
+  "HART 1303": {
+    "text": "Required : HART 1407 , HART 1401 , HART 1310 . This course is cross-listed as HART 1403 . The student may register for either HART 1303 or HART 1403 but may receive credit for only one of the two",
+    "courses": [
+      "HART 1310",
+      "HART 1401",
+      "HART 1403",
+      "HART 1407"
+    ]
+  },
+  "HART 1345": {
+    "text": "HART 1401 and HART 1407 or instructor approval. Course scheduling information",
+    "courses": [
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "HART 1351": {
+    "text": "Required : HART 1407 , HART 1401 , HART 1310",
+    "courses": [
+      "HART 1310",
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "HART 1356": {
+    "text": "Required : HART 1407 , HART 1401 , HART 1310",
+    "courses": [
+      "HART 1310",
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "HART 1366": {
+    "text": "Required : Instructor approval required",
+    "courses": []
+  },
+  "HART 1380": {
+    "text": "HART 1310 , HART 1301 , HART 1307 , and approval of the division chair",
+    "courses": [
+      "HART 1301",
+      "HART 1307",
+      "HART 1310"
+    ]
+  },
+  "HART 1381": {
+    "text": "HART 1380 and approval of the division chair",
+    "courses": [
+      "HART 1380"
+    ]
+  },
   "HART 1391": {
     "text": "HART 2336 Assessment Levels: R1, E1, M0. 15.0501",
     "courses": [
       "HART 2336"
+    ]
+  },
+  "HART 1394": {
+    "text": "Required : HART 1407 , HART 1401 This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "HART 1401",
+      "HART 1407"
     ]
   },
   "HART 1403": {
@@ -2515,12 +5793,50 @@
       "HART 2338"
     ]
   },
+  "HART 2334": {
+    "text": "Required : HART 2349",
+    "courses": [
+      "HART 2349"
+    ]
+  },
   "HART 2336": {
     "text": "HART 1341 and HART 1345 and HART 2338",
     "courses": [
       "HART 1341",
       "HART 1345",
       "HART 2338"
+    ]
+  },
+  "HART 2338": {
+    "text": "Required : HART 2349",
+    "courses": [
+      "HART 2349"
+    ]
+  },
+  "HART 2341": {
+    "text": "HART 1301 and HART 1307 or approval of the division chair",
+    "courses": [
+      "HART 1301",
+      "HART 1307"
+    ]
+  },
+  "HART 2342": {
+    "text": "HART 1307 and HART 1301 or approval of the division chair",
+    "courses": [
+      "HART 1301",
+      "HART 1307"
+    ]
+  },
+  "HART 2343": {
+    "text": "Required : HART 2349",
+    "courses": [
+      "HART 2349"
+    ]
+  },
+  "HART 2345": {
+    "text": "HART 1401 or instructor approval. Course scheduling information",
+    "courses": [
+      "HART 1401"
     ]
   },
   "HART 2349": {
@@ -2530,10 +5846,71 @@
       "HART 1345"
     ]
   },
+  "HART 2357": {
+    "text": "HART 1401 and HART 1407 with a grade of “C” or better or approval of the professor",
+    "courses": [
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "HART 2368": {
+    "text": "Required : HART 1407 , HART 1401 , HART 1310",
+    "courses": [
+      "HART 1310",
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "HART 2370": {
+    "text": "HART 2477 with a grade of “C” or better",
+    "courses": [
+      "HART 2477"
+    ]
+  },
+  "HART 2378": {
+    "text": "HART 2477 with a grade of “C” or better",
+    "courses": [
+      "HART 2477"
+    ]
+  },
+  "HART 2379": {
+    "text": "HART 2477 with a grade of “C” or better",
+    "courses": [
+      "HART 2477"
+    ]
+  },
+  "HART 2380": {
+    "text": "HART 1281 and approval of the division chair",
+    "courses": [
+      "HART 1281"
+    ]
+  },
   "HART 2434": {
     "text": "HART 2431. R1, E1, M0 15.0501",
     "courses": [
       "HART 2431"
+    ]
+  },
+  "HART 2436": {
+    "text": "Required : HART 2349 This course is cross-listed as HART 2336 . The student may register for either HART 2436 or HART 2336 but may receive credit for only one of the two",
+    "courses": [
+      "HART 2336",
+      "HART 2349"
+    ]
+  },
+  "HART 2438": {
+    "text": "Recommended : HART 1441 , HART 1445 and HART 2449 . Background Search Required: No",
+    "courses": [
+      "HART 1441",
+      "HART 1445",
+      "HART 2449"
+    ]
+  },
+  "HART 2441": {
+    "text": "Required : HART 2349 . This course is cross-listed as HART 2341 . The student may register for either HART 2341 or HART 2441 but may receive credit for only one of the two",
+    "courses": [
+      "HART 2341",
+      "HART 2349"
     ]
   },
   "HART 2442": {
@@ -2557,11 +5934,46 @@
       "HART 1441"
     ]
   },
+  "HART 2476": {
+    "text": "HART 1401 and HART 1407",
+    "courses": [
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "HART 2477": {
+    "text": "HART 2476 with a grade of “C” or better",
+    "courses": [
+      "HART 2476"
+    ]
+  },
+  "HDEV 0110": {
+    "text": "Limited to students in Technical Occupational Programs",
+    "courses": []
+  },
   "HECO 1322": {
     "text": "ENGL 0327 (min C) or ENGL 0327 (min CT) or ENGL 0302 (min C) or ENGL 0302 (min CT)",
     "courses": [
       "ENGL 0327",
       "ENGL 0302"
+    ]
+  },
+  "HEMR 1304": {
+    "text": "DEMR 1329 or instructor approval. Course scheduling information",
+    "courses": [
+      "DEMR 1329"
+    ]
+  },
+  "HEMR 1370": {
+    "text": "HEMR 1304 or instructor approval. Course scheduling information",
+    "courses": [
+      "HEMR 1304"
+    ]
+  },
+  "HEMR 1371": {
+    "text": "HEMR 1304 or instructor approval. Course scheduling information",
+    "courses": [
+      "HEMR 1304"
     ]
   },
   "HIST 1301": {
@@ -2585,6 +5997,58 @@
       "ENGL 0302"
     ]
   },
+  "HIST 2301": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2311": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2312": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2321": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2322": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2327": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2328": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2381": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HIST 2382": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "HITT 1167": {
+    "text": "HITT 1301 ; HITT 1305 ; HITT 1341 ; and HITT 1353",
+    "courses": [
+      "HITT 1301",
+      "HITT 1305",
+      "HITT 1341",
+      "HITT 1353"
+    ]
+  },
+  "HITT 1211": {
+    "text": "HITT 1301 and COSC 1301 (may be taken concurrently)",
+    "courses": [
+      "COSC 1301",
+      "HITT 1301"
+    ]
+  },
   "HITT 1261": {
     "text": "HPRS 2201, HITT 1205, HITT 1301, HITT 1349, HITT 1341, HITT 1353, HITT 1345, HITT 1191, HITT 1342, HITT 2335, ITSW 1307. Assessment Levels: R3, E3, M2. 51.0707",
     "courses": [
@@ -2599,6 +6063,12 @@
       "HITT 1342",
       "HITT 2335",
       "ITSW 1307"
+    ]
+  },
+  "HITT 1301": {
+    "text": "BCIS 1405 with a grade of “C” or better and Acceptance into the Health Information Technology Program",
+    "courses": [
+      "BCIS 1405"
     ]
   },
   "HITT 1303": {
@@ -2623,6 +6093,12 @@
       "BIOL 2404"
     ]
   },
+  "HITT 1342": {
+    "text": "Required : HITT 1341 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "HITT 1341"
+    ]
+  },
   "HITT 1345": {
     "text": "HITT 1301. Assessment Levels: R3, E3, M2. 51.0707",
     "courses": [
@@ -2641,6 +6117,47 @@
       "HITT 1191"
     ]
   },
+  "HITT 2149": {
+    "text": "HITT 1205 , HITT 1301 , HITT 1311 , HITT 1341 , HITT 1342 , HITT 1345 , HITT 1353 , and HITT 2339 . Corequisite(s): HITT 2160 . Course scheduling information",
+    "courses": [
+      "HITT 1205",
+      "HITT 1301",
+      "HITT 1311",
+      "HITT 1341",
+      "HITT 1342",
+      "HITT 1345",
+      "HITT 1353",
+      "HITT 2160",
+      "HITT 2339"
+    ]
+  },
+  "HITT 2160": {
+    "text": "HITT 1205 , HITT 1301 , HITT 1311 , HITT 1341 , HITT 1342 , HITT 1345 , HITT 1353 , and HITT 2339 . Course scheduling information",
+    "courses": [
+      "HITT 1205",
+      "HITT 1301",
+      "HITT 1311",
+      "HITT 1341",
+      "HITT 1342",
+      "HITT 1345",
+      "HITT 1353",
+      "HITT 2339"
+    ]
+  },
+  "HITT 2161": {
+    "text": "HITT 1341 and HITT 1342 Course scheduling information",
+    "courses": [
+      "HITT 1341",
+      "HITT 1342"
+    ]
+  },
+  "HITT 2166": {
+    "text": "HITT 2435 and HITT 2443",
+    "courses": [
+      "HITT 2435",
+      "HITT 2443"
+    ]
+  },
   "HITT 2167": {
     "text": "HITT 2335 (min C) and HITT 1341 (min C)",
     "courses": [
@@ -2654,11 +6171,25 @@
       "HITT 1191"
     ]
   },
+  "HITT 2245": {
+    "text": "POFM 1300 and POFM 2310 with a grade of “C” or better",
+    "courses": [
+      "POFM 1300",
+      "POFM 2310"
+    ]
+  },
   "HITT 2246": {
     "text": "HITT 2335 (min C) and HITT 1341 (min C)",
     "courses": [
       "HITT 2335",
       "HITT 1341"
+    ]
+  },
+  "HITT 2249": {
+    "text": "Required : HITT 2239 and HITT 2246 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "HITT 2239",
+      "HITT 2246"
     ]
   },
   "HITT 2260": {
@@ -2682,6 +6213,19 @@
       "HITT 1301"
     ]
   },
+  "HITT 2339": {
+    "text": "HITT 1301 . Course scheduling information",
+    "courses": [
+      "HITT 1301"
+    ]
+  },
+  "HITT 2340": {
+    "text": "HITT 1341 and HITT 1342 . Course scheduling information",
+    "courses": [
+      "HITT 1341",
+      "HITT 1342"
+    ]
+  },
   "HITT 2343": {
     "text": "HITT 1301 (min C) and HITT 1345 (min C) and HITT 1253 (min C)",
     "courses": [
@@ -2697,10 +6241,36 @@
       "POFM 2310"
     ]
   },
+  "HITT 2360": {
+    "text": "Required : HITT 1253 , HITT 2246 , HITT 2335 . Background Search Required: No",
+    "courses": [
+      "HITT 1253",
+      "HITT 2246",
+      "HITT 2335"
+    ]
+  },
+  "HITT 2443": {
+    "text": "HITT 1353 with a grade of “C” or better",
+    "courses": [
+      "HITT 1353"
+    ]
+  },
+  "HITT 2472": {
+    "text": "HITT 2471 with a grade of “C” or better",
+    "courses": [
+      "HITT 2471"
+    ]
+  },
   "HPRS 1370": {
     "text": "HPRS 1470",
     "courses": [
       "HPRS 1470"
+    ]
+  },
+  "HPRS 2210": {
+    "text": "Required : HPRS 1204 with a grade of “C” or better. Background Search Required: No",
+    "courses": [
+      "HPRS 1204"
     ]
   },
   "HPRS 2301": {
@@ -2711,10 +6281,143 @@
       "POFI 1341"
     ]
   },
+  "HRPO 1391": {
+    "text": "Required: HRPO 1302 , HRPO 2303 , HRPO 2304 , HRPO 2306 , or approval from instructor. This course was designed to be repeated multiple times to improve student proficiency. Please visit this page for more information",
+    "courses": [
+      "HRPO 1302",
+      "HRPO 2303",
+      "HRPO 2304",
+      "HRPO 2306"
+    ]
+  },
+  "HTMS 4301": {
+    "text": "HTMS 3300 , HTMS 3301 , HTMS 3302 , HTMS 3303 , HTMS 3305 , HTMS 3410 , HTMS 4300 , HTMS 4401 , HTMS 4302 , HTMS 4304 and HTMS 4306",
+    "courses": [
+      "HTMS 3300",
+      "HTMS 3301",
+      "HTMS 3302",
+      "HTMS 3303",
+      "HTMS 3305",
+      "HTMS 3410",
+      "HTMS 4300",
+      "HTMS 4302",
+      "HTMS 4304",
+      "HTMS 4306",
+      "HTMS 4401"
+    ]
+  },
+  "HTMS 4306": {
+    "text": "HTMS 3300 , HTMS 3301 , HTMS 3302 , HTMS 3303 , HTMS 3305 , HTMS 3410 , HTMS 4300 , HTMS 4401 and HTMS 4302",
+    "courses": [
+      "HTMS 3300",
+      "HTMS 3301",
+      "HTMS 3302",
+      "HTMS 3303",
+      "HTMS 3305",
+      "HTMS 3410",
+      "HTMS 4300",
+      "HTMS 4302",
+      "HTMS 4401"
+    ]
+  },
+  "HUMA 1301": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "HUMA 1302": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "HUMA 1305": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "HUMA 2319": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "HYDR 1345": {
+    "text": "IEIR 1304 [Power Plant Technology] or CETT 1402 [Industrial Maintenance Technology] with a grade of “C” or better",
+    "courses": [
+      "CETT 1402",
+      "IEIR 1304"
+    ]
+  },
+  "IEIR 1302": {
+    "text": "TECM 1303 with a grade of “C” or better",
+    "courses": [
+      "TECM 1303"
+    ]
+  },
+  "IEIR 1304": {
+    "text": "IEIR 1302 with a grade of “C” or better",
+    "courses": [
+      "IEIR 1302"
+    ]
+  },
+  "IEIR 1312": {
+    "text": "Required : ELPT 1311 , ELPT 1321",
+    "courses": [
+      "ELPT 1311",
+      "ELPT 1321"
+    ]
+  },
+  "IEIR 2388": {
+    "text": "TECM 1303 , IEIR 1302 , IEIR 1304 , ELPT 1325 and CETT 1325 with a grade of “C” or better",
+    "courses": [
+      "CETT 1325",
+      "ELPT 1325",
+      "IEIR 1302",
+      "IEIR 1304",
+      "TECM 1303"
+    ]
+  },
+  "IFWA 1001": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "IFWA 1050": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "IFWA 1280": {
+    "text": "Completion of Culinary Arts: Occupational Life Skills-Food Preparation, OSA",
+    "courses": []
+  },
+  "IFWA 1281": {
+    "text": "IFWA 1280 with a grade of “C” or better",
+    "courses": [
+      "IFWA 1280"
+    ]
+  },
   "IFWA 1318": {
     "text": "CHEF 1301. 12.0508",
     "courses": [
       "CHEF 1301"
+    ]
+  },
+  "IFWA 1527": {
+    "text": "IFWA 1501 with a grade of “C” or better",
+    "courses": [
+      "IFWA 1501"
+    ]
+  },
+  "IFWA 2280": {
+    "text": "IFWA 1281 with a grade of “C” or better",
+    "courses": [
+      "IFWA 1281"
+    ]
+  },
+  "IFWA 2346": {
+    "text": "IFWA 1527 with a grade of “C” or better",
+    "courses": [
+      "IFWA 1527"
+    ]
+  },
+  "IFWA 2441": {
+    "text": "IFWA 1527 with a grade of “C” or better",
+    "courses": [
+      "IFWA 1527"
     ]
   },
   "IMED 1191": {
@@ -2723,10 +6426,31 @@
       "ITSC 1405"
     ]
   },
+  "IMED 1316": {
+    "text": "ITSC 1301 OR POFI 1301 OR BCIS 1305 OR ITSC 1305 or approval of the division chair",
+    "courses": [
+      "BCIS 1305",
+      "ITSC 1301",
+      "ITSC 1305",
+      "POFI 1301"
+    ]
+  },
   "IMED 1341": {
     "text": "IMED 1301 11.0801",
     "courses": [
       "IMED 1301"
+    ]
+  },
+  "IMED 1345": {
+    "text": "IMED 1301 with a grade of “C” or better",
+    "courses": [
+      "IMED 1301"
+    ]
+  },
+  "IMED 1359": {
+    "text": "Recommended : ENGL 1301 . Background Search Required: No",
+    "courses": [
+      "ENGL 1301"
     ]
   },
   "IMED 2311": {
@@ -2735,11 +6459,27 @@
       "IMED 2305"
     ]
   },
+  "IMED 2313": {
+    "text": "Recommended : Completion of two semesters of multimedia coursework. This course is cross-listed as IMED 2413 . The student may register for either IMED 2313 or IMED 2413 but may receive credit for only one of the two",
+    "courses": [
+      "IMED 2413"
+    ]
+  },
   "IMED 2315": {
     "text": "IMED 1316",
     "courses": [
       "IMED 1316"
     ]
+  },
+  "IMED 2345": {
+    "text": "Recommended : IMED 1345 or instructor approval. Background Search Required: No",
+    "courses": [
+      "IMED 1345"
+    ]
+  },
+  "IMED 2388": {
+    "text": "Recommended : Completion of the Level I Multimedia Certificate. Background Search Required: No",
+    "courses": []
   },
   "IMED 2415": {
     "text": "IMED 1301 and 1316. Suggested prerequisites: ITSE 1402 and ITSC 1405. Assessment Levels: R1, E1, M1. 11.0801",
@@ -2749,12 +6489,166 @@
       "ITSC 1405"
     ]
   },
+  "INCR 1302": {
+    "text": "IEIR 1304 with a grade of “C” or better",
+    "courses": [
+      "IEIR 1304"
+    ]
+  },
   "INCR 1442": {
     "text": "INCR 1402 (min C) and CETT 1405 (min C)",
     "courses": [
       "INCR 1402",
       "CETT 1405"
     ]
+  },
+  "INDS 1191": {
+    "text": "Required : Interior Design AAS or ATC Major. Student must earn a grade of “C” or better. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": []
+  },
+  "INDS 1300": {
+    "text": "Required : Interior Design Major. INDS 1319 passed with a “C” or better",
+    "courses": [
+      "INDS 1319"
+    ]
+  },
+  "INDS 1301": {
+    "text": "Required : Interior Design Major. Must be taken in the students’ first semester. Interior Design Major. Students must earn a grade of “C” or better. Background Search Required: No",
+    "courses": []
+  },
+  "INDS 1311": {
+    "text": "Required : Interior Design Major. Must be taken in the students’ first semester. Students must earn a grade of “C” or better. Background Search Required: No",
+    "courses": []
+  },
+  "INDS 1315": {
+    "text": "Required : Interior Design Major. INDS 1311 and INDS 1300 passed with a “C” or better. Background Search Required: No",
+    "courses": [
+      "INDS 1300",
+      "INDS 1311"
+    ]
+  },
+  "INDS 1319": {
+    "text": "Required : Interior Design Major. Must be taken in the students’ first semester. Student must earn a grade of “C” or better. Background Search Required: No",
+    "courses": []
+  },
+  "INDS 1345": {
+    "text": "Required : Interior Design Major. INDS 1300 , INDS 1315 , INDS 1351 , INDS 1352 , INDS 2313 , INDS 2317 , and INDS 2321 passed with a “C” or better",
+    "courses": [
+      "INDS 1300",
+      "INDS 1315",
+      "INDS 1351",
+      "INDS 1352",
+      "INDS 2313",
+      "INDS 2317",
+      "INDS 2321"
+    ]
+  },
+  "INDS 1349": {
+    "text": "Required : Interior Design Major. INDS 1301 , INDS 1311 , INDS 1319 . Student must earn a grade of “C” or better",
+    "courses": [
+      "INDS 1301",
+      "INDS 1311",
+      "INDS 1319"
+    ]
+  },
+  "INDS 1351": {
+    "text": "Recommended : Interior Design Major. Student must earn a grade of “C” or better. Background Search Required: No",
+    "courses": []
+  },
+  "INDS 1352": {
+    "text": "Recommended : Interior Design Major. Student must earn a grade of “C” or better. Background Search Required: No",
+    "courses": []
+  },
+  "INDS 1370": {
+    "text": "Required : Interior Design AAS or ATC Major. Student must earn a grade of “C” or better",
+    "courses": []
+  },
+  "INDS 1371": {
+    "text": "Required : Interior Design AAS or ATC Major. INDS 1370 . Student must earn a grade of “C” or better",
+    "courses": [
+      "INDS 1370"
+    ]
+  },
+  "INDS 1372": {
+    "text": "Required : Interior Design AAS or ATC Major. INDS 1371 . Student must earn a grade of “C” or better",
+    "courses": [
+      "INDS 1371"
+    ]
+  },
+  "INDS 1373": {
+    "text": "Required : Interior Design AAS or ATC Major. INDS 1370 . Student must earn a grade of “C” or better",
+    "courses": [
+      "INDS 1370"
+    ]
+  },
+  "INDS 1374": {
+    "text": "Required : Interior Design AAS or ATC Major. Program Permission. Student must earn a grade of “C” or better",
+    "courses": []
+  },
+  "INDS 2305": {
+    "text": "Required : Interior Design AAS or ATC Major. Student must earn a grade of “C” or better",
+    "courses": []
+  },
+  "INDS 2313": {
+    "text": "Required : Interior Design Major. INDS 1301 , INDS 1311 , and INDS 1319 passed with a “C” or better. Background Search Required: No",
+    "courses": [
+      "INDS 1301",
+      "INDS 1311",
+      "INDS 1319"
+    ]
+  },
+  "INDS 2315": {
+    "text": "Required : Interior Design Major. INDS 1300 , INDS 1315 , INDS 2313 , and INDS 2321 passed with a “C” or better. Background Search Required: No",
+    "courses": [
+      "INDS 1300",
+      "INDS 1315",
+      "INDS 2313",
+      "INDS 2321"
+    ]
+  },
+  "INDS 2317": {
+    "text": "Required : Interior Design Major. INDS 1300 and INDS 2321 passed with a “C” or better. Background Search Required: No",
+    "courses": [
+      "INDS 1300",
+      "INDS 2321"
+    ]
+  },
+  "INDS 2321": {
+    "text": "Required : Interior Design Major. INDS 1301 , INDS 1311 and INDS 1319 passed with a “C” or better. Background Search Required: No",
+    "courses": [
+      "INDS 1301",
+      "INDS 1311",
+      "INDS 1319"
+    ]
+  },
+  "INDS 2325": {
+    "text": "Required : Interior Design AAS or ATC Major. INDS 1315 . Student must earn a grade of “C” or better",
+    "courses": [
+      "INDS 1315"
+    ]
+  },
+  "INDS 2330": {
+    "text": "Required : Interior Design AAS or ATC Major. INDS 1345 , INDS 2315 . Student must earn a grade of “C” or better",
+    "courses": [
+      "INDS 1345",
+      "INDS 2315"
+    ]
+  },
+  "INDS 2337": {
+    "text": "Required : Interior Design Major. INDS 2313 , INDS 2317 , and INDS 2335 passed with a “C” or better. Background Search Required: No",
+    "courses": [
+      "INDS 2313",
+      "INDS 2317",
+      "INDS 2335"
+    ]
+  },
+  "INDS 2380": {
+    "text": "Required : Interior Design AAS or ATC Major. Student must earn a grade of “C” or better",
+    "courses": []
+  },
+  "INEW 1340": {
+    "text": "Recommended : Programming courses in Visual Basic.NET, Java, C#, or other languages that may apply or instructor approval",
+    "courses": []
   },
   "INEW 2334": {
     "text": "ITSE 1311 and ITSE 1302",
@@ -2781,10 +6675,45 @@
       "RBTC 1401"
     ]
   },
+  "INMT 1419": {
+    "text": "INMT 2301 , TECM 1301 and CETT 1402 with a grade of “C” or better",
+    "courses": [
+      "CETT 1402",
+      "INMT 2301",
+      "TECM 1301"
+    ]
+  },
+  "INMT 1480": {
+    "text": "Requires assignment by the Program Director",
+    "courses": []
+  },
   "INMT 2301": {
     "text": "INMT 1305 (min C)",
     "courses": [
       "INMT 1305"
+    ]
+  },
+  "INMT 2303": {
+    "text": "ELMT 2452 (Power Plant Technology) OR INMT 2301 (Industrial Maintenance Technology) with a grade of “C” or better",
+    "courses": [
+      "ELMT 2452",
+      "INMT 2301"
+    ]
+  },
+  "INMT 2345": {
+    "text": "ELPT 2319 , HYDR 1345 , INMT 2303 , and PFPB 2308 with a grade of “C” or better",
+    "courses": [
+      "ELPT 2319",
+      "HYDR 1345",
+      "INMT 2303",
+      "PFPB 2308"
+    ]
+  },
+  "INMT 2388": {
+    "text": "HYDR 1345 and PFPB 2308 with a grade of “C” or better",
+    "courses": [
+      "HYDR 1345",
+      "PFPB 2308"
     ]
   },
   "INRW 0114": {
@@ -2825,6 +6754,31 @@
       "ENGL 1301"
     ]
   },
+  "INTC 1307": {
+    "text": "Recommended : Credit or concurrent enrollment in CETT 1405 . Background Search Required: No",
+    "courses": [
+      "CETT 1405"
+    ]
+  },
+  "INTC 1315": {
+    "text": "Grade of “C” or better in INTC 1401 and INTC 1291 . May be concurrently enrolled in INTC 1291",
+    "courses": [
+      "INTC 1291",
+      "INTC 1401"
+    ]
+  },
+  "INTC 1325": {
+    "text": "INMT 1317 or instructor permission. Course scheduling information",
+    "courses": [
+      "INMT 1317"
+    ]
+  },
+  "INTC 1341": {
+    "text": "INCR 1302 with a grade of “C” or better",
+    "courses": [
+      "INCR 1302"
+    ]
+  },
   "INTC 1343": {
     "text": "CETT 1303 (min D) and CETT 1305 (min D)",
     "courses": [
@@ -2832,11 +6786,68 @@
       "CETT 1305"
     ]
   },
+  "INTC 1348": {
+    "text": "INTC 2330 AND INTC 2359",
+    "courses": [
+      "INTC 2330",
+      "INTC 2359"
+    ]
+  },
+  "INTC 1350": {
+    "text": "Grade of ‘C’ or better in PTAC 1432 or INTC 1401",
+    "courses": [
+      "INTC 1401",
+      "PTAC 1432"
+    ]
+  },
+  "INTC 1356": {
+    "text": "INMT 1317 or instructor permission. Course scheduling information",
+    "courses": [
+      "INMT 1317"
+    ]
+  },
+  "INTC 1357": {
+    "text": "CETT 1302 or instructor permission. Course scheduling information",
+    "courses": [
+      "CETT 1302"
+    ]
+  },
   "INTC 1358": {
     "text": "INTC 1301 (min C) and INCR 1402 (min C)",
     "courses": [
       "INTC 1301",
       "INCR 1402"
+    ]
+  },
+  "INTC 1375": {
+    "text": "Completion of, or concurrent enrollment in INTC 1348 or Division Chair Approval",
+    "courses": [
+      "INTC 1348"
+    ]
+  },
+  "INTC 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "INTC 1441": {
+    "text": "Grade of “C” or better in INTC 1401 and INTC 1291 . May be concurrently enrolled in INTC 1291",
+    "courses": [
+      "INTC 1291",
+      "INTC 1401"
+    ]
+  },
+  "INTC 1443": {
+    "text": "Grade of “C” or better in INTC 1441 and INTC 1291 . May be concurrently enrolled in INTC 1291",
+    "courses": [
+      "INTC 1291",
+      "INTC 1441"
+    ]
+  },
+  "INTC 1450": {
+    "text": "Completion of PTAC 1432 or INTC 1401",
+    "courses": [
+      "INTC 1401",
+      "PTAC 1432"
     ]
   },
   "INTC 1457": {
@@ -2852,11 +6863,56 @@
       "INTC 1341"
     ]
   },
+  "INTC 2330": {
+    "text": "Grade of “C” or better in INTC 1315 , INTC 2410 , and INTC 1443",
+    "courses": [
+      "INTC 1315",
+      "INTC 1443",
+      "INTC 2410"
+    ]
+  },
+  "INTC 2333": {
+    "text": "Grade of “C” or better in INTC 1315 , INTC 2410 , and INTC 1443",
+    "courses": [
+      "INTC 1315",
+      "INTC 1443",
+      "INTC 2410"
+    ]
+  },
   "INTC 2336": {
     "text": "CETT 1303 (min C) and CETT 1325 (min C)",
     "courses": [
       "CETT 1303",
       "CETT 1325"
+    ]
+  },
+  "INTC 2339": {
+    "text": "Grade of “C” or better in INTC 1343",
+    "courses": [
+      "INTC 1343"
+    ]
+  },
+  "INTC 2350": {
+    "text": "INMT 1317 or instructor permission. Course scheduling information",
+    "courses": [
+      "INMT 1317"
+    ]
+  },
+  "INTC 2359": {
+    "text": "Grade of “C” or better in INTC 1443",
+    "courses": [
+      "INTC 1443"
+    ]
+  },
+  "INTC 2380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "INTC 2410": {
+    "text": "Grade of “C” or better in INTC 1401 and INTC 1441",
+    "courses": [
+      "INTC 1401",
+      "INTC 1441"
     ]
   },
   "INTC 2480": {
@@ -2872,6 +6928,46 @@
       "ENGL 1301"
     ]
   },
+  "ITAI 2373": {
+    "text": "ITAI 1370",
+    "courses": [
+      "ITAI 1370"
+    ]
+  },
+  "ITAI 2377": {
+    "text": "ITAI 1370 and DSAI 1371",
+    "courses": [
+      "DSAI 1371",
+      "ITAI 1370"
+    ]
+  },
+  "ITAI 4301": {
+    "text": "Required : ITSE 2371",
+    "courses": [
+      "ITSE 2371"
+    ]
+  },
+  "ITAI 4350": {
+    "text": "Required : ITAI 4301",
+    "courses": [
+      "ITAI 4301"
+    ]
+  },
+  "ITCC 1291": {
+    "text": "Admission to the program",
+    "courses": []
+  },
+  "ITCC 1314": {
+    "text": "Recommended : ITNW 1325 /ITNW 1425 or ITNW 1458 or IT Essentials skills earned in ITSC 1325 /ITSC 1405 or ITSC 1305 /ITSC 1405 or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITNW 1325",
+      "ITNW 1425",
+      "ITNW 1458",
+      "ITSC 1305",
+      "ITSC 1325",
+      "ITSC 1405"
+    ]
+  },
   "ITCC 1340": {
     "text": "ITCC 1414. 11.1002.",
     "courses": [
@@ -2883,6 +6979,14 @@
     "courses": [
       "ITCC 1314"
     ]
+  },
+  "ITCC 1391": {
+    "text": "Admission to the program",
+    "courses": []
+  },
+  "ITCC 1408": {
+    "text": "Recommended : Basic networking course, networking experience, or instructor approval",
+    "courses": []
   },
   "ITCC 2312": {
     "text": "ITCC 1340. 11.1002.",
@@ -2896,11 +7000,108 @@
       "ITCC 1344"
     ]
   },
+  "ITCC 2330": {
+    "text": "Recommended : ITCC 2320 /ITCC 2420 or ITCC 2413 or CCNA Certification or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITCC 2320",
+      "ITCC 2413",
+      "ITCC 2420"
+    ]
+  },
+  "ITCC 2335": {
+    "text": "Recommended : ITCC 2320 /ITCC 2420 or ITCC 2413 or CCNA Certification or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITCC 2320",
+      "ITCC 2413",
+      "ITCC 2420"
+    ]
+  },
+  "ITCC 2343": {
+    "text": "Recommended : ITSY 1300 /ITSY 1400 or ITSY 1342 /ITSY 1442 or ITNW 1325 /ITNW 1425 or ITCC 1314 /ITCC 1414 or ITCC 1344 /ITCC 1444 or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITCC 1314",
+      "ITCC 1344",
+      "ITCC 1414",
+      "ITCC 1444",
+      "ITNW 1325",
+      "ITNW 1425",
+      "ITSY 1300",
+      "ITSY 1342",
+      "ITSY 1400",
+      "ITSY 1442"
+    ]
+  },
+  "ITCC 2459": {
+    "text": "Recommended : EECT 2337 or EECT 2437 or instructor approval. This course is cross-listed as ITCC 2359. The student may register for either ITCC 2359 or ITCC 2459 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "EECT 2337",
+      "EECT 2437",
+      "ITCC 2359"
+    ]
+  },
+  "ITDA 3320": {
+    "text": "Required : ITSE 1303 or departmental approval",
+    "courses": [
+      "ITSE 1303"
+    ]
+  },
+  "ITDA 4330": {
+    "text": "Required : ITDA 3320",
+    "courses": [
+      "ITDA 3320"
+    ]
+  },
+  "ITDA 4340": {
+    "text": "Required : ITDA 4330",
+    "courses": [
+      "ITDA 4330"
+    ]
+  },
+  "ITDA 4350": {
+    "text": "Required : ITDA 4340",
+    "courses": [
+      "ITDA 4340"
+    ]
+  },
+  "ITDF 1300": {
+    "text": "Suggested: ITSC 1325 or concurrent enrollment",
+    "courses": [
+      "ITSC 1325"
+    ]
+  },
+  "ITMT 1403": {
+    "text": "Recommended : Prior networking course, networking experience, or instructor approval",
+    "courses": []
+  },
+  "ITMT 1405": {
+    "text": "Recommended : Instructor approval. Background Search Required: No",
+    "courses": []
+  },
+  "ITMT 1406": {
+    "text": "Recommended : Instructor approval. Background Search Required: No",
+    "courses": []
+  },
+  "ITMT 1458": {
+    "text": "Recommended : Instructor approval. Background Search Required: No",
+    "courses": []
+  },
+  "ITMT 2304": {
+    "text": "Recommended : Instructor approval. Background Search Required: No",
+    "courses": []
+  },
   "ITMT 2305": {
     "text": "CPMT 1351",
     "courses": [
       "CPMT 1351"
     ]
+  },
+  "ITMT 2440": {
+    "text": "Recommended : Instructor approval",
+    "courses": []
+  },
+  "ITNW 1274": {
+    "text": "Recommended : Successful completion of all Semester I Internet Development Technologies core curriculum or equivalent experiences approved by instructor consent. Background Search Required: No",
+    "courses": []
   },
   "ITNW 1309": {
     "text": "ITCC 1314",
@@ -2913,6 +7114,31 @@
     "courses": [
       "ITSC 1325",
       "ITCC 1314"
+    ]
+  },
+  "ITNW 1316": {
+    "text": "ITSC 1305 and ITSC 1325",
+    "courses": [
+      "ITSC 1305",
+      "ITSC 1325"
+    ]
+  },
+  "ITNW 1335": {
+    "text": "ITNW 1325",
+    "courses": [
+      "ITNW 1325"
+    ]
+  },
+  "ITNW 1336": {
+    "text": "ITNW 1309",
+    "courses": [
+      "ITNW 1309"
+    ]
+  },
+  "ITNW 1345": {
+    "text": "ITNW 1316",
+    "courses": [
+      "ITNW 1316"
     ]
   },
   "ITNW 1351": {
@@ -2928,10 +7154,107 @@
       "ITCC 1314"
     ]
   },
+  "ITNW 1358": {
+    "text": "ITCC 1344 or instructor approval. Course scheduling information",
+    "courses": [
+      "ITCC 1344"
+    ]
+  },
+  "ITNW 1364": {
+    "text": "Recommended : Instructor approval. Background Search Required: No",
+    "courses": []
+  },
+  "ITNW 1373": {
+    "text": "Recommended : ITNW 1309 , ITNW 1378 . Background Search Required: No",
+    "courses": [
+      "ITNW 1309",
+      "ITNW 1378"
+    ]
+  },
+  "ITNW 1377": {
+    "text": "Recommended : ITNW 1309 , ITNW 1336 . Background Search Required: No",
+    "courses": [
+      "ITNW 1309",
+      "ITNW 1336"
+    ]
+  },
+  "ITNW 2305": {
+    "text": "Completion of or concurrent enrollment in ITNW 1325 or approval of the division chair",
+    "courses": [
+      "ITNW 1325"
+    ]
+  },
+  "ITNW 2312": {
+    "text": "ITNW 1325 or ITCC 1314 or instructor approval. Course scheduling information",
+    "courses": [
+      "ITCC 1314",
+      "ITNW 1325"
+    ]
+  },
+  "ITNW 2313": {
+    "text": "Completion of or concurrent enrollment in ITNW 1325 or approval of the division chair",
+    "courses": [
+      "ITNW 1325"
+    ]
+  },
+  "ITNW 2327": {
+    "text": "ITSC 1307",
+    "courses": [
+      "ITSC 1307"
+    ]
+  },
+  "ITNW 2329": {
+    "text": "ITNW 1336",
+    "courses": [
+      "ITNW 1336"
+    ]
+  },
   "ITNW 2332": {
     "text": "ITSC 1358. Assessment Levels: R1, E1, M1. 11.0901",
     "courses": [
       "ITSC 1358"
+    ]
+  },
+  "ITNW 2335": {
+    "text": "ITNW 1325",
+    "courses": [
+      "ITNW 1325"
+    ]
+  },
+  "ITNW 2350": {
+    "text": "Recommended : ITSC 1425/ITSC 1405 or CPMT 1451 or ITSC 2439 or instructor approval. Background Search Required: No",
+    "courses": [
+      "CPMT 1451",
+      "ITSC 1405",
+      "ITSC 1425",
+      "ITSC 2439"
+    ]
+  },
+  "ITNW 2352": {
+    "text": "Recommended : ITSE 1303 or ITSE 1346 or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITSE 1303",
+      "ITSE 1346"
+    ]
+  },
+  "ITNW 2354": {
+    "text": "ITNW 1354 and ITCC 1314 with a grade of “C” or better",
+    "courses": [
+      "ITCC 1314",
+      "ITNW 1354"
+    ]
+  },
+  "ITNW 2355": {
+    "text": "ITNW 1313",
+    "courses": [
+      "ITNW 1313"
+    ]
+  },
+  "ITNW 2370": {
+    "text": "Recommended : ITNW 1378 and ITSC 1316 or Instructor Approval. Background Search Required: No",
+    "courses": [
+      "ITNW 1378",
+      "ITSC 1316"
     ]
   },
   "ITNW 2435": {
@@ -2942,16 +7265,76 @@
       "ITCC 1401"
     ]
   },
+  "ITSC 1192": {
+    "text": "Approval of the Division Chair",
+    "courses": []
+  },
+  "ITSC 1291": {
+    "text": "Approval of the Division Chair",
+    "courses": []
+  },
   "ITSC 1305": {
     "text": "ITSC 1301",
     "courses": [
       "ITSC 1301"
     ]
   },
+  "ITSC 1315": {
+    "text": "Recommended : Basic understanding of personal computers and operating systems as obtained in ITSC 1401 or BCIS 1405 or COSC 1401 or equivalent experience approved by instructor",
+    "courses": [
+      "BCIS 1405",
+      "COSC 1401",
+      "ITSC 1401"
+    ]
+  },
+  "ITSC 1316": {
+    "text": "Recommended : Basic understanding of personal computers and operating systems as obtained in ITSC 1401 or BCIS 1405 or COSC 1401 or equivalent experience approved by instructor",
+    "courses": [
+      "BCIS 1405",
+      "COSC 1401",
+      "ITSC 1401"
+    ]
+  },
+  "ITSC 1321": {
+    "text": "ITSC 1305 with a grade of “C” or better",
+    "courses": [
+      "ITSC 1305"
+    ]
+  },
   "ITSC 1325": {
     "text": "ITSC 1301. 47.0104",
     "courses": [
       "ITSC 1301"
+    ]
+  },
+  "ITSC 1370": {
+    "text": "Recommended : POFI 1301 . Background Search Required: No",
+    "courses": [
+      "POFI 1301"
+    ]
+  },
+  "ITSC 1380": {
+    "text": "Recommended : Instructor approval prior to enrollment. Background Search Required: No",
+    "courses": []
+  },
+  "ITSC 2321": {
+    "text": "POFI 2301 and POFI 1349 or approval of the division chair",
+    "courses": [
+      "POFI 1349",
+      "POFI 2301"
+    ]
+  },
+  "ITSC 2325": {
+    "text": "Recommended : ITSC 1316 /ITSC 1416 or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITSC 1316",
+      "ITSC 1416"
+    ]
+  },
+  "ITSC 2335": {
+    "text": "Recommended : Any advanced application software course or equivalent software use. This course is cross-listed as ITSC 2435 . The student may register for either ITSC 2335 or ITSC 2435 but may receive credit for only one of the two",
+    "courses": [
+      "ITSC 2435"
     ]
   },
   "ITSC 2339": {
@@ -2961,17 +7344,144 @@
       "ITNW 1308"
     ]
   },
+  "ITSC 2370": {
+    "text": "ITSE 2321 , ITSE 2313 , or instructor permission. Course scheduling information",
+    "courses": [
+      "ITSE 2313",
+      "ITSE 2321"
+    ]
+  },
+  "ITSC 2380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "ITSC 2381": {
+    "text": "ITSC 2380",
+    "courses": [
+      "ITSC 2380"
+    ]
+  },
+  "ITSC 2387": {
+    "text": "ITNW 1354 and ITCC 1314 with a grade of “C” or better or concurrent enrollment",
+    "courses": [
+      "ITCC 1314",
+      "ITNW 1354"
+    ]
+  },
+  "ITSC 2421": {
+    "text": "Recommended : ITSW 1401 or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITSW 1401"
+    ]
+  },
+  "ITSC 2431": {
+    "text": "Recommended : ITSC 1409 or instructor consent",
+    "courses": [
+      "ITSC 1409"
+    ]
+  },
+  "ITSC 2437": {
+    "text": "Recommended : ITSC 1407 or instructor consent. Background Search Required: No",
+    "courses": [
+      "ITSC 1407"
+    ]
+  },
+  "ITSC 2439": {
+    "text": "Recommended : ITSC 1405 and (ITSW 1401 or ITSC 2421 ) or (ITSW 1404 or ITSW 1434) or (ITSW 1407 or ITSW 2437) or instructor approval. Background Search Required: No",
+    "courses": [
+      "ITSC 1405",
+      "ITSC 2421",
+      "ITSW 1401",
+      "ITSW 1404",
+      "ITSW 1407",
+      "ITSW 1434",
+      "ITSW 2437"
+    ]
+  },
+  "ITSD 3301": {
+    "text": "Recommended : ITSY 1300 and ITSE 1350",
+    "courses": [
+      "ITSE 1350",
+      "ITSY 1300"
+    ]
+  },
+  "ITSD 3330": {
+    "text": "Required : INEW 2332 or ITSC 1364 or departmental approval",
+    "courses": [
+      "INEW 2332",
+      "ITSC 1364"
+    ]
+  },
+  "ITSD 4340": {
+    "text": "Required : ITSD 3330",
+    "courses": [
+      "ITSD 3330"
+    ]
+  },
+  "ITSD 4350": {
+    "text": "Required : ITSD 4340",
+    "courses": [
+      "ITSD 4340"
+    ]
+  },
+  "ITSE 1301": {
+    "text": "Recommended : Prior working knowledge and experience with personal computers or instructor approval",
+    "courses": []
+  },
   "ITSE 1302": {
     "text": "ITSE 1329",
     "courses": [
       "ITSE 1329"
     ]
   },
+  "ITSE 1306": {
+    "text": "Recommended : Basic web page generation skills or instructor approval",
+    "courses": []
+  },
+  "ITSE 1307": {
+    "text": "Recommended : Basic understanding of problem solving and logic structures used with computers obtained in ITSE 1329 or equivalent experiences approved by instructor consent. Background Search Required: No",
+    "courses": [
+      "ITSE 1329"
+    ]
+  },
+  "ITSE 1330": {
+    "text": "ITSE 1302",
+    "courses": [
+      "ITSE 1302"
+    ]
+  },
+  "ITSE 1345": {
+    "text": "Recommended : Basic understanding of problem solving and logic structures used with computers obtained in ITSE 1429 or equivalent experiences approved by instructor consent",
+    "courses": [
+      "ITSE 1429"
+    ]
+  },
+  "ITSE 1350": {
+    "text": "Recommended : Any ITSE programming course or instructor approval",
+    "courses": []
+  },
+  "ITSE 1359": {
+    "text": "Recommended : Basic web page generation skills or instructor approval. Background Search Required: No",
+    "courses": []
+  },
   "ITSE 2302": {
     "text": "COSC 1436, IMED 1316, or permission of department chair. 11.0801",
     "courses": [
       "COSC 1436",
       "IMED 1316"
+    ]
+  },
+  "ITSE 2305": {
+    "text": "Recommended : Basic understanding of problem solving and logic structures used with computers obtained in ITSE 1429 or equivalent experiences approved by instructor consent. This course is cross-listed as ITSE 2405. The student may register for either ITSE 2305 or ITSE 2405 but may receive credit for only one of the two. This course may be repeated if topics and learning outcomes vary. Background Search Required: No",
+    "courses": [
+      "ITSE 1429",
+      "ITSE 2405"
+    ]
+  },
+  "ITSE 2310": {
+    "text": "Recommended : ITSE 1429 or instructor approval",
+    "courses": [
+      "ITSE 1429"
     ]
   },
   "ITSE 2313": {
@@ -2993,10 +7503,49 @@
       "ITSE 1302"
     ]
   },
+  "ITSE 2331": {
+    "text": "Recommended : ITSE 1307 /ITSE 1407 or instructor approval",
+    "courses": [
+      "ITSE 1307",
+      "ITSE 1407"
+    ]
+  },
+  "ITSE 2349": {
+    "text": "ITSE 1332 or approval of division chair",
+    "courses": [
+      "ITSE 1332"
+    ]
+  },
+  "ITSE 2353": {
+    "text": "Recommended : ITSE 1330 /ITSE 1430 or instructor approval",
+    "courses": [
+      "ITSE 1330",
+      "ITSE 1430"
+    ]
+  },
+  "ITSE 2354": {
+    "text": "ITSE 1345 or instructor permission. Course scheduling information",
+    "courses": [
+      "ITSE 1345"
+    ]
+  },
   "ITSE 2357": {
     "text": "ITSE 2321 (min C)",
     "courses": [
       "ITSE 2321"
+    ]
+  },
+  "ITSE 2370": {
+    "text": "Recommended : ITSE 1370 . Background Search Required: No",
+    "courses": [
+      "ITSE 1370"
+    ]
+  },
+  "ITSE 2371": {
+    "text": "Recommended : ITSE 2370 , MATH 1314 . Background Search Required: No",
+    "courses": [
+      "ITSE 2370",
+      "MATH 1314"
     ]
   },
   "ITSE 2402": {
@@ -3021,6 +7570,34 @@
       "COSC 1437"
     ]
   },
+  "ITSE 2449": {
+    "text": "ITSE 1332 or approval of the division chair",
+    "courses": [
+      "ITSE 1332"
+    ]
+  },
+  "ITSW 1301": {
+    "text": "POFT 1227 or instructor permission. Course scheduling information",
+    "courses": [
+      "POFT 1227"
+    ]
+  },
+  "ITSW 1304": {
+    "text": "Computer knowledge",
+    "courses": []
+  },
+  "ITSW 1307": {
+    "text": "ITSC 1301 OR POFI 1301 OR BCIS 1305 or approval of the division chair",
+    "courses": [
+      "BCIS 1305",
+      "ITSC 1301",
+      "POFI 1301"
+    ]
+  },
+  "ITSW 1310": {
+    "text": "Knowledge of software file management and keyboarding skills. Course scheduling information",
+    "courses": []
+  },
   "ITSW 2334": {
     "text": "POFI 1349",
     "courses": [
@@ -3033,11 +7610,28 @@
       "ITSW 1307"
     ]
   },
+  "ITSW 2434": {
+    "text": "ITSW 1304 or instructor permission. Course scheduling information",
+    "courses": [
+      "ITSW 1304"
+    ]
+  },
+  "ITSY 1291": {
+    "text": "Admission to the program",
+    "courses": []
+  },
   "ITSY 1342": {
     "text": "ITSC 1325 and ITCC 1314",
     "courses": [
       "ITSC 1325",
       "ITCC 1314"
+    ]
+  },
+  "ITSY 2300": {
+    "text": "Recommended : ITSY 1342 /ITSY 1442 or instructor approval",
+    "courses": [
+      "ITSY 1342",
+      "ITSY 1442"
     ]
   },
   "ITSY 2301": {
@@ -3064,10 +7658,73 @@
       "ITSY 2301"
     ]
   },
+  "ITSY 2343": {
+    "text": "ITSY 2330",
+    "courses": [
+      "ITSY 2330"
+    ]
+  },
+  "ITSY 2345": {
+    "text": "Recommended : ITSY 2300 /ITSY 2400, ITSY 2301 /ITSY 2401, ITSY 2342 /ITSY 2442, or instructor approval. This course is cross-listed as ITSY 2445 . The student may register for either ITSY 2345 or ITSY 2445 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "ITSY 2300",
+      "ITSY 2301",
+      "ITSY 2342",
+      "ITSY 2400",
+      "ITSY 2401",
+      "ITSY 2442",
+      "ITSY 2445"
+    ]
+  },
+  "ITSY 2359": {
+    "text": "ITSY 2342",
+    "courses": [
+      "ITSY 2342"
+    ]
+  },
+  "ITSY 2372": {
+    "text": "Recommended : ITSY 2300 /ITSY 2400, ITSY 2301 /ITSY 2401, ITSY 2342 /ITSY 2442 or instructor approval Background Search Required: No",
+    "courses": [
+      "ITSY 2300",
+      "ITSY 2301",
+      "ITSY 2342",
+      "ITSY 2400",
+      "ITSY 2401",
+      "ITSY 2442"
+    ]
+  },
+  "ITSY 2386": {
+    "text": "ITSY 2342",
+    "courses": [
+      "ITSY 2342"
+    ]
+  },
   "ITSY 2417": {
     "text": "ITSY 2400. Assessment Levels: R1, E1, M1. 11.1003",
     "courses": [
       "ITSY 2400"
+    ]
+  },
+  "ITSY 2430": {
+    "text": "Recommended : ITSY 2400 and ITSY 2401 or instructor approval",
+    "courses": [
+      "ITSY 2400",
+      "ITSY 2401"
+    ]
+  },
+  "ITSY 2445": {
+    "text": "Recommended : ITSY 2400, ITSY 2401, ITSY 2442, or instructor approval. This course is cross-listed as ITSY 2345 . The student may register for either ITSY 2345 or ITSY 2445 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "ITSY 2345",
+      "ITSY 2400",
+      "ITSY 2401",
+      "ITSY 2442"
+    ]
+  },
+  "JAPN 1412": {
+    "text": "JAPN 1411 with a grade of “C” or better",
+    "courses": [
+      "JAPN 1411"
     ]
   },
   "JAPN 2311": {
@@ -3088,11 +7745,120 @@
       "KINE 1114"
     ]
   },
+  "KINE 1127": {
+    "text": "Instructor permission required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 1131": {
+    "text": "Instructor permission required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 1133": {
+    "text": "Instructor permission required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 1135": {
+    "text": "Instructor permission required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 1148": {
+    "text": "KINE 1147 with a grade of “C” or better",
+    "courses": [
+      "KINE 1147"
+    ]
+  },
+  "KINE 1301": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "KINE 1306": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "KINE 1331": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2105": {
+    "text": "Enrollment only with departmental approval. Course scheduling information",
+    "courses": []
+  },
   "KINE 2112": {
     "text": "KINE 1112",
     "courses": [
       "KINE 1112"
     ]
+  },
+  "KINE 2125": {
+    "text": "Instructor permission is required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2127": {
+    "text": "Instructor permission required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2131": {
+    "text": "Instructor permission is required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2133": {
+    "text": "Instructor permission is required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2135": {
+    "text": "Instructor permission is required. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2136": {
+    "text": "KINE 2135 with a grade of “C” or better",
+    "courses": [
+      "KINE 2135"
+    ]
+  },
+  "KINE 2147": {
+    "text": "KINE 1148 with a grade of “C” or better",
+    "courses": [
+      "KINE 1148"
+    ]
+  },
+  "KINE 2148": {
+    "text": "KINE 2147 with a grade of “C” or better",
+    "courses": [
+      "KINE 2147"
+    ]
+  },
+  "KINE 2356": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "KINE 2362": {
+    "text": "Required : BIOL 2401 , BIOL 2402",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402"
+    ]
+  },
+  "LATI 1412": {
+    "text": "LATI 1411. Course scheduling information",
+    "courses": [
+      "LATI 1411"
+    ]
+  },
+  "LATI 2311": {
+    "text": "LATI 1412 . Course scheduling information",
+    "courses": [
+      "LATI 1412"
+    ]
+  },
+  "LATI 2312": {
+    "text": "LATI 2311 . Course scheduling information",
+    "courses": [
+      "LATI 2311"
+    ]
+  },
+  "LGLA 1301": {
+    "text": "Required : College-level ready in Reading and Writing. Background Search Required: No",
+    "courses": []
   },
   "LGLA 1303": {
     "text": "LGLA 1313 and LGLA 1342",
@@ -3100,6 +7866,10 @@
       "LGLA 1313",
       "LGLA 1342"
     ]
+  },
+  "LGLA 1305": {
+    "text": "TSI ELAR (Reading and Writing) requirement met",
+    "courses": []
   },
   "LGLA 1345": {
     "text": "LGLA 1307 and LGLA 1401. Assessment Levels: R3, E3, M2. 22.0302",
@@ -3115,6 +7885,15 @@
       "LGLA 1344"
     ]
   },
+  "LGLA 1351": {
+    "text": "Recommended : LGLA 1301 , LGLA 1311 , LGLA 1313 , LGLA 1317 . Background Search Required: No",
+    "courses": [
+      "LGLA 1301",
+      "LGLA 1311",
+      "LGLA 1313",
+      "LGLA 1317"
+    ]
+  },
   "LGLA 1353": {
     "text": "LGLA 1303 and LGLA 1344",
     "courses": [
@@ -3122,10 +7901,26 @@
       "LGLA 1344"
     ]
   },
+  "LGLA 1355": {
+    "text": "Recommended : LGLA 1301 , LGLA 1311 , LGLA 1313 , LGLA 1317 . Background Search Required: No",
+    "courses": [
+      "LGLA 1301",
+      "LGLA 1311",
+      "LGLA 1313",
+      "LGLA 1317"
+    ]
+  },
   "LGLA 1401": {
     "text": "LGLA 1307. Assessment Levels: R3, E3, M22. 22.0302",
     "courses": [
       "LGLA 1307"
+    ]
+  },
+  "LGLA 1405": {
+    "text": "ENGL 1301 and LGLA 1403 with a grade of “C” or better or concurrent enrollment",
+    "courses": [
+      "ENGL 1301",
+      "LGLA 1403"
     ]
   },
   "LGLA 2303": {
@@ -3170,11 +7965,39 @@
       "LGLA 1344"
     ]
   },
+  "LGLA 2331": {
+    "text": "LGLA 1301 . Course scheduling information",
+    "courses": [
+      "LGLA 1301"
+    ]
+  },
   "LGLA 2333": {
     "text": "LGLA 1307 AND LGLA 1401. Assessment Levels: R3, E3, M2. 22.0302",
     "courses": [
       "LGLA 1307",
       "LGLA 1401"
+    ]
+  },
+  "LGLA 2335": {
+    "text": "LGLA 1345 . Course scheduling information",
+    "courses": [
+      "LGLA 1345"
+    ]
+  },
+  "LGLA 2337": {
+    "text": "Recommended : LGLA 1311",
+    "courses": [
+      "LGLA 1311"
+    ]
+  },
+  "LGLA 2339": {
+    "text": "Faculty approval required. Course scheduling information",
+    "courses": []
+  },
+  "LGLA 2380": {
+    "text": "LGLA 1403 with a grade of “C” or better, sophomore level and approval of both the department chair and an approved law office",
+    "courses": [
+      "LGLA 1403"
     ]
   },
   "LGLA 2388": {
@@ -3188,6 +8011,26 @@
   },
   "LMGT 1323": {
     "text": "LMGT 1319 (min C)",
+    "courses": [
+      "LMGT 1319"
+    ]
+  },
+  "LMGT 1325": {
+    "text": "Required : LMGT 1319 , LMGT 1321",
+    "courses": [
+      "LMGT 1319",
+      "LMGT 1321"
+    ]
+  },
+  "LMGT 1349": {
+    "text": "Required : LMGT 1319 , LMGT 1321",
+    "courses": [
+      "LMGT 1319",
+      "LMGT 1321"
+    ]
+  },
+  "LMGT 2334": {
+    "text": "LMGT 1319 Introduction to Business Logistics",
     "courses": [
       "LMGT 1319"
     ]
@@ -3236,6 +8079,18 @@
     "text": "MATH 1332",
     "courses": [
       "MATH 1332"
+    ]
+  },
+  "MATH 0308": {
+    "text": "MATH 0306 or TSI Placement",
+    "courses": [
+      "MATH 0306"
+    ]
+  },
+  "MATH 0312": {
+    "text": "MATH 0308 or TSI Placement",
+    "courses": [
+      "MATH 0308"
     ]
   },
   "MATH 0314": {
@@ -3342,6 +8197,14 @@
       "MATH 1350"
     ]
   },
+  "MATH 1414": {
+    "text": "Required : College level ready in Mathematics algebra-based level",
+    "courses": []
+  },
+  "MATH 1442": {
+    "text": "Students must have satisfied the TSI readiness requirement in Mathematics or have Mathematics Department Chair approval. Course Fee Course scheduling information",
+    "courses": []
+  },
   "MATH 2305": {
     "text": "MATH 2413 - Calculus I. Assessment Levels: R3, E3, M3. 27.0101.5819.",
     "courses": [
@@ -3391,10 +8254,95 @@
       "MATH 2414"
     ]
   },
+  "MATH 2418": {
+    "text": "Required : MATH 2414 or equivalent. This course is cross-listed as MATH 2318 . The student may register for either MATH 2318 or MATH 2418 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "MATH 2318",
+      "MATH 2414"
+    ]
+  },
+  "MATH 2420": {
+    "text": "MATH 2414",
+    "courses": [
+      "MATH 2414"
+    ]
+  },
   "MCHN 1308": {
     "text": "MCHN 1338",
     "courses": [
       "MCHN 1338"
+    ]
+  },
+  "MCHN 1326": {
+    "text": "Required : DFTG 2350 , MCHN 2331 , MCHN 2334 , MCHN 1338 . Background Search Required: No",
+    "courses": [
+      "DFTG 2350",
+      "MCHN 1338",
+      "MCHN 2331",
+      "MCHN 2334"
+    ]
+  },
+  "MCHN 1338": {
+    "text": "Required : DFTG 1409 , MCHN 1200 , MCHN 1320 . This course is cross-listed as MCHN 1438 . The student may register for either MCHN 1338 or MCHN 1438 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "DFTG 1409",
+      "MCHN 1200",
+      "MCHN 1320",
+      "MCHN 1438"
+    ]
+  },
+  "MCHN 1352": {
+    "text": "Required : MCHN 1338 . Background Search Required: No",
+    "courses": [
+      "MCHN 1338"
+    ]
+  },
+  "MCHN 1358": {
+    "text": "MCHN 1308",
+    "courses": [
+      "MCHN 1308"
+    ]
+  },
+  "MCHN 1381": {
+    "text": "MCHN 1380",
+    "courses": [
+      "MCHN 1380"
+    ]
+  },
+  "MCHN 1393": {
+    "text": "Recommended : MCHN 1326 , MCHN 1352 . This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "MCHN 1326",
+      "MCHN 1352"
+    ]
+  },
+  "MCHN 2331": {
+    "text": "Required : MCHN 1200 , MCHN 1320 . This course is cross-listed as MCHN 2431 . The student may register for either MCHN 2331 or MCHN 2431 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "MCHN 1200",
+      "MCHN 1320",
+      "MCHN 2431"
+    ]
+  },
+  "MCHN 2334": {
+    "text": "Required : MCHN 1200 , MCHN 1320 . Background Search Required: No",
+    "courses": [
+      "MCHN 1200",
+      "MCHN 1320"
+    ]
+  },
+  "MCHN 2335": {
+    "text": "Required : MCHN 1326 , MCHN 1352 . This course is cross-listed as MCHN 2435 . The student may register for either MCHN 2335 or MCHN 2435 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "MCHN 1326",
+      "MCHN 1352",
+      "MCHN 2435"
+    ]
+  },
+  "MCHN 2338": {
+    "text": "Recommended : INMT 1343 . Background Search Required: No",
+    "courses": [
+      "INMT 1343"
     ]
   },
   "MCHN 2341": {
@@ -3405,17 +8353,139 @@
       "MCHN 2372"
     ]
   },
+  "MCHN 2380": {
+    "text": "MCHN 1381",
+    "courses": [
+      "MCHN 1381"
+    ]
+  },
+  "MCHN 2403": {
+    "text": "TSI ELAR (Reading and Writing) and Math requirements met",
+    "courses": []
+  },
+  "MCHN 2447": {
+    "text": "Required : MCHN 1352 , MCHN 1326 , MCHN 2331 . Background Search Required: No",
+    "courses": [
+      "MCHN 1326",
+      "MCHN 1352",
+      "MCHN 2331"
+    ]
+  },
+  "MDCA 1205": {
+    "text": "Recommended : GED or High School Diploma. Background Search Required: No",
+    "courses": []
+  },
   "MDCA 1254": {
     "text": "MDCA 1417) Students will earn an A, B, C, D, F, or W. A preparation for one of the National Commission for Certifying Agencies NCCA recognized credentialing exams. Lab fee.",
     "courses": [
       "MDCA 1417"
     ]
   },
+  "MDCA 1260": {
+    "text": "Required: MDCA 1313 , MDCA 1421 , MDCA 1443 , MDCA 1391",
+    "courses": [
+      "MDCA 1313",
+      "MDCA 1391",
+      "MDCA 1421",
+      "MDCA 1443"
+    ]
+  },
+  "MDCA 1313": {
+    "text": "Recommended : GED or High School Diploma and admission to program. Background Search Required: No",
+    "courses": []
+  },
+  "MDCA 1352": {
+    "text": "Recommended : MDCA 1313 , MDCA 1409 and admission to the Medical Assisting Program at El Centro College. Background Search Required: No",
+    "courses": [
+      "MDCA 1313",
+      "MDCA 1409"
+    ]
+  },
+  "MDCA 1391": {
+    "text": "Recommended : MDCA 1313 , MDCA 1409 and admission to the Medical Assisting Program at El Centro Campus OR MDCA 1313 and admission to the Medical Front Office program at Brookhaven campus. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "MDCA 1313",
+      "MDCA 1409"
+    ]
+  },
+  "MDCA 1417": {
+    "text": "Recommended : MDCA 1313 , MDCA 1409 and admission to the Medical Assisting Program at El Centro College. Background Search Required: No",
+    "courses": [
+      "MDCA 1313",
+      "MDCA 1409"
+    ]
+  },
+  "MDCA 1421": {
+    "text": "Recommended : MDCA 1313 . Background Search Required: No",
+    "courses": [
+      "MDCA 1313"
+    ]
+  },
+  "MDCA 1443": {
+    "text": "Recommended : MDCA 1313 . Background Search Required: No",
+    "courses": [
+      "MDCA 1313"
+    ]
+  },
+  "MDCA 2361": {
+    "text": "Recommended : Admission into the El Centro College Medical Assisting Program, MDCA 1313 , MDCA 1201, MDCA 1205 , MDCA 1443 , MDCA 1421 , MDCA 1247, MRMT 1211, MRMT 1192, MDCA 1216, MDCA 1217, MDCA 1251, ENGL 1301 , SPCH 1311 . Background Search Required: No",
+    "courses": [
+      "ENGL 1301",
+      "MDCA 1201",
+      "MDCA 1205",
+      "MDCA 1216",
+      "MDCA 1217",
+      "MDCA 1247",
+      "MDCA 1251",
+      "MDCA 1313",
+      "MDCA 1421",
+      "MDCA 1443",
+      "MRMT 1192",
+      "MRMT 1211",
+      "SPCH 1311"
+    ]
+  },
+  "MFGT 2459": {
+    "text": "Required : ELPT 2419 . Background Search Required: No",
+    "courses": [
+      "ELPT 2419"
+    ]
+  },
+  "MHSM 3303": {
+    "text": "Completion of a college level mathematics course",
+    "courses": []
+  },
+  "MHSM 4354": {
+    "text": "Senior standing or by permission of the program chair. Course scheduling information",
+    "courses": []
+  },
+  "MHSM 4361": {
+    "text": "This course must be taken in the final semester of the program with the approval of the program chair or division chair",
+    "courses": []
+  },
+  "MHSM 4451": {
+    "text": "Senior standing or by permission of the program chair. Course scheduling information",
+    "courses": []
+  },
   "MLAB 1127": {
     "text": "MLAB 1201 and MLAB 1415",
     "courses": [
       "MLAB 1201",
       "MLAB 1415"
+    ]
+  },
+  "MLAB 1167": {
+    "text": "Recommended : Acceptance into the Medical Laboratory Technology Program",
+    "courses": []
+  },
+  "MLAB 1201": {
+    "text": "Acceptance to MLT program or permission of the department chair",
+    "courses": []
+  },
+  "MLAB 1227": {
+    "text": "Recommended : MLAB 1335 . Background Search Required: No",
+    "courses": [
+      "MLAB 1335"
     ]
   },
   "MLAB 1231": {
@@ -3426,16 +8496,153 @@
       "MLAB 2401"
     ]
   },
+  "MLAB 1235": {
+    "text": "MLAB 1201 , MLAB 1415 and PLAB 1223 with a grade of “C” or better",
+    "courses": [
+      "MLAB 1201",
+      "MLAB 1415",
+      "PLAB 1223"
+    ]
+  },
+  "MLAB 1311": {
+    "text": "MLAB 1201 , MLAB 1415 and PLAB 1223 with a grade of “C” or better",
+    "courses": [
+      "MLAB 1201",
+      "MLAB 1415",
+      "PLAB 1223"
+    ]
+  },
+  "MLAB 1415": {
+    "text": "Recommended : MLAB 1335 . Background Search Required: No",
+    "courses": [
+      "MLAB 1335"
+    ]
+  },
+  "MLAB 2132": {
+    "text": "MLAB 2501 , MLAB 2431 AND MLAB 1227 with a grade of “C” or better",
+    "courses": [
+      "MLAB 1227",
+      "MLAB 2431",
+      "MLAB 2501"
+    ]
+  },
+  "MLAB 2266": {
+    "text": "Recommended : MLAB 1167 . Background Search Required: No",
+    "courses": [
+      "MLAB 1167"
+    ]
+  },
+  "MLAB 2267": {
+    "text": "Recommended : MLAB 2431 and MLAB 2534 . Background Search Required: No",
+    "courses": [
+      "MLAB 2431",
+      "MLAB 2534"
+    ]
+  },
   "MLAB 2338": {
     "text": "MLAB 2232",
     "courses": [
       "MLAB 2232"
     ]
   },
+  "MLAB 2401": {
+    "text": "Recommended : MLAB 1211 . Background Search Required: No",
+    "courses": [
+      "MLAB 1211"
+    ]
+  },
+  "MLAB 2431": {
+    "text": "Recommended : MLAB 1415 . Background Search Required: No",
+    "courses": [
+      "MLAB 1415"
+    ]
+  },
   "MLAB 2434": {
     "text": "MLAB 1211",
     "courses": [
       "MLAB 1211"
+    ]
+  },
+  "MLAB 2466": {
+    "text": "MLAB 2501 , MLAB 2431 and MLAB 1227 with a grade of “C” or better",
+    "courses": [
+      "MLAB 1227",
+      "MLAB 2431",
+      "MLAB 2501"
+    ]
+  },
+  "MLAB 2501": {
+    "text": "MLAB 2534 , MLAB 1311 and MLAB 1235 with a grade of “C” or better",
+    "courses": [
+      "MLAB 1235",
+      "MLAB 1311",
+      "MLAB 2534"
+    ]
+  },
+  "MLAB 2534": {
+    "text": "Recommended : MLAB 1415 . Background Search Required: No",
+    "courses": [
+      "MLAB 1415"
+    ]
+  },
+  "MRIT 1191": {
+    "text": "Recommended : Acceptance into the Magnetic Resonance Imaging (MRI) program or other Diagnostic Imaging program. This course was designed to be repeated multiple times to improve student proficiency. Please visit this page for more information . Background Search Required: Yes",
+    "courses": []
+  },
+  "MRIT 1291": {
+    "text": "Recommended : Admission to the program or administrative approval. This course was designed to be repeated multiple times to improve student proficiency. Background Search Required: Yes",
+    "courses": []
+  },
+  "MRIT 2330": {
+    "text": "Recommended : Acceptance into the Magnetic Resonance Imaging (MRI) Program. Background Search Required: Yes",
+    "courses": []
+  },
+  "MRIT 2334": {
+    "text": "Recommended : MRIT 2330 . Background Search Required: Yes",
+    "courses": [
+      "MRIT 2330"
+    ]
+  },
+  "MRIT 2355": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
+  "MRIT 2374": {
+    "text": "Recommended : MRIT 2334 . Background Search Required: Yes",
+    "courses": [
+      "MRIT 2334"
+    ]
+  },
+  "MRKG 1381": {
+    "text": "Recommended : Students must already have marketing professional experience OR should have completed MRKG 1311 , MRKG 1301 , MRKG 1302 , and MRKG 2333 . This capstone course is part of the Marketing Degree Pathway. Background Search Required: No",
+    "courses": [
+      "MRKG 1301",
+      "MRKG 1302",
+      "MRKG 1311",
+      "MRKG 2333"
+    ]
+  },
+  "MRKG 2312": {
+    "text": "Recommended : Integrated Software Applications I for E-Commerce Program or none for Internet Development Technologies Programs. Background Search Required: No",
+    "courses": []
+  },
+  "MRKG 2370": {
+    "text": "Recommended : MRKG 1311",
+    "courses": [
+      "MRKG 1311"
+    ]
+  },
+  "MRKG 2372": {
+    "text": "Recommended:",
+    "courses": []
+  },
+  "MRKG 2381": {
+    "text": "Recommended : Students must already have marketing professional experience OR should have completed MRKG 1311 , MRKG 1301 , MRKG 1302 , and MRKG 2333 . This capstone course is part of the Marketing Degree Pathway. Background Search Required: No",
+    "courses": [
+      "MRKG 1301",
+      "MRKG 1302",
+      "MRKG 1311",
+      "MRKG 2333"
     ]
   },
   "MRKG 2470": {
@@ -3468,6 +8675,412 @@
       "MSCI 1171"
     ]
   },
+  "MSSG 2311": {
+    "text": "MSSG 1411",
+    "courses": [
+      "MSSG 1411"
+    ]
+  },
+  "MSSG 2314": {
+    "text": "MSSG 1413",
+    "courses": [
+      "MSSG 1413"
+    ]
+  },
+  "MSSG 2413": {
+    "text": "MSSG 1413",
+    "courses": [
+      "MSSG 1413"
+    ]
+  },
+  "MUAP 1165": {
+    "text": "MUAP 1164 or instructor approval. Course scheduling information",
+    "courses": [
+      "MUAP 1164"
+    ]
+  },
+  "MUAP 1166": {
+    "text": "Piano experience AND permission from professor",
+    "courses": []
+  },
+  "MUAP 1169": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1170": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1172": {
+    "text": "MUAP 1171 . Course scheduling information",
+    "courses": [
+      "MUAP 1171"
+    ]
+  },
+  "MUAP 1174": {
+    "text": "MUAP 1173 . Course scheduling information",
+    "courses": [
+      "MUAP 1173"
+    ]
+  },
+  "MUAP 1176": {
+    "text": "MUAP 1175 . Course scheduling information",
+    "courses": [
+      "MUAP 1175"
+    ]
+  },
+  "MUAP 1177": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUAP 1178": {
+    "text": "MUAP 1177 . Course scheduling information",
+    "courses": [
+      "MUAP 1177"
+    ]
+  },
+  "MUAP 1180": {
+    "text": "MUAP 1179 . Course scheduling information",
+    "courses": [
+      "MUAP 1179"
+    ]
+  },
+  "MUAP 1181": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1182": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1222": {
+    "text": "Student must be a music major",
+    "courses": []
+  },
+  "MUAP 1223": {
+    "text": "MUAP 1222 or Division Chair approval",
+    "courses": [
+      "MUAP 1222"
+    ]
+  },
+  "MUAP 1246": {
+    "text": "Student must be a music major",
+    "courses": []
+  },
+  "MUAP 1247": {
+    "text": "MUAP 1246 or Division Chair approval",
+    "courses": [
+      "MUAP 1246"
+    ]
+  },
+  "MUAP 1260": {
+    "text": "Student must be a music major",
+    "courses": []
+  },
+  "MUAP 1261": {
+    "text": "MUAP 1260 or Division Chair approval",
+    "courses": [
+      "MUAP 1260"
+    ]
+  },
+  "MUAP 1265": {
+    "text": "Piano experience AND permission from professor",
+    "courses": []
+  },
+  "MUAP 1266": {
+    "text": "Piano experience AND permission from professor",
+    "courses": []
+  },
+  "MUAP 1269": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1270": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1271": {
+    "text": "MUAP 1270 or Division Chair approval",
+    "courses": [
+      "MUAP 1270"
+    ]
+  },
+  "MUAP 1281": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 1282": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2164": {
+    "text": "MUAP 1165 or instructor approval. Course scheduling information",
+    "courses": [
+      "MUAP 1165"
+    ]
+  },
+  "MUAP 2165": {
+    "text": "MUAP 2164 or instructor approval. Course scheduling information",
+    "courses": [
+      "MUAP 2164"
+    ]
+  },
+  "MUAP 2166": {
+    "text": "Piano experience AND permission from professor",
+    "courses": []
+  },
+  "MUAP 2169": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2170": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2171": {
+    "text": "MUAP 1172 . Course scheduling information",
+    "courses": [
+      "MUAP 1172"
+    ]
+  },
+  "MUAP 2172": {
+    "text": "MUAP 2171 . Course scheduling information",
+    "courses": [
+      "MUAP 2171"
+    ]
+  },
+  "MUAP 2173": {
+    "text": "MUAP 1174 . Course scheduling information",
+    "courses": [
+      "MUAP 1174"
+    ]
+  },
+  "MUAP 2174": {
+    "text": "MUAP 2173 . Course scheduling information",
+    "courses": [
+      "MUAP 2173"
+    ]
+  },
+  "MUAP 2175": {
+    "text": "MUAP 1176 . Course scheduling information",
+    "courses": [
+      "MUAP 1176"
+    ]
+  },
+  "MUAP 2176": {
+    "text": "MUAP 2175 . Course scheduling information",
+    "courses": [
+      "MUAP 2175"
+    ]
+  },
+  "MUAP 2177": {
+    "text": "MUAP 1178 . Course scheduling information",
+    "courses": [
+      "MUAP 1178"
+    ]
+  },
+  "MUAP 2178": {
+    "text": "MUAP 2177 . Course scheduling information",
+    "courses": [
+      "MUAP 2177"
+    ]
+  },
+  "MUAP 2179": {
+    "text": "MUAP 1180 . Course scheduling information",
+    "courses": [
+      "MUAP 1180"
+    ]
+  },
+  "MUAP 2180": {
+    "text": "MUAP 2179 . Course scheduling information",
+    "courses": [
+      "MUAP 2179"
+    ]
+  },
+  "MUAP 2181": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2182": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2222": {
+    "text": "MUAP 1223 or Division Chair approval",
+    "courses": [
+      "MUAP 1223"
+    ]
+  },
+  "MUAP 2223": {
+    "text": "MUAP 2222 or Division Chair approval",
+    "courses": [
+      "MUAP 2222"
+    ]
+  },
+  "MUAP 2246": {
+    "text": "MUAP 1247 or Division Chair approval",
+    "courses": [
+      "MUAP 1247"
+    ]
+  },
+  "MUAP 2247": {
+    "text": "MUAP 2246 or Division Chair approval",
+    "courses": [
+      "MUAP 2246"
+    ]
+  },
+  "MUAP 2260": {
+    "text": "MUAP 1261 or Division Chair approval",
+    "courses": [
+      "MUAP 1261"
+    ]
+  },
+  "MUAP 2261": {
+    "text": "MUAP 2260 or Division Chair approval",
+    "courses": [
+      "MUAP 2260"
+    ]
+  },
+  "MUAP 2265": {
+    "text": "Piano experience AND permission from professor",
+    "courses": []
+  },
+  "MUAP 2266": {
+    "text": "Piano experience AND permission from professor",
+    "courses": []
+  },
+  "MUAP 2269": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2270": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2271": {
+    "text": "MUAP 2270 or Division Chair approval",
+    "courses": [
+      "MUAP 2270"
+    ]
+  },
+  "MUAP 2281": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUAP 2282": {
+    "text": "For all Music -Applied courses - Successful completion of or concurrent enrollment in the appropriate freshman theory courses, and/or appropriate ensemble and/or approval of the division chair",
+    "courses": []
+  },
+  "MUEN 1121": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1122": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1123": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1124": {
+    "text": "MUEN 1123 . Course scheduling information",
+    "courses": [
+      "MUEN 1123"
+    ]
+  },
+  "MUEN 1125": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1126": {
+    "text": "MUEN 1125 . Course scheduling information",
+    "courses": [
+      "MUEN 1125"
+    ]
+  },
+  "MUEN 1131": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1132": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1133": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1134": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1135": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1136": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 1137": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1138": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1140": {
+    "text": "MUEN 1139 . Course scheduling information",
+    "courses": [
+      "MUEN 1139"
+    ]
+  },
+  "MUEN 1141": {
+    "text": "Previous singing experience in a high school or church choir is desired. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1142": {
+    "text": "MUEN 1141 . Course scheduling information",
+    "courses": [
+      "MUEN 1141"
+    ]
+  },
+  "MUEN 1143": {
+    "text": "Previous singing experience in a high school or church choir is desired. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1144": {
+    "text": "MUEN 1143 . Course scheduling information",
+    "courses": [
+      "MUEN 1143"
+    ]
+  },
+  "MUEN 1145": {
+    "text": "Previous singing experience in a high school or church choir is desired. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1146": {
+    "text": "MUEN 1145 . Course scheduling information",
+    "courses": [
+      "MUEN 1145"
+    ]
+  },
+  "MUEN 1147": {
+    "text": "Previous singing experience in a high school or church choir is desired. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 1148": {
+    "text": "MUEN 1147 . Course scheduling information",
+    "courses": [
+      "MUEN 1147"
+    ]
+  },
+  "MUEN 1151": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
   "MUEN 1152": {
     "text": "Instructor's approval. Assessment Levels: R1, E1, M1. 50.0908",
     "courses": []
@@ -3479,6 +9092,126 @@
   "MUEN 1154": {
     "text": "By audition) Students will earn an A, B, C, D, F, or W. A select choral ensemble specializing in the performance of jazz and popular literature. Public appearances are scheduled throughout the academic year. Lab fee.",
     "courses": []
+  },
+  "MUEN 2121": {
+    "text": "MUEN 1122 . Course scheduling information",
+    "courses": [
+      "MUEN 1122"
+    ]
+  },
+  "MUEN 2122": {
+    "text": "MUEN 2121 . Course scheduling information",
+    "courses": [
+      "MUEN 2121"
+    ]
+  },
+  "MUEN 2123": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 2124": {
+    "text": "MUEN 2123 . Course scheduling information",
+    "courses": [
+      "MUEN 2123"
+    ]
+  },
+  "MUEN 2125": {
+    "text": "MUEN 1126 . Course scheduling information",
+    "courses": [
+      "MUEN 1126"
+    ]
+  },
+  "MUEN 2126": {
+    "text": "MUEN 2125 . Course scheduling information",
+    "courses": [
+      "MUEN 2125"
+    ]
+  },
+  "MUEN 2131": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2132": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2133": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2134": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2135": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2136": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2137": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2138": {
+    "text": "Instructor’s permission. Course scheduling information",
+    "courses": []
+  },
+  "MUEN 2139": {
+    "text": "MUEN 1140 . Course scheduling information",
+    "courses": [
+      "MUEN 1140"
+    ]
+  },
+  "MUEN 2140": {
+    "text": "MUEN 2139 . Course scheduling information",
+    "courses": [
+      "MUEN 2139"
+    ]
+  },
+  "MUEN 2141": {
+    "text": "Recommended : Demonstrated competence approved by the instructor. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated",
+    "courses": []
+  },
+  "MUEN 2142": {
+    "text": "Recommended : Demonstrated competence approved by the instructor, and ability to sing soprano or alto. This course may be repeated a limited number of times before additional fees may be charged. Students should carefully examine degree requirements to determine the appropriate number of times the course should be repeated. Please visit this page for more information",
+    "courses": []
+  },
+  "MUEN 2143": {
+    "text": "Recommended : Demonstrated competence approved by the instructor, and ability to sing tenor or bass",
+    "courses": []
+  },
+  "MUEN 2144": {
+    "text": "MUEN 2143 . Course scheduling information",
+    "courses": [
+      "MUEN 2143"
+    ]
+  },
+  "MUEN 2145": {
+    "text": "MUEN 1146 . Course scheduling information",
+    "courses": [
+      "MUEN 1146"
+    ]
+  },
+  "MUEN 2146": {
+    "text": "MUEN 2145 . Course scheduling information",
+    "courses": [
+      "MUEN 2145"
+    ]
+  },
+  "MUEN 2147": {
+    "text": "MUEN 1148 . Course scheduling information",
+    "courses": [
+      "MUEN 1148"
+    ]
+  },
+  "MUEN 2148": {
+    "text": "MUEN 2147 . Course scheduling information",
+    "courses": [
+      "MUEN 2147"
+    ]
   },
   "MUEN 2151": {
     "text": "By audition) Students will earn an A, B, C, D, F, or W. A selective choral group specializing in the performance of major works from all periods. Public appearances scheduled throughout the academic year. Lab fee.",
@@ -3510,6 +9243,16 @@
     "text": "MUSC 1327",
     "courses": [
       "MUSC 1327"
+    ]
+  },
+  "MUSC 1333": {
+    "text": "Completion of a Music Fundamentals, Music Theory, Private Piano, Class Piano course, or MIDI I. Background Search Required: No",
+    "courses": []
+  },
+  "MUSC 1396": {
+    "text": "MUSC 2327 with a grade of “C” or better",
+    "courses": [
+      "MUSC 2327"
     ]
   },
   "MUSC 1400": {
@@ -3551,6 +9294,12 @@
       "MUSC 1331"
     ]
   },
+  "MUSC 2345": {
+    "text": "Recommended : MUSC 1333 . Background Search Required: No",
+    "courses": [
+      "MUSC 1333"
+    ]
+  },
   "MUSC 2347": {
     "text": "MUSC 2327 (min C)",
     "courses": [
@@ -3562,6 +9311,18 @@
     "courses": [
       "RTVB 2330",
       "RTVB 1347"
+    ]
+  },
+  "MUSC 2355": {
+    "text": "Recommended : MUSC 1331 or demonstrated competence approved by the instructor. Background Search Required: No",
+    "courses": [
+      "MUSC 1331"
+    ]
+  },
+  "MUSC 2386": {
+    "text": "MUSC 2327 with a grade of “C” or better",
+    "courses": [
+      "MUSC 2327"
     ]
   },
   "MUSC 2402": {
@@ -3674,6 +9435,12 @@
       "MUSI 1212"
     ]
   },
+  "MUSI 1307": {
+    "text": "ENGL 1301 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1301"
+    ]
+  },
   "MUSI 1311": {
     "text": "MUSI 1301 and MUSI 1071",
     "courses": [
@@ -3704,6 +9471,12 @@
     "text": "MUSI 1182 (min D)",
     "courses": [
       "MUSI 1182"
+    ]
+  },
+  "MUSI 2182": {
+    "text": "MUSI 2181 or approval of the division chair",
+    "courses": [
+      "MUSI 2181"
     ]
   },
   "MUSI 2212": {
@@ -3745,6 +9518,12 @@
       "MUSI 1212"
     ]
   },
+  "NCBI 0300": {
+    "text": "NCBI 0300 TSI Placement or Advisor/Instructor recommendation or completion of INRW 0300",
+    "courses": [
+      "INRW 0300"
+    ]
+  },
   "NCBM 0110": {
     "text": "MATH 0421",
     "courses": [
@@ -3761,6 +9540,30 @@
     "text": "MATH 1332",
     "courses": [
       "MATH 1332"
+    ]
+  },
+  "NCBM 0224": {
+    "text": "MATH 0308 or TSI Placement",
+    "courses": [
+      "MATH 0308"
+    ]
+  },
+  "NCBM 0232": {
+    "text": "MATH 0308 or TSI Placement",
+    "courses": [
+      "MATH 0308"
+    ]
+  },
+  "NCBM 0242": {
+    "text": "MATH 0308 or TSI Placement",
+    "courses": [
+      "MATH 0308"
+    ]
+  },
+  "NCBM 0314": {
+    "text": "MATH 0308 or TSI Placement",
+    "courses": [
+      "MATH 0308"
     ]
   },
   "NCBT 0111": {
@@ -3857,6 +9660,53 @@
     "text": "NMTT 1367 and approval of the NMT program director for assignment of specific clinical location. Assessment Levels: R3, E3, M3. 51.0905",
     "courses": [
       "NMTT 1367"
+    ]
+  },
+  "NUCP 1370": {
+    "text": "ENER 1350 or PTAC 1302",
+    "courses": [
+      "ENER 1350",
+      "PTAC 1302"
+    ]
+  },
+  "NUCP 1371": {
+    "text": "TSI ELAR (Reading and Writing) and Math requirements met",
+    "courses": []
+  },
+  "NUCP 1372": {
+    "text": "ENER 1350 or PTAC 1302",
+    "courses": [
+      "ENER 1350",
+      "PTAC 1302"
+    ]
+  },
+  "NUCP 1373": {
+    "text": "ENER 1350 or PTAC 1302 ; and NUCP 1370 ; or concurrent enrollment",
+    "courses": [
+      "ENER 1350",
+      "NUCP 1370",
+      "PTAC 1302"
+    ]
+  },
+  "NUCP 1480": {
+    "text": "Requires assignment by the Program Director",
+    "courses": []
+  },
+  "NUCP 2470": {
+    "text": "ENER 1350 or PTAC 1302 ; NUCP 1370 ; and NUCP 1373",
+    "courses": [
+      "ENER 1350",
+      "NUCP 1370",
+      "NUCP 1373",
+      "PTAC 1302"
+    ]
+  },
+  "NUCP 2471": {
+    "text": "NUCP 1370 ; NUCP 1373 ; and NUCP 2470",
+    "courses": [
+      "NUCP 1370",
+      "NUCP 1373",
+      "NUCP 2470"
     ]
   },
   "NURA 1160": {
@@ -3977,9 +9827,221 @@
       "NURS 3326"
     ]
   },
+  "OPTS 1319": {
+    "text": "OPTS 1292 , OPTS 1305 , OPTS 1311 , OPTS 1315 , OPTS 1501 , and OPTS 2341 with a grade of “C” or better",
+    "courses": [
+      "OPTS 1292",
+      "OPTS 1305",
+      "OPTS 1311",
+      "OPTS 1315",
+      "OPTS 1501",
+      "OPTS 2341"
+    ]
+  },
+  "OPTS 1391": {
+    "text": "OPTS 1292 , OPTS 1305 , OPTS 1311 , OPTS 1315 , OPTS 1501 , and OPTS 2341 with a grade of “C” or better",
+    "courses": [
+      "OPTS 1292",
+      "OPTS 1305",
+      "OPTS 1311",
+      "OPTS 1315",
+      "OPTS 1501",
+      "OPTS 2341"
+    ]
+  },
+  "OPTS 2166": {
+    "text": "OPTS 1292 , OPTS 1305 , OPTS 1311 , OPTS 1315 , OPTS 1501 , and OPTS 2341 with a grade of “C” or better",
+    "courses": [
+      "OPTS 1292",
+      "OPTS 1305",
+      "OPTS 1311",
+      "OPTS 1315",
+      "OPTS 1501",
+      "OPTS 2341"
+    ]
+  },
+  "OPTS 2266": {
+    "text": "OPTS 1319 , OPTS 1391 , OPTS 2166 , OPTS 2335 , OPTS 2345 , and OPTS 2531",
+    "courses": [
+      "OPTS 1319",
+      "OPTS 1391",
+      "OPTS 2166",
+      "OPTS 2335",
+      "OPTS 2345",
+      "OPTS 2531"
+    ]
+  },
+  "OPTS 2335": {
+    "text": "OPTS 1292 , OPTS 1305 , OPTS 1311 , OPTS 1315 , OPTS 1501 , and OPTS 2341 with a grade of “C” or better",
+    "courses": [
+      "OPTS 1292",
+      "OPTS 1305",
+      "OPTS 1311",
+      "OPTS 1315",
+      "OPTS 1501",
+      "OPTS 2341"
+    ]
+  },
+  "OPTS 2345": {
+    "text": "OPTS 1292 , OPTS 1305 , OPTS 1311 , OPTS 1315 , OPTS 1501 , and OPTS 2341 with a grade of “C” or better",
+    "courses": [
+      "OPTS 1292",
+      "OPTS 1305",
+      "OPTS 1311",
+      "OPTS 1315",
+      "OPTS 1501",
+      "OPTS 2341"
+    ]
+  },
+  "OPTS 2531": {
+    "text": "OPTS 1292 , OPTS 1305 , OPTS 1311 , OPTS 1315 , OPTS 1501 , and OPTS 2341 with a grade of “C” or better",
+    "courses": [
+      "OPTS 1292",
+      "OPTS 1305",
+      "OPTS 1311",
+      "OPTS 1315",
+      "OPTS 1501",
+      "OPTS 2341"
+    ]
+  },
+  "ORGL 3302": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 3303": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 3304": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 3305": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 4301": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 4302": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 4303": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 4304": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 4305": {
+    "text": "ORGL 3301 Leadership Fundamentals",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "ORGL 4306": {
+    "text": "ORGL 3301",
+    "courses": [
+      "ORGL 3301"
+    ]
+  },
+  "OSHT 1309": {
+    "text": "OSHT 1301 OR PTAC 1308 OR OSHT 1405 OR OSHT 2309",
+    "courses": [
+      "OSHT 1301",
+      "OSHT 1405",
+      "OSHT 2309",
+      "PTAC 1308"
+    ]
+  },
+  "OSHT 1313": {
+    "text": "OSHT 1301 OR PTAC 1308 OR OSHT 1405 OR OSHT 2309",
+    "courses": [
+      "OSHT 1301",
+      "OSHT 1405",
+      "OSHT 2309",
+      "PTAC 1308"
+    ]
+  },
+  "OSHT 1321": {
+    "text": "One of the following courses: OSHT 1405 or OSHT 2309",
+    "courses": [
+      "OSHT 1405",
+      "OSHT 2309"
+    ]
+  },
+  "OSHT 1380": {
+    "text": "Concurrent registration in additional credit course and employment in a safety related industrial job half time or better",
+    "courses": []
+  },
+  "OSHT 1381": {
+    "text": "Concurrent registration in additional credit course and employment in a safety related industrial job half time or better",
+    "courses": []
+  },
+  "OSHT 1401": {
+    "text": "HART 1401 and HART 1407",
+    "courses": [
+      "HART 1401",
+      "HART 1407"
+    ]
+  },
+  "OSHT 2305": {
+    "text": "OSHT 1301 OR OSHT 1405 OR OSHT 2309",
+    "courses": [
+      "OSHT 1301",
+      "OSHT 1405",
+      "OSHT 2309"
+    ]
+  },
+  "OSHT 2337": {
+    "text": "OSHT 1405 OR OSHT 2309 OR OSHT 1301",
+    "courses": [
+      "OSHT 1301",
+      "OSHT 1405",
+      "OSHT 2309"
+    ]
+  },
+  "OSHT 2380": {
+    "text": "Concurrent registration in additional credit course and employment in a safety related industrial job half time or better",
+    "courses": []
+  },
   "OSHT 2388": {
     "text": "Permission of instructor. Assessment Levels: R1, E1, M1. 15.0701",
     "courses": []
+  },
+  "OSHT 2401": {
+    "text": "OSHT 1301 OR OSHT 1405 OR OSHT 2309",
+    "courses": [
+      "OSHT 1301",
+      "OSHT 1405",
+      "OSHT 2309"
+    ]
+  },
+  "OTHA 1161": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
+    ]
   },
   "OTHA 1162": {
     "text": "OTHA 1341 and OTHA 1315 and OTHA 1161",
@@ -3987,6 +10049,13 @@
       "OTHA 1341",
       "OTHA 1315",
       "OTHA 1161"
+    ]
+  },
+  "OTHA 1163": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
     ]
   },
   "OTHA 1211": {
@@ -4003,10 +10072,41 @@
       "OTHA 1415"
     ]
   },
+  "OTHA 1253": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
+    ]
+  },
+  "OTHA 1260": {
+    "text": "OTHA 1301 , OTHA 1309 , OTHA 1315 and OTHA 1341 with a grade of “C” or better",
+    "courses": [
+      "OTHA 1301",
+      "OTHA 1309",
+      "OTHA 1315",
+      "OTHA 1341"
+    ]
+  },
   "OTHA 1262": {
     "text": "OTHA 1211, 1309, 1319, 1405, 2301, 2309. Assessment Levels: R2, E2, M2. 51.0803",
     "courses": [
       "OTHA 1211"
+    ]
+  },
+  "OTHA 1301": {
+    "text": "BIOL 2404 or BIOL 2401 , ENGL 1301 , and PSYC 2314 with a grade of “C” of better",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2404",
+      "ENGL 1301",
+      "PSYC 2314"
+    ]
+  },
+  "OTHA 1305": {
+    "text": "Required : BIOL 2401 , admission into the Occupational Therapy Assistant Program",
+    "courses": [
+      "BIOL 2401"
     ]
   },
   "OTHA 1309": {
@@ -4023,6 +10123,36 @@
       "OTHA 1262"
     ]
   },
+  "OTHA 1319": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315 . Background Search Required: No",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
+    ]
+  },
+  "OTHA 1341": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
+    ]
+  },
+  "OTHA 1349": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
+    ]
+  },
+  "OTHA 1353": {
+    "text": "OTHA 1301 , OTHA 1309 , OTHA 1315 and OTHA 1341 with a grade of “C” or better",
+    "courses": [
+      "OTHA 1301",
+      "OTHA 1309",
+      "OTHA 1315",
+      "OTHA 1341"
+    ]
+  },
   "OTHA 1415": {
     "text": "OTHA 1309",
     "courses": [
@@ -4035,6 +10165,13 @@
       "OTHA 1253",
       "OTHA 2335",
       "OTHA 2405"
+    ]
+  },
+  "OTHA 2209": {
+    "text": "Recommended : OTHA 1305 , OTHA 1315 . Background Search Required: No",
+    "courses": [
+      "OTHA 1305",
+      "OTHA 1315"
     ]
   },
   "OTHA 2230": {
@@ -4060,6 +10197,36 @@
       "OTHA 2402"
     ]
   },
+  "OTHA 2261": {
+    "text": "OTHA 1260 , OTHA 1353 , OTHA 2301 , and OTHA 2309 with a grade of “C” or better",
+    "courses": [
+      "OTHA 1260",
+      "OTHA 1353",
+      "OTHA 2301",
+      "OTHA 2309"
+    ]
+  },
+  "OTHA 2262": {
+    "text": "OTHA 1419 and OTHA 2261 with a grade of “C” or better",
+    "courses": [
+      "OTHA 1419",
+      "OTHA 2261"
+    ]
+  },
+  "OTHA 2266": {
+    "text": "Recommended : OTHA 2331 , OTHA 2305 , Instructor Approval. Background Search Required: No",
+    "courses": [
+      "OTHA 2305",
+      "OTHA 2331"
+    ]
+  },
+  "OTHA 2267": {
+    "text": "Recommended : OTHA 2331 , OTHA 2305 , Instructor Approval. Background Search Required: No",
+    "courses": [
+      "OTHA 2305",
+      "OTHA 2331"
+    ]
+  },
   "OTHA 2301": {
     "text": "OTHA 1405",
     "courses": [
@@ -4074,6 +10241,14 @@
       "OTHA 2304"
     ]
   },
+  "OTHA 2305": {
+    "text": "Recommended : OTHA 1161 , OTHA 1319 , OTHA 1349",
+    "courses": [
+      "OTHA 1161",
+      "OTHA 1319",
+      "OTHA 1349"
+    ]
+  },
   "OTHA 2309": {
     "text": "OTHA 1309, 1405, and 2301. Corequisites: OTHA 1211 and 1319. Assessment Levels: R2, E2, M2. 51.0803",
     "courses": [
@@ -4086,6 +10261,13 @@
     "courses": [
       "OTHA 1211",
       "OTHA 2235"
+    ]
+  },
+  "OTHA 2335": {
+    "text": "OTHA 1419 and OTHA 2261 with a grade of “C” or better",
+    "courses": [
+      "OTHA 1419",
+      "OTHA 2261"
     ]
   },
   "OTHA 2405": {
@@ -4103,6 +10285,89 @@
       "OTHA 2330"
     ]
   },
+  "PFPB 1370": {
+    "text": "Recommended : PFPB 1373 . Background Search Required: No",
+    "courses": [
+      "PFPB 1373"
+    ]
+  },
+  "PFPB 1371": {
+    "text": "Recommended : PFPB 1370 . Background Search Required: No",
+    "courses": [
+      "PFPB 1370"
+    ]
+  },
+  "PFPB 2308": {
+    "text": "INMT 2301 , TECM 1301 and CETT 1402 with a grade of “C” or better",
+    "courses": [
+      "CETT 1402",
+      "INMT 2301",
+      "TECM 1301"
+    ]
+  },
+  "PFPB 2309": {
+    "text": "Required : PFPB 1321",
+    "courses": [
+      "PFPB 1321"
+    ]
+  },
+  "PFPB 2370": {
+    "text": "Recommended : PFPB 1371 . Background Search Required: No",
+    "courses": [
+      "PFPB 1371"
+    ]
+  },
+  "PHED 1105": {
+    "text": "PHED 1103",
+    "courses": [
+      "PHED 1103"
+    ]
+  },
+  "PHED 1117": {
+    "text": "PHED 1107",
+    "courses": [
+      "PHED 1107"
+    ]
+  },
+  "PHED 1301": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300 or ENGL 1301 /NCBI 0300",
+    "courses": [
+      "ENGL 1301",
+      "INRW 0300",
+      "NCBI 0300"
+    ]
+  },
+  "PHED 1304": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300 or ENGL 1301 /NCBI 0300",
+    "courses": [
+      "ENGL 1301",
+      "INRW 0300",
+      "NCBI 0300"
+    ]
+  },
+  "PHED 1306": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300 or ENGL 1301 /NCBI 0300",
+    "courses": [
+      "ENGL 1301",
+      "INRW 0300",
+      "NCBI 0300"
+    ]
+  },
+  "PHED 1346": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300 or ENGL 1301 /NCBI 0300",
+    "courses": [
+      "ENGL 1301",
+      "INRW 0300",
+      "NCBI 0300"
+    ]
+  },
+  "PHED 2362": {
+    "text": "BIOL 2401 and BIOL 2402 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402"
+    ]
+  },
   "PHIL 1301": {
     "text": "INRW 0100 (min S) or INRW 0473 (min DC) or (BRDG) Developmental Reading 0372 (min DC) or ENGL 1301 (min C) or ENGL 1301 (min TC) or HIST 1301 (min C) or HIST 1301 (min TC) or GOVT 2305 (min C) or GOVT 2305 (min TC) or GOVT 2306 (min C) or GOVT 2306 (min TC) or PSYC 2301 (min C) or PSYC 2301 (min TC) or INRW 0373 (min DC) and INRW 0173 (min S)",
     "courses": [
@@ -4118,16 +10383,49 @@
       "INRW 0173"
     ]
   },
+  "PHIL 1304": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "PHIL 2303": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
   "PHIL 2306": {
     "text": "ENGL 1301",
     "courses": [
       "ENGL 1301"
     ]
   },
+  "PHIL 2307": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "PHIL 2316": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
+  "PHIL 2321": {
+    "text": "Required : College level ready in Reading. Background Search Required: No",
+    "courses": []
+  },
   "PHRA 1243": {
     "text": "PHRA 1202, 1201, 1205, 1309, 1313, 1349) Students will earn an A, B, C, D, F, or W. A review of major topics covered on the national Pharmacy Technician Certification Examination (PTCE). Lab fee $193 includes skills lab fee, practice certification exam and national certification fee.",
     "courses": [
       "PHRA 1202"
+    ]
+  },
+  "PHRA 1304": {
+    "text": "PHRA 1301 , PHRA 1305 , PHRA 1313 , and PHRA 2360 . Corequisite: PHRA 1309 , PHRA 1349 , PHRA 1445 , and PHRA 2361",
+    "courses": [
+      "PHRA 1301",
+      "PHRA 1305",
+      "PHRA 1309",
+      "PHRA 1313",
+      "PHRA 1349",
+      "PHRA 1445",
+      "PHRA 2360",
+      "PHRA 2361"
     ]
   },
   "PHRA 1305": {
@@ -4142,6 +10440,101 @@
     "courses": [
       "PHRA 1267",
       "PHRA 2266"
+    ]
+  },
+  "PHRA 1309": {
+    "text": "PHRA 1301 , PHRA 1305 , PHRA 1313 , and PHRA 2360 . Corequisite: PHRA 1304 , PHRA 1349 , PHRA 1445 , and PHRA 2361",
+    "courses": [
+      "PHRA 1301",
+      "PHRA 1304",
+      "PHRA 1305",
+      "PHRA 1313",
+      "PHRA 1349",
+      "PHRA 1445",
+      "PHRA 2360",
+      "PHRA 2361"
+    ]
+  },
+  "PHRA 1345": {
+    "text": "Registered Pharmacist, Certified Pharmacy Technician or prior approval from Program Director",
+    "courses": []
+  },
+  "PHRA 1349": {
+    "text": "PHRA 1301 , PHRA 1305 , PHRA 1313 , and PHRA 2360 . Corequisite: PHRA 1304 , PHRA 1309 , PHRA 1445 , and PHRA 2361",
+    "courses": [
+      "PHRA 1301",
+      "PHRA 1304",
+      "PHRA 1305",
+      "PHRA 1309",
+      "PHRA 1313",
+      "PHRA 1445",
+      "PHRA 2360",
+      "PHRA 2361"
+    ]
+  },
+  "PHRA 1445": {
+    "text": "PHRA 1301 , PHRA 1305 , PHRA 1313 , and PHRA 2360 . Corequisite: PHRA 1304 , PHRA 1309 , PHRA 1349 , and PHRA 2361",
+    "courses": [
+      "PHRA 1301",
+      "PHRA 1304",
+      "PHRA 1305",
+      "PHRA 1309",
+      "PHRA 1313",
+      "PHRA 1349",
+      "PHRA 2360",
+      "PHRA 2361"
+    ]
+  },
+  "PHRA 2361": {
+    "text": "PHRA 1301 , PHRA 1305 , PHRA 1313 , and PHRA 2360 . Corequisite: PHRA 1304 , PHRA 1309 , PHRA 1349 , and PHRA 1445",
+    "courses": [
+      "PHRA 1301",
+      "PHRA 1304",
+      "PHRA 1305",
+      "PHRA 1309",
+      "PHRA 1313",
+      "PHRA 1349",
+      "PHRA 1445",
+      "PHRA 2360"
+    ]
+  },
+  "PHTC 1345": {
+    "text": "PHTC 1311 with a grade of “C” or better",
+    "courses": [
+      "PHTC 1311"
+    ]
+  },
+  "PHTC 2301": {
+    "text": "Required : PHTC 1311 . Background Search Required: No",
+    "courses": [
+      "PHTC 1311"
+    ]
+  },
+  "PHYS 1101": {
+    "text": "Successful completion of, or concurrent enrollment in PHYS 1301",
+    "courses": [
+      "PHYS 1301"
+    ]
+  },
+  "PHYS 1102": {
+    "text": "Successful completion of, or concurrent enrollment in, PHYS 1302",
+    "courses": [
+      "PHYS 1302"
+    ]
+  },
+  "PHYS 1301": {
+    "text": "MATH 1314 or MATH 1414 approval of the division chair",
+    "courses": [
+      "MATH 1314",
+      "MATH 1414"
+    ]
+  },
+  "PHYS 1302": {
+    "text": "MATH 1314 or MATH 1414 AND PHYS 1301 or approval of the division chair",
+    "courses": [
+      "MATH 1314",
+      "MATH 1414",
+      "PHYS 1301"
     ]
   },
   "PHYS 1305": {
@@ -4173,10 +10566,48 @@
       "PHYS 1401"
     ]
   },
+  "PHYS 1403": {
+    "text": "Recommended: This course follows PHYS 1404 in sequence and explores the universe beyond our solar system. Completion of PHYS 1404 prior to taking this course is essential for developing foundational concepts",
+    "courses": [
+      "PHYS 1404"
+    ]
+  },
+  "PHYS 1404": {
+    "text": "Recommended: This is the first course in a two-course sequence on introductory astronomy. It builds the foundations that are essential for subsequent astronomy courses, including PHYS 1403",
+    "courses": [
+      "PHYS 1403"
+    ]
+  },
+  "PHYS 1415": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "PHYS 1417": {
+    "text": "Students must have satisfied the TSI readiness requirement in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "PHYS 2125": {
+    "text": "Successful completion of, or concurrent enrollment in, PHYS 2325",
+    "courses": [
+      "PHYS 2325"
+    ]
+  },
+  "PHYS 2126": {
+    "text": "Successful completion of, or concurrent enrollment in, PHYS 2326",
+    "courses": [
+      "PHYS 2326"
+    ]
+  },
   "PHYS 2325": {
     "text": "MATH 2413 (min C)",
     "courses": [
       "MATH 2413"
+    ]
+  },
+  "PHYS 2326": {
+    "text": "PHYS 2325 or the equivalent",
+    "courses": [
+      "PHYS 2325"
     ]
   },
   "PHYS 2425": {
@@ -4193,11 +10624,21 @@
       "MATH 2414"
     ]
   },
+  "PIAN 2370": {
+    "text": "Required : PIAN 1370",
+    "courses": [
+      "PIAN 1370"
+    ]
+  },
   "PLAB 1163": {
     "text": "PLAB 1223",
     "courses": [
       "PLAB 1223"
     ]
+  },
+  "PLAB 1223": {
+    "text": "Acceptance to program or permission of the department chair",
+    "courses": []
   },
   "PLAB 1323": {
     "text": "See health occupations advisor) Students will earn an A, B, C, D, F, or W. Skill development in the performance of a variety of blood collection methods using proper techniques and standard precautions. Includes vacuum collection devices, syringes, capillary skin puncture, butterfly needles and blood culture, and specimen collection on adults, children and infants. Emphasis on infection prevention",
@@ -4216,6 +10657,24 @@
       "PMHS 1166"
     ]
   },
+  "PMHS 2260": {
+    "text": "CHLT 1309 ; PSYT 1329 ; concurrent enrollment in DAAC 1317 ; and Division Chair approval",
+    "courses": [
+      "CHLT 1309",
+      "DAAC 1317",
+      "PSYT 1329"
+    ]
+  },
+  "POFI 1301": {
+    "text": "Recommended : Keyboarding Proficiency. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": []
+  },
+  "POFI 1341": {
+    "text": "Recommended : POFI 1301 , Computer Applications I or equivalent. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": [
+      "POFI 1301"
+    ]
+  },
   "POFI 1349": {
     "text": "BUSG 1404 or ITSW 1404",
     "courses": [
@@ -4223,9 +10682,35 @@
       "ITSW 1404"
     ]
   },
+  "POFI 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "POFI 1381": {
+    "text": "POFI 1380 and approval of the division chair",
+    "courses": [
+      "POFI 1380"
+    ]
+  },
   "POFI 2301": {
     "text": "Keyboarding proficiency of 35 words per minute and knowledge of keyboarding procedures and formatting. 52.0407",
     "courses": []
+  },
+  "POFI 2331": {
+    "text": "Recommended : Keyboarding Skills. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": []
+  },
+  "POFI 2340": {
+    "text": "ITSW 1301 . Course scheduling information",
+    "courses": [
+      "ITSW 1301"
+    ]
+  },
+  "POFI 2380": {
+    "text": "POFI 1381 and approval of the division chair",
+    "courses": [
+      "POFI 1381"
+    ]
   },
   "POFI 2401": {
     "text": "POFT 1329 or POFT 1301 or COSC 1401",
@@ -4235,10 +10720,48 @@
       "COSC 1401"
     ]
   },
+  "POFI 2431": {
+    "text": "ITSW 1301 or instructor permission. Course scheduling information",
+    "courses": [
+      "ITSW 1301"
+    ]
+  },
+  "POFM 1280": {
+    "text": "Required : MDCA 1313 , POFM 1317 , POFM 1327 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "MDCA 1313",
+      "POFM 1317",
+      "POFM 1327"
+    ]
+  },
   "POFM 1300": {
     "text": "MDCA 1313) Students will earn an A, B, C, D, F, or W. Presentation and application of basic coding rules, principles, guidelines and conventions utilizing various coding systems.",
     "courses": [
       "MDCA 1313"
+    ]
+  },
+  "POFM 1302": {
+    "text": "Recommended : Basic keyboarding and computer skills. Background Search Required: No",
+    "courses": []
+  },
+  "POFM 1391": {
+    "text": "POFM 1300 with a grade of “C” or better",
+    "courses": [
+      "POFM 1300"
+    ]
+  },
+  "POFM 2280": {
+    "text": "POFT 1313 and POFM 1302 with a grade of “C” or better",
+    "courses": [
+      "POFM 1302",
+      "POFT 1313"
+    ]
+  },
+  "POFM 2310": {
+    "text": "POFM 1327 and POFM 1300 with a grade of “C” or better",
+    "courses": [
+      "POFM 1300",
+      "POFM 1327"
     ]
   },
   "POFM 2386": {
@@ -4254,6 +10777,46 @@
     "text": "POFI 1349",
     "courses": [
       "POFI 1349"
+    ]
+  },
+  "POFT 1309": {
+    "text": "Recommended : Basic keyboarding skills. Background Search Required: No",
+    "courses": []
+  },
+  "POFT 1313": {
+    "text": "POFM 1317 and ITSW 1301 with a grade of “C” or better",
+    "courses": [
+      "ITSW 1301",
+      "POFM 1317"
+    ]
+  },
+  "POFT 1325": {
+    "text": "Recommended : POFI 1301 . Background Search Required: No",
+    "courses": [
+      "POFI 1301"
+    ]
+  },
+  "POFT 1328": {
+    "text": "Recommended : Basic Computer Skills. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information",
+    "courses": []
+  },
+  "POFT 2312": {
+    "text": "Recommended : Business English",
+    "courses": []
+  },
+  "POFT 2331": {
+    "text": "Grade of C or better in POFI 1301",
+    "courses": [
+      "POFI 1301"
+    ]
+  },
+  "POFT 2431": {
+    "text": "ITSW 1301 , ITSW 1304 , ITSW 1307 , ITSW 1310 and instructor permission. Course scheduling information",
+    "courses": [
+      "ITSW 1301",
+      "ITSW 1304",
+      "ITSW 1307",
+      "ITSW 1310"
     ]
   },
   "PSGT 1310": {
@@ -4276,6 +10839,32 @@
       "PSGT 1310"
     ]
   },
+  "PSTR 1001": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "PSTR 1002": {
+    "text": "As a Continuing Education course, enrollment will be determined by Culinary Arts departmental assessment",
+    "courses": []
+  },
+  "PSTR 1206": {
+    "text": "PSTR 1301 with a grade of “C” or better",
+    "courses": [
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1210": {
+    "text": "PSTR 1301 with a grade of “C” or better",
+    "courses": [
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1302": {
+    "text": "PSTR 1401 with a grade of “C” or better",
+    "courses": [
+      "PSTR 1401"
+    ]
+  },
   "PSTR 1305": {
     "text": "CHEF 1301, 1305, PSTR 1301. Assessment Levels: R1, E1, M1. 12.0501",
     "courses": [
@@ -4294,6 +10883,12 @@
     "text": "CHEF 1301, 1305; PSTR 1301. Assessment Levels: R1, E1, M1. 12.0501",
     "courses": [
       "CHEF 1301",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 1343": {
+    "text": "Required : PSTR 1301 with a “C” or better",
+    "courses": [
       "PSTR 1301"
     ]
   },
@@ -4318,6 +10913,12 @@
       "PSTR 1301"
     ]
   },
+  "PSTR 2207": {
+    "text": "Required : PSTR 1206 with a “C” or better",
+    "courses": [
+      "PSTR 1206"
+    ]
+  },
   "PSTR 2301": {
     "text": "CHEF 1301, 1305; PSTR 1301, 2431. 12.0501",
     "courses": [
@@ -4325,10 +10926,60 @@
       "PSTR 1301"
     ]
   },
+  "PSTR 2307": {
+    "text": "PSTR 1306 with a grade of “C” or better",
+    "courses": [
+      "PSTR 1306"
+    ]
+  },
+  "PSTR 2330": {
+    "text": "Required : PSTR 1305 and PSTR 2331 with a grade of “C” or better",
+    "courses": [
+      "PSTR 1305",
+      "PSTR 2331"
+    ]
+  },
+  "PSTR 2331": {
+    "text": "Required : PSTR 1301 and CHEF 1305 with a grade of “C” or better",
+    "courses": [
+      "CHEF 1305",
+      "PSTR 1301"
+    ]
+  },
+  "PSTR 2364": {
+    "text": "Required : PSTR 1364 with a “C” or better",
+    "courses": [
+      "PSTR 1364"
+    ]
+  },
+  "PSYC 1300": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300 or ENGL 1301 /NCBI 0300",
+    "courses": [
+      "ENGL 1301",
+      "INRW 0300",
+      "NCBI 0300"
+    ]
+  },
   "PSYC 2301": {
     "text": "READ 1072",
     "courses": [
       "READ 1072"
+    ]
+  },
+  "PSYC 2306": {
+    "text": "Required : College level ready in Reading. This course is cross-listed as SOCI 2306 . The student may register for either PSYC 2306 or SOCI 2306 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "SOCI 2306"
+    ]
+  },
+  "PSYC 2307": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
+  },
+  "PSYC 2308": {
+    "text": "PSYC 2301 . Course scheduling information",
+    "courses": [
+      "PSYC 2301"
     ]
   },
   "PSYC 2314": {
@@ -4369,6 +11020,20 @@
       "PSYC 2301"
     ]
   },
+  "PSYT 2164": {
+    "text": "CHLT 1309 ; PSYT 1329 ; concurrent enrollment in DAAC 1317 ; and Division Chair approval",
+    "courses": [
+      "CHLT 1309",
+      "DAAC 1317",
+      "PSYT 1329"
+    ]
+  },
+  "PSYT 2345": {
+    "text": "PSYC 2301",
+    "courses": [
+      "PSYC 2301"
+    ]
+  },
   "PTAC 1332": {
     "text": "PTAC 1302",
     "courses": [
@@ -4383,10 +11048,31 @@
       "PHYS 1105"
     ]
   },
+  "PTAC 1408": {
+    "text": "TSI ELAR (Reading and Writing) requirement met or concurrent enrollment in INRW 0300",
+    "courses": [
+      "INRW 0300"
+    ]
+  },
   "PTAC 1410": {
     "text": "PTAC 1302. 41.0301",
     "courses": [
       "PTAC 1302"
+    ]
+  },
+  "PTAC 1432": {
+    "text": "Credit for or concurrent enrollment in PTAC 1302 or ENER 1350 or INMT 1305",
+    "courses": [
+      "ENER 1350",
+      "INMT 1305",
+      "PTAC 1302"
+    ]
+  },
+  "PTAC 1454": {
+    "text": "PTAC 1410 and PTAC 1432",
+    "courses": [
+      "PTAC 1410",
+      "PTAC 1432"
     ]
   },
   "PTAC 2314": {
@@ -4402,6 +11088,12 @@
     "courses": [
       "PTAC 1410",
       "PTAC 1302"
+    ]
+  },
+  "PTAC 2436": {
+    "text": "PTAC 1432",
+    "courses": [
+      "PTAC 1432"
     ]
   },
   "PTAC 2438": {
@@ -4427,10 +11119,63 @@
       "PTHA 1413"
     ]
   },
+  "PTHA 1225": {
+    "text": "BIOL 2401 , ENGL 1301 , and HITT 1305 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301",
+      "HITT 1305"
+    ]
+  },
+  "PTHA 1266": {
+    "text": "PTHA 1321 , PTHA 1431 , PTHA 2201 , PTHA 2509 and PSYC 2314 with a grade of “C” or better",
+    "courses": [
+      "PSYC 2314",
+      "PTHA 1321",
+      "PTHA 1431",
+      "PTHA 2201",
+      "PTHA 2509"
+    ]
+  },
+  "PTHA 1301": {
+    "text": "ENGL 1301 and BIOL 2401 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301"
+    ]
+  },
+  "PTHA 1321": {
+    "text": "PTHA 1225 , PTHA 1301 , PTHA 1405 , PTHA 1413 and BIOL 2402 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2402",
+      "PTHA 1225",
+      "PTHA 1301",
+      "PTHA 1405",
+      "PTHA 1413"
+    ]
+  },
+  "PTHA 1360": {
+    "text": "PTHA 2205",
+    "courses": [
+      "PTHA 2205"
+    ]
+  },
   "PTHA 1405": {
     "text": "PTHA 1201",
     "courses": [
       "PTHA 1201"
+    ]
+  },
+  "PTHA 1409": {
+    "text": "Admission to the PTA Program",
+    "courses": []
+  },
+  "PTHA 1413": {
+    "text": "BIOL 2401 , ENGL 1301 , and HITT 1305 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "ENGL 1301",
+      "HITT 1305"
     ]
   },
   "PTHA 1431": {
@@ -4439,16 +11184,51 @@
       "PTHA 1321"
     ]
   },
+  "PTHA 1531": {
+    "text": "PTHA 1409 ; PTHA 1413",
+    "courses": [
+      "PTHA 1409",
+      "PTHA 1413"
+    ]
+  },
+  "PTHA 2201": {
+    "text": "PTHA 1225 , PTHA 1301 , PTHA 1405 , PTHA 1413 , and BIOL 2402 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2402",
+      "PTHA 1225",
+      "PTHA 1301",
+      "PTHA 1405",
+      "PTHA 1413"
+    ]
+  },
   "PTHA 2205": {
     "text": "PTHA 1201, 1321, 1413, 1431, 2509. Assessment Levels: R3, E3, M3. 51.0806",
     "courses": [
       "PTHA 1201"
     ]
   },
+  "PTHA 2239": {
+    "text": "PHIL 2306 , PTHA 2205 , PTHA 2431 , PTHA 2435 with a grade of “C” or better",
+    "courses": [
+      "PHIL 2306",
+      "PTHA 2205",
+      "PTHA 2431",
+      "PTHA 2435"
+    ]
+  },
   "PTHA 2266": {
     "text": "PTHA 1201, 1321, 1413, 1431, 2509. Assessment Levels: R3, E3, M3. 51.0806",
     "courses": [
       "PTHA 1201"
+    ]
+  },
+  "PTHA 2267": {
+    "text": "PHIL 2306 , PTHA 2205 , PTHA 2431 , PTHA 2435 with a grade of “C” or better",
+    "courses": [
+      "PHIL 2306",
+      "PTHA 2205",
+      "PTHA 2431",
+      "PTHA 2435"
     ]
   },
   "PTHA 2301": {
@@ -4478,6 +11258,13 @@
       "PTHA 2535"
     ]
   },
+  "PTHA 2409": {
+    "text": "PTHA 1409 ; PTHA 1413",
+    "courses": [
+      "PTHA 1409",
+      "PTHA 1413"
+    ]
+  },
   "PTHA 2431": {
     "text": "PTHA 1260 and PTHA 1301 and PTHA 1405 and PTHA 1413 and PTHA 1431 and PTHA 2301 and PTHA 2409 and PTHA 1321 and PTHA 2435",
     "courses": [
@@ -4498,10 +11285,39 @@
       "PTHA 1201"
     ]
   },
+  "PTHA 2460": {
+    "text": "PTHA 2360",
+    "courses": [
+      "PTHA 2360"
+    ]
+  },
   "PTHA 2509": {
     "text": "PTHA 1201, 1305, 1413. Assessment Levels: R3, E3, M3. 51.0806",
     "courses": [
       "PTHA 1201"
+    ]
+  },
+  "QCTC 1243": {
+    "text": "Recommended : Credit or concurrent enrollment in MATH 1414 or the equivalent. Background Search Required: No",
+    "courses": [
+      "MATH 1414"
+    ]
+  },
+  "QCTC 1446": {
+    "text": "TSI ELAR (Reading and Writing) and Math requirements met",
+    "courses": []
+  },
+  "RADR 1166": {
+    "text": "Acceptance into the Radiologic Technology Program; BIOL 2401 ; and BIOL 2402",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402"
+    ]
+  },
+  "RADR 1167": {
+    "text": "RADR 1266 . Course scheduling information",
+    "courses": [
+      "RADR 1266"
     ]
   },
   "RADR 1201": {
@@ -4529,6 +11345,10 @@
       "RADR 1311"
     ]
   },
+  "RADR 1250": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
   "RADR 1260": {
     "text": "RADR 1309 and HPRS 1106, 1204. Assessment Levels: R3, E3, M3.",
     "courses": [
@@ -4551,6 +11371,22 @@
       "RADR 1411"
     ]
   },
+  "RADR 1267": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
+  "RADR 1268": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
+  "RADR 1291": {
+    "text": "Recommended : Admission to the program or administrative approval. This course may be repeated if topics and learning outcomes vary. Please visit this page for more information . Background Search Required: Yes",
+    "courses": []
+  },
+  "RADR 1309": {
+    "text": "Admission to the Radiologic Technology Program. Course scheduling information",
+    "courses": []
+  },
   "RADR 1311": {
     "text": "RADR 1266",
     "courses": [
@@ -4561,6 +11397,13 @@
     "text": "RADR 1309 (min C)",
     "courses": [
       "RADR 1309"
+    ]
+  },
+  "RADR 1409": {
+    "text": "Acceptance into the Radiologic Technology Program; BIOL 2401 ; and BIOL 2402",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402"
     ]
   },
   "RADR 1411": {
@@ -4581,6 +11424,17 @@
       "RADR 1202"
     ]
   },
+  "RADR 2167": {
+    "text": "RADR 2367 and RADR 2331 with a grade of “C” or better",
+    "courses": [
+      "RADR 2331",
+      "RADR 2367"
+    ]
+  },
+  "RADR 2205": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
   "RADR 2213": {
     "text": "RADR 2361. Assessment Levels: R3, E3, M3. 51.0911",
     "courses": [
@@ -4596,11 +11450,36 @@
       "RADR 2366"
     ]
   },
+  "RADR 2233": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
   "RADR 2235": {
     "text": "RADR 2362. Assessment Levels: R3, E3, M3.",
     "courses": [
       "RADR 2362"
     ]
+  },
+  "RADR 2236": {
+    "text": "RADR 2313 , RADR 1213 , RADR 2301 and RADR 1267 with a grade of “C” or better",
+    "courses": [
+      "RADR 1213",
+      "RADR 1267",
+      "RADR 2301",
+      "RADR 2313"
+    ]
+  },
+  "RADR 2266": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
+  "RADR 2267": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
+  },
+  "RADR 2301": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: Yes",
+    "courses": []
   },
   "RADR 2305": {
     "text": "RADR 2217",
@@ -4620,6 +11499,10 @@
       "RADR 1266"
     ]
   },
+  "RADR 2331": {
+    "text": "Recommended : Admission to the program or administrative approval",
+    "courses": []
+  },
   "RADR 2333": {
     "text": "RADR 2401 (min C)",
     "courses": [
@@ -4632,6 +11515,10 @@
       "RADR 2361"
     ]
   },
+  "RADR 2340": {
+    "text": "Recommended : Admission to the program or administrative approval. Background Search Required: No",
+    "courses": []
+  },
   "RADR 2362": {
     "text": "RADR 1261 and 2361. Assessment Levels: R3, E3, M3. 51.0911",
     "courses": [
@@ -4642,6 +11529,12 @@
     "text": "RADR 2217",
     "courses": [
       "RADR 2217"
+    ]
+  },
+  "RADR 2367": {
+    "text": "RADR 2366 . Course scheduling information",
+    "courses": [
+      "RADR 2366"
     ]
   },
   "RADR 2401": {
@@ -4656,10 +11549,36 @@
       "RADT 2366"
     ]
   },
+  "RBTC 1305": {
+    "text": "INMT 2301 , TECM 1301 and CETT 1402 with a grade of “C” or better",
+    "courses": [
+      "CETT 1402",
+      "INMT 2301",
+      "TECM 1301"
+    ]
+  },
+  "RBTC 1347": {
+    "text": "MFGT 1302 with a grade of “C” or better",
+    "courses": [
+      "MFGT 1302"
+    ]
+  },
   "RBTC 1401": {
     "text": "CETT 1405 (min C)",
     "courses": [
       "CETT 1405"
+    ]
+  },
+  "RBTC 1405": {
+    "text": "Required : RBTC 1401",
+    "courses": [
+      "RBTC 1401"
+    ]
+  },
+  "RBTC 2347": {
+    "text": "MFGT 1302 with a grade of “C” or better",
+    "courses": [
+      "MFGT 1302"
     ]
   },
   "RELE 1200": {
@@ -4728,12 +11647,26 @@
       "RELE 1278"
     ]
   },
+  "RELE 2378": {
+    "text": "Completion (or concurrent enrollment) in 5 RELE required state licensing courses: RELE 1406 , RELE 1200 , RELE 1211 , RELE 1219 and RELE 2201",
+    "courses": [
+      "RELE 1200",
+      "RELE 1211",
+      "RELE 1219",
+      "RELE 1406",
+      "RELE 2201"
+    ]
+  },
   "RNSG 1105": {
     "text": "RNSG 1413 and RNSG 1201",
     "courses": [
       "RNSG 1413",
       "RNSG 1201"
     ]
+  },
+  "RNSG 1108": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
   },
   "RNSG 1118": {
     "text": "Admission to Nursing Program, BIOL 2401, 2402, ENGL 1301 and PSYC 2301. Corequisites/Concurrent: SPCH 1311, or 1315, or 1321, RNSG 1125 and 1324. Assessment Levels: R3, E3, M3. 51.3801",
@@ -4782,14 +11715,37 @@
       "RNSG 1262"
     ]
   },
+  "RNSG 1144": {
+    "text": "Required : RNSG 1413 ; RNSG 1105 ; RNSG 1360",
+    "courses": [
+      "RNSG 1105",
+      "RNSG 1360",
+      "RNSG 1413"
+    ]
+  },
+  "RNSG 1160": {
+    "text": "Recommended : Admission to the Professional Nursing Program or administrative approval. Background Search Required: No",
+    "courses": []
+  },
   "RNSG 1161": {
     "text": "RNSG 1216",
     "courses": [
       "RNSG 1216"
     ]
   },
+  "RNSG 1162": {
+    "text": "RNSG 1105 . Corequisite(s): RNSG 1413 . Course scheduling information",
+    "courses": [
+      "RNSG 1105",
+      "RNSG 1413"
+    ]
+  },
   "RNSG 1163": {
     "text": "Acceptance into the Transition Nursing Program) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills and concepts. Direct supervision is provided by the clinical professional. Lab fee includes drug screening and lab fee. Requires computer/web access.",
+    "courses": []
+  },
+  "RNSG 1171": {
+    "text": "Admission into the program",
     "courses": []
   },
   "RNSG 1201": {
@@ -4806,6 +11762,36 @@
       "RNSG 1360"
     ]
   },
+  "RNSG 1207": {
+    "text": "BIOL 2401 , BIOL 2402 , BIOL 2420 , ENGL 1301 , MATH 1314 (or MATH 1342 ), RNSG 1300 , RNSG 1311 , and Admission to the Registered Nursing Transition Program",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "BIOL 2420",
+      "ENGL 1301",
+      "MATH 1314",
+      "MATH 1342",
+      "RNSG 1300",
+      "RNSG 1311"
+    ]
+  },
+  "RNSG 1210": {
+    "text": "BIOL 2401 , BIOL 2402 , BIOL 2420 , ENGL 1301 , MATH 1314 (or MATH 1342 ), RNSG 1300 , RNSG 1311 , and Admission to the Registered Nursing Transition Program",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "BIOL 2420",
+      "ENGL 1301",
+      "MATH 1314",
+      "MATH 1342",
+      "RNSG 1300",
+      "RNSG 1311"
+    ]
+  },
+  "RNSG 1215": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
   "RNSG 1216": {
     "text": "Admission to Nursing Program, BIOL 2401, 2402, ENGL 1301 and PSYC 2301. Corequisites/Concurrent: RNSG 1125, 1128, 1161, and 1430. Assessment Levels: R3, E3, M3. 51.3801",
     "courses": [
@@ -4821,6 +11807,14 @@
       "RNSG 1424"
     ]
   },
+  "RNSG 1227": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Nursing, A.D.N. of this catalog",
+    "courses": []
+  },
+  "RNSG 1244": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
   "RNSG 1251": {
     "text": "RNSG 2460 and RNSG 2461",
     "courses": [
@@ -4828,11 +11822,29 @@
       "RNSG 2461"
     ]
   },
+  "RNSG 1260": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
+  "RNSG 1261": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Nursing, A.D.N. of this catalog",
+    "courses": []
+  },
   "RNSG 1300": {
     "text": "BIOL 2301 (min C) and BIOL 2101 (min C)",
     "courses": [
       "BIOL 2301",
       "BIOL 2101"
+    ]
+  },
+  "RNSG 1301": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
+  "RNSG 1311": {
+    "text": "Recommended : BIOL 2401",
+    "courses": [
+      "BIOL 2401"
     ]
   },
   "RNSG 1324": {
@@ -4845,10 +11857,47 @@
       "RNSG 1118"
     ]
   },
+  "RNSG 1327": {
+    "text": "Admission to the Registered Nursing Transition Program. BIOL 2401 , BIOL 2402 , BIOL 2420 , ENGL 1301 , MATH 1314 (or MATH 1342 ), RNSG 1300 , and RNSG 1311 . Corequisite: RNSG 2261",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "BIOL 2420",
+      "ENGL 1301",
+      "MATH 1314",
+      "MATH 1342",
+      "RNSG 1300",
+      "RNSG 1311",
+      "RNSG 2261"
+    ]
+  },
+  "RNSG 1341": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
+  "RNSG 1343": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
   "RNSG 1360": {
     "text": "RNSG 1205",
     "courses": [
       "RNSG 1205"
+    ]
+  },
+  "RNSG 1361": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Nursing, A.D.N. of this catalog",
+    "courses": []
+  },
+  "RNSG 1362": {
+    "text": "Recommended : Admission to the Professional Nursing Program or administrative approval",
+    "courses": []
+  },
+  "RNSG 1412": {
+    "text": "Successful completion of all RNSG courses from the previous semester - traditional option. Corequisite(s): RNSG 2262 , traditional option; RNSG 1161 , bridge option. Course scheduling information",
+    "courses": [
+      "RNSG 1161",
+      "RNSG 2262"
     ]
   },
   "RNSG 1413": {
@@ -4931,6 +11980,10 @@
       "RNSG 1461"
     ]
   },
+  "RNSG 2130": {
+    "text": "Successful completion of all RNSG courses from the previous semester. Course scheduling information",
+    "courses": []
+  },
   "RNSG 2138": {
     "text": "BIOL 2420 (min C) or BIOL 2420 (min CT) and RNSG 1137 (min C) or RNSG 1137 (min CT) and RNSG 1538 (min C) or RNSG 1538 (min CT) and RNSG 2361 (min C) or RNSG 2361 (min CT)",
     "courses": [
@@ -4938,6 +11991,28 @@
       "RNSG 1137",
       "RNSG 1538",
       "RNSG 2361"
+    ]
+  },
+  "RNSG 2160": {
+    "text": "Required : RNSG 1144 ; RNSG 1441 ; RNSG 2362",
+    "courses": [
+      "RNSG 1144",
+      "RNSG 1441",
+      "RNSG 2362"
+    ]
+  },
+  "RNSG 2161": {
+    "text": "Required : RNSG 1144 ; RNSG 1441 ; RNSG 2362",
+    "courses": [
+      "RNSG 1144",
+      "RNSG 1441",
+      "RNSG 2362"
+    ]
+  },
+  "RNSG 2163": {
+    "text": "Successful completion of all RNSG courses from the previous semester. Corequisite(s): RNSG 2221 . Course scheduling information",
+    "courses": [
+      "RNSG 2221"
     ]
   },
   "RNSG 2201": {
@@ -4948,11 +12023,25 @@
       "RNSG 2460"
     ]
   },
+  "RNSG 2208": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
   "RNSG 2213": {
     "text": "RNSG 1461 or RNSG 1163",
     "courses": [
       "RNSG 1461",
       "RNSG 1163"
+    ]
+  },
+  "RNSG 2221": {
+    "text": "All courses in the ADN program must be taken in a prescribed sequence. See the program description in Associate Degree Nursing (A.D.N.) Full-Time Track of this catalog",
+    "courses": []
+  },
+  "RNSG 2260": {
+    "text": "Successful completion of all RNSG courses from the previous semester. Corequisite(s): RNSG 1443 . Course scheduling information",
+    "courses": [
+      "RNSG 1443"
     ]
   },
   "RNSG 2261": {
@@ -4965,6 +12054,12 @@
     "text": "RNSG 1433",
     "courses": [
       "RNSG 1433"
+    ]
+  },
+  "RNSG 2331": {
+    "text": "Successful completion of all RNSG courses from the previous semester. Corequisite(s): RNSG 2362 , traditional option; RNSG 2362 bridge option. Course scheduling information",
+    "courses": [
+      "RNSG 2362"
     ]
   },
   "RNSG 2360": {
@@ -5033,6 +12128,41 @@
       "RNSG 1251"
     ]
   },
+  "RNSG 2514": {
+    "text": "RNSG 2262 Admission to the Registered Nursing Transition Program. BIOL 2401 , BIOL 2402 , BIOL 2420 , ENGL 1301 , MATH 1314 (or MATH 1342 ), RNSG 1300 , RNSG 1311 , RNSG 1327 and RNSG 2261 . Corequisite: In order to receive credit for RNSG 2514, the course must be successfully completed simultaneously with RNSG 2362",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "BIOL 2420",
+      "ENGL 1301",
+      "MATH 1314",
+      "MATH 1342",
+      "RNSG 1300",
+      "RNSG 1311",
+      "RNSG 1327",
+      "RNSG 2261",
+      "RNSG 2262",
+      "RNSG 2362"
+    ]
+  },
+  "RNSG 2535": {
+    "text": "Admission to the Registered Nursing Transition Program. BIOL 2401 , BIOL 2402 , BIOL 2420 , ENGL 1301 , MATH 1314 (or MATH 1342 ), RNSG 1300 , RNSG 1311 ,RNSG 1327 , RNSG 2261 , RNSG 2514 , and RNSG 2262 . Corequisite: In order to receive credit for RNSG 2535, the course must be successfully completed simultaneously with RNSG 2363",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "BIOL 2420",
+      "ENGL 1301",
+      "MATH 1314",
+      "MATH 1342",
+      "RNSG 1300",
+      "RNSG 1311",
+      "RNSG 1327",
+      "RNSG 2261",
+      "RNSG 2262",
+      "RNSG 2363",
+      "RNSG 2514"
+    ]
+  },
   "RNSG 2539": {
     "text": "BIOL 2420 (min C) or BIOL 2420 (min CT) and RNSG 1137 (min C) or RNSG 1137 (min CT) and RNSG 1260 (min C) or RNSG 1260 (min CT) and RNSG 1538 (min C) or RNSG 1538 (min CT) and RNSG 2361 (min C) or RNSG 2361 (min CT)",
     "courses": [
@@ -5041,6 +12171,12 @@
       "RNSG 1260",
       "RNSG 1538",
       "RNSG 2361"
+    ]
+  },
+  "RSPT 1113": {
+    "text": "Recommended : A grade of “C” in RSPT 1410",
+    "courses": [
+      "RSPT 1410"
     ]
   },
   "RSPT 1166": {
@@ -5052,6 +12188,10 @@
       "RSPT 1410"
     ]
   },
+  "RSPT 1201": {
+    "text": "Required : Admission to the Respiratory Care Program and a grade of “C” or better. Background Search Required: No",
+    "courses": []
+  },
   "RSPT 1237": {
     "text": "PSGT 1360 and PSGT 2411 and PSGT 2205 and PSGT 2561 and PSGT 1310",
     "courses": [
@@ -5062,10 +12202,72 @@
       "PSGT 1310"
     ]
   },
+  "RSPT 1260": {
+    "text": "Admission to the program. Course scheduling information",
+    "courses": []
+  },
   "RSPT 1261": {
     "text": "RSPT 1213, 1260, 1310. Assessment Levels: R3, E3, M3. 51.0908",
     "courses": [
       "RSPT 1213"
+    ]
+  },
+  "RSPT 1311": {
+    "text": "Recommended : A grade of “C” in RSPT 1410 . Background Search Required: No",
+    "courses": [
+      "RSPT 1410"
+    ]
+  },
+  "RSPT 1340": {
+    "text": "Recommended : A grade of “C” in RSPT 1410 . Background Search Required: No",
+    "courses": [
+      "RSPT 1410"
+    ]
+  },
+  "RSPT 1360": {
+    "text": "Recommended : A grade of “C” in RSPT 1410 . Background Search Required: No",
+    "courses": [
+      "RSPT 1410"
+    ]
+  },
+  "RSPT 1362": {
+    "text": "RSPT 1360 . Course scheduling information",
+    "courses": [
+      "RSPT 1360"
+    ]
+  },
+  "RSPT 1371": {
+    "text": "Admission to the program. Course scheduling information",
+    "courses": []
+  },
+  "RSPT 1410": {
+    "text": "Required : A grade of “C” in RSPT 1201 . Background Search Required: No",
+    "courses": [
+      "RSPT 1201"
+    ]
+  },
+  "RSPT 1411": {
+    "text": "RSPT 1410 . Course scheduling information",
+    "courses": [
+      "RSPT 1410"
+    ]
+  },
+  "RSPT 2130": {
+    "text": "Required : A grade of “C” in RSPT 1311 . Background Search Required: No",
+    "courses": [
+      "RSPT 1311"
+    ]
+  },
+  "RSPT 2147": {
+    "text": "Required : A grade of “C” in RSPT 1360 , RSPT 1340 , RSPT 1311 , RSPT 2258 , RSPT 2310 , RSPT 1113 , and RSPT 2217",
+    "courses": [
+      "RSPT 1113",
+      "RSPT 1311",
+      "RSPT 1340",
+      "RSPT 1360",
+      "RSPT 2217",
+      "RSPT 2258",
+      "RSPT 2310"
     ]
   },
   "RSPT 2161": {
@@ -5088,10 +12290,58 @@
       "RSPT 1213"
     ]
   },
+  "RSPT 2217": {
+    "text": "Recommended : A grade of “C” in RSPT 1340 and RSPT 1113",
+    "courses": [
+      "RSPT 1113",
+      "RSPT 1340"
+    ]
+  },
+  "RSPT 2230": {
+    "text": "Required : A grade of “C” in RSPT 1360 , RSPT 1340 , RSPT 1311 , RSPT 2258 , RSPT 2310 , RSPT 1113 , and RSPT 2217",
+    "courses": [
+      "RSPT 1113",
+      "RSPT 1311",
+      "RSPT 1340",
+      "RSPT 1360",
+      "RSPT 2217",
+      "RSPT 2258",
+      "RSPT 2310"
+    ]
+  },
+  "RSPT 2231": {
+    "text": "Recommended : A grade of “C” in RSPT 1360 , RSPT 1311 , RSPT 2258 , RSPT 2310 , and RSPT 2217 . This course is cross-listed as RSPT 2131. The student may register for either RSPT 2131 or RSPT 2231 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "RSPT 1311",
+      "RSPT 1360",
+      "RSPT 2131",
+      "RSPT 2217",
+      "RSPT 2258",
+      "RSPT 2310"
+    ]
+  },
+  "RSPT 2258": {
+    "text": "Recommended : A grade of “C” in RSPT 1340 and RSPT 1113 . Background Search Required: No",
+    "courses": [
+      "RSPT 1113",
+      "RSPT 1340"
+    ]
+  },
   "RSPT 2260": {
     "text": "RSPT 1260, 1261, 2161. Assessment Levels: R3, E3, M3. 51.0908",
     "courses": [
       "RSPT 1260"
+    ]
+  },
+  "RSPT 2263": {
+    "text": "Recommended : A grade of “C” in RSPT 2453 , RSPT 2314 , RSPT 2325 , RSPT 2231 , RSPT 2130 , RSPT 2362 . Background Search Required: No",
+    "courses": [
+      "RSPT 2130",
+      "RSPT 2231",
+      "RSPT 2314",
+      "RSPT 2325",
+      "RSPT 2362",
+      "RSPT 2453"
     ]
   },
   "RSPT 2266": {
@@ -5100,6 +12350,13 @@
       "RSPT 2310",
       "RSPT 2353",
       "RSPT 2358"
+    ]
+  },
+  "RSPT 2310": {
+    "text": "Recommended : A grade of “C” in RSPT 1340 and RSPT 1113 . Background Search Required: No",
+    "courses": [
+      "RSPT 1113",
+      "RSPT 1340"
     ]
   },
   "RSPT 2314": {
@@ -5120,10 +12377,77 @@
       "RSPT 2560"
     ]
   },
+  "RSPT 2362": {
+    "text": "RSPT 1362 . Course scheduling information",
+    "courses": [
+      "RSPT 1362"
+    ]
+  },
+  "RSPT 2363": {
+    "text": "RSPT 2362 . Course scheduling information",
+    "courses": [
+      "RSPT 2362"
+    ]
+  },
   "RSPT 53": {
     "text": "RSPT 2161, 2314. Assessment Levels: R3, E3, M3. 51.0908",
     "courses": [
       "RSPT 2161"
+    ]
+  },
+  "RSTO 1304": {
+    "text": "Required : CHEF 1301 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "CHEF 1301"
+    ]
+  },
+  "RSTO 1306": {
+    "text": "Required : CHEF 1301 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "CHEF 1301"
+    ]
+  },
+  "RSTO 1325": {
+    "text": "Required : CHEF 1301 with a “C” or better. Background Search Required: No",
+    "courses": [
+      "CHEF 1301"
+    ]
+  },
+  "RSTO 2301": {
+    "text": "Required : CHEF 2331 with a grade of “C” or better",
+    "courses": [
+      "CHEF 2331"
+    ]
+  },
+  "RSTO 2307": {
+    "text": "Required : CHEF 1301 and CHEF 1305 with a “C” or better and a minimum of a food handler’s certificate, preferred ServSafe Food Manager Certificate or the Texas Food Guard Certification. Failure to comply will result in student being dropped from this course. Background Search Required: No",
+    "courses": [
+      "CHEF 1301",
+      "CHEF 1305"
+    ]
+  },
+  "RSTO 2431": {
+    "text": "HAMG 2301 with grade of “C” or better",
+    "courses": [
+      "HAMG 2301"
+    ]
+  },
+  "SCIT 1307": {
+    "text": "Required : College level ready in Reading. This course is cross-listed as SCIT 1407 . The student may register for either SCIT 1307 or SCIT 1407 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "SCIT 1407"
+    ]
+  },
+  "SCIT 1407": {
+    "text": "Required : College level ready in Reading. This course is cross-listed as SCIT 1307 . The student may register for either SCIT 1407 or SCIT 1307 but may receive credit for only one of the two. Background Search Required: No",
+    "courses": [
+      "SCIT 1307"
+    ]
+  },
+  "SCIT 1408": {
+    "text": "Required : SCIT 1407 . Background Search Required: No",
+    "courses": [
+      "SCIT 1407"
     ]
   },
   "SCIT 2401": {
@@ -5147,10 +12471,29 @@
       "SGNL 1401"
     ]
   },
+  "SGNL 2301": {
+    "text": "SGNL 1402 . Course scheduling information",
+    "courses": [
+      "SGNL 1402"
+    ]
+  },
+  "SGNL 2302": {
+    "text": "SGNL 2301 . Course scheduling information",
+    "courses": [
+      "SGNL 2301"
+    ]
+  },
   "SLNG 1211": {
     "text": "SGNL 1302 or instructor approval. Assessment Levels: R2, E2, M1. 16.1603",
     "courses": [
       "SGNL 1302"
+    ]
+  },
+  "SLNG 1305": {
+    "text": "SGNL 1301 or SLNG 1304 with a grade of “C” or better",
+    "courses": [
+      "SGNL 1301",
+      "SLNG 1304"
     ]
   },
   "SLNG 1307": {
@@ -5166,16 +12509,51 @@
       "SGNL 1301"
     ]
   },
+  "SLNG 1344": {
+    "text": "SGNL 1302 or SLNG 1305 with a grade of “C” or better",
+    "courses": [
+      "SGNL 1302",
+      "SLNG 1305"
+    ]
+  },
+  "SLNG 1345": {
+    "text": "SGNL 2301 or SLNG 1344 with a grade of “C” or better",
+    "courses": [
+      "SGNL 2301",
+      "SLNG 1344"
+    ]
+  },
   "SLNG 1347": {
     "text": "SGNL 1302 or instructor approval. Assessment Levels: R3, E3, M1. 16.1603",
     "courses": [
       "SGNL 1302"
     ]
   },
+  "SLNG 1348": {
+    "text": "ENGL 1301 and SLNG 1307 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1301",
+      "SLNG 1307"
+    ]
+  },
+  "SLNG 1350": {
+    "text": "SGNL 2302 or SLNG 1345 with a grade of “C” or better",
+    "courses": [
+      "SGNL 2302",
+      "SLNG 1345"
+    ]
+  },
   "SLNG 1444": {
     "text": "SGNL 1302 or instructor approval. Assessment Levels: R2, E2, M1. 16.1603",
     "courses": [
       "SGNL 1302"
+    ]
+  },
+  "SLNG 2266": {
+    "text": "SLNG 2311 and SLNG 2431 or concurrent enrollment; pass mid-program evaluation with “C” or better",
+    "courses": [
+      "SLNG 2311",
+      "SLNG 2431"
     ]
   },
   "SLNG 2286": {
@@ -5190,10 +12568,33 @@
       "SLNG 2286"
     ]
   },
+  "SLNG 2301": {
+    "text": "SGNL 1301 or SLNG 1304 , and SLNG 1321 , with a grade of “C” or better",
+    "courses": [
+      "SGNL 1301",
+      "SLNG 1304",
+      "SLNG 1321"
+    ]
+  },
   "SLNG 2302": {
     "text": "SLNG 2301. Assessment Levels: R3, E3, M2.",
     "courses": [
       "SLNG 2301"
+    ]
+  },
+  "SLNG 2303": {
+    "text": "SGNL 2301 or SLNG 1344 with a grade of “C” or better",
+    "courses": [
+      "SGNL 2301",
+      "SLNG 1344"
+    ]
+  },
+  "SLNG 2311": {
+    "text": "SGNL 2302 or SLNG 1345 , and SLNG 2302 , with a grade of “C” or better; and pass mid-program evaluation with a grade of “C” or better",
+    "courses": [
+      "SGNL 2302",
+      "SLNG 1345",
+      "SLNG 2302"
     ]
   },
   "SLNG 2334": {
@@ -5215,11 +12616,51 @@
       "SLNG 2401"
     ]
   },
+  "SLNG 2431": {
+    "text": "SGNL 2302 or SLNG 1345 , and SLNG 2302 , with a grade of “C” or better; and pass mid-program evaluation with a grade of “C” or better",
+    "courses": [
+      "SGNL 2302",
+      "SLNG 1345",
+      "SLNG 2302"
+    ]
+  },
   "SLNG 2434": {
     "text": "SLNG 1445 or instructor approval. Assessment Levels: R3, E3, M1. 16.1603",
     "courses": [
       "SLNG 1445"
     ]
+  },
+  "SOCI 1301": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
+  },
+  "SOCI 1306": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
+  },
+  "SOCI 2301": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
+  },
+  "SOCI 2306": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "SOCI 2319": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
+  },
+  "SOCI 2326": {
+    "text": "Students must have satisfied TSI readiness in ELAR. Course scheduling information",
+    "courses": []
+  },
+  "SOCI 2336": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
+  },
+  "SOCI 2340": {
+    "text": "TSI Reading and Writing Complete",
+    "courses": []
   },
   "SOCW 2362": {
     "text": "SOCI 1301",
@@ -5257,6 +12698,26 @@
       "SPAN 2311"
     ]
   },
+  "SPCH 2333": {
+    "text": "Any first-year level speech course",
+    "courses": []
+  },
+  "SPCH 2335": {
+    "text": "Any first-year level speech course",
+    "courses": []
+  },
+  "SPCH 2389": {
+    "text": "Any two speech courses",
+    "courses": []
+  },
+  "SRGT 1266": {
+    "text": "HITT 1305 , BIOL 2401 and BIOL 2402 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "HITT 1305"
+    ]
+  },
   "SRGT 1405": {
     "text": "BIOL 2401 (min C) or BIOL 2401 (min CT) and BIOL 2402 (min C) or BIOL 2402 (min CT) and BIOL 2420 (min C) or BIOL 2420 (min CT) and NURA 1301 (min C) or NURA 1301 (min CT) and NURA 1160 (min C) or NURA 1160 (min CT) and HITT 1305 (min C) or HITT 1305 (min CT)",
     "courses": [
@@ -5265,6 +12726,14 @@
       "BIOL 2420",
       "NURA 1301",
       "NURA 1160",
+      "HITT 1305"
+    ]
+  },
+  "SRGT 1409": {
+    "text": "HITT 1305 , BIOL 2401 and BIOL 2402 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
       "HITT 1305"
     ]
   },
@@ -5307,6 +12776,14 @@
       "SRGT 1461"
     ]
   },
+  "SRGT 1541": {
+    "text": "HITT 1305 , BIOL 2401 and BIOL 2402 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "HITT 1305"
+    ]
+  },
   "SRGT 1542": {
     "text": "SRGT 1505 or SRGT 1405 or SRGT 1541",
     "courses": [
@@ -5335,10 +12812,198 @@
       "SRGT 1405"
     ]
   },
+  "SRVY 1335": {
+    "text": "SRVY 1301 and SRVY 1309 with a grade of “C” or better",
+    "courses": [
+      "SRVY 1301",
+      "SRVY 1309"
+    ]
+  },
+  "SRVY 1341": {
+    "text": "Required : SRVY 1301 , SRVY 1335 , SRVY 2343 , SRVY 2331 . Background Search Required: No",
+    "courses": [
+      "SRVY 1301",
+      "SRVY 1335",
+      "SRVY 2331",
+      "SRVY 2343"
+    ]
+  },
+  "SRVY 2164": {
+    "text": "Required : SRVY 2343",
+    "courses": [
+      "SRVY 2343"
+    ]
+  },
+  "SRVY 2305": {
+    "text": "Required : SRVY 1335",
+    "courses": [
+      "SRVY 1335"
+    ]
+  },
+  "SRVY 2309": {
+    "text": "DFTG 1305 . Course scheduling information",
+    "courses": [
+      "DFTG 1305"
+    ]
+  },
+  "SRVY 2331": {
+    "text": "Required : SRVY 1335 , MATH 1314 , MATH 1316",
+    "courses": [
+      "MATH 1314",
+      "MATH 1316",
+      "SRVY 1335"
+    ]
+  },
+  "SRVY 2335": {
+    "text": "SRVY 1301 and SRVY 1309 with a grade of “C” or better or concurrent enrollment",
+    "courses": [
+      "SRVY 1301",
+      "SRVY 1309"
+    ]
+  },
+  "SRVY 2339": {
+    "text": "Required : SRVY 1335 , MATH 1314 , MATH 1316",
+    "courses": [
+      "MATH 1314",
+      "MATH 1316",
+      "SRVY 1335"
+    ]
+  },
+  "SRVY 2343": {
+    "text": "Required : SRVY 1335 , MATH 1314 , MATH 1316",
+    "courses": [
+      "MATH 1314",
+      "MATH 1316",
+      "SRVY 1335"
+    ]
+  },
+  "SRVY 2344": {
+    "text": "Required : SRVY 2343 . Background Search Required: No",
+    "courses": [
+      "SRVY 2343"
+    ]
+  },
+  "SRVY 2371": {
+    "text": "Required : SRVY 2339",
+    "courses": [
+      "SRVY 2339"
+    ]
+  },
+  "SRVY 2455": {
+    "text": "Required : SRVY 2343 , SRVY 1370 , SRVY 2331",
+    "courses": [
+      "SRVY 1370",
+      "SRVY 2331",
+      "SRVY 2343"
+    ]
+  },
+  "TECA 1303": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
+  "TECA 1311": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
+  "TECA 1318": {
+    "text": "Required : College level ready in Reading",
+    "courses": []
+  },
   "TECA 1354": {
     "text": "CDEC 1166",
     "courses": [
       "CDEC 1166"
+    ]
+  },
+  "TECM 1317": {
+    "text": "Recommended : TECM 1341 . Background Search Required: No",
+    "courses": [
+      "TECM 1341"
+    ]
+  },
+  "TECM 1341": {
+    "text": "Required : One year of high school algebra and an appropriate assessment test score or DMAT 0305 or DMAT 0308 or DMAT 0309. Background Search Required: No",
+    "courses": [
+      "DMAT 0305",
+      "DMAT 0308",
+      "DMAT 0309"
+    ]
+  },
+  "TECM 1349": {
+    "text": "Recommended : TECM 1317 . Background Search Required: No",
+    "courses": [
+      "TECM 1317"
+    ]
+  },
+  "TMGT 3302": {
+    "text": "MATH 1342 . Course scheduling information",
+    "courses": [
+      "MATH 1342"
+    ]
+  },
+  "TMGT 3336": {
+    "text": "BUSI 2301 or instructor permission. Course scheduling information",
+    "courses": [
+      "BUSI 2301"
+    ]
+  },
+  "TMGT 3338": {
+    "text": "Recommended : ACCT 2301",
+    "courses": [
+      "ACCT 2301"
+    ]
+  },
+  "TMGT 3340": {
+    "text": "TMGT 3305",
+    "courses": [
+      "TMGT 3305"
+    ]
+  },
+  "TMGT 3350": {
+    "text": "Successful completion of a college level mathematics course",
+    "courses": []
+  },
+  "TMGT 3358": {
+    "text": "ITNW 1354 or instructor permission. Course scheduling information",
+    "courses": [
+      "ITNW 1354"
+    ]
+  },
+  "TMGT 3391": {
+    "text": "BCIS 1305 or ITSC 1309 or ITSW 1304 . Course scheduling information",
+    "courses": [
+      "BCIS 1305",
+      "ITSC 1309",
+      "ITSW 1304"
+    ]
+  },
+  "TMGT 4385": {
+    "text": "Department chair approval. Course scheduling information",
+    "courses": []
+  },
+  "TMGT 4386": {
+    "text": "TMGT 4385 and instructor permission. Course scheduling information",
+    "courses": [
+      "TMGT 4385"
+    ]
+  },
+  "TMGT 4396": {
+    "text": "Department chair approval. Course scheduling information",
+    "courses": []
+  },
+  "TMGT 4398": {
+    "text": "Department chair approval. Course scheduling information",
+    "courses": []
+  },
+  "TRVM 1280": {
+    "text": "Recommended : Student must complete two TRVM Classes. Background Search Required: No",
+    "courses": []
+  },
+  "TRVM 2300": {
+    "text": "Recommended : TRVM 2301 , POFI 1301 , or demonstrated competence in meeting planning and Microsoft office software. Background Search Required: No",
+    "courses": [
+      "POFI 1301",
+      "TRVM 2301"
     ]
   },
   "TRVM 2301": {
@@ -5349,6 +13014,125 @@
       "HAMG 1321",
       "HAMG 1340",
       "HAMG 1313"
+    ]
+  },
+  "TRVM 2331": {
+    "text": "Recommended : TRVM 2301 or TRVM 1300 or demonstrated competence in meeting planning or travel management. Background Search Required: No",
+    "courses": [
+      "TRVM 1300",
+      "TRVM 2301"
+    ]
+  },
+  "TRVM 2333": {
+    "text": "Recommended : TRVM 2301 or demonstrated basic knowledge in meeting planning. Background Search Required: No",
+    "courses": [
+      "TRVM 2301"
+    ]
+  },
+  "TRVM 2341": {
+    "text": "Recommended : TRVM 2301 or demonstrated basic knowledge in meeting planning. Background Search Required: No",
+    "courses": [
+      "TRVM 2301"
+    ]
+  },
+  "TRVM 2355": {
+    "text": "Recommended : TRVM 1325 . Background Search Required: No",
+    "courses": [
+      "TRVM 1325"
+    ]
+  },
+  "UNIV 3332": {
+    "text": "College",
+    "courses": []
+  },
+  "UXUI 2372": {
+    "text": "Required : UXUI 1372 Background Search Required: No",
+    "courses": [
+      "UXUI 1372"
+    ]
+  },
+  "UXUI 2373": {
+    "text": "Required : UXUI 1373 Background Search Required: No",
+    "courses": [
+      "UXUI 1373"
+    ]
+  },
+  "UXUI 2374": {
+    "text": "Required : UXUI 1370 , UXUI 1372 , UXUI 1374 and concurrent enrollment in UXUI 1373 Background Search Required: No",
+    "courses": [
+      "UXUI 1370",
+      "UXUI 1372",
+      "UXUI 1373",
+      "UXUI 1374"
+    ]
+  },
+  "UXUI 2378": {
+    "text": "Required : UXUI 1370 , UXUI 1372 , UXUI 1374 and concurrent enrollment in UXUI 1373 Background Search Required: No",
+    "courses": [
+      "UXUI 1370",
+      "UXUI 1372",
+      "UXUI 1373",
+      "UXUI 1374"
+    ]
+  },
+  "VIRT 1310": {
+    "text": "Recommended : SCIT 1408 or BIOL 2402 , RADR 2240 and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "BIOL 2402",
+      "RADR 2240",
+      "SCIT 1408"
+    ]
+  },
+  "VIRT 1320": {
+    "text": "Recommended : SCIT 1408 or BIOL 2402 , RADR 2240 and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "BIOL 2402",
+      "RADR 2240",
+      "SCIT 1408"
+    ]
+  },
+  "VIRT 2164": {
+    "text": "Recommended : SCIT 1408 or BIOL 2402 , and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "BIOL 2402",
+      "SCIT 1408"
+    ]
+  },
+  "VIRT 2265": {
+    "text": "Recommended : VIRT 2164 , VIRT 2364 , and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "VIRT 2164",
+      "VIRT 2364"
+    ]
+  },
+  "VIRT 2310": {
+    "text": "Recommended : SCIT 1408 or BIOL 2402 , RADR 2240 and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "BIOL 2402",
+      "RADR 2240",
+      "SCIT 1408"
+    ]
+  },
+  "VIRT 2330": {
+    "text": "Recommended : SCIT 1408 or BIOL 2402 , RADR 2240 and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "BIOL 2402",
+      "RADR 2240",
+      "SCIT 1408"
+    ]
+  },
+  "VIRT 2340": {
+    "text": "Recommended : SCIT 1408 or BIOL 2402 , RADR 2240 and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "BIOL 2402",
+      "RADR 2240",
+      "SCIT 1408"
+    ]
+  },
+  "VIRT 2364": {
+    "text": "Recommended : VIRT 2164 and ARRT registered in radiography or registry eligible or instructor permission. Background Search Required: Yes",
+    "courses": [
+      "VIRT 2164"
     ]
   },
   "VNSG 1119": {
@@ -5365,6 +13149,50 @@
     "text": "Acceptance into the Vocational Nursing Program) Students will earn an A, B, C, D, F, or W. Introduction to the nursing profession and its responsibilities. Includes legal and ethical issues in nursing practice. Concepts related to the physical, emotional and psychosocial self-care of the learner/professional. Lab fee.",
     "courses": []
   },
+  "VNSG 1133": {
+    "text": "Admission to the LVN Program",
+    "courses": []
+  },
+  "VNSG 1136": {
+    "text": "Admission to the Vocational Nursing Program, BIOL 2401 , BIOL 2402 , VNSG 1423 , VNSG 1402 , VNSG 1461 , VNSG 1122 , and VNSG 1227 Corequisite: VNSG 1231 , VNSG 1462 , VNSG 1138 , and VNSG 2413",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "VNSG 1122",
+      "VNSG 1138",
+      "VNSG 1227",
+      "VNSG 1231",
+      "VNSG 1402",
+      "VNSG 1423",
+      "VNSG 1461",
+      "VNSG 1462",
+      "VNSG 2413"
+    ]
+  },
+  "VNSG 1138": {
+    "text": "Admission to the Vocational Nursing Program, BIOL 2401 , BIOL 2402 , VNSG 1160 and VNSG 1323 or VNSG 1423 , VNSG 1227 , VNSG 1402 , VNSG 1461 , VNSG 1122 . Corequisite: VNSG 2413 , VNSG 1231 and VNSG 1462",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "VNSG 1122",
+      "VNSG 1160",
+      "VNSG 1227",
+      "VNSG 1231",
+      "VNSG 1323",
+      "VNSG 1402",
+      "VNSG 1423",
+      "VNSG 1461",
+      "VNSG 1462",
+      "VNSG 2413"
+    ]
+  },
+  "VNSG 1160": {
+    "text": "Student must have a “C” average in VNSG 1227 and VNSG 1133",
+    "courses": [
+      "VNSG 1133",
+      "VNSG 1227"
+    ]
+  },
   "VNSG 1201": {
     "text": "VNSG 1230",
     "courses": [
@@ -5378,11 +13206,19 @@
       "NURA 1301"
     ]
   },
+  "VNSG 1205": {
+    "text": "Successful completion of all second semester courses with a grade of “C” or higher",
+    "courses": []
+  },
   "VNSG 1219": {
     "text": "RNSG 1126, 1533, and 2362. Assessment Levels: R3, E3, M3. 51.3901",
     "courses": [
       "RNSG 1126"
     ]
+  },
+  "VNSG 1226": {
+    "text": "Admission to the LVN Program",
+    "courses": []
   },
   "VNSG 1227": {
     "text": "VNSG 1423",
@@ -5428,6 +13264,10 @@
       "VNSG 1329"
     ]
   },
+  "VNSG 1238": {
+    "text": "Successful completion of all second semester courses with a grade of “C” or higher",
+    "courses": []
+  },
   "VNSG 1260": {
     "text": "VNSG 1423",
     "courses": [
@@ -5445,6 +13285,29 @@
   "VNSG 1262": {
     "text": "See advisor) Students will earn an A, B, C, D, F, or W. A health-related work-based learning experience that enables the student to apply specialized occupational theory, skills and concepts. Direct supervision is provided by the clinical professional. A preceptorship at the end of the semester provides a capstone experience and allows the student to integrate technical skills, nursing concepts, a",
     "courses": []
+  },
+  "VNSG 1301": {
+    "text": "VNSG 1204 , VNSG 1231 , VNSG 1260 , VNSG 1323 , VNSG 1329 , and VNSG 1400 with a grade of “C” or better",
+    "courses": [
+      "VNSG 1204",
+      "VNSG 1231",
+      "VNSG 1260",
+      "VNSG 1323",
+      "VNSG 1329",
+      "VNSG 1400"
+    ]
+  },
+  "VNSG 1320": {
+    "text": "Admission to the LVN Program",
+    "courses": []
+  },
+  "VNSG 1323": {
+    "text": "BIOL 2404 , or BIOL 2401 and BIOL 2402 , with a grade of “C” or better",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "BIOL 2404"
+    ]
   },
   "VNSG 1329": {
     "text": "VNSG 1231 and VNSG 1236 and VNSG 1261",
@@ -5467,10 +13330,41 @@
       "VNSG 1423"
     ]
   },
+  "VNSG 1360": {
+    "text": "VNSG 1204 , VNSG 1231 , VNSG 1260 , VNSG 1323 , VNSG 1329 , and VNSG 1400 with a grade of “C” or better",
+    "courses": [
+      "VNSG 1204",
+      "VNSG 1231",
+      "VNSG 1260",
+      "VNSG 1323",
+      "VNSG 1329",
+      "VNSG 1400"
+    ]
+  },
+  "VNSG 1361": {
+    "text": "VNSG 1301 , VNSG 1360 , VNSG 1409 , and VNSG 2331 with a grade of “C” or better",
+    "courses": [
+      "VNSG 1301",
+      "VNSG 1360",
+      "VNSG 1409",
+      "VNSG 2331"
+    ]
+  },
   "VNSG 1400": {
     "text": "VNSG 1423",
     "courses": [
       "VNSG 1423"
+    ]
+  },
+  "VNSG 1402": {
+    "text": "Admission to the Vocational Nursing Program, BIOL 2401 , BIOL 2402 Corequisite: VNSG 1423 , VNSG 1461 , VNSG 1122 , and VNSG 1227",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "VNSG 1122",
+      "VNSG 1227",
+      "VNSG 1423",
+      "VNSG 1461"
     ]
   },
   "VNSG 1409": {
@@ -5509,6 +13403,19 @@
     "courses": [
       "VNSG 1409",
       "VNSG 1260"
+    ]
+  },
+  "VNSG 1461": {
+    "text": "Admission to the Vocational Nursing Program, BIOL 2401 , BIOL 2402 , VNSG 1160 , and VNSG 1323 . Corequisite: VNSG 1227 , VNSG 1122 , VNSG 1136 , and VNSG 1402",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "VNSG 1122",
+      "VNSG 1136",
+      "VNSG 1160",
+      "VNSG 1227",
+      "VNSG 1323",
+      "VNSG 1402"
     ]
   },
   "VNSG 1462": {
@@ -5553,6 +13460,10 @@
       "VNSG 1231"
     ]
   },
+  "VNSG 2313": {
+    "text": "Successful completion of all first semester courses with a grade of “C” or higher",
+    "courses": []
+  },
   "VNSG 2331": {
     "text": "VNSG 1423 and VNSG 1460",
     "courses": [
@@ -5571,6 +13482,22 @@
       "VNSG 1462"
     ]
   },
+  "VNSG 2413": {
+    "text": "Admission to the Vocational Nursing Program, BIOL 2401 , BIOL 2402 ,VNSG 1423 , VNSG 1402 , VNSG 1227 , VNSG 1122 , and VNSG 1461 . Corequisite: VNSG 1136 , VNSG 1138 , VNSG 1231 , and VNSG 1462",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "VNSG 1122",
+      "VNSG 1136",
+      "VNSG 1138",
+      "VNSG 1227",
+      "VNSG 1231",
+      "VNSG 1402",
+      "VNSG 1423",
+      "VNSG 1461",
+      "VNSG 1462"
+    ]
+  },
   "VNSG 2460": {
     "text": "VNSG 1119 and VNSG 1230 and VNSG 1234 and VNSG 1432 and VNSG 2460",
     "courses": [
@@ -5581,8 +13508,139 @@
       "VNSG 2460"
     ]
   },
+  "VNSG 2463": {
+    "text": "Admission to the Vocational Nursing Program, BIOL 2401 , BIOL 2402 , VNSG 1160 , VNSG 1138 , VNSG 1323 or VNSG 1423 , VNSG 1227 , VNSG 1231 , VNSG 1402 , VNSG 1461 , VNSG 1122 , VNSG 1136 , VNSG 1462 , and VNSG 2413 . Corequisite: VNSG 1230 , VNSG 1234 , and VNSG 2214",
+    "courses": [
+      "BIOL 2401",
+      "BIOL 2402",
+      "VNSG 1122",
+      "VNSG 1136",
+      "VNSG 1138",
+      "VNSG 1160",
+      "VNSG 1227",
+      "VNSG 1230",
+      "VNSG 1231",
+      "VNSG 1234",
+      "VNSG 1323",
+      "VNSG 1402",
+      "VNSG 1423",
+      "VNSG 1461",
+      "VNSG 1462",
+      "VNSG 2214",
+      "VNSG 2413"
+    ]
+  },
   "VNSG 2473": {
     "text": "Acceptance into the Vocatiional Nursing Program) Students will earn an A, B, C, D, F, or W. Continuation of application of advanced nursing skills to meet patient needs utilizing the nursing process and related scientific principles. Lab fee.",
+    "courses": []
+  },
+  "VTHT 1125": {
+    "text": "MATH 1332 or MATH 1342 /MATH 1442 or MATH 1314 /MATH 1414 with a grade of “C” or better",
+    "courses": [
+      "MATH 1314",
+      "MATH 1332",
+      "MATH 1342",
+      "MATH 1414",
+      "MATH 1442"
+    ]
+  },
+  "VTHT 1209": {
+    "text": "VTHT 1301 and VTHT 1205 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1205",
+      "VTHT 1301"
+    ]
+  },
+  "VTHT 1345": {
+    "text": "VTHT 1413 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1413"
+    ]
+  },
+  "VTHT 1349": {
+    "text": "VTHT 1125 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1125"
+    ]
+  },
+  "VTHT 1413": {
+    "text": "VTHT 1301 and VTHT 1205 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1205",
+      "VTHT 1301"
+    ]
+  },
+  "VTHT 1441": {
+    "text": "VTHT 1413 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1413"
+    ]
+  },
+  "VTHT 2213": {
+    "text": "VTHT 1301 and VTHT 1205 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1205",
+      "VTHT 1301"
+    ]
+  },
+  "VTHT 2301": {
+    "text": "VTHT 1301 and VTHT 1205 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1205",
+      "VTHT 1301"
+    ]
+  },
+  "VTHT 2323": {
+    "text": "VTHT 1413 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1413"
+    ]
+  },
+  "VTHT 2425": {
+    "text": "VTHT 1441 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1441"
+    ]
+  },
+  "VTHT 2460": {
+    "text": "VTHT 1345 , VTHT 1349 , VTHT 1441 and VTHT 2323 with a grade of “C” or better",
+    "courses": [
+      "VTHT 1345",
+      "VTHT 1349",
+      "VTHT 1441",
+      "VTHT 2323"
+    ]
+  },
+  "WLDG 1280": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "WLDG 1281": {
+    "text": "WLDG 1280 and approval of the division chair",
+    "courses": [
+      "WLDG 1280"
+    ]
+  },
+  "WLDG 1307": {
+    "text": "WLDG 1200",
+    "courses": [
+      "WLDG 1200"
+    ]
+  },
+  "WLDG 1312": {
+    "text": "WLDG 1430 with a grade of “C” or better",
+    "courses": [
+      "WLDG 1430"
+    ]
+  },
+  "WLDG 1317": {
+    "text": "WLDG 1313 with a grade of “C” or better",
+    "courses": [
+      "WLDG 1313"
+    ]
+  },
+  "WLDG 1327": {
+    "text": "Department chair approval",
     "courses": []
   },
   "WLDG 1371": {
@@ -5606,6 +13664,16 @@
       "WLDG 2372"
     ]
   },
+  "WLDG 1380": {
+    "text": "Approval of the division chair",
+    "courses": []
+  },
+  "WLDG 1381": {
+    "text": "WLDG 1280 and approval of the division chair",
+    "courses": [
+      "WLDG 1280"
+    ]
+  },
   "WLDG 1412": {
     "text": "WLDG 1417 and WLDG 1434",
     "courses": [
@@ -5627,6 +13695,12 @@
     "text": "WLDG 1307",
     "courses": [
       "WLDG 1307"
+    ]
+  },
+  "WLDG 1430": {
+    "text": "WLDG 1204 with a grade of “C” or better",
+    "courses": [
+      "WLDG 1204"
     ]
   },
   "WLDG 1434": {
@@ -5662,10 +13736,22 @@
       "WLDG 1428"
     ]
   },
+  "WLDG 2352": {
+    "text": "WLDG 1307",
+    "courses": [
+      "WLDG 1307"
+    ]
+  },
   "WLDG 2372": {
     "text": "WLDG 1317 (min C)",
     "courses": [
       "WLDG 1317"
+    ]
+  },
+  "WLDG 2380": {
+    "text": "WLDG 1281 and approval of the division chair",
+    "courses": [
+      "WLDG 1281"
     ]
   },
   "WLDG 2406": {
@@ -5721,6 +13807,12 @@
       "WLDG 2447"
     ]
   },
+  "WLDG 2452": {
+    "text": "WLDG 1417",
+    "courses": [
+      "WLDG 1417"
+    ]
+  },
   "WLDG 2453": {
     "text": "WLDG 2406 and WLDG 2447 and WLDG 2451 and WLDG 1453 and WLDG 2435",
     "courses": [
@@ -5729,6 +13821,12 @@
       "WLDG 2451",
       "WLDG 1453",
       "WLDG 2435"
+    ]
+  },
+  "WLDG 2513": {
+    "text": "WLDG 2451 or approval of the division chair",
+    "courses": [
+      "WLDG 2451"
     ]
   },
   "WLDG 2535": {

--- a/lib/states/tx/config.ts
+++ b/lib/states/tx/config.ts
@@ -150,7 +150,16 @@ const txConfig: StateConfig = {
     transfers: [
       { scripts: ["scripts/tx/scrape-transfer-tccns.ts"], runner: "http" },
     ],
-    // manual-only: prereqs — Phase 4.
+    prereqs: [
+      // Six TX colleges publish their course catalog via Acalog but don't
+      // expose a public class-section endpoint. The Acalog detail pages
+      // embed a Prerequisites sentence — that's enough to enrich the
+      // semester planner's prereq chain for these colleges' courses.
+      // Brazosport, Dallas, Midland, Tyler Jr, Lamar State Orange,
+      // Wharton County — all six are Imperva-gated; the scraper acquires
+      // WAF cookies via headless Chromium once per base URL.
+      { scripts: ["scripts/tx/scrape-acalog-prereqs.ts"], runner: "playwright" },
+    ],
     // manual-only: programs — Phase 5+.
   },
 };

--- a/scripts/tx/scrape-acalog-prereqs.ts
+++ b/scripts/tx/scrape-acalog-prereqs.ts
@@ -1,0 +1,459 @@
+/**
+ * Texas — Acalog catalog → prereqs scrape
+ *
+ * Six TX community colleges publish their course catalog via Acalog but
+ * don't expose a public class-section endpoint we can scrape. The catalog
+ * IS publicly readable, and each course detail page embeds a Prerequisites
+ * sentence — that's enough to populate `data/tx/prereqs.json` for these
+ * colleges' courses so the semester planner's prereq chain resolves.
+ *
+ * Six catalogs covered (catoid + course-list navoid discovered via the
+ * one-shot probe at scripts/tx/_discover-acalog-navoids.ts on 2026-05-28):
+ *
+ *   brazosport-college              catoid=36  navoid=6282 (Course Directory)
+ *   dallas-college                  catoid=5   navoid=1222 (Course Descriptions)
+ *   midland-college                 catoid=21  navoid=4631 (Course Descriptions)
+ *   tyler-junior-college            catoid=20  navoid=1234 (Course Descriptions)
+ *   lamar-state-college-orange      catoid=6   navoid=554  (Course Descriptions)
+ *   wharton-county-junior-college   catoid=2   navoid=54   (Course Descriptions)
+ *
+ * Closely modeled on scripts/ms/scrape-catalog-prereqs.ts (the MS 6-college
+ * version). The catoid is auto-rediscovered each run via discoverAcalogCatoid
+ * so the scraper survives the annual catalog rollover; the navoid is
+ * hard-coded since Acalog's navigation tree numbers are stable.
+ *
+ * Output: merges new prereq entries into data/tx/prereqs.json without
+ * clobbering existing entries from section scrapers or Coursedog catalogs.
+ *
+ * Usage:
+ *   npx tsx scripts/tx/scrape-acalog-prereqs.ts
+ *   npx tsx scripts/tx/scrape-acalog-prereqs.ts --limit=20
+ *   npx tsx scripts/tx/scrape-acalog-prereqs.ts --college=brazosport-college
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { chromium } from "playwright";
+import { discoverAcalogCatoid } from "../lib/discover-catalog.js";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 60;
+const MAX_PAGES = 25;
+
+interface CollegeConfig {
+  name: string;
+  base: string;
+  catoid: number; // fallback — auto-rediscovered each run
+  navoid: number;
+}
+
+const COLLEGES: Record<string, CollegeConfig> = {
+  "brazosport-college": {
+    name: "Brazosport College",
+    base: "https://catalog.brazosport.edu",
+    catoid: 36,
+    navoid: 6282,
+  },
+  "dallas-college": {
+    name: "Dallas College",
+    base: "https://dallas.catalog.acalog.com",
+    catoid: 5,
+    navoid: 1222,
+  },
+  "midland-college": {
+    name: "Midland College",
+    base: "https://catalog.midland.edu",
+    catoid: 21,
+    navoid: 4631,
+  },
+  "tyler-junior-college": {
+    name: "Tyler Junior College",
+    base: "https://catalog.tjc.edu",
+    catoid: 20,
+    navoid: 1234,
+  },
+  "lamar-state-college-orange": {
+    name: "Lamar State College Orange",
+    base: "https://catalog.lsco.edu",
+    catoid: 6,
+    navoid: 554,
+  },
+  "wharton-county-junior-college": {
+    name: "Wharton County Junior College",
+    base: "https://wcjc.catalog.acalog.com",
+    catoid: 2,
+    navoid: 54,
+  },
+};
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+interface CourseDetail {
+  coid: string;
+  prefix: string;
+  number: string;
+  html: string;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// All six TX Acalog catalogs sit behind Imperva — bare `fetch` returns
+// HTTP 202 with an empty body until the JS challenge is solved. We pop a
+// headless Chromium per base URL once, harvest the cookies it sets after
+// the challenge clears, and attach them to every subsequent fetch.
+const wafCookies = new Map<string, string>();
+
+async function acquireWafCookies(baseUrl: string): Promise<string> {
+  const cached = wafCookies.get(baseUrl);
+  if (cached) return cached;
+  console.log(`  Acquiring WAF cookies via headless browser: ${baseUrl}`);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const ctx = await browser.newContext({ userAgent: UA });
+    const page = await ctx.newPage();
+    await page.goto(baseUrl, { waitUntil: "networkidle", timeout: 30_000 });
+    const cookies = await ctx.cookies();
+    const cookieStr = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    wafCookies.set(baseUrl, cookieStr);
+    return cookieStr;
+  } finally {
+    await browser.close();
+  }
+}
+
+async function retryFetch(
+  url: string,
+  label: string,
+  attempts = 3,
+  baseUrl?: string
+): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const headers: Record<string, string> = {
+        "User-Agent": UA,
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      };
+      if (baseUrl) {
+        const cookies = wafCookies.get(baseUrl);
+        if (cookies) headers["Cookie"] = cookies;
+      }
+      const res = await fetch(url, { headers });
+
+      // 202 = Imperva WAF challenge — solve via Playwright, then retry.
+      if (res.status === 202 && baseUrl && i === 0) {
+        await acquireWafCookies(baseUrl);
+        continue;
+      }
+
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status} on ${label}`);
+        await sleep(500 * (i + 1));
+        continue;
+      }
+      throw new Error(`HTTP ${res.status} on ${label}`);
+    } catch (e) {
+      lastErr = e;
+      await sleep(500 * (i + 1));
+    }
+  }
+  console.warn(`  ⚠ ${label} failed after ${attempts} attempts: ${lastErr}`);
+  return "";
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+function listUrl(
+  base: string,
+  catoid: number,
+  navoid: number,
+  cpage: number
+): string {
+  return (
+    `${base}/content.php?catoid=${catoid}` +
+    `&catoid=${catoid}` +
+    `&navoid=${navoid}` +
+    `&filter%5Bitem_type%5D=3` +
+    `&filter%5Bonly_active%5D=1` +
+    `&filter%5B3%5D=1` +
+    `&filter%5Bcpage%5D=${cpage}`
+  );
+}
+
+function detailUrl(base: string, catoid: number, coid: string): string {
+  return `${base}/preview_course_nopop.php?catoid=${catoid}&coid=${coid}`;
+}
+
+function extractCoids(html: string): string[] {
+  const matches =
+    html.match(/preview_course_nopop\.php\?catoid=\d+&(?:amp;)?coid=(\d+)/g) ||
+    [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+function extractCourseCode(
+  html: string
+): { prefix: string; number: string } | null {
+  const m =
+    html.match(/<h1[^>]*>\s*([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*[-–:]/) ||
+    html.match(/<title>\s*([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*[-–:]/);
+  if (!m) return null;
+  return { prefix: m[1].toUpperCase(), number: m[2] };
+}
+
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&ldquo;/g, "“")
+    .replace(/&rdquo;/g, "”")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+/**
+ * Extract prereq text from an Acalog detail page. Handles a few common
+ * Acalog formats (per MS scraper):
+ *   1. `(Prerequisite: text)` parenthesized inline
+ *   2. `<strong>Prerequisite(s):</strong> text<br>`
+ */
+function extractPrereqBlock(html: string): string | null {
+  let m = html.match(
+    /\(Pre-?requisite(?:s|\(s\))?\s*:\s*([\s\S]{1,2000}?)\)\s/i
+  );
+  if (m) return m[1];
+
+  m = html.match(
+    /(?:<strong>\s*)?Pre-?requisite(?:s|\(s\))?\s*:\s*(?:<\/strong>)?\s*([\s\S]*?)(?:<br\s*\/?>\s*(?:<br|$)|<\/p>|<strong>(?!<\/strong>))/i
+  );
+  if (m) return m[1];
+
+  return null;
+}
+
+function extractAnchorCoids(htmlBlock: string): string[] {
+  const matches = htmlBlock.match(/coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+const BOILERPLATE_RE =
+  /^(none|not applicable|n\/a|no prerequisites?)\s*\.?\s*$/i;
+
+async function scrapeCollege(
+  slug: string,
+  config: CollegeConfig,
+  limit: number
+): Promise<Map<string, PrereqEntry>> {
+  console.log(`\n--- ${config.name} (${slug}) ---`);
+  console.log(`  Base: ${config.base}`);
+
+  // Probe once; if Imperva is in front, acquire WAF cookies up front so
+  // the catoid auto-discovery below has cookies on its first attempt too.
+  try {
+    const probe = await fetch(config.base, {
+      headers: { "User-Agent": UA },
+      redirect: "follow",
+    });
+    if (probe.status === 202) await acquireWafCookies(config.base);
+  } catch {
+    await acquireWafCookies(config.base);
+  }
+
+  let catoid = config.catoid;
+  try {
+    const discovered = await discoverAcalogCatoid(config.base, config.catoid);
+    if (discovered > 0) catoid = discovered;
+  } catch {
+    // fall through to fallback
+  }
+  console.log(`  catoid=${catoid} navoid=${config.navoid}`);
+
+  // Paginate course list
+  const allCoids = new Set<string>();
+  for (let cpage = 1; cpage <= MAX_PAGES; cpage++) {
+    const html = await retryFetch(
+      listUrl(config.base, catoid, config.navoid, cpage),
+      `${slug}/list(cpage=${cpage})`,
+      3,
+      config.base
+    );
+    const coids = extractCoids(html);
+    if (coids.length === 0) break;
+    const before = allCoids.size;
+    for (const c of coids) allCoids.add(c);
+    if (allCoids.size === before) break; // no new coids — done
+    await sleep(100);
+  }
+  let coidList = Array.from(allCoids);
+  console.log(`  ${coidList.length} total coids`);
+
+  if (limit > 0) {
+    coidList = coidList.slice(0, limit);
+    console.log(`  Limited to ${limit} for smoke test`);
+  }
+
+  // Fetch detail pages
+  const details: CourseDetail[] = [];
+  const codeByCoid = new Map<string, string>();
+  await pmap(coidList, CONCURRENCY, async (coid) => {
+    const html = await retryFetch(
+      detailUrl(config.base, catoid, coid),
+      `${slug}/detail(${coid})`,
+      3,
+      config.base
+    );
+    if (!html) return;
+    const code = extractCourseCode(html);
+    if (!code) return;
+    details.push({ coid, prefix: code.prefix, number: code.number, html });
+    codeByCoid.set(coid, `${code.prefix} ${code.number}`);
+  });
+  console.log(`  Fetched ${details.length} course pages`);
+
+  // Parse prereqs
+  const prereqs = new Map<string, PrereqEntry>();
+  let resolvedAnchors = 0;
+  for (const d of details) {
+    const block = extractPrereqBlock(d.html);
+    if (!block) continue;
+
+    const text = htmlToText(block);
+    if (!text || BOILERPLATE_RE.test(text)) continue;
+
+    const courses = new Set<string>();
+    const codeRegex = /\b([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\b/g;
+    let m: RegExpExecArray | null;
+    while ((m = codeRegex.exec(text)) !== null) {
+      const code = `${m[1]} ${m[2]}`;
+      if (code !== `${d.prefix} ${d.number}`) courses.add(code);
+    }
+
+    for (const anchorCoid of extractAnchorCoids(block)) {
+      const resolved = codeByCoid.get(anchorCoid);
+      if (resolved && resolved !== `${d.prefix} ${d.number}`) {
+        courses.add(resolved);
+        resolvedAnchors++;
+      }
+    }
+
+    const key = `${d.prefix} ${d.number}`;
+    if (!prereqs.has(key)) {
+      prereqs.set(key, { text, courses: Array.from(courses).sort() });
+    }
+  }
+  console.log(
+    `  ${prereqs.size} courses with prereqs (${resolvedAnchors} anchor refs resolved)`
+  );
+  return prereqs;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limit = parseInt(
+    args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0",
+    10
+  );
+  const collegeFilter = args
+    .find((a) => a.startsWith("--college="))
+    ?.split("=")[1];
+
+  console.log("Texas multi-college Acalog prereq scraper");
+
+  const slugs = collegeFilter ? [collegeFilter] : Object.keys(COLLEGES);
+
+  // Load existing prereqs to merge with
+  const outDir = path.join(process.cwd(), "data", "tx");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  let merged: Record<string, PrereqEntry> = {};
+  if (fs.existsSync(outPath)) {
+    merged = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    console.log(`  Loaded ${Object.keys(merged).length} existing prereqs`);
+  }
+
+  for (const slug of slugs) {
+    const config = COLLEGES[slug];
+    if (!config) {
+      console.error(`Unknown college: ${slug}`);
+      continue;
+    }
+    try {
+      const collegePrereqs = await scrapeCollege(slug, config, limit);
+      let added = 0;
+      for (const [key, entry] of collegePrereqs) {
+        if (!merged[key]) {
+          merged[key] = entry;
+          added++;
+        }
+      }
+      console.log(
+        `  +${added} new (${collegePrereqs.size - added} already known)`
+      );
+    } catch (e) {
+      console.error(`  ⚠ ${slug} failed: ${e}`);
+      console.error(`  Continuing with remaining colleges...`);
+    }
+  }
+
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(merged).sort()) {
+    sorted[key] = merged[key];
+  }
+
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

The TX semester planner's prerequisite chain gets dramatically better. The `prereqs.json` file that powers "you must take X before Y" arrows grows from 831 to **2,162 unique courses** — a **2.6× increase** in a single PR. Concretely: when a TX student picks a course and the planner says "this course requires …", that hint will resolve correctly for ~1,331 more courses than it did yesterday, across six colleges that were previously catalog-only in our data.

The six colleges covered are Brazosport, Dallas College, Midland, Tyler Junior, Lamar State Orange, and Wharton County — all colleges where we couldn't scrape live class sections (their SIS is login-gated), so this Acalog ingest is the only way their courses' prereq info lands in our planner.

## What changes on the technical front

A new scraper at **`scripts/tx/scrape-acalog-prereqs.ts`**, closely modeled on the existing `scripts/ms/scrape-catalog-prereqs.ts` (a 6-college MS Acalog scraper). For each TX college, it:

1. Probes the catalog homepage, acquires Imperva WAF cookies via headless Chromium (all six TX Acalog hosts return HTTP 202 to bare `fetch`).
2. Auto-rediscovers the current `catoid` via `scripts/lib/discover-catalog.ts` so the scraper survives the annual catalog rollover.
3. Paginates the courses-list `navoid` to collect every `coid` (Acalog's per-course identifier).
4. Fetches each `preview_course_nopop.php?coid=…` detail page in parallel (concurrency 6, 60 ms gentle pacing) and extracts the embedded "Prerequisite(s): …" sentence.
5. Resolves the prereq sentence into both a human-readable `text` and a deduped `courses` list (anchor `coid=` refs in the sentence are resolved to actual course codes via the coid index).
6. Merges new entries into `data/tx/prereqs.json` without clobbering existing entries from section scrapers or the earlier Coursedog catalog ingest.

Per-catalog yield from the smoke run:

| College | Course pages | With prereqs | New in `prereqs.json` |
|---|---:|---:|---:|
| Brazosport | 780 | 317 | +197 |
| Dallas | 2,500 | 814 | **+570** |
| Midland | 842 | 415 | +199 |
| Tyler Junior | 1,127 | 473 | +203 |
| Lamar State Orange | 570 | 113 | +40 |
| Wharton County | 523 | 391 | +122 |
| **Total** | **6,342** | **2,523** | **+1,331** |

The navoid for each college's "Course Descriptions" page was discovered via a one-shot probe (now deleted; the discovered numbers are hardcoded in `COLLEGES`).

**`lib/states/tx/config.ts`** — declares the new scraper under `StateConfig.scrapers.prereqs` so the unified `scheduled-scrape.yml` workflow runs it on cron. Replaces the prior `// manual-only: prereqs — Phase 4.` marker.

## What's next (the rest of the TX plan)

- **C.2 (deferred earlier)** — Lone Star (~93k students) PS Classic with embedded guest credentials. SUBJECT_SRCH commit issue needs deeper debugging in a dedicated session.
- **F** — Bespoke Playwright sweep of the 8 deferred-investigation colleges (El Paso, Cisco, Clarendon, Frank Phillips, Western TX, Hill, Ranger, NETCC). Several look promising (Clarendon has a confirmed-public ASP.NET form; El Paso has Banner SSB but behind ADFS).
- CourseLeaf catalogs (San Jacinto, Grayson) deferred — different parser pattern from Acalog; smaller win than Phase E.

Cumulative state after merge:
- **Sections**: 32 / 59 colleges live (54%)
- **Prereqs**: 2,162 unique courses (was 416 before Phase D, 831 after Phase D; 2,162 after Phase E)
- **Transfers**: 187,494 rows across 29 CCs → 43 universities (unchanged since Phase A)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run check:scrapers` passes (41 states × 4 datatypes)
- [x] Smoke: Brazosport `--limit=20` → 6 prereqs extracted, sane format
- [x] Full run: all 6 catalogs scraped, 1,331 new prereqs merged into `prereqs.json`
- [x] WAF handling verified: all 6 catalogs returned HTTP 202 to bare fetch, succeeded after Playwright cookie acquisition
- [ ] Next scheduled-scrape cron tick re-runs the scraper without errors
- [ ] Post-merge: semester planner for e.g. Dallas College `BIOL 1408` resolves its prereq chain correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)