### PR TITLE
docs(pa): record probe-receipts for Bucks + Butler permanent gaps

### DIFF
--- a/lib/states/pa/config.ts
+++ b/lib/states/pa/config.ts
@@ -67,9 +67,17 @@ const paConfig: StateConfig = {
     // (CCAC, Luzerne, MC3, RACC), CampusNexus / Anthology
     // (Westmoreland), and a static JSON dump (Northampton).
     //
-    // The 5 colleges still without scrapers are:
-    //   - bucks         Workday Student (no template; needs investigation)
-    //   - butler        Ellucian Experience SSO portal only (no public SIS)
+    // The 5 colleges still without scrapers are permanent gaps —
+    // each was probed end-to-end and confirmed auth-only:
+    //   - bucks         Workday Student — 14 endpoints probed
+    //                   2026-05-28 (Workday /d/inst/, /d/anon/, /d/guest/,
+    //                   CXS catalog APIs, all SIS sibling subdomains,
+    //                   PDF + Acalog + Coursedog + SmartCatalogIQ
+    //                   tenants); every public-looking path JS-redirects
+    //                   to authgwy/bucks/login.htmld
+    //   - butler        Ellucian Experience SSO portal only — 17+ SIS
+    //                   probes all DNS-dead; only public link is to
+    //                   experience.elluciancloud.com/bccc564/
     //   - ccbc          Jenzabar JICS behind SAML
     //   - pa-highlands  Jenzabar JICS behind SAML
     //   - penn-college  SSO-gated (Penn State affiliate)


### PR DESCRIPTION
## What changes for someone using the site

Nothing. This is a one-line documentation diff in `lib/states/pa/config.ts` updating the comment that lists PA's 5 still-uncovered colleges. Code behavior is unchanged.

## What changes on the technical front

Makes Bucks's and Butler's classification explicit and dated, so a future investigator doesn't burn time re-probing them.

**Bucks** was investigated end-to-end on 2026-05-28 — 14 distinct probes:
- Workday public-looking paths: `/d/inst/`, `/d/anon/`, `/d/guest/`, multiple `/d/task/*` IDs
- Workday CXS catalog APIs: `Catalog_for_Course_Offerings/`, `Find_Course_Offerings/`
- All sibling SIS subdomains: `selfservice.bucks.edu`, `banner.bucks.edu`, `ssb.bucks.edu`, `my.bucks.edu`, `mybucks.bucks.edu`, `register.bucks.edu`, `ce.bucks.edu`, `catalog.bucks.edu` — all DNS-dead
- Third-party catalog tenants: `bucks.coursedog.com`, `bucks.smartcatalogiq.com`, Acalog — all 404 or no tenant
- PDF schedule probe — none published
- Static JSON probe (Northampton pattern) — no `.json` data file referenced anywhere
- `bucks.edu/catalog/courses/` — course descriptions only, no sections

Every public-looking Workday path JS-redirects to `authgwy/bucks/login.htmld`. There is no legacy SIS lingering alongside it.

**Butler** had the same probe shape — 17+ SIS subdomain DNS-dead probes, with `experience.elluciancloud.com/bccc564/` as the only public link. Ellucian Experience is the SSO portal aggregator, not a SIS.

## Branch chain

This PR is **based on `claude/pa-3more-colleges` (PR #722)**, not main, because #722 introduced the comment block this is editing. The correct merge order is:

1. Squash & merge #722 first (3 new PA scrapers + 3,806 sections)
2. Squash & merge this PR next (1-line comment update)

If GitHub doesn't let you merge until the base branch points to main, change this PR's base to main from the UI — the diff will rebase cleanly against the squash-merged #722.

## Test plan

- [x] `git diff --stat` shows only `lib/states/pa/config.ts | 14 +++++++++-----`
- [x] `npx tsc --noEmit` — no impact (comment-only change)
- [x] `npm run check:scrapers` — no impact (no scrapers added or removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)