### PR TITLE
feat(la): Northshore Coursedog catalog — 12th LCTCS college (prereqs +14)

### DIFF
--- a/data/la/coursedog-catalog/northshore-technical-community-college.json
+++ b/data/la/coursedog-catalog/northshore-technical-community-college.json
@@ -1,0 +1,5892 @@
+[
+  {
+    "prefix": "INTE",
+    "number": "2545",
+    "title": "Network Security",
+    "credits": 3,
+    "description": "This course is designed to provide an overview and understanding of established cyber security strategy as well as provide students with the opportunity to engage in strategic decision making in the context of cyber security. The course will assess current threats in varying contexts including conducting a threat or vulnerability assessment for a non-profit or government service organization, as well as evaluate current methodology and approaches to pave the way for the development and implementation of cyber security strategy at the organization or corporate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "1203",
+    "title": "Practical Nursing Perspectives",
+    "credits": 3,
+    "description": "This course includes the discussion of the concepts of health, health maintenance, and human development throughout the life cycle, effects of stress and related defense or coping mechanisms are introduced along with the use of therapeutic communication. The course identifies trends in health care and local, state, and national health resources available for the maintenance of health. Patients’ rights and responsibilities are explained to students as well as the local, state, and national resources that are available to help patients make informed decisions. Students learn about the role of the practical nurse, the history of practical nursing education, necessary vocational adjustments, and the Louisiana State Board of Practical Nurse Examiners, and an introduction to the laws and rules governing practical nursing practice in Louisiana (the Revised Statutes, Title 37, Chapter 11, Subpart II, Practical Nurses and LAC 46:XLVII, Nurses, Subpart 1, Practical Nurses). Legal, ethical, and cultural issues relevant to client care are addressed. Medical terms and commonly used medical/nursing abbreviations are also covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "2010",
+    "title": "Anatomy and Physiology II",
+    "credits": 2,
+    "description": "The study of the function and structure of muscular, circulatory, endocrine, reproductive, nervous and respiratory systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2125",
+    "title": "Pharm Tech Clinical Ext I",
+    "credits": 4,
+    "description": "This course provides the Pharmacy Technician clinical student the opportunity to work in pharmacy setting under the supervision of a registered pharmacist. Emphasis is placed on effective communication, understanding pharmacy operations, and dispensing of medications. The student will be assigned to community pharmacies as available preceptors permit for 120 externship hours. The 120 hours are expected to be achieved in the normal semester time frame of the course, usually 20-30 hours /week of commitment to this experiential training is required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1530",
+    "title": "System Protection",
+    "credits": 2,
+    "description": "This course is an introduction to power system components and power system protection. Topics include protection of generators and motors, protection of transformers and reactors, and protection of transmission lines.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2314",
+    "title": "Adv High Risk Maternal/Child",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1601",
+    "title": "Basic Electrical Fundamentals",
+    "credits": 5,
+    "description": "An introductory course in the basic concepts in D.C. and A.C. automotive electricity. Topics include Ohm’s Law, series and parallel circuits, Kirchhoff’s Voltage and Current Laws, Thevenin’s equivalent circuits, and A.C. power generation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "2140",
+    "title": "Intro Maritime Transportation",
+    "credits": 3,
+    "description": "Introduction to the business of maritime transportation focusing on the commercial aspects of shipping. The maritime transportation system as a whole is analyzed starting from the source of cargo to the end destination. Topics include concepts of shipping management, shipping regulatory frameworks, types of shipping, the role of marine terminals, and understanding freight rates. Several types of ships, shipping services and types of cargos are described including tramp shipping, chartering, passenger operations, industrial carriers, and inland waterway vessels.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2523",
+    "title": "Mental Illness/Psychiatric Nur",
+    "credits": 2,
+    "description": "This course is the study of the client experiencing emotional, mental and social alterations utilizing the nursing process approach with integrated pharmacology and application of life span principles. Geriatric considerations are addressed. Utilizing a nursing process approach, the student will perform applicable practical nursing clinical skills to clients in mental health facilities under the supervision and at the discretion of practical nursing faculty. This course includes a 30-hour clinical component.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2400",
+    "title": "Nursing Concepts III",
+    "credits": 5,
+    "description": "Focuses on nursing care of adult clients experiencing complex health problems. Focuses on nursing care of women of child-bearing age.Prerequisites: Successful completion of the first four semesters of the ASN curriculum pattern.",
+    "prerequisite_text": "Successful completion of the first four semesters of the ASN curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1310",
+    "title": "Patient/Hlth Navig Clinical II",
+    "credits": 1,
+    "description": "This course will provide the clinical experiences for entry-level patient navigators. Students will attend clinical experience in which they will shadow various healthcare personel in patient navigator roles in the inpatient, outpatient, and insurance settings. The students will experience the following areas during their clinical experience: Discharge planning, Insurance Navigators, and Clinic Population Health departments by specialty (must experience a minimum of 2 different clinic specialties).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1010B",
+    "title": "Anatomy and Physiology I",
+    "credits": 2,
+    "description": "This course is the study of human anatomy and physiology including chemical composition, cells, tissues, topography and the skeletal and digestive systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "2500",
+    "title": "Safety Mgmt, Training & Develo",
+    "credits": 3,
+    "description": "This course covers best practices for management of occupation health and safety procedures and training programs. Topics include the planning, organization, budgeting, resourcing, operating, implementation, reporting and evaluation of workplace safety. This course covers the topics in OSHA #2455.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HSOM",
+    "number": "1020",
+    "title": "Medical Terminology I",
+    "credits": 3,
+    "description": "This course covers basic medical terms and focuses on work analysis, spelling, and pronunciation with an explanation of medical terms used to describe health and disease. The body systems covered include the digestive, urinary, reproductive, nervous, and cardiovascular systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2411",
+    "title": "Practical Nursing III Clinical",
+    "credits": 4,
+    "description": "Students will utilize a nursing process approach to individualize client care, and will perform 180 hours of applicable practical nursing clinical skills in the care of multiple assigned adult and/or geriatric client(s) experiencing a variety of medical/surgical conditions. Students will also perform 25 hours of applicable practical nursing clinical skills with pediatric clients. Students are required to demonstrate use critical thinking skills while learning to make interdependent practical nursing decisions. All client care will be provided in approved health care facilities under the supervision, and at the discretion, of practical nursing faculty. This course includes 205 total clinical hours, 180 of which is in a med-surg setting and 25 in a pediatric setting.Requires: Concurrent enrollment in HNUR 2410; 2410 & 2411 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1230",
+    "title": "National Electric Code",
+    "credits": 4,
+    "description": "A study of the NEC calculations including: voltage/drops, fill capacities for boxes and conduits, service sizing, box sizing, grounding, and bonding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1440",
+    "title": "Basic Word Processing",
+    "credits": 3,
+    "description": "This course provides hands-on experience of word processing techniques and functions with emphasis on features and commands using a current version of word processing software.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1331",
+    "title": "Drywall",
+    "credits": 5,
+    "description": "A course covering the basic concepts and applications of carpentry. Includes safety, use of basic hand and power tools, and construction techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "2020",
+    "title": "Intermediate French II",
+    "credits": 3,
+    "description": "A course with emphasis on proficiency in reading and continuation of grammar review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "1300",
+    "title": "Intro to Regulatory Compliance",
+    "credits": 3,
+    "description": "This course covers OSHA Standards, policies, and procedures in general industry. Topics include the OSHA General Industry Standards, general industry principles and case studies emphasizing hazard identification and standards applications. This course covers OSHA #511 – Occupational Safety and Health Standards for General Industry as well as three NC3 3M PPE certifications: Head, Face and Eye Protection, Hearing Protection and Respiratory Protection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2033",
+    "title": "Piping Techniques",
+    "credits": 3,
+    "description": "Describe the different methods for joining plastic, copper and steel pipe. Describe the hangers and fasteners used to support pipe. Describe the protection of various pipes in concealed locations. Explain methods of pressure testing pipe.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2997",
+    "title": "Special Projects V",
+    "credits": 1,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1110",
+    "title": "Introduction & Safety",
+    "credits": 1,
+    "description": "This course provides an overview of the Building Technology Specialist occupational area. Topics include basic safety, fire prevention and health information to prepare individuals entering the work force.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2541",
+    "title": "Internship Part II: Culn Cafe",
+    "credits": 5,
+    "description": "Advanced experiential course involving all facets in regional foods preparation and in operations of culinary enterprises. Instructor approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2015",
+    "title": "Fundamentals of Client/Server",
+    "credits": 3,
+    "description": "Provides students with the knowledge and skills that are required to manage the latest Windows Operating System and Windows Server through systems design, deployment, management, and troubleshooting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1231",
+    "title": "Diesel Engine Control Systems",
+    "credits": 3,
+    "description": "This course will include the identity of type and functions of fuel injectors, nozzles, and unit injectors. Also, this course includes identification and functions of vehicle computer control systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SCML",
+    "number": "2300",
+    "title": "Transportation Management",
+    "credits": 3,
+    "description": "This course covers the modes of transportation as they relate supply chain and logistics issues. Along with inventory management and warehouse management course, this course also covers a portion of the topics for MSSC Certified Logistics Technician (CLT 4.0) including the global supply chain, the logistics environment, safety, safe equipment operation, material handling equipment, quality control, workplace communication, teamwork and problem solving and using computers for email and MS Office applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1412",
+    "title": "SMAW V Grove BU/Gouge",
+    "credits": 3,
+    "description": "Safely setup and operate Shielded Metal Arc Welding (SMAW) equipment with practice of V-Groove welds with a backing or back gouging in the flat, horizontal, vertical, and overhead positions using various electrodes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2410A",
+    "title": "Appl of Nursing Concepts III",
+    "credits": 4,
+    "description": "Application of the nursing process in the formulation, organization, and evaluation of care for selected groups of clients experiencing complex health problems. Application of the nursing process for women of child-bearing age.Prerequisites: Successful completion of first four semesters of the ASN curriculum pattern.",
+    "prerequisite_text": "Successful completion of first four semesters of the ASN curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1430",
+    "title": "Ground Maintenance",
+    "credits": 2,
+    "description": "Identification and use of equipment and chemicals used in daily pool maintenance. Also daily procedures, water analysis and treatment, filter and pump maintenance, and precautions in using and mixing chemicals.Dean of Technical Studies approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Practical Nursing program. Associate Provost of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1310",
+    "title": "Cutting Processes-CAC/PAC",
+    "credits": 2,
+    "description": "An introduction to the principals of safely operating Air Carbon Arc Cutting (CAC-A) and Plasma Arc Cutting (PAC) equipment including practice cutting and gouging ferrous and non-ferrous metals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1200",
+    "title": "Basic Industrial Scaffolding",
+    "credits": 3,
+    "description": "This simulation workshop provides the opportunity for hands-on practice with industrial scaffolding. Participants will actually demonstrate how to perform the proper methods of identifying, inspecting, erecting, dismantling, racking and stacking scaffolding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2005",
+    "title": "Professionalism for Pharm Tech",
+    "credits": 3,
+    "description": "This course reinforces the professional habits and soft skills required to bridge the gap between formal education/training and employment in a pharmacy setting . This course will consist of activities that will help reinforce the concepts and critical thinking skills that the pharmacy technician students have learned and will evaluate how well they can apply their new skills to the realistic pharmacy workplace environment. This course will address career readiness, planning, and management for the pharmacy technician. The course will help develop techniques in setting goals, creating a positive professional image, preparing a portfolio, and compiling a resume. This course will introduce and reinforce concepts and principles in pharmacy law and ethics as it relates to the role of a pharmacy technician.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1020",
+    "title": "Chemistry II NonScience Mjr",
+    "credits": 3,
+    "description": "The second of a two course lecture sequence in Introductory Chemistry for non-science majors. The topics to be covered include the kinetic molecular theory of gases, intermolecular forces, colligative properties, chemical equilibrium, oxidation and reduction with selected topics in radioactivity and nuclear chemistry, organic chemistry, and biochemistry. The course emphasizes understanding basic principles and problem solving.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "2020",
+    "title": "Intermediate Spanish II",
+    "credits": 3,
+    "description": "A course with emphasis on proficiency in reading and continuation of grammar review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1200",
+    "title": "Introduction To Power Safety",
+    "credits": 3,
+    "description": "This course will begin with a basic safety and fire prevention and an introduction to the systems and components that make up a basic electrical system, including generation, transmission and distribution.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1113",
+    "title": "EKG Applications",
+    "credits": 2,
+    "description": "This course introduces the student to the electrocardiogram (EKG) purposes and procedures. Students will gain knowledge regarding the normal structure and function of the heart with emphasis on the conduction system. A supervised lab portion (35 hours.) is an integral portion of this course and will allow student performance of EKG procedures. This course includes a minimum of 10 hours of clinical externship to be performed by the student under the supervision of a preceptor or course instructor in a variety of health care settings.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1310",
+    "title": "Pole Climbing",
+    "credits": 4,
+    "description": "This course is designed to provide instruction on climbing a utility pole safely using the latest OSHA fall resistant requirements. At the completion of this course, you will be able to safely ascend and descend a utility pole using gaffs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1340",
+    "title": "Deviance",
+    "credits": 3,
+    "description": "A study of the theories used to explain criminal behavior.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1230",
+    "title": "Family Relationships & Issues",
+    "credits": 3,
+    "description": "A study of the dynamics of family cycles, interpersonal relationships and application of principles of child and family development to relationships among young children, their families and teachers/ communities",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "2400",
+    "title": "Fire Protection and Prevention",
+    "credits": 3,
+    "description": "This course provides an in-depth exploration of fire prevention programs, focusing on fire inspection, code enforcement, and the application of model building standards and codes. Students will examine the legal, economic, and political aspects of the fire inspection process, as well as the essential components of plans review and public education initiatives. Emphasis is placed on understanding regulatory practices, fire-resistant construction materials, and the procedures for ensuring the safety and compliance of buildings with fire codes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1410",
+    "title": "Children With Special Needs",
+    "credits": 3,
+    "description": "A study of information regarding children with special needs including assessment and programming, strategies for developing adaptive environments, utilizing family input and community resources, legislation, and possible causes and characteristics of exceptionalities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2211",
+    "title": "Clinical Pathology II for VTs",
+    "credits": 2,
+    "description": "This course expounds on VETT 2111 to cover the advanced principles of clinical pathology including the fundamentals of microbiology and immunology, necropsy, and cytology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1103",
+    "title": "Animal Care & Handling",
+    "credits": 2,
+    "description": "This course introduces the basic care and husbandry of common companion and farm animals. This course will cover basic animal behavior as well as restraint and handling of domestic and exotic animals. Students will learn how to take a history and perform a physical examination. Species, breed, and sex determination of domestic animals will be covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1060",
+    "title": "Image Acquisition",
+    "credits": 3.5,
+    "description": "A study of the controlling and influencing factors that affect radiographic quality. This includes a study of Bremsstrahlung and characteristic radiation, radiographic artifacts, image qualities, and exposure factors.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1330",
+    "title": "Motors and Generators",
+    "credits": 3,
+    "description": "This course includes the fundamentals and principles of single phase and three phase motors and generators theory, application, and characteristics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "1020",
+    "title": "Elementary Spanish II",
+    "credits": 3,
+    "description": "This course is an elementary level course designed to develop and strengthen oral and written communication, reading, and listening skills. Students will be exposed to the language as a means of communication in order to develop communicative language ability. Therefore, your instructor will speak mainly Spanish in class, and English will be kept to a minimum. A laboratory fee is required for this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2400",
+    "title": "Patient/Hlth Navig Lead & Mgmt",
+    "credits": 2,
+    "description": "This comprehensive course in Patient/Health Navigator Leadership & Management is designed to equip healthcare professionals with the necessary skills and knowledge to excel in the critical role of guiding and supporting patients through the complex healthcare system. Navigators play a pivotal role in enhancing patient experience, improving health outcomes, and promoting effective communication between patients and healthcare providers. This course will assist students in the development of leadership skills and abilities essential for patient and health navigation, including effective communication, problem-solving, and decision-making in a healthcare context. Students will learn patient-centered care principles to enhance the quality of healthcare services, with an emphasis on empathy, cultural competence, ethical considerations in patient interactions, and health literacy. This course will assist students to gain a deep understanding of the healthcare system, including insurance processes, healthcare policies, and access to resources. This course is designed to assist students to develop strategies for efficient navigation within complex healthcare structures and the different roles of the healthcare team member. These students will learn principles of quality improvement and skills necessary in assessing and optimizing the effectiveness of patient navigation programs. This course will assist the student in developing skills in providing emotional support to patients facing health crises and crisis intervention techniques and strategies to address the emotional aspects of healthcare navigation. This course will also cover basic leadership and management principles & concepts. Students completing this course will be prepared to lead or supervise other patient navigators or a team of navigators.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1460",
+    "title": "Intro to Programmable Logic",
+    "credits": 3,
+    "description": "An introduction to Microprocessors, PLC types, theory, installation, applications, operations, and documentation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1620",
+    "title": "Plane Trigonometry",
+    "credits": 3,
+    "description": "This course is designed as a study of trigonometric functions. Topics include the laws of sine and cosine, the trigonometric functions and their graphs, inverse trigonometric functions, trigonometric identities and equations, and polar coordinate system. Trigonometry and trigonometric functions will be used to model and solve real world applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1440",
+    "title": "Motor Controls",
+    "credits": 3,
+    "description": "This course presents information on advanced motor control applications. Topics in-clude: installation and troubleshooting of motors, reversing starters, and VFD (Variable Frequency Drive).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1220",
+    "title": "Electrical Raceways",
+    "credits": 3,
+    "description": "An introduction to various methods of installing AC cable, EMT, rigid metallic conduit, PVC, flexible and surface raceway. Lab requirements include cutting, bending, and installing conduit.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2093",
+    "title": "Piping and Sizing",
+    "credits": 3,
+    "description": "Size supply systems correctly so that they reliably provide adequate water at the correct pressure. Properly install water supply systems. Calculate the correct pipe size for a system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ECON",
+    "number": "2010",
+    "title": "Principles of Macroeconomics",
+    "credits": 3,
+    "description": "The nature of economics, economic concepts and institutions, monetary theory, national income theory, financing of business, population problems and economic stability.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "1150",
+    "title": "PC Hardware & Software Lab",
+    "credits": 3,
+    "description": "PC Hardware and Software is a hands-on, career-oriented e-learning solutions with an emphasis on practical experience to help students develop fundamental computer skills, along with essential career skills. This course covers mobile devices, networking technology, hardware, virtualization and cloud computing, and network troubleshooting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2200",
+    "title": "Robotics II",
+    "credits": 3,
+    "description": "This course provides further exploration of industrial robot operations, programming and automation for multitasking applications, teaching robots in complex assembly environments, sensors, vision, payloads, motion control and factory integration principles. During this course students complete the requirements for NC3 Applied Robotics, which includes programming and troubleshooting a robot assembly workcell.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSN",
+    "number": "2000",
+    "title": "Intro to Supply Chain & Logist",
+    "credits": 3,
+    "description": "This course introduces learners to supply chain and logistics activities involved in the flow of products and information among the suppliers, producers, and distributors to fulfill consumer’s demand. Hands-on experiential learning activities are used to enhance learning of concepts and field trips and guest speakers are provided to demonstrated concepts in real world application. At the end of the course, students would be able to identify the supply chain units, describe the materials management processes, and use method and tools to solve organizational problems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SSPA",
+    "number": "1200",
+    "title": "Student Success & Study Skills",
+    "credits": 3,
+    "description": "SSPA 1200 is designed to help students create greater success in college and in life. In the course, students will learn proven strategies for succeeding in college, critical thinking, and learning and study strategies. Topics covered in the course include, but are not limited to, accepting personal responsibility, goal setting, studying skills, critical thinking, learning strategies, reading strategies, note-taking strategies, and test taking techniques. This course is required for all SLU Cross-Enrolled students who need Developmental Math and Developmental English courses.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1520",
+    "title": "Three-Phase URD Systems",
+    "credits": 2,
+    "description": "Three-phase circuits and power flow, analysis of magnetic circuits, performance of single-phase and three-phase transformers, principles of electromechanical energy conversion, steady-state characteristics and performance of alternating current and direct current machinery.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1250",
+    "title": "Comm and Industrial Wiring I",
+    "credits": 5,
+    "description": "An introduction to various methods of installing commercial and industrial wiring methods, AC cable, EMT, rigid metallic conduit, PVC, flexible and surface raceway. Lab requirements include cutting, bending, installing conduit, wiring commercial and industrial apparatus.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACCT",
+    "number": "2110",
+    "title": "Managerial Accounting",
+    "credits": 3,
+    "description": "Reviews the principles and methods of accounting primarily concerned with data gathering and presentation for the purpose of internal management and decision-making.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1100",
+    "title": "Records and Information Mgmt",
+    "credits": 3,
+    "description": "Introduction to basic records and information management. Includes the life cycle of a record, manual and electronic records management, basic filing procedures and rules. This course examines how different organizational, technological, regulatory, and cultural factors affect the strategies, practices, and tools that organizations can employ to manage electronic records. Problems of long-term preservation and con-tinuing access to electronic records are analyzed and addressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1300",
+    "title": "Tort Law for Paralegals",
+    "credits": 3,
+    "description": "This course introduces students to tort liability, more commonly known as personal injury law. The course examines the topics of intentional torts, negligence, strict liability, and products liability through statutory law and selected case law.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1803",
+    "title": "Advance Engine Performance",
+    "credits": 8,
+    "description": "A comprehensive course in the procedures and methods necessary to diagnose and repair fuel supply and fuel delivery systems. Topics include intake and exhaust systems, emissions controls systems, mechanical timing devices, and cooling system components.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2540",
+    "title": "InternshipPart I:Culinary Cafe",
+    "credits": 5,
+    "description": "Experiential course involving all facets of food preparation and operations in a culinary enterprise. Instructor approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HSOM",
+    "number": "1030",
+    "title": "Medical Terminology II",
+    "credits": 3,
+    "description": "HSOM 1030 is a continuation of HSOM 1020. It covers the respiratory system, blood system, lymphatic and immune systems, musculoskeletal system, oncology, radiology, nuclear medicine and radiation therapy, pharmacology, and psychiatry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Pharmacy Technician program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ARTS",
+    "number": "1005",
+    "title": "Beginning Painting",
+    "credits": 3,
+    "description": "This course introduces students to classical and contemporary painting, techniques and concepts. Painting from still-life, landscapes, self-portrait, and life models from observation will be geared towards realism, but various other styles could be explored. Color theory, compositional structure, visual perception, and critical thinking skills will be emphasized. Acrylic will be the primary medium for this class. Six hours of studio per week. Not counted as a Fine Arts elective.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1420",
+    "title": "Cabinetmaking",
+    "credits": 6,
+    "description": "This course teaches cabinetmaking skills. Topics include face frames, drawers, and raised panels.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "JOBS",
+    "number": "2450",
+    "title": "Job Seeking Skills",
+    "credits": 2,
+    "description": "This course assists students in making immediate and future decisions concerning job choices and educational growth by compiling résumés, evaluating job offers, and outlining information essential to finding, applying for, and terminating a job. It also includes personal/career assessments including foundational Work Keys assessments, application for the Louisiana Work Ready! (National Career Ready) Certificate. The completion of a student career presentation portfolio to minimum specifications will be a requirement for course completion.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1410",
+    "title": "Plumbing I",
+    "credits": 6,
+    "description": "A study of the tools, equipment, materials, and techniques used in the maintenance of plumbing systems. Emphasizes working with and joining pipe and tubing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1510",
+    "title": "Live Line Work Clearanc/Switch",
+    "credits": 2,
+    "description": "This course is to establish clear and consistent guidelines for live-line work. The term live-line maintenance, as used in this manual, includes maintenance activities using the hotstick or the barehanded technique.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2999",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RELG",
+    "number": "2015",
+    "title": "Intro to World Religion",
+    "credits": 3,
+    "description": "The purposes of this course is to acquaint students with certain issues in religious studies. Three such issues have been specifically identified for this course: 1) the philosophical foundations for a critical analysis of religion; 2) the foundations of Christianity; 3) and a cross-cultural examination of the major world religions. By selecting these three issues, it is intended that studnets will become sensitive to the philosophical nature and presuppositions of many religious claims, to the origin of Christianity and Christian beliefs about Jesus, and to the unique, as well as common perspectives of the major world religions",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2103",
+    "title": "Animal Nursing II",
+    "credits": 3,
+    "description": "This course will further develop clinical skills including but not limited to: radiographic positioning and acquisition, emergency and critical care, sample collection, and advanced technical skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1130",
+    "title": "Sanitation and Safety",
+    "credits": 2,
+    "description": "Safety and fire prevention, personal hygiene, and sanitary work procedures required to prevent food-borne illnesses.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1030",
+    "title": "Business English for MAs",
+    "credits": 3,
+    "description": "This course is a concentrated and intensive study of English grammar and usage as applied to business documents and applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2300",
+    "title": "Externship II",
+    "credits": 2,
+    "description": "This clinical experience is designed to expound upon the student’s knowledge, skill, and attitude. The tasks and duties to be performed in the externship will parallel the courses completed in the second year with a requirement of 150 hours of supervised clinical experience at an approved veterinary facility.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2210",
+    "title": "Fundamentals of Suspension",
+    "credits": 3,
+    "description": "The course includes the theory of operation and service procedures for medium/heavy duty truck suspension systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2310A",
+    "title": "Practical Nursing IIA",
+    "credits": 3,
+    "description": "This course includes theory related to nursing care provided to adult and geriatric clients experiencing alterations in the respiratory, gastrointestinal, and integumentary function. Included is a review of anatomy and physiology, therapeutic/modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process reviewed. This course includes 60 theory hours of medical-surgical nursing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1110",
+    "title": "Animal Anatomy Physiology Lab",
+    "credits": 1,
+    "description": "This lab is designed to reinforce lecture material and allow students to practice bone/joint identification and dissection of preserved specimens in order to identify major muscles and organs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2431",
+    "title": "Advanced Mill",
+    "credits": 4,
+    "description": "The advanced mill course allows students to perform multi-angular set-ups, gear cutting, advanced indexing operations and other advanced cutting operations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Pharmacy Technician program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1204",
+    "title": "Pipe Drafting",
+    "credits": 3,
+    "description": "The application of various industry standards to drawings and schematics utilized in process manufacturing, including piping components, equipment, structural systems and industry codes and practices. 2D AutoCAD and AutoCAD Plant 3D will be utilized in this course. Course concepts based on the Society of Piping Engineers and Designers credentialing exam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2211",
+    "title": "Practical Nursing I Clinical",
+    "credits": 4,
+    "description": "Students will begin to utilize a nursing process approach to individualize client care, and will perform applicable practical nursing clinical skills to assign adult and/or geriatric client(s) experiencing a variety of medical/surgical and mental health disorders in approved health care and mental health care facilities under the supervision and discretion of practical nursing faculty. This course includes a 180-hour clinical component in the Med-Surg setting and 25 hours in the Mental Health setting.Requires: Concurrent enrollment in HNUR 2210; 2210 & 2211 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 5,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1320",
+    "title": "Introduction to Spreadsheets",
+    "credits": 3,
+    "description": "This course focuses on the basic fundamentals of producing spreadsheets and graphs through problem-solving activities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2996",
+    "title": "Special Projects, IV",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2135",
+    "title": "Pharmacy Clinical Ext III",
+    "credits": 4,
+    "description": "This course provides the Pharmacy Technician clinical student the opportunity to work in pharmacy setting under the supervision of a registered pharmacist. Emphasis is placed on effective communication, understanding pharmacy operations, safe, and accurate dispensing of medications, and participation in others roles expected of a pharmacy technician. The student will be assigned to community and/or institutional pharmacies for 100 externship hours. The 100 hours are expected to be achieved in the normal semester time frame of the course, usually 20-30 hours /week commitment to this training is required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1203",
+    "title": "Avian & Exotic Medicine",
+    "credits": 2,
+    "description": "This course covers the anatomy, husbandry, preventative health, handling, nursing, and diseases of avian and exotic pets.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "1120",
+    "title": "Applied Lead. Develop Lab I",
+    "credits": 1,
+    "description": "The practical application of skills and knowledge taught during MS 1110. Laboratory develops importance of team building and individual contribution to mission accomplishment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2100",
+    "title": "Programmable Logic Controls II",
+    "credits": 3,
+    "description": "This course continues from PLC1 with advanced applications of PLC's using a smart factory industrial-grade training system. Emphasis will be on designing and troubleshooting electro-pneumatic and control circuits with solenoid-actuated valves, interacting with input and output devices (sensors, switches LEDs, pumps and motors), and communication/data collection from networked devices. During this course, students will progress through projects in NC3 Applied PLCs (Siemens and Allen-Bradley) certifications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1170",
+    "title": "Medical Terminology for MA",
+    "credits": 1,
+    "description": "Analyzing and combining prefixes, root words, and suffixes to spell, use and pronounce medical terminology correctly and recognize medical terms. Medical abbreviations are included.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSYC",
+    "number": "2040",
+    "title": "Developmental Psychology",
+    "credits": 3,
+    "description": "The purpose of this course focuses on human growth and development throughout the lifespan. Topics include developmental milestones, major theories and perspectives as they explain the developmental stages, and the research to explore language, socioemotional, physical, and cognitive development.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1207",
+    "title": "Parasitology for Vet Techs",
+    "credits": 2,
+    "description": "This course is the study of common internal and external parasites found in domestic animals. The characteristics, methods of transmission, life cycle, and clinical signs commonly seen in animals will be studied including a review of safety concerns when dealing with these samples.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1120",
+    "title": "Radiation Physics I",
+    "credits": 2.5,
+    "description": "This course is a study of the production and characteristics of radiation, electrostatics, dynamics and magnetism. Introduces mathematical concepts and measurements, the structure of matter and radiation interactions with matter.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1510",
+    "title": "Pharmacology I",
+    "credits": 2,
+    "description": "This course introduces the pharmacy technician student to the general principles of pharmacology, emphasizes drug therapy, defines major drug classifications, drug nomenclature and drug dosage forms. The course is designed to provide the Pharmacy Technician candidate with a foundation in drug related information and for actual preparation to dispense medications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1202",
+    "title": "Mechanical Design",
+    "credits": 3,
+    "description": "A study of the principles, methods, and standards used in the design and manufacturing of mechanical parts and assemblies through working drawings, according to industry-based standards and current practices using AutoCAD.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1110",
+    "title": "Prin of Patient/Health Navig I",
+    "credits": 3,
+    "description": "The course is designed to provide students with a foundational understanding of health navigation, a crucial aspect of healthcare management and patient advocacy. The course explores the fundamental principles, skills, and knowledge required for effectively guiding individuals through the complex healthcare system. Key topics covered: Introduction to health navigation, patient advocacy, specific medical terminology, immunizations, screenings, early detection methods, health promotion and education strategies for individuals and communities, documentation, the healthcare system, effective communication and interpersonal skills, evolution in healthcare navigation, and current trends and challenges in healthcare and patient/health navigation. Healthcare systems and policies, patient rights, and understanding medical records and health professionals documentation will be covered. This course is designed to assist students in understanding the role of the patient/health navigator in the multiple healthcare settings. Students will develop the necessary competencies to serve as effective health navigators, helping individuals navigate the complexities of the healthcare system and achieve optimal health outcomes by integrating theoretical concepts with practical skills through case studies, role-playing, and real-world scenarios.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "2997",
+    "title": "Special Projects V",
+    "credits": 1,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Medical Assistant program. Dean of Health Sciences approval required",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1430",
+    "title": "Blueprint Interpretation",
+    "credits": 4,
+    "description": "An introduction to blueprint reading skills, which includes specifications and trade-related elements. The course includes making a material list from a blueprint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1110",
+    "title": "Occupational Orient and Safety",
+    "credits": 3,
+    "description": "An introduction to the occupation of welding including facility layout, policies, safety, fire prevention and health procedures, information and practice concerning basic safety, safe operation of hand and power tools, materials handling and maintenance of a safe working environment. Students are also introduced to safe welding practices, communication and employability skills, and essential workplace skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2200",
+    "title": "Digital Tele Health",
+    "credits": 1,
+    "description": "This course is designed to equip patient navigators with the essential knowledge and skills needed to navigate the dynamic landscape of digital telehealth and health informatics. As the healthcare industry increasingly integrates technology to enhance patient care and streamline healthcare delivery, patient navigators play a crucial role in ensuring seamless communication and support for patients. This course will include an introduction to telehealth and its impact on healthcare delivery, various telehealth modalities (virtual visits, remote monitoring, teleconsultations, etc.), basic health informatics and its role in managing health information, electronic health records, and digital tools for patient navigation. Legal and ethical aspects of telehealth and health informatics, privacy regulations, data security, and patient confidentiality in the digital healthcare space will be taught. This course will explore cultural competence in telehealth and how to develop cultural competence in the context of digital healthcare delivery in a diverse and multicultural patient population. This course will cover patient empowerment and engagement for active patient participation in healthcare through digital tools with strategies for promoting patient engagement and adherence to telehealth interventions. The student will learn to identify common challenges and barriers in adoption of telehealth and how to problem-solve and develop strategies to address obstacles. This course will also briefly explore current trends and innovations in digital health.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1540",
+    "title": "Fundmen Skills For Crew Leader",
+    "credits": 1,
+    "description": "The course covers basic leadership skills and explains different leadership styles, communication, delegating, and problem solving. Job-site safety and the crew leader’s role in safety are also discussed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2210",
+    "title": "Bench Work",
+    "credits": 3,
+    "description": "A course that teaches the proper use and care of tools that are used by precision metalworkers. Topics include the techniques of manufacturing mechanical parts using layout tools, precision measuring tools, and various types of measuring instruments.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSN",
+    "number": "2100",
+    "title": "Career Mgmt & Communication",
+    "credits": 3,
+    "description": "This course provides opportunities for students to learn how to use computer networks and other traditional methods to facilitate the following tasks: compose and submit routine business messages; interact with peers on problem-solving teams; research, draft, format, and submit business reports; create and deliver business presentation; and seek and maximize job search resources. Activities in this class are designed to help achieve the following: effective communication skills and functional business knowledge.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1090B",
+    "title": "Radiographic Pathology",
+    "credits": 2,
+    "description": "A study of various pathological terminologies, conditions, injuries, tissues, systemic diseases and their relevance to radiographic procedures",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "The course is designed to prepare the practical nursing students for the NCLEX-PN exam. The course will provide the student with an overall review of material taught within the program and it will assist the student in developing constructive test taking skills and strategies in order to successfully complete their licensure examination.Requires: Concurrent enrollment in, or successful completion of, HNUR 2410, HNUR 2411, and HNUR 2813.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1420",
+    "title": "Judicial Process",
+    "credits": 3,
+    "description": "This course examines the role, function, and structure of the courts and their relationship to the criminal justice system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SSPA",
+    "number": "1000",
+    "title": "Student Success Pathways",
+    "credits": 3,
+    "description": "Student Success Pathways is designed to help students create greater success in college and in life. In the course students will learn proven strategies for academic, professional and personal achievement. Topics covered in the course include, but are not limited to, accepting personal responsibility, gaining self-awareness, discovering self-motivation, adopting lifelong learning, goal setting, decision making, study techniques, time/priority management, critical thinking skills, leaning styles, stress management, and career exploration. Program Coordinator approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1220",
+    "title": "Electrical Components",
+    "credits": 3,
+    "description": "This course provides instruction in identifying, installing and testing commonly used components in an air conditioning system. Topics include: pressure switches; overload devices; transformers; magnetic starters; other commonly used controls; diagnostic techniques; installation procedures; and safety.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2243",
+    "title": "Intro to Robotic Welding",
+    "credits": 3,
+    "description": "This course introduces students to robotic welding including safety, robotic welding set up and procedures, programming and comparing robotic vs manual welding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ACCT",
+    "number": "1010",
+    "title": "Accounting Fundamentals",
+    "credits": 3,
+    "description": "ACCT 1010 is designed to help students understand fundamental accounting concepts and principles, as well as to develop the capability to perform the basic accounting functions: the recognition, valuation, measurement and recording of the most common business transactions and the preparation of accounting statements.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1300",
+    "title": "Patient/Hlth Navig Clinical I",
+    "credits": 1,
+    "description": "This course will provide the clinical experience for entry-level patient navigators. Students will attend clinical experience in which they will shadow various employees in different settings at a facility with a community industry partner. The students will experience the following areas during their clinical experience: Patient Access and Registration in an inpatient, emergency room, and outpatient setting; Discharge Planning in the inpatient setting; Population health navigation in the outpatient setting; Insurance-based navigation. Students will observe assessments of social determinants of health, income-based needs, and specific health screenings. Students will be given a project to present to the class that explores a patient/health navigation topic in-depth during this clinical experience (e.g., HEDIS measures, heart health screening tools, etc.).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2330",
+    "title": "GMAW--Aluminum Multi-Joint",
+    "credits": 4,
+    "description": "An introduction to the principles of Gas Metal Arc Welding Aluminum (GMAW-A), component and consumable identification including the safe setup of equipment and practice of welding beads, fillet welds, and groove welds in the flat, vertical, horizontal, and overhead position.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2998",
+    "title": "Special Projects V",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1140",
+    "title": "Processing",
+    "credits": 7,
+    "description": "Introduction to the evaluation of radiographic systems to assure consistency in the production of quality radiographic services. Equipment quality control components identified and testing methods will be discussed. Taught in conjunction with Clinical Practice Applications III.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "POLI",
+    "number": "2010",
+    "title": "Introduction to American Gover",
+    "credits": 3,
+    "description": "A course designed to consider the basic aspects of American politics and government: institutions, mass political behavior, and public policy. The purpose of the course is to encourage students to think analytically and critically about the United States Federal Government and the American political system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1600",
+    "title": "Sterile Compounding Lab",
+    "credits": 2,
+    "description": "Provides hands-on experience in aseptic techniques, admixture preparation, incompatibility and stability, irrigation solutions, calculations for intravenous solutions, total parenteral nutrition and chemotherapy.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "1013",
+    "title": "Tools and Mechanics",
+    "credits": 3,
+    "description": "Learning to use the tools of the trade safely and maintain them properly is essential to the trade. Emphasis is given on the importance of investing in quality tools that pertain to the work they perform and skills they develop.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2900",
+    "title": "Internship/Job Seeking Skills",
+    "credits": 3,
+    "description": "The internship will be the final course taken by students in their last semester. Students will be assigned projects at the school site or at an employer’s site to gain practical hands-on workplace related skills. In addition, there will be opportunities for job seeking lectures on resume creation and skills to help with employment skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "2200",
+    "title": "Imperial & Modern Britain",
+    "credits": 3,
+    "description": "A detailed study of the British Isles from the rise of the Second Empire to the present. Three units on the British Empire and World War I (1900-20); Recovery, Depression, and World War II (1920-45); and Postwar Britain (1945-present). Includes in-depth coverage of the role of women and minorities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1220",
+    "title": "Infant/Todd Care & Curriculum",
+    "credits": 3,
+    "description": "Designing culturally sensitive environments and education practices appropriate to developmental needs of infant/toddlers from conception to age 3, including facilities, schedules, activities, and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2322",
+    "title": "GMAW--6G",
+    "credits": 4,
+    "description": "Safely setup and operate Gas Metal Arc Welding Pipe (GMAW-Pipe) equipment, proper assembly of a 6G - 45° fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 6G - 45° fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "1010",
+    "title": "Elementary Spanish I",
+    "credits": 3,
+    "description": "This course is an elementary level course designed to develop and strengthen oral and written communication, reading, and listening skills. Students will be exposed to the language as a means of communication in order to develop communicative language ability. Therefore, your instructor will speak mainly Spanish in class, and English will be kept to a minimum. A laboratory fee is required for this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2311",
+    "title": "Practical Nursing II Clinical",
+    "credits": 4,
+    "description": "Students will utilize a nursing process approach to individualize client care, and will perform 180 hours of applicable practical nursing clinical skills in the care of assigned adult and/or geriatric clients experience a variety of medical/surgical conditions. Students will also perform 30 hours of applicable practical nursing clinical skills with maternal and neonatal clients during the antepartum, intrapartum, and postpartum periods. Students are expected to demonstrate use of critical thinking skills while learning to make interdependent practical nursing decisions. All client care will be provided in approved health care facilities under the supervision, and at the discretion, of practical nursing faculty.This course includes a 205-hour clinical component, of which, 180 are in the Med-Surg clinical setting and 25 in Obstetrics setting.Requires: Concurrent enrollment in HNUR 2310; 2310 & 2311 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2011",
+    "title": "Communication and Work Ethics",
+    "credits": 1,
+    "description": "Instruction in the areas of problem-solving and effective interaction with others help to ensure success in the plumbing industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "1140",
+    "title": "Applied Lead. Develop. Lab II",
+    "credits": 1,
+    "description": "The practical application of leadership skills and light infantry squad tactics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1030",
+    "title": "Clinical Practice",
+    "credits": 5,
+    "description": "Students assigned to clinical education centers for supervised clinical practice and observation to include basic positioning, radiographic examinations, and patient care and communication skills. The rotation will emphasize the radiographic examinations covered in Radiographic Positioning I.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1650",
+    "title": "Pre-Calculus with Trigonometry",
+    "credits": 5,
+    "description": "This course is designed as a combined course covering advanced algebra and trigonometry. Topics include function properties and graphs; inverse functions; linear, quadratic, polynomial, rational, exponential and logarithmic functions with applications; systems of equations; trigonometric functions and graphs; inverse trigonometric functions; fundamental identities and angle formulas; solving trigonometric equations, triangles with applications; polar coordinate system. MATH 1650 is intended for students who must take MATH 2000 for their major.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1210",
+    "title": "Basic Diesel Electrical System",
+    "credits": 4,
+    "description": "An introductory class in electrical fundamentals. Topics covered in this course will include electrical safety practices; tool use; connecting and disconnecting techniques; direct current symbols, components, and sche-matics; principles of DC voltage and current; Ohm’s Law; and troubleshoot, repair, and calibrate electrical/electronic systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1410",
+    "title": "Garde Manager",
+    "credits": 4,
+    "description": "Principles of preparation of salads, cold sauces, appetizers, and garnishes and their applications. Emphasis on color, texture, and temperature in preparation and presentation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in practicum do not receive compensation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1000",
+    "title": "Intro to Paralegal Studies",
+    "credits": 3,
+    "description": "This course introduces students to the United States legal system, the legal profession in general, and the paralegal profession in particular. Special focus is given to the skills necessary to obtain paralegal employment, the various duties performed by paralegals, and the ethical obligations of paralegals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "0150",
+    "title": "Suppl Inst for Finite Math",
+    "credits": 1,
+    "description": "This course serves as supplemental instruction for Finite Mathematics. Instruction is an overview of topics in finite mathematics together with their applications and is taken primarily by students of the social sciences, communications, and liberal arts. This course includes linear equations, linear inequalities, linear programming, financial math, sets, counting, permutations, combinations, and introduction to probability and statistics, matrices.",
+    "prerequisite_text": "MATH1500",
+    "prerequisite_courses": [
+      "MATH1500"
+    ]
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1300",
+    "title": "Electric Line Safety",
+    "credits": 3,
+    "description": "Meets OSHA’s requirements for a construction industry training program. This course provides employees with best practices for some of the most common and hazardous situations on the job site.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "2110",
+    "title": "Basic Lead. Skills Develop. I",
+    "credits": 2,
+    "description": "Must be taken concurrently with MILS 2120. Discussion of leadership and its application to communication skills and human relations. Practical application of military writing--draft and edit military correspondence. Introduction to military briefings. Application of small unit tactics; individual and squad movement techniques--the responsibility of the leader.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2100",
+    "title": "Adv Prin of Patient/Hlth Navig",
+    "credits": 2,
+    "description": "The course is designed to provide students with an advanced and comprehensive understanding of health navigation, a crucial aspect of healthcare management and patient advocacy. The course explores the advanced principles, skills, and knowledge required for effectively guiding individuals through the complex healthcare system. Key Topics Covered: advanced motivational interviewing techniques, advanced health navigation principles, advanced patient advocacy, advanced medical terminology, advanced documentation, comprehensive information on the healthcare system, advanced communication and interpersonal skills, trends and evolutions in healthcare navigation, current advanced challenges in healthcare and patient/health navigation, healthcare systems, governmental policies, patient rights & ethics. Advanced concepts and solutions to social determinants of health and access to care will be covered. This course is designed to assist students in understanding the more advanced and specialized role of the patient/health navigator in multiple healthcare settings. This course will also include basic data collection and management concepts for navigators. The course integrates theoretical concepts with practical skills through case studies, role-playing, and real-world scenarios. Students will develop the necessary competencies to serve as effective health navigators, helping individuals navigate the complexities of the healthcare system and achieve optimal health outcomes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2302",
+    "title": "Intro to Oncology",
+    "credits": 3,
+    "description": "This comprehensive course serves as an essential introduction to the specialty concentration of Patient Navigation within the fields of Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults/Gerontology, or High-Risk Maternal/Child. Designed for individuals aspiring to navigate patients through the complex landscape of one of these concentrations. This course provides a foundational understanding of key concepts, skills, ethical and legal considerations. Students will leave this course with an understanding of the fundamentals of the chosen specialty concentration, including common conditions, symptoms, and prevalence. Students will be guided to examine the interconnected nature of patient issues and an understanding of the impact of co-occurring disorders. Students will learn patient-centered support techniques and will develop effective communication skills for engaging with patients and their families, emphasizing empathy and cultural competence particular to the specialty concentration. The student will learn strategies for promoting patient self-advocacy and shared decision-making in their specialty contexts. Students will learn to assist patients to navigate the complex healthcare system, including insurance, treatment options, and available support services for the specific specialty concentration. Students will understand the role of patient navigators in facilitating access to appropriate care and resources specific to the specialty concentration. Students will examine the ethical principles guiding patient navigation within the specialty concentration appropriate settings, understand legal considerations, confidentiality, and the importance of advocation for patients' rights. Students will learn the importance of interdisciplinary collaboration in addressing challenges, and develop skills for effective teamwork and communication with healthcare professionals, social workers, and community organizations. Students will gain insights into crisis intervention strategies for emergencies, and understand the signs of health risks and learn how to provide appropriate support and referral. In this course, students will learn to enhance cultural competence to navigate diverse populations with sensitivity, and explore the impact of cultural factors on the specialty concentration treatment and develop strategies for inclusive patient navigation. This course combines theoretical knowledge with practical skills, preparing participants to become effective patient navigator in the challenging and critical field chosen by the student for one of the following: Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults and Geriatric patients, or High-Risk Maternal/Child care. Through case studies, interactive discussions, and hands-on activities, participants will gain the expertise needed to support individuals on their journey to their specialty concentration.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1400",
+    "title": "Chronic Disease Prev & Mgmt I",
+    "credits": 3,
+    "description": "This course is designed to provide students with an overview of the principles, strategies, and interventions related to the prevention and management of chronic diseases. Chronic diseases, such as cardiovascular diseases, diabetes, and respiratory conditions, pose significant challenges to global health, requiring multifaceted approaches for effective prevention and management. Throughout this course, students will explore the pathophysiology of chronic diseases, risk factors, and the social determinants of health that contribute to their prevalence. Emphasis will be placed on evidence-based practices for preventing the onset of chronic diseases, as well as strategies for managing and mitigating their impact on individuals and communities. The definition, classification, global burden, epidemiology, and trends in prevalence of major chronic conditions will be covered. Students will learn the risk factors and determinants of these chronic diseases and explore behavioral, environmental, genetic, and socio-economic factors contributing to chronic diseases. Students will gain understanding of the social determinants of health and their impact on disease development, as well as lifestyle modifications, health promotion, and public health initiatives aimed at preventing the onset of the disease. This course will cover community-based interventions and policy approaches to promote healthy behaviors screening programs and early detection methods for those chronic diseases, and strategies for identifying and managing pre-existing risk factors to prevent disease progression. The student will learn evidence-based approaches to the clinical management of chronic diseases, including: patient-centered care, pharmacological interventions, and interdisciplinary healthcare collaboration. The student will learn techniques for effective patient education and behavior change, while learning to promote self-management and empowerment in individuals with chronic conditions. By the end of Chronic Disease Prevention and Management I, students will have gained a solid foundation in the complexities of these stated chronic diseases, equipping them with the knowledge and skills necessary for implementing effective prevention and management strategies in diverse healthcare settings. This course covers half of the Chronic Disease Prevention and Management content. Students will need to take PNAV 1410 to complete the full content of Chronic Disease Prevention and Management.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1130",
+    "title": "Child Guidance and Behaviors",
+    "credits": 3,
+    "description": "Typical, age-related behavior patterns, child guidance practices and their consequences; techniques and procedures for successful management.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2114",
+    "title": "FCAW Pipe 6G",
+    "credits": 4,
+    "description": "Safely setup and operate Flux Core Arc Welding pipe (FCAW-Pipe) equipment, proper assembly of a 6G(R) - 45° fixed position pipe joint with/without a restriction ring, proper weld quality, safe setup of equipment and practice welding a 6G(R) pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1505",
+    "title": "Pharm Tech Practice Lab I",
+    "credits": 2,
+    "description": "This course is designed to teach pharmacy technician students entry level skills performed in community and institutional pharmacy settings. The primary objective is to provide the students with practical, hands-on experience in the duties performed by a pharmacy technician in everyday pharmacy practice. This course addresses topics of instruction that includes information sources, reviewing and processing prescriptions and medication orders, applications of rules and regulations, non-sterile compounding, aseptic technique, calculations and business applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1251",
+    "title": "Alternative Fuel Systems",
+    "credits": 2,
+    "description": "This course includes an introduction to various fuel systems, components, and their functions and the proper storage, identification and grading of fuels.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1420",
+    "title": "Advanced Spreadsheets",
+    "credits": 3,
+    "description": "This course contains advanced techniques for developing and modifying spreadsheets, and includes macros and data analysis functions, linked worksheets, workgroup features, creation of “what-if” scenarios and pivot tables.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNUR",
+    "number": "1001",
+    "title": "Intro. to Nursing Studies",
+    "credits": 4,
+    "description": "This course is designed to assist students in transitioning to nursing to gain necessary skills for success in the Practical Nursing and Registered Nursing programs.Course content includes medical terminology, medical abbreviations are included. Introduces identifying body structures with the appropriate medical terminology. Students will get through this content in an asynchronous format over the duration of the course. This course also contains a self-paced program that will develop each student's academic readiness to equip them with the knowledge and skills to prepare for Nursing program entry. Course content includes basic academic subjects: reading comprehension, math, science, and English; intensive review of anatomy and physiology fundamentals; skill building study techniques. This program will require coaching sessions with a virtual instructor. Additionally, the course will include virtual synchronous lessons on fundamental numerical operations needed for Healthcare workers. The Lab component will expose students to basic nursing skills concepts for the entry-level healthcare worker that includes Basic Concepts for the Healthcare worker and Code of Conduct for Nursing students.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1220",
+    "title": "Advanced Diesel Electrical Sys",
+    "credits": 4,
+    "description": "A course covering the theory of operation, repair and diagnostic procedures used on heavy-duty truck and tractor electrical systems, electronic engines and transmissions. Topics covered in this course will include the study of DC resistance and conductors, principles of DC circuits, fundamentals of alternating current and semiconductors, basic electronic circuits, and digital electronics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1100",
+    "title": "Gen Biology I (Science Major)",
+    "credits": 3,
+    "description": "Principles of biology from the cellular level including biochemistry, cell biology, metabolism, photosynthesis, molecular biology, and genetics. This course is designed for students planning to major in biology or related discipline.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1100",
+    "title": "Methods of Patient Care",
+    "credits": 1,
+    "description": "Classroom lectures and discussions that are designed to develop competency in the fundamentals of patient care and to better understand the patient’s physical and emotional needs in radiographic preparation/procedures. Also, this course will introduce the specifics of radiographic nursing procedures and will include venipuncture techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2110",
+    "title": "PN Foundations & Perspectives",
+    "credits": 6,
+    "description": "This course focuses on the qualities and personal characteristics needed to practice practical nursing safely, effectively, and with compassion, including development of self-awareness and critical thinking. The course includes instruction in the history, trends and evolution of practical nursing, as well as the laws and rules governing practical nursing as defined by the Louisiana Revised Statutes, Title 37, Chapter 11, Subpart II-Practical Nurses and LAC 46:XLVII.Nursing, subpart 1 - Practical Nurses. Ethical, legal and cultural issues and trends, communication techniques, and personal and family growth and development are addressed. The course includes discussion of the concepts of health maintenance, restoration and rehabilitation, with identification of available local, state and national health maintenance resources. Emphasis is placed on foundational nursing concepts, including health assessment, and clinical reasoning using the nursing process to meet the physiological, psychosocial, socio-cultural, and spiritual needs of clients in various health care environments and across the lifespan. Special emphasis is placed on the normal aging process, care of the elderly, and end-of-life care. Safety and infection control, including information on microbes, modes of transmission, methods of destruction or control, and skills to prevent the spread of infections are also emphasized as part of this course.Requires: Concurrent enrollment or successful completion of HNUR 2000 and HMDT 1170. Concurrent enrollment in HNUR 2111; 2110 & 2111 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2810",
+    "title": "Commercial Air Conditioning I",
+    "credits": 6,
+    "description": "This course introduces fundamental theory and techniques to identify major components and functions of commercial systems. Instruction is given on types of commercial air conditioning systems pressure, and temperature charts.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "1103",
+    "title": "Valves and Water Heaters",
+    "credits": 3,
+    "description": "Determine proper valve selection and understand the intended application as well as the valve's material, size, and rating. Learn to install and service centrally located water heaters.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2130",
+    "title": "Brakes",
+    "credits": 4,
+    "description": "The course includes nomenclature, theory of operation, and ser-vice procedure for medium/heavy duty truck braking systems to include air and hydraulics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1500",
+    "title": "Basic Pharmacology Patient/Hlt",
+    "credits": 3,
+    "description": "This course is designed to provide patient and health navigators with a basic understanding of pharmacology, equipping them with the knowledge necessary to support patients in managing their medications effectively. The course covers essential basic concepts in pharmacology, drug classifications, and their impact on various health conditions. Participants will develop the skills needed to communicate medication information to patients, address common concerns, and assist in fostering medication adherence. Students will learn the major drug classifications and therapeutic uses, identification of common medications for various health conditions, and the differentiation between prescription and over-the-counter drugs. Students will learn techniques for effective communication with patients about medications, approaches for addressing patient concerns, fears, and misconceptions related to medication, as well as strategies for promoting medication adherence and understanding the importance of follow-up. Students will learn to recognize and assist patients in understanding and managing common side effects and adverse reactions, and awareness of drug allergies and interactions. The influence of cultural beliefs and practices on medication adherence will be covered, along with strategies for providing culturally sensitive medication information. Students will learn basic math for meds for basic dosage and calculations for in-home patient and health navigators to play a vital role in supporting patients in their medication journeys. Upon completion, participants will be better equipped to navigate the complexities of pharmacology, foster patient understanding, and contribute to improved health outcomes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2012",
+    "title": "Pharmacy Clinical Externship I",
+    "credits": 4,
+    "description": "This course provides the Pharmacy Technician clinical student the opportunity to work in pharmacy setting under the supervision of a registered pharmacist. Emphasis is placed on effective communication, understanding pharmacy operations, and dispensing of medications. The student will be assigned to retail and/or hospital pharmacies for 180 hours.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HEMS",
+    "number": "1200",
+    "title": "Emergency Medical Tech I",
+    "credits": 3,
+    "description": "This course provides and introduction to the roles, responsibilities and scope of practice of the EMR within the EMS, and emphasizes protecting the well-being of the EMR. Instruction is provided in medical/legal/ethical and cultural issues, communication and documentations techniques, anatomy, physiology, and pathophysiology of the human body, methods utilized in lifting and moving patients, procedures for maintaining open airways and oxygenation, resuscitation, obtaining a medical history and vital signs, principles of assessment, and general pharmacology. Treatment of a variety of medical emergencies are covered in the course, as well as bleeding, shock, soft tissue, musculoskeletal, chest and abdominal injuries. Practical application of EMR skills are included in the classroom setting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2220",
+    "title": "GTAW - PIPE 5G",
+    "credits": 4,
+    "description": "An introduction to the principals of Gas Tungsten Arc Welding of Pipe (GTAW-Pipe) in the 5G horizontal fixed position, proper assembly of a 5G pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G horizontal fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "1115",
+    "title": "Application of Nursing Fundame",
+    "credits": 1,
+    "description": "Provides the foundation upon which subsequent technical skills are developed. Acquisition of competency in nursing skills in a supervised laboratory setting. Limited clinical laboratory practice will be arranged in selected health care agencies. Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENTP",
+    "number": "1000",
+    "title": "Fundamentals of Entrepreneur",
+    "credits": 3,
+    "description": "The purpose of this course is to introduce the students to those basic thoughts, skills, and ideas that are common to new ventures. The course is taught by leading the students through the process of finding and developing an idea and summarizing what they discover and conclude in a \"business concept plan.\" Topics include an introduction to major business concepts, including strategy, finance, and industrial organization.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENGL",
+    "number": "2020",
+    "title": "American Literature",
+    "credits": 3,
+    "description": "This course is designed to introduce students to poetry, prose, and drama produced by significant writers of American literature, with an emphasis on the development of understanding and appreciation. In this course, students will be exposed to representative works from major periods of American literature. Each reading assignment will be discussed in class and supplemented with lectures, notes, and assignments.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "2120",
+    "title": "Introduction To Marine Safety",
+    "credits": 3,
+    "description": "This course indoctrinates students to a comprehensive maritime safety culture. Personal conduct, awareness and knowledge focused on understanding the laws and liabilities associated with employment in the industry is emphasized to ensure marine safety competencies and compliance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1130",
+    "title": "Communication & Emp Skills",
+    "credits": 2,
+    "description": "This course is designed to develop communication skills and interpersonal skills of individuals entering the workforce.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1110",
+    "title": "Working With Young Children",
+    "credits": 3,
+    "description": "An introduction to Care and Development of Young Children as a part of total education to include the study of CLASS domains instructional support, engaged support for learning and responsive caregiving; professionalism, technology and developmentally appropriate practices (DAP).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HEMS",
+    "number": "1170",
+    "title": "EMT - Ambulance Operation",
+    "credits": 1,
+    "description": "Discussion of emergency vehicles operation, gaining access, roles and responsibilities at the crash scene, hazardous materials, incident management systems, mass casualty situations, and basic triage. Included are observation and the practical application of EMT-Basic skills in various clinical sites under the supervision of a preceptor and /or faculty.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "1361",
+    "title": "Pharmacology Applications",
+    "credits": 2,
+    "description": "Medical math is an integral component of this course. The terminology and principles of medication administration are presented in this course. Drug classifications and their effect on the various body systems are presented. Specific drugs in each classification are emphasized according to expected effects, side effects, and adverse effects. Routes of drug administration and variables that influence drug action are covered including dangerous drug interactions and nursing implications related to each drug. Safety precautions which will help to decrease the incidence of errors in medication administration are stressed. Advanced medication calculations will be required to demonstrate knowledge of safe dosing parameters. The nursing process is utilized to assess the client’s learning needs and effects of all pharmacological interventions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1630",
+    "title": "Applied Calculus",
+    "credits": 3,
+    "description": "This course is designed as an introduction to differential and integral calculus designed for non-STEM majors. Topics will include limits, the derivative, applications of the derivative, antiderivatives, and the definite integral. Polynomial, rational, radical, exponential, and logarithmic functions will be studied.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "2413",
+    "title": "Mental Health Nursing",
+    "credits": 3,
+    "description": "The student utilizes the nursing process to provide care to clients experiencing psychopathological, emotional, and behavioral alterations. Appropriate pharmacological agents, their actions, uses, and side effects are discussed. Client education on proper nutrition and diet modifications related to the use of these medications are stressed as well as proper nutrition and diet therapy necessary for health restoration and to maintain health are included in the discussions. Health promotion activities necessary to promote and maintain optimal mental health are explored. Using the nursing process, students demonstrate appropriate communication techniques and have the opportunity to participate as a member of a multidisciplinary health care team in the care of a selected client in the mental health setting. This course includes a 45-hour clinical component.Note: Students must pass both the theory and clinical components of this course with 80% in each component to successfully complete the course and advance in the Practical Nursing Program.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2530",
+    "title": "Residential System Design",
+    "credits": 2,
+    "description": "This course presents theory and practice of different types of residential air conditioning systems heat loads. Topics include calculations, duct design, air filtration, and safety practices.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1175",
+    "title": "Allied Health Algebra",
+    "credits": 2,
+    "description": "Allied Health Algebra is designed to provide basic skills in elementary algebra. The major topics include: operations with rational numbers, simplifying variable expressions, solving equations and inequalities, ratio and proportions, and operations with exponents and polynomials.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2550",
+    "title": "Residential Heating II",
+    "credits": 3,
+    "description": "This course presents the application of service procedures, controls (electrical & gas), gas valves, piping, ventilation, code requirements and safety for gas and electrical heating systems for residential and small commercial uses.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2520",
+    "title": "Drugs Crime and Society",
+    "credits": 3,
+    "description": "This course provides an overview of drug use in modern society, with a focus on relating the latest information on drugs to their effects on society and human behavior.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "2315",
+    "title": "Anatomy & Physiology LAB II",
+    "credits": 1,
+    "description": "A course designed to utilize a series of laboratory exercises to illustrate the course material in BIOL 2300. This course includes anatomical and physiological studies of the endocrine, cardiovascular, respiratory, digestive, excretory, and reproductive systems, as well as dissections.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2321",
+    "title": "GMAW--Pipe 5G",
+    "credits": 4,
+    "description": "Safely setup and operate Gas Metal Arc Welding pipe (GMAW-Pipe) equipment, proper assembly of a 5G horizontal fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G horizontal fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "1100",
+    "title": "Intro to Workplace Safety",
+    "credits": 3,
+    "description": "This course explores the safety and health management responsibilities for frontline workers, focusing on the significant hazards typically encountered in industrial environments. Participants will learn various methods for controlling workplace hazards and enhancing safety protocols. Key topics include understanding safety-related roles and responsibilities, identifying common occupational hazards, and applying hazard identification and analysis techniques. The course also covers approaches to safety and health management systems for controlling workplace risks and integrates adult learning strategies for effective workplace safety and health training.Upon successful completion of this course, students will be prepared for the following training/certifications: OSHA 10 & 30 DOL completion cards; NC3 Data Analytics 1.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2611",
+    "title": "IV Therapy",
+    "credits": 1,
+    "description": "The role of the practical nurse, legal implications of intravenous (IV) therapy, and equipment/devices used, anatomy/physiology, methods and techniques, infection control measures, complications, and other vital information related to intravenous therapy is discussed. Supervised lab performance (15hrs) is an integral part of this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1650",
+    "title": "Basic Desktop Publishing",
+    "credits": 3,
+    "description": "This course introduces students to the principles of design applicable to publications created using desktop publishing software and computer technology. Emphasis is on efficient use of a page layout software package to create, design, and print publications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2211",
+    "title": "Practicum In CDYC",
+    "credits": 5,
+    "description": "Individualized program under supervision and guidance; practical or field experience in organized programs in Care and Development of Young Children.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1500",
+    "title": "Introduction to Computers",
+    "credits": 3,
+    "description": "The course prepares students to work with latest version of Microsoft Office in a career setting or for personal use. Using courseware that incorporates an accelerated, step-by-step, project-based approach, students develop an introductory-level competency in Word, Excel, Access, and PowerPoint and explore the essential features of the latest version of Windows and Internet Explorer. Students also develop an understanding of key ethical issues they face in the context of using information technology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2552",
+    "title": "Criminal Justice Externship",
+    "credits": 3,
+    "description": "Students will become familiar with the daily aspects and duties of various criminal justice agencies. They will be introduced to areas of law enforcement, corrections, parole, probation, juvenile facilities, marshal office, and border patrol agencies. They will apply theories and concepts introduced in the classroom to the realities of life that criminal justice agents face on a daily basis. This experience will add to the students’ classroom knowledge.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1330",
+    "title": "Motors and Generators",
+    "credits": 3,
+    "description": "This course includes the fundamentals and principles of single phase and three phase motors and generators theory, application, and characteristics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1225",
+    "title": "Clinical Medical Assisting I",
+    "credits": 5,
+    "description": "This course discussed federal regulations and guidelines including CDC, CLIA88, OSHA Standards, and universal precaution. Emergency procedures, first aid and CPR, infection control measures, laboratory safety and quality control issues, rehabilitation, medical practices, general safety measures/precautions used in the office/facility environment for employee/patient/client safety issues are also included. Orientation to clinical facilities is introduced. This course also provides basic knowledge of drug classifications, mathematical computations and principles of medication administration as it related to the Medical Assistant.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "2100",
+    "title": "History of Louisiana",
+    "credits": 3,
+    "description": "The course explores major political, economic and cultural influences on the development of Louisiana. Includes in-depth coverage of the role of women and minorities, with particular attention to African-American and Cajun influence. Lectures, readings, and discussions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "2130",
+    "title": "Basic Lead. Skills Develop. II",
+    "credits": 2,
+    "description": "A discussion of leadership relating to a small unit leader’s mission analysis and planning to accomplish the selected course of action; supervision to accomplish a task, motivational techniques to influence others and molding a unit as a team. A survey of leadership case studies. The fundamentals of map reading: marginal information, the grid system, the contour system and the method of navigating using a military map and lensatic compass.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1320",
+    "title": "Preschool Curriculum",
+    "credits": 3,
+    "description": "An introduction to Care and Development of Young Children as a part of total education to include the study of CLASS domains emotional support, emotional and behavioral support, and responsive caregiving; families.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1130",
+    "title": "Sanitation and Safety",
+    "credits": 2,
+    "description": "Safety and fire prevention, personal hygiene, and sanitary work procedures required to prevent food-borne illnesses.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2200",
+    "title": "Digital Tele Health",
+    "credits": 1,
+    "description": "This course is designed to equip patient navigators with the essential knowledge and skills needed to navigate the dynamic landscape of digital telehealth and health informatics. As the healthcare industry increasingly integrates technology to enhance patient care and streamline healthcare delivery, patient navigators play a crucial role in ensuring seamless communication and support for patients. This course will include an introduction to telehealth and its impact on healthcare delivery, various telehealth modalities (virtual visits, remote monitoring, teleconsultations, etc.), basic health informatics and its role in managing health information, electronic health records, and digital tools for patient navigation. Legal and ethical aspects of telehealth and health informatics, privacy regulations, data security, and patient confidentiality in the digital healthcare space will be taught. This course will explore cultural competence in telehealth and how to develop cultural competence in the context of digital healthcare delivery in a diverse and multicultural patient population. This course will cover patient empowerment and engagement for active patient participation in healthcare through digital tools with strategies for promoting patient engagement and adherence to telehealth interventions. The student will learn to identify common challenges and barriers in adoption of telehealth and how to problem-solve and develop strategies to address obstacles. This course will also briefly explore current trends and innovations in digital health.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1310",
+    "title": "Community Based Corrections",
+    "credits": 3,
+    "description": "History, philosophy, operations of the correctional system’s absence of incarceration, including probation, parole, diversion, other alternatives; stress on community role and responsibility in crime prevention, offender programs, and improvement of correctional processes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "1500",
+    "title": "World Hist Perspective of Oil",
+    "credits": 3,
+    "description": "This course is designed to focus on the major events, themes, and people who influenced the oil industry from its beginnings in the Industrial Revolution to the present day. Emphasis will be placed on the political and social importance of oil on modern history.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2111",
+    "title": "Clinical Pathology I for VTs",
+    "credits": 2,
+    "description": "This course covers the basic fundamentals of hematology and urinalysis. Emphasis is placed on testing procedures, clinical significance of the tests, and quality control on performing the tests.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "1850",
+    "title": "Intro to Linux",
+    "credits": 3,
+    "description": "This course is designed to provide students with the skills needed to install and support the Linux operating system, including user administration, file permissions, software configurations, and the fundamental management of Linux systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1100",
+    "title": "Methods of Patient Care",
+    "credits": 1,
+    "description": "Classroom lectures and discussions that are designed to develop competency in the fundamentals of patient care and to better understand the patient’s physical and emotional needs in radiographic preparation/procedures. Also, this course will introduce the specifics of radiographic nursing procedures and will include venipuncture techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "2110",
+    "title": "Marine Hazardous Materials",
+    "credits": 3,
+    "description": "This course will introduce the student to the laws, standards and regulations that apply to hazardous materials incidents and response and provide the student with information to recognize a hazardous materials incident, appropriate notification procedures, appropriate authorities, and how to maintain the safety of personnel. The student will acquire the knowledge and skills of how to take defensive actions at a scene involving hazardous materials or hazardous waste and in doing so protect themselves, the public, property, and the environment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1240",
+    "title": "Applied Elec & Troubleshooting",
+    "credits": 3,
+    "description": "This course provides instruction on wiring various types of air conditioning systems. Topics include: servicing procedures; troubleshooting procedures; solid state controls; system wiring; control circuits; and safety.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1140",
+    "title": "Engines I",
+    "credits": 3,
+    "description": "Engine disassembly is performed and basic parts operation and service are explained forrebuilding of light- and medium-duty diesel engines. Troubleshooting and tune-up procedures are performed on the different engine designs. The course will include disassembly, inspection and evaluation, repair and reassembly of engines.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "1020",
+    "title": "Historical Geology",
+    "credits": 3,
+    "description": "Study of the origin and history of the earth and the development of life on Earth as revealed in the rocks and fossils. Major topics include the formation of the universe and Earth, plate tectonics, geologic time, sedimentary processes and fossilization, and evolution. Students will also explore each of the major eons and eras of geologic time in sequence to explore the changes in Earth's landscapes and life.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1120",
+    "title": "Health, Safety & Nutrition",
+    "credits": 3,
+    "description": "This course examines fire prevention, health, safety, and nutrition for children. Topics covered include: signs and symptoms of common communicable diseases, pediatric first aid, and infant/child Cardiopulmonary Resuscitation (CPR). Also covered is application of the principles of nutrition to children with emphasis on prenatal nutrition, the special requirements of various age levels from birth through adolescence, and problems related to children and nutrition. Menus that meet nutritional needs for all children are planned and prepared.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "2110",
+    "title": "Basic Lead. Skills Develop. I",
+    "credits": 2,
+    "description": "Must be taken concurrently with MILS 2120. Discussion of leadership and its application to communication skills and human relations. Practical application of military writing--draft and edit military correspondence. Introduction to military briefings. Application of small unit tactics; individual and squad movement techniques--the responsibility of the leader.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2920",
+    "title": "Commercial Refrig Controls",
+    "credits": 7,
+    "description": "This course places emphasis on the service of commercial refrigeration systems and safety. Also provides troubleshooting and repair of major component parts of a commercial refrigeration systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1214",
+    "title": "Nursing Assistant Skills Appli",
+    "credits": 1,
+    "description": "The student will perform, demonstrate, and practice a minimum of 45 hours of basic nursing assistant care in approved facilities, to include a minimum of 40 hours of long term care, under the supervision of NTCC faculty. The application of the nursing process will be used in meeting biological, psychosocial, cultural, and spiritual needs of geriatric clients in selected environments. Major components included are rehabilitative care and support of death with dignity utilizing therapeutic and preventive measures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "0150",
+    "title": "Suppl Inst for Finite Math",
+    "credits": 1,
+    "description": "This course serves as supplemental instruction for Finite Mathematics. Instruction is an overview of topics in finite mathematics together with their applications and is taken primarily by students of the social sciences, communications, and liberal arts. This course includes linear equations, linear inequalities, linear programming, financial math, sets, counting, permutations, combinations, and introduction to probability and statistics, matrices.",
+    "prerequisite_text": "MATH1500",
+    "prerequisite_courses": [
+      "MATH1500"
+    ]
+  },
+  {
+    "prefix": "MGMT",
+    "number": "2310",
+    "title": "Legal Environment of Business",
+    "credits": 3,
+    "description": "A survey of business in its legal environment including topics of ethics, courts, and alternative dispute resolution, torts and criminal law, intellectual property, contracts, sales and product liability, creditor-debtor relations and bankruptcy, business organizations, employment law and discrimination, administrative agencies, and consumer protection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1511",
+    "title": "SMAW--Pipe 5G",
+    "credits": 4,
+    "description": "Safely setup equipment and apply principals of Shielded Metal Arc Welding of Pipe (SMAW-Pipe) in the 5G horizontal fixed position, review joint preparation, review proper weld quality and qualification testing, and practice welding Shielded Metal Arc Welding of Pipe (SMAW-Pipe) in the 5G horizontal fixed position.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2312",
+    "title": "Advanced Oncology",
+    "credits": 3,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HEMS",
+    "number": "1110",
+    "title": "Introduction to Basic EMT",
+    "credits": 1,
+    "description": "Role, responsibility and well being of the EMT-Basic. Discussion of medical/legal/ethical and cultural issues, communication and documentations techniques, the human body and methods utilized in lifting and moving patients.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2200A",
+    "title": "Nursing Concepts I",
+    "credits": 5,
+    "description": "Focuses on nursing care of adult clients with oxygenation, perfusion, sensory, integumentary, renal, fluid and electrolyte imbalance, and acid-base imbalances/disorders. Focuses on nursing care of clients experiencing mental health problems across the lifespan. Use of therapeutic drug classifications associated with the imbalances/disorders.Prerequisites: Successful completion of the first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "prerequisite_text": "Successful completion of the first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2210",
+    "title": "Appl of Nursing Concepts I",
+    "credits": 3,
+    "description": "Application of the nursing process in the care of selected clients with disorders associated with oxygenation, perfusion, sensory, integumentary, renal, fluid and electrolytes, acid-base, and mental health disorders. Clinical laboratory practice in health care agencies will be arranged.Prerequisites: Successful completion of first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "prerequisite_text": "Successful completion of first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2153",
+    "title": "Venting, Pumps and Traps",
+    "credits": 3,
+    "description": "Describe sewage pumps, sumps, and vents and explain how to size and install them.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1113",
+    "title": "EKG Applications",
+    "credits": 2,
+    "description": "This course introduces the student to the electrocardiogram (EKG) purposes and procedures. Students will gain knowledge regarding the normal structure and function of the heart with emphasis on the conduction system. A supervised lab portion (35 hours.) is an integral portion of this course and will allow student performance of EKG procedures. This course includes a minimum of 10 hours of clinical externship to be performed by the student under the supervision of a preceptor or course instructor in a variety of health care settings.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MUSC",
+    "number": "1010",
+    "title": "Music Appreciation",
+    "credits": 3,
+    "description": "Basic elements and vocabulary of music; appreciation and understanding of diverse styles of music past and present; developing listening skills. Includes opportunities for experiencing music (recorded and/or live).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2700",
+    "title": "Victimology",
+    "credits": 3,
+    "description": "This course is an overview of victims of crime in America, focusing on index crime victims, as well as the victim’s role in preventing or assisting crime, and the relation of the victim to the criminal justice system. Special crime victims such as missing children, abused children, the elderly and battered women will be given attention.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2500",
+    "title": "Data Management",
+    "credits": 2,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Pharmacy Technician program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "1203",
+    "title": "Practical Nursing Perspectives",
+    "credits": 3,
+    "description": "This course includes the discussion of the concepts of health, health maintenance, and human development throughout the life cycle, effects of stress and related defense or coping mechanisms are introduced along with the use of therapeutic communication. The course identifies trends in health care and local, state, and national health resources available for the maintenance of health. Patients’ rights and responsibilities are explained to students as well as the local, state, and national resources that are available to help patients make informed decisions. Students learn about the role of the practical nurse, the history of practical nursing education, necessary vocational adjustments, and the Louisiana State Board of Practical Nurse Examiners, and an introduction to the laws and rules governing practical nursing practice in Louisiana (the Revised Statutes, Title 37, Chapter 11, Subpart II, Practical Nurses and LAC 46:XLVII, Nurses, Subpart 1, Practical Nurses). Legal, ethical, and cultural issues relevant to client care are addressed. Medical terms and commonly used medical/nursing abbreviations are also covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1220",
+    "title": "Masonry/Ceramic Tile",
+    "credits": 6,
+    "description": "A course covering the basic concepts of masonry and repairing and installing ceramic tile. Emphasis is placed on identification and use of tools and equipment, correct mixture ratios, layout, and jointing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "POLI",
+    "number": "2020",
+    "title": "State & Local Politics",
+    "credits": 3,
+    "description": "A course designed to provide students with a basic understanding of how public policy is formulated and political decisions are made by state and local governments. This course will examine the general principles of federalism as that process impacts upon state and local governments. That examination will explore the relationships and factors that impact upon state and local electoral politics, political institutions, and public policies. This course will analyze in greater depth a sampling of state and local governments.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2300",
+    "title": "Advanced Manufacturing II",
+    "credits": 4,
+    "description": "This course introduces students to Advanced Manufacturing with an emphasis on applied Industry 4.0, lean manufacturing and the industrial internet of things (IIoT) including laser cutting, additive manufacturing (3D printing), rapid prototyping with desktop CNC milling, precision measuring instruments (continued), product ID and data analytics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2102",
+    "title": "Pharmacology For Vet Tech",
+    "credits": 3,
+    "description": "This course is the study of the theory and application of pharmacology. The classifications of drugs and their usage, with specific information on mechanism of action, side effects, and dosing will be taught, using fundamentals of chemistry and mathematics",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Practical Nursing program. Associate Provost of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1330",
+    "title": "Literature/Language Methods",
+    "credits": 3,
+    "description": "This course will examine young children’s emergent use and understanding of literacy. Topics covered include to analyze current practices in teaching language arts, as well as, the methods and materials appropriate for promoting and assessing the literacy development of young children, to consider and promote issues of individual and cultural differences, and to explore technology in language and literacy development.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "1120",
+    "title": "Applied Lead. Develop Lab I",
+    "credits": 1,
+    "description": "The practical application of skills and knowledge taught during MS 1110. Laboratory develops importance of team building and individual contribution to mission accomplishment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HSOM",
+    "number": "1020",
+    "title": "Medical Terminology I",
+    "credits": 3,
+    "description": "This course covers basic medical terms and focuses on work analysis, spelling, and pronunciation with an explanation of medical terms used to describe health and disease. The body systems covered include the digestive, urinary, reproductive, nervous, and cardiovascular systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1410",
+    "title": "Garde Manager",
+    "credits": 4,
+    "description": "Principles of preparation of salads, cold sauces, appetizers, and garnishes and their applications. Emphasis on color, texture, and temperature in preparation and presentation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1000",
+    "title": "Introduction to Computers",
+    "credits": 2,
+    "description": "An introductory study of computer system components, operating system environments., Internet concepts, and security issues. Includes a hands-on study emphasizing computer hardware and various operating systems features.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ARTS",
+    "number": "1005",
+    "title": "Beginning Painting",
+    "credits": 3,
+    "description": "This course introduces students to classical and contemporary painting, techniques and concepts. Painting from still-life, landscapes, self-portrait, and life models from observation will be geared towards realism, but various other styles could be explored. Color theory, compositional structure, visual perception, and critical thinking skills will be emphasized. Acrylic will be the primary medium for this class. Six hours of studio per week. Not counted as a Fine Arts elective.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1500",
+    "title": "Business Law for Paralegals",
+    "credits": 3,
+    "description": "This is a survey course focusing on legal issues typically related to business. The course serves as an introduction to various business entities, including partnerships and corporations, and the laws that structure them. Additionally, this course examines the general principles of contract law and also includes a unit focusing on real estate transactions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1400",
+    "title": "Chronic Disease Prev & Mgmt I",
+    "credits": 3,
+    "description": "This course is designed to provide students with an overview of the principles, strategies, and interventions related to the prevention and management of chronic diseases. Chronic diseases, such as cardiovascular diseases, diabetes, and respiratory conditions, pose significant challenges to global health, requiring multifaceted approaches for effective prevention and management. Throughout this course, students will explore the pathophysiology of chronic diseases, risk factors, and the social determinants of health that contribute to their prevalence. Emphasis will be placed on evidence-based practices for preventing the onset of chronic diseases, as well as strategies for managing and mitigating their impact on individuals and communities. The definition, classification, global burden, epidemiology, and trends in prevalence of major chronic conditions will be covered. Students will learn the risk factors and determinants of these chronic diseases and explore behavioral, environmental, genetic, and socio-economic factors contributing to chronic diseases. Students will gain understanding of the social determinants of health and their impact on disease development, as well as lifestyle modifications, health promotion, and public health initiatives aimed at preventing the onset of the disease. This course will cover community-based interventions and policy approaches to promote healthy behaviors screening programs and early detection methods for those chronic diseases, and strategies for identifying and managing pre-existing risk factors to prevent disease progression. The student will learn evidence-based approaches to the clinical management of chronic diseases, including: patient-centered care, pharmacological interventions, and interdisciplinary healthcare collaboration. The student will learn techniques for effective patient education and behavior change, while learning to promote self-management and empowerment in individuals with chronic conditions. By the end of Chronic Disease Prevention and Management I, students will have gained a solid foundation in the complexities of these stated chronic diseases, equipping them with the knowledge and skills necessary for implementing effective prevention and management strategies in diverse healthcare settings. This course covers half of the Chronic Disease Prevention and Management content. Students will need to take PNAV 1410 to complete the full content of Chronic Disease Prevention and Management.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1160",
+    "title": "Medical Math",
+    "credits": 2,
+    "description": "This applied mathematics course provides a review for the student who needs to master the fundamental numerical operations of addition, subtraction, multiplication, and division of whole numbers, fractions, and decimals. This course also assists the student in acquiring a better understanding of percent, ratio and proportion, and measurements. This course is designed to provide a foundation for enrollment into a health science program and improving proficiency in career preparation courses. An essential part of this course is to utilize the concepts to solve application problems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1300",
+    "title": "Patient/Hlth Navig Clinical I",
+    "credits": 1,
+    "description": "This course will provide the clinical experience for entry-level patient navigators. Students will attend clinical experience in which they will shadow various employees in different settings at a facility with a community industry partner. The students will experience the following areas during their clinical experience: Patient Access and Registration in an inpatient, emergency room, and outpatient setting; Discharge Planning in the inpatient setting; Population health navigation in the outpatient setting; Insurance-based navigation. Students will observe assessments of social determinants of health, income-based needs, and specific health screenings. Students will be given a project to present to the class that explores a patient/health navigation topic in-depth during this clinical experience (e.g., HEDIS measures, heart health screening tools, etc.).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MGMT",
+    "number": "2010",
+    "title": "Microcomputer Applications Bus",
+    "credits": 3,
+    "description": "In this course, students will learn hands-on usage of microcomputer applications needed by business such as information/word processing, data base management, spreadsheets and graphics, and other relevant computer applications as developed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2723",
+    "title": "Pediatrics",
+    "credits": 2,
+    "description": "This course presents essential information related to growth and development of infants, toddlers, preschool through school age and adolescents, and those diseases common but not exclusive to the particular age groups. Included is a review of anatomy and physiology, and therapeutic/ modified diets. Pharmacological interventions/commonly used medications for each body system and age group are discussed at length. Utilizing a nursing process approach, the student will perform applicable practical nursing clinical skills to pediatric clients in appropriate clinical sites under the supervision and at the discretion of practical nursing faculty. This course includes a 30-hour clinical component.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1300",
+    "title": "Tort Law for Paralegals",
+    "credits": 3,
+    "description": "This course introduces students to tort liability, more commonly known as personal injury law. The course examines the topics of intentional torts, negligence, strict liability, and products liability through statutory law and selected case law.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1700",
+    "title": "Drones I",
+    "credits": 3,
+    "description": "This course is designed to introduce students to properly and safely operating an UAS in both a recreational and professional endeavors. The course will include training focused on aviation fundamentals that are required to pass the FAA part 107 exam, UAS mission planning, UAS usage in an agricultural capacity, and use of GIS software.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1102",
+    "title": "Vet Office&Hospital Procedures",
+    "credits": 2,
+    "description": "This course teaches clinical and hospital operations including office and managerial duties, such as client/team communication, veterinary economics, admitting and discharging patients, scheduling, general cleaning, maintenance protocols, security, and inventory control. This course will also focus on teamwork dynamics and compassion fatigue regarding the veterinary profession.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1205",
+    "title": "Pharmacy Practice II",
+    "credits": 2,
+    "description": "This course familiarizes the student with the role and responsibilities of the Pharmacy Technician both in community and in institutional pharmacy settings. The course also addresses some entry and advanced level competencies needed to succeed in pharmacy practice settings. This course prepares students by providing foundational knowledge in areas of pharmacy practice including non-sterile compounding, USP chapter 795, hospital pharmacy dispensing ,medication reconciliation, medication therapy management ,investigational drugs, infection control, hand hygiene and aseptic technique, USP chapter 797 , and medication safety",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2550",
+    "title": "Residential Heating II",
+    "credits": 3,
+    "description": "This course presents the application of service procedures, controls (electrical & gas), gas valves, piping, ventilation, code requirements and safety for gas and electrical heating systems for residential and small commercial uses.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2510",
+    "title": "Residential Central Air Cond I",
+    "credits": 3,
+    "description": "This course presents the study and theory of the major components and functions of central air conditioning systems. Topics include the study of different air conditioning systems types and the proper and safe use of instruments and safety.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "2240",
+    "title": "Medical Microbiology Lab",
+    "credits": 1,
+    "description": "Laboratory exercises are designed to illustrate the material studied in BIOL 2230 for students majoring in biology, biotechnology, nursing and certain allied health and technical fields. Topics include bacterial cell type identification using staining procedures (i.e. gram, spore an acid-fast stains), biochemical testing, food microbiology and microbial growth methods. This course focuses on diagnostic identification and research procedures for clinical microbiology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific needs in instruction through the Veterinary Technology program.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1150",
+    "title": "Protection",
+    "credits": 2,
+    "description": "The study of principles and concepts of radiation units of detection, measurements, exposure monitoring, dose equivalencies and radiation limiting devices. Also includes the study of radiation agencies, surveys and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2302",
+    "title": "Intro to Oncology",
+    "credits": 3,
+    "description": "This comprehensive course serves as an essential introduction to the specialty concentration of Patient Navigation within the fields of Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults/Gerontology, or High-Risk Maternal/Child. Designed for individuals aspiring to navigate patients through the complex landscape of one of these concentrations. This course provides a foundational understanding of key concepts, skills, ethical and legal considerations. Students will leave this course with an understanding of the fundamentals of the chosen specialty concentration, including common conditions, symptoms, and prevalence. Students will be guided to examine the interconnected nature of patient issues and an understanding of the impact of co-occurring disorders. Students will learn patient-centered support techniques and will develop effective communication skills for engaging with patients and their families, emphasizing empathy and cultural competence particular to the specialty concentration. The student will learn strategies for promoting patient self-advocacy and shared decision-making in their specialty contexts. Students will learn to assist patients to navigate the complex healthcare system, including insurance, treatment options, and available support services for the specific specialty concentration. Students will understand the role of patient navigators in facilitating access to appropriate care and resources specific to the specialty concentration. Students will examine the ethical principles guiding patient navigation within the specialty concentration appropriate settings, understand legal considerations, confidentiality, and the importance of advocation for patients' rights. Students will learn the importance of interdisciplinary collaboration in addressing challenges, and develop skills for effective teamwork and communication with healthcare professionals, social workers, and community organizations. Students will gain insights into crisis intervention strategies for emergencies, and understand the signs of health risks and learn how to provide appropriate support and referral. In this course, students will learn to enhance cultural competence to navigate diverse populations with sensitivity, and explore the impact of cultural factors on the specialty concentration treatment and develop strategies for inclusive patient navigation. This course combines theoretical knowledge with practical skills, preparing participants to become effective patient navigator in the challenging and critical field chosen by the student for one of the following: Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults and Geriatric patients, or High-Risk Maternal/Child care. Through case studies, interactive discussions, and hands-on activities, participants will gain the expertise needed to support individuals on their journey to their specialty concentration.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2220",
+    "title": "GTAW - PIPE 5G",
+    "credits": 4,
+    "description": "An introduction to the principals of Gas Tungsten Arc Welding of Pipe (GTAW-Pipe) in the 5G horizontal fixed position, proper assembly of a 5G pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G horizontal fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1130",
+    "title": "Positioning and Processing",
+    "credits": 7,
+    "description": "A study of the processes for routine and special views for radiographic procedures, to include upper and lower extremities, pelvic and shoulder girdles, vertebral column and bony thorax, with the structure and function of demonstrated anatomy.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1440",
+    "title": "Pool Maintenance",
+    "credits": 1,
+    "description": "Identification and use of equipment and chemicals used in daily pool maintenance. Also daily procedures, water analysis and treatment, filter and pump maintenance, and precautions in using and mixing chemicals.Dean of Technical Studies approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2310A",
+    "title": "Practical Nursing IIA",
+    "credits": 3,
+    "description": "This course includes theory related to nursing care provided to adult and geriatric clients experiencing alterations in the respiratory, gastrointestinal, and integumentary function. Included is a review of anatomy and physiology, therapeutic/modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process reviewed. This course includes 60 theory hours of medical-surgical nursing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1125",
+    "title": "Medical Assisting I",
+    "credits": 5,
+    "description": "Analysis of the job market, salaries, working conditions, and job responsibilities and desirable attributes required of the Medical Assistant. Historical issues and current health care trends are also discussed. This course also includes discussion of AMA principles of medical ethics and the law, Patient's Bill of Rights, confidentiality, medical records, and other medical/legal/ethical issues and responsibilities of Medical Assistant. In addition, this course includes discussion of the components of effective client/staff communication, both verbal and nonverbal. Beginning front office activities such as scheduling, insurance, billing and patient/client education methods are covered. Practical application activities are integrated throughout this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "2410",
+    "title": "Elementary Statistics",
+    "credits": 3,
+    "description": "This course is designed as an introduction to statistical reasoning. Topics include graphical display of data, measures of central tendency and variability, sampling theory, the normal curve, standard scores, Student’s T, Chi Square, and correlation techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2950",
+    "title": "Advanced Cloud Computing",
+    "credits": 3,
+    "description": "Students will effectively demonstrate knowledge of how to architect and deploy secure and robust applications on AWS technologies. They will also define a solution using architectural design principles based on customer requirements and provide implementation guidance based on best practices to the organization throughout the life cycle of the project.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2350",
+    "title": "Advanced Networking",
+    "credits": 3,
+    "description": "This course is designed to provide students with the skills needed to configure and troubleshoot networks, LAN switching & WAN technologies, routing technologies including IPv4 and IPv6, infrastructure services, and infrastructure maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 5,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1102",
+    "title": "AutoCAD",
+    "credits": 3,
+    "description": "Creating computer drawings using AutoCAD tools, properties, functions, and operations to make drawing used across various drafting fields. This course examines the concepts found in the AutoCAD Certified Professional exam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SCML",
+    "number": "2000",
+    "title": "Purchasing Management",
+    "credits": 3,
+    "description": "This course covers procurement fundamentals including sourcing, purchase order and contract management, purchasing cycles, material and technical specifications, quality management, relationship management, capital goods and services, sustainability and supply chain analysis and tools with respect to procurement. Through this course, students will be prepared for the ASCM Procurement Certificate (additional test fee.)",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2133",
+    "title": "Medical Surgical III",
+    "credits": 8,
+    "description": "Prerequisite: HNUR 1361 and HNUR 2123. This course includes the study of genitourinary, reproductive, sensory, neurological and musculoskeletal disorders with emphasis on pathophysiology and pharmacology for the adult client. Included is a review of anatomy and physiology, and therapeutic/modified diets. Pharmacological interventions/commonly used medications for each body system addressed are discussed at length. Geriatric considerations are addressed. Utilizing a nursing process approach, the student will perform applicable practical nursing clinical skills to multiple clients experiencing serious illnesses in approved health care facilities under the supervision and discretion of practical nursing faculty. Critical thinking skills are utilized while the student begins to make interdependent practical nursing decisions. Students will be expected to perform clinical skills with indirect supervision of the clinical instructor. This course includes a 180-hour clinical component.",
+    "prerequisite_text": "HNUR 1361 and HNUR 2123. This course includes the study of genitourinary, reproductive, sensory, neurological and musculoskeletal disorders with emphasis on pathophysiology and pharmacology for the adult client. Included is a review of anatomy and physiology, and therapeutic/modified diets. Pharmacological interventions/commonly used medications for each body system addressed are discussed at len",
+    "prerequisite_courses": [
+      "HNUR 1361",
+      "HNUR 2123"
+    ]
+  },
+  {
+    "prefix": "ARTS",
+    "number": "1000",
+    "title": "Basic Drawing",
+    "credits": 3,
+    "description": "This course is an introduction to the material, skills, and techniques of the drawing process. Completion of this course will help with the development of observational skills, visual organization, motor skills, and problem-solving skills. Six hours of studio per week. Not counted as a Fine Arts elective.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HEMS",
+    "number": "1200",
+    "title": "Emergency Medical Tech I",
+    "credits": 3,
+    "description": "This course provides and introduction to the roles, responsibilities and scope of practice of the EMR within the EMS, and emphasizes protecting the well-being of the EMR. Instruction is provided in medical/legal/ethical and cultural issues, communication and documentations techniques, anatomy, physiology, and pathophysiology of the human body, methods utilized in lifting and moving patients, procedures for maintaining open airways and oxygenation, resuscitation, obtaining a medical history and vital signs, principles of assessment, and general pharmacology. Treatment of a variety of medical emergencies are covered in the course, as well as bleeding, shock, soft tissue, musculoskeletal, chest and abdominal injuries. Practical application of EMR skills are included in the classroom setting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2995",
+    "title": "Special Projects",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2540",
+    "title": "Logic Functions",
+    "credits": 2,
+    "description": "An introduction to the uses and applications of logic technology. The course utilizes test equipment and schematic diagrams to troubleshoot and repair circuits while practicing safety procedures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2997",
+    "title": "Special Project IV",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "2020",
+    "title": "Intermediate French II",
+    "credits": 3,
+    "description": "A course with emphasis on proficiency in reading and continuation of grammar review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1420",
+    "title": "SMAW - V - Groove Open",
+    "credits": 4,
+    "description": "An introduction to the safe setup of equipment and principals of Shielded Metal Arc Welding (SMAW) for open V-Groove welds, joint preparation, proper weld quality, qualification testing, and practice welding open V-Groove welds in the flat, horizontal, vertical, and overhead positions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2304",
+    "title": "Intro to High Risk Maternal/Ch",
+    "credits": 3,
+    "description": "This comprehensive course serves as an essential introduction to the specialty concentration of Patient Navigation within the fields of Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults/Gerontology, or High-Risk Maternal/Child. Designed for individuals aspiring to navigate patients through the complex landscape of one of these concentrations. This course provides a foundational understanding of key concepts, skills, ethical and legal considerations. Students will leave this course with an understanding of the fundamentals of the chosen specialty concentration, including common conditions, symptoms, and prevalence. Students will be guided to examine the interconnected nature of patient issues and an understanding of the impact of co-occurring disorders. Students will learn patient-centered support techniques and will develop effective communication skills for engaging with patients and their families, emphasizing empathy and cultural competence particular to the specialty concentration. The student will learn strategies for promoting patient self-advocacy and shared decision-making in their specialty contexts. Students will learn to assist patients to navigate the complex healthcare system, including insurance, treatment options, and available support services for the specific specialty concentration. Students will understand the role of patient navigators in facilitating access to appropriate care and resources specific to the specialty concentration. Students will examine the ethical principles guiding patient navigation within the specialty concentration appropriate settings, understand legal considerations, confidentiality, and the importance of advocation for patients' rights. Students will learn the importance of interdisciplinary collaboration in addressing challenges, and develop skills for effective teamwork and communication with healthcare professionals, social workers, and community organizations. Students will gain insights into crisis intervention strategies for emergencies, and understand the signs of health risks and learn how to provide appropriate support and referral. In this course, students will learn to enhance cultural competence to navigate diverse populations with sensitivity, and explore the impact of cultural factors on the specialty concentration treatment and develop strategies for inclusive patient navigation. This course combines theoretical knowledge with practical skills, preparing participants to become effective patient navigator in the challenging and critical field chosen by the student for one of the following: Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults and Geriatric patients, or High-Risk Maternal/Child care. Through case studies, interactive discussions, and hands-on activities, participants will gain the expertise needed to support individuals on their journey to their specialty concentration.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1460",
+    "title": "Intro to Programmable Logic",
+    "credits": 3,
+    "description": "An introduction to Microprocessors, PLC types, theory, installation, applications, operations, and documentation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2112",
+    "title": "Social Problems for CJ",
+    "credits": 3,
+    "description": "This course is designed to provide students with an introduction to the issues of social problems in our world. The primary focus of this course is to provide students with knowledge and understanding of human behavior and development from a social systems approach as affected by biological, cultural, environmental, and psychosocial factors. Emphasis is on the role of individual, family, small group, organization and community in human behavior as related to criminal justice practice areas. Cultural, ethnic and life-style diversity and their effects on the development of human systems is stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2172",
+    "title": "Safety Applications",
+    "credits": 2,
+    "description": "Identify methods used to establish work zone safety with various work areas.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "2400",
+    "title": "Quality Management",
+    "credits": 7,
+    "description": "An introduction to the evaluation of radiographic systems to assure consistency in the production of quality radiographic services. Equipment quality control components are identified and testing methods are discussed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2150",
+    "title": "Networking I",
+    "credits": 3,
+    "description": "This course is an introduction and is a foundation networking course that will cover the following topics: media and topologies, protocols and standards, network implementation, and network support.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "2120",
+    "title": "Applied Basic Lead. Skills I",
+    "credits": 1,
+    "description": "Practical application of the skills and knowledge taught during MILS 2110. The student will participate in a physical fitness program and employ tactical communications. The student will participate in tactical leadership problems at squad level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1010",
+    "title": "Business Math",
+    "credits": 3,
+    "description": "A study of various business-related mathematical processes, principles, and techniques used to solve business problems on the electronic calculator.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2410",
+    "title": "Practical Nursing III",
+    "credits": 6,
+    "description": "This course includes the study of nursing care provided to adult and geriatric clients experiencing alterations in genitourinary, reproductive, sensory, neurological and musculoskeletal functions, as well as essential information related to growth and development of infants, toddlers, preschool, school age, and adolescent children. Diseases and disorders common in children are covered. Included is a review of anatomy and physiology, therapeutic or modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process. This course in 120 theory hours, which includes 90 hours in med-surg and 30 in pediatrics.Requires: Successful completion of HNUR 2500, HNUR 2310, HNUR 2311. Concurrent enrollment in HNUR 2411; 2410 & 2411 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1141",
+    "title": "Engines II",
+    "credits": 3,
+    "description": "This course is a continuation of Engines I, but covers heavy-duty diesel engines. Students gain knowledge in operation, troubleshooting, rebuilding and tuning all types of diesel engines. Workincludes disassembly, assembly, injection timing and adjustment common to diesel engines used in the transportation and industrial industries.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2052",
+    "title": "Applications of Plumbing Math",
+    "credits": 2,
+    "description": "Calculate travel and lay out stand offsets of varying angles. Describe how to calculate rolling offsets of varying angles.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENGL",
+    "number": "0015",
+    "title": "Suppl Inst for Engl Comp",
+    "credits": 1,
+    "description": "ENGL 0015 is designed to provide supplemental instruction for a college-level English Composition I course. It serves as a foundation of basic writing skills and instills the fundamentals of grammar and mechanics in the context of writing. The focus of this course is to help students improve their reading, writing, critical thinking, and revision skills. These skills will be practices through reading assignments, paragraphs and essay writing, classroom discussions, and group critiques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1150",
+    "title": "Hand/Power Tools",
+    "credits": 3,
+    "description": "Basic skills and safety in the use of hand and power tools.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2331",
+    "title": "Advanced Lathe",
+    "credits": 4,
+    "description": "This course will cover the assembling and removing of all lathe accessories and producing projects to a given size. Topics include precision cutting of tapers, advanced threading operations, multi-lead threading, and other advanced cutting operations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1010B",
+    "title": "Anatomy and Physiology I",
+    "credits": 2,
+    "description": "This course is the study of human anatomy and physiology including chemical composition, cells, tissues, topography and the skeletal and digestive systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2110",
+    "title": "FCAW - Basic Fillet Welds",
+    "credits": 3,
+    "description": "An introduction to the principals of Flux Core Arc Welding (FCAW), component and consumable identification including the safe setup of equipment and practice of fillet welds in the flat, vertical, horizontal, and overhead positions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "1010",
+    "title": "Elementary French I",
+    "credits": 3,
+    "description": "FREN 1010 is designed to introduce students to the French language and francophone culture, through written communication, reading and listening. Students will be exposed to the language as a means of communication in order to develop communicative language ability. Therefore, your instructor will speak mainly French in class, and English will be kept to a minimum.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1110",
+    "title": "Pharmacology and Drug Admin",
+    "credits": 1,
+    "description": "Introduces the student to the various categories of drugs within radiology (i.e. contrast media), expected actions/reactions, administration of various drugs and preparing for injection utilizing aseptic techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1210",
+    "title": "Intro To The Power Industry",
+    "credits": 3,
+    "description": "This course will study the history behind electrical utility industry. Students will study how the electrical system in the United States was established and how Thomas Edison and George Westinghouse, Jr. influenced the development of electrical systems. Students will also learn how the electrical industry was first regulated and how regulation of the industry has changed as well as learning specific employability skills. Students will also gain knowledge of how the electrical industry is currently being \"re-regulated\" to encourage competition and gain knowledge of the system operations and marketing of electricity. Finally, this course will teach how the electrical industry is segmented into utility sectors, such as investor owned, Federal owned, publicly owned and cooperatively owned utilities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1050",
+    "title": "Fundamentals of Radiology Sci",
+    "credits": 1,
+    "description": "An introduction to Radiologic Technology along with specifics to this program. The student will undergo both hospital and program orientation. The course covers departmental administration and management, medical/technology history, rules and regulations and is designed for the student to have an understanding of the professional technologist.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2220",
+    "title": "Air Conditioning",
+    "credits": 3,
+    "description": "This course covers the physical and chemical laws governing the principles of refrigera-tion. The basic cycle and components will be covered. Applications will include alternate refrigerants, trans-ferring, evacuation and system reprocessing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1500",
+    "title": "Basic Pharmacology Patient/Hlt",
+    "credits": 3,
+    "description": "This course is designed to provide patient and health navigators with a basic understanding of pharmacology, equipping them with the knowledge necessary to support patients in managing their medications effectively. The course covers essential basic concepts in pharmacology, drug classifications, and their impact on various health conditions. Participants will develop the skills needed to communicate medication information to patients, address common concerns, and assist in fostering medication adherence. Students will learn the major drug classifications and therapeutic uses, identification of common medications for various health conditions, and the differentiation between prescription and over-the-counter drugs. Students will learn techniques for effective communication with patients about medications, approaches for addressing patient concerns, fears, and misconceptions related to medication, as well as strategies for promoting medication adherence and understanding the importance of follow-up. Students will learn to recognize and assist patients in understanding and managing common side effects and adverse reactions, and awareness of drug allergies and interactions. The influence of cultural beliefs and practices on medication adherence will be covered, along with strategies for providing culturally sensitive medication information. Students will learn basic math for meds for basic dosage and calculations for in-home patient and health navigators to play a vital role in supporting patients in their medication journeys. Upon completion, participants will be better equipped to navigate the complexities of pharmacology, foster patient understanding, and contribute to improved health outcomes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SOCL",
+    "number": "2015",
+    "title": "Introduction to Sociology",
+    "credits": 3,
+    "description": "This course is designed to help the uninformed student to come to a realization of the role that sociology can play in his or her everyday life. We will look at the forces and practices that create our world socially and examine some of the reasons why and how individuals, groups and even governments do what they do. This course is designed for Louisiana Transfer Degree students.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1420",
+    "title": "Food, Bev, & Labor Cost Contro",
+    "credits": 3,
+    "description": "Principles of menu development; menu writing; recipe costing, usage, and conversion; yield percentage; production control; and food selection and procurement.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2231",
+    "title": "Intro to Aluminum Welding Proc",
+    "credits": 3,
+    "description": "An introduction to the principles of Gas Metal Arc Welding Aluminum (GMAWA) components and consumable identification including the safe setup ofequipment and practice of welding fillet and groove welds in the flat, horizontal, vertical, and overhead positions. Emphasis on lean manufacturing, energy efficiency, distortion control and quality inspection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Medical Assistant program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1530",
+    "title": "System Protection",
+    "credits": 2,
+    "description": "This course is an introduction to power system components and power system protection. Topics include protection of generators and motors, protection of transformers and reactors, and protection of transmission lines.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2510",
+    "title": "Precision Grinding",
+    "credits": 2,
+    "description": "This course will use surface grinders to perform precision grinding operations. Topics include types of grinders, accessories, set-up operations, wheel dressing and maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2420",
+    "title": "Basic Mill II",
+    "credits": 3,
+    "description": "Perform multi-angular set-ups, gear cutting, advanced indexing operations and other advanced cutting operations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Prerequisite: Dean of Academics approval. A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_text": "Dean of Academics approval. A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2830",
+    "title": "Cabling Infrastructure",
+    "credits": 3,
+    "description": "Introduction of basic concepts of network cabling systems through the use of copper wiring and fiber optics. Focus on networking cabling design, installation, testing, certification, and troubleshooting for voice, video, and data networks.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2135",
+    "title": "Pharmacy Clinical Ext III",
+    "credits": 4,
+    "description": "This course provides the Pharmacy Technician clinical student the opportunity to work in pharmacy setting under the supervision of a registered pharmacist. Emphasis is placed on effective communication, understanding pharmacy operations, safe, and accurate dispensing of medications, and participation in others roles expected of a pharmacy technician. The student will be assigned to community and/or institutional pharmacies for 100 externship hours. The 100 hours are expected to be achieved in the normal semester time frame of the course, usually 20-30 hours /week commitment to this training is required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "2500",
+    "title": "Safety Mgmt, Training & Develo",
+    "credits": 3,
+    "description": "This course covers best practices for management of occupation health and safety procedures and training programs. Topics include the planning, organization, budgeting, resourcing, operating, implementation, reporting and evaluation of workplace safety. This course covers the topics in OSHA #2455.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in practicum do not receive compensation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1230",
+    "title": "Technical Report Writing",
+    "credits": 3,
+    "description": "General procedures in writing police reports and law enforcement related reports, including development and organization of thoughts and ideas; covers grammar skills, proper punctuation, capitalization, and effective.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "2229",
+    "title": "Medical/Surgical Nursing II",
+    "credits": 9,
+    "description": "\"This course builds upon knowledge gained from Medical/Surgical I. Nursing care of the medical/surgical adult client with alterations in the cardiovascular, hematology/immunologic/lymphatic, endocrine and reproductive functions are presented. Appropriate pharmacological agents related to these systems and their actions, uses, and side effects are discussed. Client education on proper nutrition and diet modifications related to the use of these medications are stressed as well as proper nutrition and diet therapy necessary for health restoration and to maintain health are included in the discussions. This course includes a 180-hour clinical component. The clinical portion of this course builds upon Medical/Surgical Nursing Clinical I. Students utilize the nursing process to demonstrate basic to advanced clinical nursing skills in a variety of health care settings under the supervision of an instructor. The role and responsibilities of the practical nurse as a health team member are emphasized.Note: Students must pass both the theory and clinical components of this course with 80% in each component to successfully complete the course and advance in the Practical Nursing Program.\"",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1320",
+    "title": "Line Equipment Operation",
+    "credits": 4,
+    "description": "This course teaches the maintenance of a company's machinery and equipment. Topics include how to run samples to ensure conformity to quality assurance standards, set up machines for production runs, and resolve operating problems and defects in manufacturing processes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Pharmacy Technician program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2093",
+    "title": "Piping and Sizing",
+    "credits": 3,
+    "description": "Size supply systems correctly so that they reliably provide adequate water at the correct pressure. Properly install water supply systems. Calculate the correct pipe size for a system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1410",
+    "title": "Juvenile Justice",
+    "credits": 3,
+    "description": "Study of juvenile delinquency with emphasis on theories, preventive programs, juvenile courts, treatment, and current problems in juvenile delinquency.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1120B",
+    "title": "Radiation Physic I Pt 2",
+    "credits": 2.5,
+    "description": "The study of diagnostic and fluoroscopy tubes, computed and digital radiography, and circuits. This course includes the study of x-ray tube charts, anode heel effect, transformers and rectification as they relate to the x-ray circuit.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1109",
+    "title": "Animal Anatomy & Physiology",
+    "credits": 3,
+    "description": "This course includes physiological and anatomical systems of domestic animals. It includes discussions on the chemical basis for life, the cells, tissues, and the integument, musculoskeletal, cardiovascular, respiratory, digestive, nervous, endocrine, urinary, and reproductive systems of domestic animals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2110",
+    "title": "Basic Hydraulics",
+    "credits": 2,
+    "description": "This course includes the principles of basic hydraulic systems and general maintenance procedures of a hydraulic system. Also included are the disassembly and assembly of hydraulic components and the application of safety rules and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1219",
+    "title": "Meat Identification & Fabricat",
+    "credits": 3,
+    "description": "Identification and fabrication of meat, seafood, and poultry. Selection, procurement, and preparation of products in commercial food service.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1000",
+    "title": "Intro to Comm, Team Based Care",
+    "credits": 2,
+    "description": "This course will provide a comprehensive understanding of the fundamental principles and introduce the study of effective communication, team-based care, and cultural competencies and how each impacts the delivery of quality healthcare amongst all provider roles and professional settings. Emphasis will be placed on applying communication theories and principles toward becoming a more competent interpersonal communicator. Participants will explore the essential skills and knowledge necessary to foster effective communication, collaborate in interdisciplinary teams, and navigate diverse cultural contexts in order to enhance patient care and promote positive outcomes. Students will develop effective verbal and non-verbal communication skills, understand the importance of active listening and empathetic communication, and learn to communicate clearly and concisely in various healthcare scenarios. Students will demonstrate therapeutic communication techniques. An introduction to Motivational Interviewing and behavior modification and importance of patient centered communication will be explored. The course will include an introduction to team-based care and explore the concept of interdisciplinary teamwork in healthcare to gain an understanding of the roles and responsibilities of different healthcare professionals. Students will learn to develop strategies for effective collaboration and communication within healthcare teams. This course will also introduce students to cultural competencies to increase awareness and sensitivity to cultural diversity in healthcare and explore the impact of cultural factors on healthcare delivery and patient outcomes. Students will be educated to develop skills to navigate cultural differences and promote culturally competent care. Students will be encouraged to self-reflect on their personal communication styles, cultural biases, and teamwork dynamics. Creating and maintaining a culturally competent workforce will be addressed. Understanding others' worldview will be practiced.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2998",
+    "title": "Special Projects V",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "2020",
+    "title": "Intermediate Spanish II",
+    "credits": 3,
+    "description": "A course with emphasis on proficiency in reading and continuation of grammar review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2211",
+    "title": "Practical Nursing I Clinical",
+    "credits": 4,
+    "description": "Students will begin to utilize a nursing process approach to individualize client care, and will perform applicable practical nursing clinical skills to assign adult and/or geriatric client(s) experiencing a variety of medical/surgical and mental health disorders in approved health care and mental health care facilities under the supervision and discretion of practical nursing faculty. This course includes a 180-hour clinical component in the Med-Surg setting and 25 hours in the Mental Health setting.Requires: Concurrent enrollment in HNUR 2210; 2210 & 2211 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "2124",
+    "title": "Adv Pharmacology & IV Therapy",
+    "credits": 4,
+    "description": "Drug classifications and their effect on the various body systems are presented. Specific drugs in each classification are emphasized according to therapeutic effects, side effects, and adverse effects. Routes of drug administration and variables that influence drug actions are covered to include dangerous drug interactions and nursing implications related to each drug. Education for clients, family, and others about their medications, effects of medications, and correct administration is discussed. Safety precautions which will aid in decreasing the incidence of errors in medication are stressed. Advanced medication calculations will be required to demonstrate knowledge of safe dosing parameters. The nursing process is utilized to assess the learning needs of the client and the effects of all pharmacological interventions. Students are also taught the role of the practical nurse in the initiation and maintenance of intravenous therapy infusions. The legal ramifications of this responsibility are stressed. Students focus on anatomy and physiology specific to intravenous infusions and are taught and demonstrate the correct procedures for IV therapy to maintain client safety. This course includes a 30-hour supervised skills lab.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "1300",
+    "title": "Advanced Manufacturing I",
+    "credits": 3,
+    "description": "This course introduces students to Advanced Manufacturing with an emphasis on Industry 4.0, Precision Measuring Instruments (PMI) and an introduction to smart factory equipment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2310A",
+    "title": "Appl of Nursing Concepts II",
+    "credits": 4,
+    "description": "Application of the nursing process in the care of selected clients with disorders associated with immunological, hematological, endocrine, musculoskeletal, and neurological. Application of nursing care of pediatric clients and their families. Clinical laboratory practice in health care agencies will be arranged.Prerequisites: Successful completion of first three semesters of Associate of Science in Nursing curriculum pattern or consent of the Dean of Nursing and Allied Health.",
+    "prerequisite_text": "Successful completion of first three semesters of Associate of Science in Nursing curriculum pattern or consent of the Dean of Nursing and Allied Health.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1010",
+    "title": "Anatomy & Physiology I",
+    "credits": 2,
+    "description": "This course is the study of human anatomy and physiology including chemical composition, cells, tissues, topography and the skeletal and digestive systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2996",
+    "title": "Certification I",
+    "credits": 4,
+    "description": "Prerequisite: Dean of Technical Education approval. A review of American Welding Society certification requirements, materials and mastered student skills, compare completed records; take an AWS closed book certification exam, and prepare workmanship qualification samples according to the AWS QC10- Entry Level Welder standard",
+    "prerequisite_text": "Dean of Technical Education approval. A review of American Welding Society certification requirements, materials and mastered student skills, compare completed records; take an AWS closed book certification exam, and prepare workmanship qualification samples according to the AWS QC10- Entry Level Welder standard",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1200",
+    "title": "Gen Biology II (Science Major)",
+    "credits": 3,
+    "description": "BIOL 1200 is designed fro students planning to major in biology or other related disciplines. This course covers the details of evolution, speciation and systemics. This course covers the details of evolution, speciation and systematics. This course is a systematic study of the structure, function, ecology and relationships of organisms. This course touches on the classification of bacteria, archaea, fungi, protista, plantae, and animalia. Other topics include animal behavior, population biology and ecosystems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1010",
+    "title": "Gen Chemistry I NonScience Mjr",
+    "credits": 3,
+    "description": "The first of a two semester sequence covering the following general topics: metric and temperature conversions, density, calorimetry, mixtures/compounds/elements, chemical and physical properties, structure of the atom and electron configuration, periodic table, bonding, chemical formulas and nomenclature, moles, stoichiometry, chemical reactions, gas laws, and properties of gases, liquids and solids.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1525",
+    "title": "Pharmacy Practice Lab II",
+    "credits": 2,
+    "description": "This course is designed to teach pharmacy technician students entry level skills and advanced level skills performed in community and institutional pharmacy settings. The objectives of this course are to provide the students with practical, hands-on experience in the duties performed by a pharmacy technician in every day pharmacy practice. This course addresses topics of instruction that include the reviewing and processing of medication orders, applications of pertinent laws, regulations and standards, calculations, extemporaneous non-sterile compounding, and medication preparation, hospital pharmacy dispensing and record keeping, medication reconciliation ,medication therapy management and briefly touches on aseptic technique and infection control.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1350",
+    "title": "Intro to Baking & Pastry",
+    "credits": 4,
+    "description": "Preparation of yeast dough products, quick breads, cakes and icings, cookies, pies, puff pastry, éclair and cream puffs, meringues, soufflés, as well as creams, custards, puddings, sauces, and frozen and fruit desserts.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1170",
+    "title": "Essentials Dining Room Service",
+    "credits": 2,
+    "description": "A study of types of service used to enhance dining pleasure, as well as the preparation of beverages.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1005",
+    "title": "College Algebra Fundamentals",
+    "credits": 3,
+    "description": "This course is designed as an overview of the study of families of functions and their graphs. Topics covered include in-depth treatment of solving equations and inequalities; function properties and graphs; inverse functions; linear, quadratic, polynomial, rational, exponential and logarithmic functions with applications; systems of equations. This course also includes additional support of algebra fundamentals including operations with exponents, polynomial and rational expressions, and factoring. A student may not receive credit for both MATH 1005 and MATH 1015. (*Students who have not met the prerequisite requirements, but are eligible for MATH 0099, will be allowed to enroll in this course with the understanding that co-requisite supplemental work in the form of worksheets, watching instructional videos, additional MyMathLab assignments, tutoring, etc. will be assigned and required in order to help support the student in achieving the desired learning outcomes.)",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2140",
+    "title": "Fundamentals of Steering",
+    "credits": 3,
+    "description": "The course contains the theory of operation and service procedures for medium/heavy duty truck steering systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1170",
+    "title": "Medical Terminology for MA",
+    "credits": 1,
+    "description": "Analyzing and combining prefixes, root words, and suffixes to spell, use and pronounce medical terminology correctly and recognize medical terms. Medical abbreviations are included.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2320",
+    "title": "GMAW--Pipe 2G",
+    "credits": 4,
+    "description": "An introduction to the principles of Gas Metal Arc Welding of Pipe (GMAW-Pipe) in the 2G vertical fixed position, proper assembly of a 2G pipe joint, proper weld quality, safe setup of equipment, and practice welding a 2G vertical fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2710",
+    "title": "CNC",
+    "credits": 6,
+    "description": "This course teaches manufacturing parts using CNC technology. Topics include coding used in CNC technology, writing CNC programs, CAD/CAM software and installing programs in CNC machines.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "1105",
+    "title": "Nursing Fundamentals",
+    "credits": 3,
+    "description": "Provides the foundation upon which all subsequent nursing courses are developed. The nurse’s role in meeting the basic human needs across the lifespan including an introduction to the nursing process and the concepts of comfort, rest, sleep, oxygenation, nutrition, and elimination.Prerequisites: Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_text": "Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1002",
+    "title": "Computer Lit. & Applications",
+    "credits": 3,
+    "description": "This course is an introductory study and application of computer system components and operating system environments. Internet concepts, electronic mail, and core components of word processing, database management, spreadsheets, and presentation software will also be addressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1500",
+    "title": "Introduction to Computers",
+    "credits": 3,
+    "description": "The course prepares students to work with latest version of Microsoft Office in a career setting or for personal use. Using courseware that incorporates an accelerated, step-by-step, project-based approach, students develop an introductory-level competency in Word, Excel, Access, and PowerPoint and explore the essential features of the latest version of Windows and Internet Explorer. Students also develop an understanding of key ethical issues they face in the context of using information technology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2311B",
+    "title": "Practical Nursing IIB",
+    "credits": 2,
+    "description": "Students will utilize a nursing process approach to individualize client care, and will perform 80 hours of applicable practical nursing clinical skills in the care of assigned adult and/or geriatric clients experience a variety of medical/surgical conditions. Students will also perform 25 hours of applicable practical nursing clinical skills with maternal and neonatal clients during the antepartum, intrapartum, and postpartum periods. Students are expected to demonstrate use of critical thinking skills while learning to make interdependent practical nursing decisions. All client care will provided in approved health care facilities under the supervision, and at the discretion, of practical nursing faculty.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1015",
+    "title": "General Biology I Lab",
+    "credits": 1,
+    "description": "Laboratory exercises for studying the principles of biology from the cellular level including biochemistry, cell biology, molecular biology, and genetics. Two hours of laboratory per week. A Laboratory fee is required for this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1203",
+    "title": "Parametric Modeling",
+    "credits": 3,
+    "description": "A parametric modeling course utilizing AutoDesk Inventor software. The course progresses through part modeling, creating and documenting assemblies, drawing generation and client presentation based on industry standards. Project work flow, documentation and file management is also included. This course includes the concepts found in the AutoCAD CErtified Professional exam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2302",
+    "title": "Large Animal Medicine",
+    "credits": 2,
+    "description": "This course covers the common diseases of large animals (horses, cattle, small ruminants, pigs) with an emphasis on the role of the veterinary technician in diagnostic tests, treatment, and client education. Fundamentals of large animal reproduction will also be covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSYC",
+    "number": "2015",
+    "title": "Introduction To Psychology",
+    "credits": 3,
+    "description": "The purpose of this course is to provide you with an introduction to psychological theory and research. Topics considered include the nature of psychology and its history, research practices, learning and conditioning, developmental psychology, personality, social psychology, psychopathology and psychotherapy. This course is designed for Louisiana Transfer Degree students.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1201",
+    "title": "Automatic Transmissions",
+    "credits": 4,
+    "description": "A comprehensive course that teaches the procedures for removal, disassembly, reassembly, and reinstallation of automatic transmissions and transaxles. Topics include transmission rebuilding with emphasis on in-service automobile repair including the repair of torque converters and oil pump assemblies.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2100",
+    "title": "Programmable Logic Controls II",
+    "credits": 3,
+    "description": "This course continues from PLC1 with advanced applications of PLC's using a smart factory industrial-grade training system. Emphasis will be on designing and troubleshooting electro-pneumatic and control circuits with solenoid-actuated valves, interacting with input and output devices (sensors, switches LEDs, pumps and motors), and communication/data collection from networked devices. During this course, students will progress through projects in NC3 Applied PLCs (Siemens and Allen-Bradley) certifications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1204",
+    "title": "Animal Nursing I",
+    "credits": 3,
+    "description": "This course covers humane animal care and nursing, with emphasis on technical skills such as: physical examinations, sample collection, medicating animals, IV catheterization/venipuncture, and bandaging. This course will also cover animal nutrition and the principles of feeding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1105",
+    "title": "Materials & Manufacturing Tech",
+    "credits": 3,
+    "description": "An exploration of the various manufacturing and construction materials, processes and technologies utilized in different drafting fields including additive manufacturing. Emphasis is placed on terminology and function.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2210",
+    "title": "Practical Nursing I",
+    "credits": 6,
+    "description": "This course is a study of the nursing process as a method of individualizing care of the adult and geriatric clients experiencing alterations in cardiovascular, lymphatic, and immune functioning with special emphasis on the essential concepts of fluid and electrolytes and acid-base balance. Included is a review of anatomy and physiology, therapeutic or modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process reviewed. This portion of the course includes 90 hours of theory.Requires: HNUR 2000, HMDT 1170, HNUR 2110, HNUR 2111. Concurrent enrollment in HNUR 2211 (PN I); 2210 & 2211 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENGL",
+    "number": "2020",
+    "title": "American Literature",
+    "credits": 3,
+    "description": "This course is designed to introduce students to poetry, prose, and drama produced by significant writers of American literature, with an emphasis on the development of understanding and appreciation. In this course, students will be exposed to representative works from major periods of American literature. Each reading assignment will be discussed in class and supplemented with lectures, notes, and assignments.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1000",
+    "title": "Intro to Paralegal Studies",
+    "credits": 3,
+    "description": "This course introduces students to the United States legal system, the legal profession in general, and the paralegal profession in particular. Special focus is given to the skills necessary to obtain paralegal employment, the various duties performed by paralegals, and the ethical obligations of paralegals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2410A",
+    "title": "Appl of Nursing Concepts III",
+    "credits": 4,
+    "description": "Application of the nursing process in the formulation, organization, and evaluation of care for selected groups of clients experiencing complex health problems. Application of the nursing process for women of child-bearing age.Prerequisites: Successful completion of first four semesters of the ASN curriculum pattern.",
+    "prerequisite_text": "Successful completion of first four semesters of the ASN curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1440",
+    "title": "Motor Controls",
+    "credits": 3,
+    "description": "This course presents information on advanced motor control applications. Topics in-clude: installation and troubleshooting of motors, reversing starters, and VFD (Variable Frequency Drive).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HMAN",
+    "number": "2015",
+    "title": "Humanities for Leaders",
+    "credits": 3,
+    "description": "A course designed to provide emerging and existing leaders the opportunity to explore the concept of leadership styles and concerns through the examination of literature and films, as well as develop leadership skills. The course integrates readings from the humanities, experiential exercises, films, and contemporary readings on leadership.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1090B",
+    "title": "Radiographic Pathology",
+    "credits": 2,
+    "description": "A study of various pathological terminologies, conditions, injuries, tissues, systemic diseases and their relevance to radiographic procedures",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNUR",
+    "number": "1001",
+    "title": "Intro. to Nursing Studies",
+    "credits": 4,
+    "description": "This course is designed to assist students in transitioning to nursing to gain necessary skills for success in the Practical Nursing and Registered Nursing programs.Course content includes medical terminology, medical abbreviations are included. Introduces identifying body structures with the appropriate medical terminology. Students will get through this content in an asynchronous format over the duration of the course. This course also contains a self-paced program that will develop each student's academic readiness to equip them with the knowledge and skills to prepare for Nursing program entry. Course content includes basic academic subjects: reading comprehension, math, science, and English; intensive review of anatomy and physiology fundamentals; skill building study techniques. This program will require coaching sessions with a virtual instructor. Additionally, the course will include virtual synchronous lessons on fundamental numerical operations needed for Healthcare workers. The Lab component will expose students to basic nursing skills concepts for the entry-level healthcare worker that includes Basic Concepts for the Healthcare worker and Code of Conduct for Nursing students.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2232",
+    "title": "Adv Aluminum Welding Processes",
+    "credits": 3,
+    "description": "An introduction to the principles of Gas Metal Arc Welding Aluminum (GMAWA) components and consumable identification including the safe setup ofequipment and practice of welding fillet and groove welds in the flat, horizontal, vertical, and overhead positions. Emphasis on lean manufacturing, energy efficiency, distortion control and quality inspection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1330",
+    "title": "Underground Equipment",
+    "credits": 1,
+    "description": "This hands-on course prepares you to install a variety of underground system components on both 15 and 25 kV systems. Learn to install primary and secondary cable, in conduit systems as well as using direct burial methods in both single- and three-phase applications. Install underground system components, such as underground risers, transformers, switchgear and pedestals to facilitate the proper termination of both primary and secondary cable systems. Use cable preparation tools to prepare the cable for installation of termination kits, elbow and inline splicing sleeves to connect equipment to systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1340",
+    "title": "Deviance",
+    "credits": 3,
+    "description": "A study of the theories used to explain criminal behavior.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2109",
+    "title": "Clinical Pathology Lab for VTs",
+    "credits": 1,
+    "description": "This course provides hands-on experience performing and interpreting clinically relevant tests and procedures covered in Clinical Pathology with appropriate biosecurity-safety protocols.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1311",
+    "title": "Residential Wiring Installatio",
+    "credits": 3,
+    "description": "A study of the NEC calculations including: voltage/drops, fill capacities for boxes and conduits, service sizing, box sizing, grounding, and bonding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1010",
+    "title": "Introduction to Biology I",
+    "credits": 3,
+    "description": "Broad biological principles for non-science majors: scientific method, biological molecules, basics of biochemistry, basics of prokaryotic and eukaryotic cell structure and function, basics of molecular biology and genetics, and introductory evolution .",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1210",
+    "title": "Oxyfuel Systems",
+    "credits": 2,
+    "description": "An introduction to the principals of cutting with an Oxyfuel (OFC) apparatus, cylinder and equipment safety, proper handling and setup including practice cutting mild steel using both the manual and machine process.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "0105",
+    "title": "Suppl Inst College Algebra Fun",
+    "credits": 3,
+    "description": "This course serves as supplemental instruction used to reinforce the following concepts taught in MATH 1005: solving equations and inequalities; function properties and graphs; inverse functions; linear, quadratic, polynomial, rational, exponential and logarithmic functions with applications; systems of equations.",
+    "prerequisite_text": "MATH1005",
+    "prerequisite_courses": [
+      "MATH1005"
+    ]
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1602",
+    "title": "Advance Electrical & Hybrid",
+    "credits": 5,
+    "description": "This is a continuation of AUTO 1601. Topics include semiconductor devices with emphasis on the junction diode, the bipolar transistor, and the field effect transistor; electro-mechanical devices, specifically the operation and fault diagnosis and repair of self-rectifying D.C. generators; cranking motors; mechanical and electrical testing equipment used to diagnose malfunctions of the ignition systems and to determine the general condition of the engine.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1160",
+    "title": "Principles of Refrigeration I",
+    "credits": 3,
+    "description": "This course teaches the proper and safe use of hand tools including power tools and materials in the HVAC Industry. This course also provides for a review of HVAC and refrigeration processes and applications. Topics include: identify various types of pipe, tubing, and fittings; swaging, flaring and cutting copper tubing; set-up and use of an oxyacetylene torch set and proper soldering and brazing techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 1,
+    "description": "Course designed for students who have demonstrated specific needs in instruction through the Veterinary Technology program.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "1010",
+    "title": "Western Civilization I",
+    "credits": 3,
+    "description": "This course is designed to present the important themes, ideas, and people from the dawn of human civilization to the Renaissance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2410",
+    "title": "Regional Cuisine",
+    "credits": 3,
+    "description": "This course includes the team preparation of a specified number and variety of regional dishes for portfolio, using advanced skills, instructor-prepared criteria, and evaluation processes. Includes a research project.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1200",
+    "title": "Gen Chemistry II (Sci Majors)",
+    "credits": 3,
+    "description": "Second semester chemistry course designed for natural engineering or life sciences majors. A continuation of CHEM 1100 required of all chemistry and physics majors and other programs whose curricula require chemistry above the introductory level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1801",
+    "title": "Engine Mech & Related Problems",
+    "credits": 2,
+    "description": "A comprehensive course in the operational theory of internal combustion engines. Topics include engine rebuilding, mechanical diagnosis, and failure analysis.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "2413",
+    "title": "Mental Health Nursing",
+    "credits": 3,
+    "description": "The student utilizes the nursing process to provide care to clients experiencing psychopathological, emotional, and behavioral alterations. Appropriate pharmacological agents, their actions, uses, and side effects are discussed. Client education on proper nutrition and diet modifications related to the use of these medications are stressed as well as proper nutrition and diet therapy necessary for health restoration and to maintain health are included in the discussions. Health promotion activities necessary to promote and maintain optimal mental health are explored. Using the nursing process, students demonstrate appropriate communication techniques and have the opportunity to participate as a member of a multidisciplinary health care team in the care of a selected client in the mental health setting. This course includes a 45-hour clinical component.Note: Students must pass both the theory and clinical components of this course with 80% in each component to successfully complete the course and advance in the Practical Nursing Program.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1090",
+    "title": "Radiographic Pathology",
+    "credits": 2,
+    "description": "A study of various pathological terminologies, conditions, injuries, tissues, systemic diseases, and their relevance to radiographic procedures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2120",
+    "title": "Advanced Hydraulics",
+    "credits": 3,
+    "description": "The course includes principles of advanced hydraulic system, troubleshooting and application of open-centered and closed-centered systems, close-centered load sensing, variable displacement pump, positive displacement pump, hydrostatic systems, and electro-hydraulic systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1350",
+    "title": "Intro to Baking & Pastry",
+    "credits": 4,
+    "description": "Preparation of yeast dough products, quick breads, cakes and icings, cookies, pies, puff pastry, éclair and cream puffs, meringues, soufflés, as well as creams, custards, puddings, sauces, and frozen and fruit desserts.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1525",
+    "title": "Pharmacy Practice Lab II",
+    "credits": 2,
+    "description": "This course is designed to teach pharmacy technician students entry level skills and advanced level skills performed in community and institutional pharmacy settings. The objectives of this course are to provide the students with practical, hands-on experience in the duties performed by a pharmacy technician in every day pharmacy practice. This course addresses topics of instruction that include the reviewing and processing of medication orders, applications of pertinent laws, regulations and standards, calculations, extemporaneous non-sterile compounding, and medication preparation, hospital pharmacy dispensing and record keeping, medication reconciliation ,medication therapy management and briefly touches on aseptic technique and infection control.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2112",
+    "title": "Social Problems for CJ",
+    "credits": 3,
+    "description": "This course is designed to provide students with an introduction to the issues of social problems in our world. The primary focus of this course is to provide students with knowledge and understanding of human behavior and development from a social systems approach as affected by biological, cultural, environmental, and psychosocial factors. Emphasis is on the role of individual, family, small group, organization and community in human behavior as related to criminal justice practice areas. Cultural, ethnic and life-style diversity and their effects on the development of human systems is stressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SCML",
+    "number": "2100",
+    "title": "Inventory Management",
+    "credits": 3,
+    "description": "This course introduces inventory control and management operations. Topics covered include inventory control and management systems, inventory cost, types and uses of inventory, planning inventory levels, maintaining accuracy, inventory analytics and the roles associated with inventory management. Along with warehouse distribution and the logistics transportation course, this course covers a portion of MSSC (Manufacturing Skill Standards Council) certification in Certified Logistics Technician (CLT 4.0) including the global supply chain, the logistics environment, safety, safe equipment operation, material handling equipment, quality control, workplace communication, teamwork and problem solving and using computers for email and MS Office applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1170",
+    "title": "Medical Terminology for MA",
+    "credits": 1,
+    "description": "Analyzing and combining prefixes, root words, and suffixes to spell, use and pronounce medical terminology correctly and recognize medical terms. Medical abbreviations are included.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2110",
+    "title": "PN Foundations & Perspectives",
+    "credits": 6,
+    "description": "This course focuses on the qualities and personal characteristics needed to practice practical nursing safely, effectively, and with compassion, including development of self-awareness and critical thinking. The course includes instruction in the history, trends and evolution of practical nursing, as well as the laws and rules governing practical nursing as defined by the Louisiana Revised Statutes, Title 37, Chapter 11, Subpart II-Practical Nurses and LAC 46:XLVII.Nursing, subpart 1 - Practical Nurses. Ethical, legal and cultural issues and trends, communication techniques, and personal and family growth and development are addressed. The course includes discussion of the concepts of health maintenance, restoration and rehabilitation, with identification of available local, state and national health maintenance resources. Emphasis is placed on foundational nursing concepts, including health assessment, and clinical reasoning using the nursing process to meet the physiological, psychosocial, socio-cultural, and spiritual needs of clients in various health care environments and across the lifespan. Special emphasis is placed on the normal aging process, care of the elderly, and end-of-life care. Safety and infection control, including information on microbes, modes of transmission, methods of destruction or control, and skills to prevent the spread of infections are also emphasized as part of this course.Requires: Concurrent enrollment or successful completion of HNUR 2000 and HMDT 1170. Concurrent enrollment in HNUR 2111; 2110 & 2111 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1010",
+    "title": "Gen Chemistry I NonScience Mjr",
+    "credits": 3,
+    "description": "The first of a two semester sequence covering the following general topics: metric and temperature conversions, density, calorimetry, mixtures/compounds/elements, chemical and physical properties, structure of the atom and electron configuration, periodic table, bonding, chemical formulas and nomenclature, moles, stoichiometry, chemical reactions, gas laws, and properties of gases, liquids and solids.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1130",
+    "title": "Communication & Emp Skills",
+    "credits": 2,
+    "description": "This course is designed to develop communication skills and interpersonal skills of individuals entering the workforce.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1002",
+    "title": "Computer Lit. & Applications",
+    "credits": 3,
+    "description": "This course is an introductory study and application of computer system components and operating system environments. Internet concepts, electronic mail, and core components of word processing, database management, spreadsheets, and presentation software will also be addressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "1223",
+    "title": "Advanced Fundamentals in PN",
+    "credits": 3,
+    "description": "This course includes the major issues in adult development and aging including biological influences, aging changes, cognitive changes, and disease factors; along with the physiological, psychosocial, socio-cultural, and spiritual needs of clients in various health care environments. Students are introduced to how concepts of families, relationships and communities relate to their participation and function in society. Concepts essential for the safe performance of nursing procedures and for the prevention of illness and/or the transfer of disease to others are discussed. The student is introduced to additional concepts of the adult population including but not limited to more detailed areas of physical assessment, urinary catheterization, monitoring of blood glucose levels, wound care with dressing changes, application of hot and cold treatments, and documentation of these findings. Principles of admitting, transferring, reporting, and discharging procedures of clients are discussed. The application of the nursing process and the development of critical thinking skills of the novice nurse practices will be incorporated. Supervised lab experiences that focus on providing more advanced nursing skills are emphasized in identifying internal and external stressors and adaptive responses that adult clients experience in the maintenance or promotion of health. This course includes 30-hour skills lab.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2300A",
+    "title": "Nursing Concepts II",
+    "credits": 5,
+    "description": "Focuses on nursing care of adult clients with immunological, hematological, endocrine, musculoskeletal, gastrointestinal, and neurological disorders. Focuses on nursing care of pediatric clients and their families. Use of therapeutic drug classifications associated with the disorders.Prerequisites: Successful completion of the first three semesters of the ASN curriculum pattern.",
+    "prerequisite_text": "Successful completion of the first three semesters of the ASN curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1412",
+    "title": "SMAW V Grove BU/Gouge",
+    "credits": 3,
+    "description": "Safely setup and operate Shielded Metal Arc Welding (SMAW) equipment with practice of V-Groove welds with a backing or back gouging in the flat, horizontal, vertical, and overhead positions using various electrodes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1203",
+    "title": "Parametric Modeling",
+    "credits": 3,
+    "description": "A parametric modeling course utilizing AutoDesk Inventor software. The course progresses through part modeling, creating and documenting assemblies, drawing generation and client presentation based on industry standards. Project work flow, documentation and file management is also included. This course includes the concepts found in the AutoCAD CErtified Professional exam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "2400",
+    "title": "Fire Protection and Prevention",
+    "credits": 3,
+    "description": "This course provides an in-depth exploration of fire prevention programs, focusing on fire inspection, code enforcement, and the application of model building standards and codes. Students will examine the legal, economic, and political aspects of the fire inspection process, as well as the essential components of plans review and public education initiatives. Emphasis is placed on understanding regulatory practices, fire-resistant construction materials, and the procedures for ensuring the safety and compliance of buildings with fire codes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2611",
+    "title": "IV Therapy",
+    "credits": 1,
+    "description": "The role of the practical nurse, legal implications of intravenous (IV) therapy, and equipment/devices used, anatomy/physiology, methods and techniques, infection control measures, complications, and other vital information related to intravenous therapy is discussed. Supervised lab performance (15hrs) is an integral part of this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2112",
+    "title": "FCAW Pipe 5G",
+    "credits": 4,
+    "description": "Safely setup and operate Flux Core Arc Welding pipe (FCAW-Pipe) equipment, proper assembly of a 5G - horizontal fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1440",
+    "title": "Basic Word Processing",
+    "credits": 3,
+    "description": "This course provides hands-on experience of word processing techniques and functions with emphasis on features and commands using a current version of word processing software.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2231",
+    "title": "Welding",
+    "credits": 2,
+    "description": "The course includes practical experience in the use of oxyacetylene and shielded arc welding of steel plate in the flat position and an introduction of oxyacetylene/cutting procedures is also included.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2331",
+    "title": "Advanced Lathe",
+    "credits": 4,
+    "description": "This course will cover the assembling and removing of all lathe accessories and producing projects to a given size. Topics include precision cutting of tapers, advanced threading operations, multi-lead threading, and other advanced cutting operations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1120",
+    "title": "Intro to Construction Drawings",
+    "credits": 3,
+    "description": "This course provides instruction and review of basic construction mathematics, weld symbol interpretation, reading welding detail drawings, basic metallurgy, metal identification, and heat treatment of metals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1110",
+    "title": "Pharmacology and Drug Admin",
+    "credits": 1,
+    "description": "Introduces the student to the various categories of drugs within radiology (i.e. contrast media), expected actions/reactions, administration of various drugs and preparing for injection utilizing aseptic techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A practicum provides supervised on-the-job work experience related to the student’s education objectives. Students participating in practicum do no receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2304",
+    "title": "Intro to High Risk Maternal/Ch",
+    "credits": 3,
+    "description": "This comprehensive course serves as an essential introduction to the specialty concentration of Patient Navigation within the fields of Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults/Gerontology, or High-Risk Maternal/Child. Designed for individuals aspiring to navigate patients through the complex landscape of one of these concentrations. This course provides a foundational understanding of key concepts, skills, ethical and legal considerations. Students will leave this course with an understanding of the fundamentals of the chosen specialty concentration, including common conditions, symptoms, and prevalence. Students will be guided to examine the interconnected nature of patient issues and an understanding of the impact of co-occurring disorders. Students will learn patient-centered support techniques and will develop effective communication skills for engaging with patients and their families, emphasizing empathy and cultural competence particular to the specialty concentration. The student will learn strategies for promoting patient self-advocacy and shared decision-making in their specialty contexts. Students will learn to assist patients to navigate the complex healthcare system, including insurance, treatment options, and available support services for the specific specialty concentration. Students will understand the role of patient navigators in facilitating access to appropriate care and resources specific to the specialty concentration. Students will examine the ethical principles guiding patient navigation within the specialty concentration appropriate settings, understand legal considerations, confidentiality, and the importance of advocation for patients' rights. Students will learn the importance of interdisciplinary collaboration in addressing challenges, and develop skills for effective teamwork and communication with healthcare professionals, social workers, and community organizations. Students will gain insights into crisis intervention strategies for emergencies, and understand the signs of health risks and learn how to provide appropriate support and referral. In this course, students will learn to enhance cultural competence to navigate diverse populations with sensitivity, and explore the impact of cultural factors on the specialty concentration treatment and develop strategies for inclusive patient navigation. This course combines theoretical knowledge with practical skills, preparing participants to become effective patient navigator in the challenging and critical field chosen by the student for one of the following: Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults and Geriatric patients, or High-Risk Maternal/Child care. Through case studies, interactive discussions, and hands-on activities, participants will gain the expertise needed to support individuals on their journey to their specialty concentration.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1220",
+    "title": "Infant/Todd Care & Curriculum",
+    "credits": 3,
+    "description": "Designing culturally sensitive environments and education practices appropriate to developmental needs of infant/toddlers from conception to age 3, including facilities, schedules, activities, and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1500",
+    "title": "Basic Pharmacology Patient/Hlt",
+    "credits": 3,
+    "description": "This course is designed to provide patient and health navigators with a basic understanding of pharmacology, equipping them with the knowledge necessary to support patients in managing their medications effectively. The course covers essential basic concepts in pharmacology, drug classifications, and their impact on various health conditions. Participants will develop the skills needed to communicate medication information to patients, address common concerns, and assist in fostering medication adherence. Students will learn the major drug classifications and therapeutic uses, identification of common medications for various health conditions, and the differentiation between prescription and over-the-counter drugs. Students will learn techniques for effective communication with patients about medications, approaches for addressing patient concerns, fears, and misconceptions related to medication, as well as strategies for promoting medication adherence and understanding the importance of follow-up. Students will learn to recognize and assist patients in understanding and managing common side effects and adverse reactions, and awareness of drug allergies and interactions. The influence of cultural beliefs and practices on medication adherence will be covered, along with strategies for providing culturally sensitive medication information. Students will learn basic math for meds for basic dosage and calculations for in-home patient and health navigators to play a vital role in supporting patients in their medication journeys. Upon completion, participants will be better equipped to navigate the complexities of pharmacology, foster patient understanding, and contribute to improved health outcomes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2000",
+    "title": "Anatomy,Phy,& Nutrition for PN",
+    "credits": 4,
+    "description": "This course provides an understanding of the basic anatomy and physiology of the human body and deviations from the normal. A study of cells, skeletal, muscular, circulatory/lymphatic, digestive, respiratory, urinary, reproductive, endocrine, nervous, sensory and integumentary systems is included. The course also includes study of the concepts of proper nutrition for all age groups and diet modifications for therapeutic purposes.Requires: Acceptance into the practical nursing program. Concurrent enrollment or successful completion of HMDT 1170.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1440",
+    "title": "Pool Maintenance",
+    "credits": 1,
+    "description": "Identification and use of equipment and chemicals used in daily pool maintenance. Also daily procedures, water analysis and treatment, filter and pump maintenance, and precautions in using and mixing chemicals.Dean of Technical Studies approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2204",
+    "title": "Surgical Nursing with Lab",
+    "credits": 3,
+    "description": "This course and lab combination covers instrument identification, aseptic technique, the roles of the surgical assistant, and the knowledge of common surgical procedures of domestic animals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HIST",
+    "number": "2020",
+    "title": "American History II",
+    "credits": 3,
+    "description": "This course is designed to present the important themes, ideas, and people in American History from Reconstruction to the present day.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1200",
+    "title": "Civil Procedure & Litigation",
+    "credits": 3,
+    "description": "This course presents a general overview of civil procedure and litigation, with a special emphasis on the pretrial discovery component. This course offers students practical experience in fulfilling a paralegal’s role in the litigation context, with exercises in organizing and maintaining a client’s file, producing and managing litigation documents, and summarizing depositions and medical records.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "1115",
+    "title": "Application of Nursing Fundame",
+    "credits": 1,
+    "description": "Provides the foundation upon which subsequent technical skills are developed. Acquisition of competency in nursing skills in a supervised laboratory setting. Limited clinical laboratory practice will be arranged in selected health care agencies. Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2303",
+    "title": "Intro to Gerontology",
+    "credits": 3,
+    "description": "This comprehensive course serves as an essential introduction to the specialty concentration of Patient Navigation within the fields of Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults/Gerontology, or High-Risk Maternal/Child. Designed for individuals aspiring to navigate patients through the complex landscape of one of these concentrations. This course provides a foundational understanding of key concepts, skills, ethical and legal considerations. Students will leave this course with an understanding of the fundamentals of the chosen specialty concentration, including common conditions, symptoms, and prevalence. Students will be guided to examine the interconnected nature of patient issues and an understanding of the impact of co-occurring disorders. Students will learn patient-centered support techniques and will develop effective communication skills for engaging with patients and their families, emphasizing empathy and cultural competence particular to the specialty concentration. The student will learn strategies for promoting patient self-advocacy and shared decision-making in their specialty contexts. Students will learn to assist patients to navigate the complex healthcare system, including insurance, treatment options, and available support services for the specific specialty concentration. Students will understand the role of patient navigators in facilitating access to appropriate care and resources specific to the specialty concentration. Students will examine the ethical principles guiding patient navigation within the specialty concentration appropriate settings, understand legal considerations, confidentiality, and the importance of advocation for patients' rights. Students will learn the importance of interdisciplinary collaboration in addressing challenges, and develop skills for effective teamwork and communication with healthcare professionals, social workers, and community organizations. Students will gain insights into crisis intervention strategies for emergencies, and understand the signs of health risks and learn how to provide appropriate support and referral. In this course, students will learn to enhance cultural competence to navigate diverse populations with sensitivity, and explore the impact of cultural factors on the specialty concentration treatment and develop strategies for inclusive patient navigation. This course combines theoretical knowledge with practical skills, preparing participants to become effective patient navigator in the challenging and critical field chosen by the student for one of the following: Mental Health and Substance Abuse, Oncology, Chronic Disease in Adults and Geriatric patients, or High-Risk Maternal/Child care. Through case studies, interactive discussions, and hands-on activities, participants will gain the expertise needed to support individuals on their journey to their specialty concentration.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2110",
+    "title": "Basic Hydraulics",
+    "credits": 2,
+    "description": "This course includes the principles of basic hydraulic systems and general maintenance procedures of a hydraulic system. Also included are the disassembly and assembly of hydraulic components and the application of safety rules and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SCML",
+    "number": "2400",
+    "title": "Supply Chain Strategy",
+    "credits": 3,
+    "description": "This course explores past and current challenges in the supply chain and examines case studies, management systems and best practices to address those challenges. Topics include supply chain optimization, the logistics environment, information systems, Industry 4.0 technologies, material handling safety, quality control principles, teamwork, and communication. This course covers the content for lean six sigma certification and MSSC Certified Logistics Associate (CLA.)",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2995",
+    "title": "Special Projects",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Prerequisite: Dean of Academics approval. A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_text": "Dean of Academics approval. A course designed for the student who has demonstrated specific special needs.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "1033",
+    "title": "Water and Waste",
+    "credits": 3,
+    "description": "Develop sanitary drainage systems including the piping system inside the building, drainpipe buried outside the building, and the public sewer.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1001",
+    "title": "Applied Algebra",
+    "credits": 3,
+    "description": "Prerequisite: MATH 0099; ACT Math 19+; SAT Math 460+; or Compass Algebra 40+.Emphasis on applications involving: solving equations and inequalities; function properties and graphs; linear, quadratic, polynomial, exponential and logarithmic functions. (Math)",
+    "prerequisite_text": "MATH 0099; ACT Math 19+; SAT Math 460+; or Compass Algebra 40+.Emphasis on applications involving: solving equations and inequalities; function properties and graphs; linear, quadratic, polynomial, exponential and logarithmic functions. (Math)",
+    "prerequisite_courses": [
+      "MATH 0099"
+    ]
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1430",
+    "title": "Ground Maintenance",
+    "credits": 2,
+    "description": "Identification and use of equipment and chemicals used in daily pool maintenance. Also daily procedures, water analysis and treatment, filter and pump maintenance, and precautions in using and mixing chemicals.Dean of Technical Studies approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "2500",
+    "title": "Safety Mgmt, Training & Develo",
+    "credits": 3,
+    "description": "This course covers best practices for management of occupation health and safety procedures and training programs. Topics include the planning, organization, budgeting, resourcing, operating, implementation, reporting and evaluation of workplace safety. This course covers the topics in OSHA #2455.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2221",
+    "title": "GTAW - PIPE 2G",
+    "credits": 4,
+    "description": "Safely setup and operate Gas Tungsten Arc Welding Pipe (GTAW-Pipe) equipment, proper assembly of a 2G vertical fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 2G vertical fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Medical Assistant program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2500A",
+    "title": "Nursing Capstone: Trans to Pro",
+    "credits": 1,
+    "description": "A non-clinical course. This course provides the framework for assisting the transition from student nurse to professional registered nurse and licensure preparation. Resume development, delegation, and the Nurse Practice Act will be discussed.Prerequisites: Successful completion of first four semesters of the ASN curriculum.",
+    "prerequisite_text": "Successful completion of first four semesters of the ASN curriculum.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1202",
+    "title": "Mechanical Design",
+    "credits": 3,
+    "description": "A study of the principles, methods, and standards used in the design and manufacturing of mechanical parts and assemblies through working drawings, according to industry-based standards and current practices using AutoCAD.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1020",
+    "title": "Chemistry II NonScience Mjr",
+    "credits": 3,
+    "description": "The second of a two course lecture sequence in Introductory Chemistry for non-science majors. The topics to be covered include the kinetic molecular theory of gases, intermolecular forces, colligative properties, chemical equilibrium, oxidation and reduction with selected topics in radioactivity and nuclear chemistry, organic chemistry, and biochemistry. The course emphasizes understanding basic principles and problem solving.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1000",
+    "title": "Business Communications",
+    "credits": 3,
+    "description": "A study of business functions, methods of business operation, types of business ownership, and the role of business organizations in contemporary society. The purpose of this course is to introduce business principles and concepts. Both theory and practical application will be addressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2950",
+    "title": "Advanced Cloud Computing",
+    "credits": 3,
+    "description": "Students will effectively demonstrate knowledge of how to architect and deploy secure and robust applications on AWS technologies. They will also define a solution using architectural design principles based on customer requirements and provide implementation guidance based on best practices to the organization throughout the life cycle of the project.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2311",
+    "title": "GMAW - Groove Weld",
+    "credits": 3,
+    "description": "Safely setup and operate Gas Metal Arc Welding (GMAW) equipment with practice of open V-Groove welds in the flat, horizontal, vertical, and overhead positions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1430",
+    "title": "Distribution Line Maintenance",
+    "credits": 3,
+    "description": "The course exposes distribution linesmen into advanced distribution lines construction maintenance system. The course covers theory and practical sessions in various lines construction & maintenance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1020",
+    "title": "Introduction To Biology II",
+    "credits": 3,
+    "description": "BIOL 1020 is designed to cover broad biological principles for non-science majors. This course touches on the classification of bacteria, archaea, fungi, protista, plantae and animalia. Other topics demonstrate fundamentals of community biology, ecosystem biology, population biology and conservation biology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "2240",
+    "title": "Medical Microbiology Lab",
+    "credits": 1,
+    "description": "Laboratory exercises are designed to illustrate the material studied in BIOL 2230 for students majoring in biology, biotechnology, nursing and certain allied health and technical fields. Topics include bacterial cell type identification using staining procedures (i.e. gram, spore an acid-fast stains), biochemical testing, food microbiology and microbial growth methods. This course focuses on diagnostic identification and research procedures for clinical microbiology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1500",
+    "title": "Finite Math",
+    "credits": 3,
+    "description": "The course is intended to give an overview of topics in finite mathematics together with their applications, and is taken primarily by students of the social sciences, communications, and liberal arts. Topics include linear equations, linear inequalities, financial math, sets, counting, permutations, combinations, an introduction to probability and statistics, and matrices. Additional topics will include symbolic logic, linear models, and linear programming. (*Students who have not met the prerequisite requirements listed below, but who are eligible for MATH 0099 or MATH 0099X, will be allowed to enroll in the 4-credit Finite Math course and will be required to complete additional supplemental support tasks both in and out of class. These tasks may include watching additional instructional videos, completing additional practice problems, tutoring, or participation in small group instruction.)",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2012",
+    "title": "Pharmacy Clinical Externship I",
+    "credits": 4,
+    "description": "This course provides the Pharmacy Technician clinical student the opportunity to work in pharmacy setting under the supervision of a registered pharmacist. Emphasis is placed on effective communication, understanding pharmacy operations, and dispensing of medications. The student will be assigned to retail and/or hospital pharmacies for 180 hours.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2400",
+    "title": "Patient/Hlth Navig Lead & Mgmt",
+    "credits": 2,
+    "description": "This comprehensive course in Patient/Health Navigator Leadership & Management is designed to equip healthcare professionals with the necessary skills and knowledge to excel in the critical role of guiding and supporting patients through the complex healthcare system. Navigators play a pivotal role in enhancing patient experience, improving health outcomes, and promoting effective communication between patients and healthcare providers. This course will assist students in the development of leadership skills and abilities essential for patient and health navigation, including effective communication, problem-solving, and decision-making in a healthcare context. Students will learn patient-centered care principles to enhance the quality of healthcare services, with an emphasis on empathy, cultural competence, ethical considerations in patient interactions, and health literacy. This course will assist students to gain a deep understanding of the healthcare system, including insurance processes, healthcare policies, and access to resources. This course is designed to assist students to develop strategies for efficient navigation within complex healthcare structures and the different roles of the healthcare team member. These students will learn principles of quality improvement and skills necessary in assessing and optimizing the effectiveness of patient navigation programs. This course will assist the student in developing skills in providing emotional support to patients facing health crises and crisis intervention techniques and strategies to address the emotional aspects of healthcare navigation. This course will also cover basic leadership and management principles & concepts. Students completing this course will be prepared to lead or supervise other patient navigators or a team of navigators.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SCML",
+    "number": "2000",
+    "title": "Purchasing Management",
+    "credits": 3,
+    "description": "This course covers procurement fundamentals including sourcing, purchase order and contract management, purchasing cycles, material and technical specifications, quality management, relationship management, capital goods and services, sustainability and supply chain analysis and tools with respect to procurement. Through this course, students will be prepared for the ASCM Procurement Certificate (additional test fee.)",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PSYC",
+    "number": "2040",
+    "title": "Developmental Psychology",
+    "credits": 3,
+    "description": "The purpose of this course focuses on human growth and development throughout the lifespan. Topics include developmental milestones, major theories and perspectives as they explain the developmental stages, and the research to explore language, socioemotional, physical, and cognitive development.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1410",
+    "title": "A/C Phase Cable & Conductor",
+    "credits": 3,
+    "description": "Students successfully completing this course will be able to correctly size circuit conductors and apply necessary temperature correction and derating factors. Students will also be shown the difference between continuous and non-continuous loads and the considerations that must be adhered to when working with them.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2520",
+    "title": "Drugs Crime and Society",
+    "credits": 3,
+    "description": "This course provides an overview of drug use in modern society, with a focus on relating the latest information on drugs to their effects on society and human behavior.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PARL",
+    "number": "1000",
+    "title": "Intro to Paralegal Studies",
+    "credits": 3,
+    "description": "This course introduces students to the United States legal system, the legal profession in general, and the paralegal profession in particular. Special focus is given to the skills necessary to obtain paralegal employment, the various duties performed by paralegals, and the ethical obligations of paralegals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "2530",
+    "title": "Office Procedures",
+    "credits": 3,
+    "description": "This course focuses on understanding the role of the office professional in today’s changing office environment. Students learn effective office, human relations, communication, decision-making, and critical thinking skills by completing assignments and live projects. Specific items covered in this course include interpersonal communications, professional presence and success behaviors, stress and time management, work ethics and diversity, current technology, telecommunications, mail and records management, business correspondence, teamwork, meetings and presentations, travel and conference arrangements, and career development.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2210",
+    "title": "Practical Nursing I",
+    "credits": 6,
+    "description": "This course is a study of the nursing process as a method of individualizing care of the adult and geriatric clients experiencing alterations in cardiovascular, lymphatic, and immune functioning with special emphasis on the essential concepts of fluid and electrolytes and acid-base balance. Included is a review of anatomy and physiology, therapeutic or modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process reviewed. This portion of the course includes 90 hours of theory.Requires: HNUR 2000, HMDT 1170, HNUR 2110, HNUR 2111. Concurrent enrollment in HNUR 2211 (PN I); 2210 & 2211 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2000",
+    "title": "Ethical, Cultural, Legal, Prof",
+    "credits": 1,
+    "description": "Patient navigators play a crucial role in the healthcare system, assisting patients in navigating complex healthcare processes and ensuring they receive appropriate care. However, like any healthcare profession, patient navigators must navigate various ethical, cultural, legal, and professional considerations. Here are some key issues and concepts in each of these areas that will be explored: ethical issues - patient autonomy, respecting and promoting patients' rights, confidentiality and privacy, & conflict of interest; cultural issues - cultural competence, language differences, health beliefs; legal issues - HIPAA compliance, scope of practice, informed consent; and professional issues - continuing education, professional boundaries, collaboration; social determinants of health - addressing social determinants, and advocacy. Regular supervision, adherence to established codes of conduct, and ongoing education for patient navigators will be covered in the course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2992",
+    "title": "Special Projects IV",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "1093",
+    "title": "Fixtures, Faucets, & Devices",
+    "credits": 3,
+    "description": "Identify the materials commonly used to make fixtures, the most common types of fixtures, and the types of faucets available. Explain how each type of fixture and faucet operates.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1440",
+    "title": "Motor Controls",
+    "credits": 3,
+    "description": "This course presents information on advanced motor control applications. Topics in-clude: installation and troubleshooting of motors, reversing starters, and VFD (Variable Frequency Drive).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1207",
+    "title": "Parasitology for Vet Techs",
+    "credits": 2,
+    "description": "This course is the study of common internal and external parasites found in domestic animals. The characteristics, methods of transmission, life cycle, and clinical signs commonly seen in animals will be studied including a review of safety concerns when dealing with these samples.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ENGL",
+    "number": "0015",
+    "title": "Suppl Inst for Engl Comp",
+    "credits": 1,
+    "description": "ENGL 0015 is designed to provide supplemental instruction for a college-level English Composition I course. It serves as a foundation of basic writing skills and instills the fundamentals of grammar and mechanics in the context of writing. The focus of this course is to help students improve their reading, writing, critical thinking, and revision skills. These skills will be practices through reading assignments, paragraphs and essay writing, classroom discussions, and group critiques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2930",
+    "title": "Commercial Refrigeration II",
+    "credits": 6,
+    "description": "This course teaches topics that will include types of commercial refrigeration systems heat loads, calculations, duct design, air filtration, and safety principles.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1220",
+    "title": "Advanced Diesel Electrical Sys",
+    "credits": 4,
+    "description": "A course covering the theory of operation, repair and diagnostic procedures used on heavy-duty truck and tractor electrical systems, electronic engines and transmissions. Topics covered in this course will include the study of DC resistance and conductors, principles of DC circuits, fundamentals of alternating current and semiconductors, basic electronic circuits, and digital electronics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2994",
+    "title": "Special V",
+    "credits": 4,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1204",
+    "title": "Animal Nursing I",
+    "credits": 3,
+    "description": "This course covers humane animal care and nursing, with emphasis on technical skills such as: physical examinations, sample collection, medicating animals, IV catheterization/venipuncture, and bandaging. This course will also cover animal nutrition and the principles of feeding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2910",
+    "title": "Commercial Refrigeration I",
+    "credits": 6,
+    "description": "This course is an introduction to the fundamental theories and techniques to identify major components and function of commercial system. Instruction is given on types of commercial refrigeration systems, and pressure and temperature charts.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "THEA",
+    "number": "1010",
+    "title": "Introduction To Theatre",
+    "credits": 3,
+    "description": "This course is designed to introduce students to the elements of theater, its history, various genres, and the techniques used in creating and preforming theatrical productions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2900",
+    "title": "Internship/Job Seeking Skills",
+    "credits": 3,
+    "description": "The internship will be the final course taken by students in their last semester. Students will be assigned projects at the school site or at an employer’s site to gain practical hands-on workplace related skills. In addition, there will be opportunities for job seeking lectures on resume creation and skills to help with employment skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SPAN",
+    "number": "2020",
+    "title": "Intermediate Spanish II",
+    "credits": 3,
+    "description": "A course with emphasis on proficiency in reading and continuation of grammar review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1515",
+    "title": "Pharmacology II",
+    "credits": 2,
+    "description": "This course introduces the pharmacy technician student to the general principles of pharmacology. Drugs are discussed in the context of drug classes, mechanisms of action, disease types, and body systems. The course is designed to provide the Pharmacy Technician with a sufficient foundation in drug related information so that they will be able to play a key role in avoiding dispensing error. In this course emphasis will be given to the actual preparation to dispense the most commonly prescribed top 100 medications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2230",
+    "title": "Drill Press",
+    "credits": 6,
+    "description": "A course to manufacture parts using drill presses, and drilling machines. Topics include identifying types and uses of drill presses, parts and controls, and manufacturing mechanical parts using drilling, boring, counter boring, counter sink, spot facing, and tapping operations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1005",
+    "title": "College Algebra Fundamentals",
+    "credits": 3,
+    "description": "This course is designed as an overview of the study of families of functions and their graphs. Topics covered include in-depth treatment of solving equations and inequalities; function properties and graphs; inverse functions; linear, quadratic, polynomial, rational, exponential and logarithmic functions with applications; systems of equations. This course also includes additional support of algebra fundamentals including operations with exponents, polynomial and rational expressions, and factoring. A student may not receive credit for both MATH 1005 and MATH 1015. (*Students who have not met the prerequisite requirements, but are eligible for MATH 0099, will be allowed to enroll in this course with the understanding that co-requisite supplemental work in the form of worksheets, watching instructional videos, additional MyMathLab assignments, tutoring, etc. will be assigned and required in order to help support the student in achieving the desired learning outcomes.)",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "1200",
+    "title": "Basic Hydraulics",
+    "credits": 3,
+    "description": "This course includes the principles of basic hydraulic systems and general maintenance procedures of a hydraulic system. Also included are the disassembly and assembly of hydraulic components and the application of safety rules and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1220",
+    "title": "Electrical Components",
+    "credits": 3,
+    "description": "This course provides instruction in identifying, installing and testing commonly used components in an air conditioning system. Topics include: pressure switches; overload devices; transformers; magnetic starters; other commonly used controls; diagnostic techniques; installation procedures; and safety.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1330",
+    "title": "Introduction to Criminal Law",
+    "credits": 3,
+    "description": "Study of the substantive criminal law including definitions of law, crime, defenses, criminal responsibility, punishments, and court systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MAST",
+    "number": "1125",
+    "title": "Medical Assisting I",
+    "credits": 5,
+    "description": "Analysis of the job market, salaries, working conditions, and job responsibilities and desirable attributes required of the Medical Assistant. Historical issues and current health care trends are also discussed. This course also includes discussion of AMA principles of medical ethics and the law, Patient's Bill of Rights, confidentiality, medical records, and other medical/legal/ethical issues and responsibilities of Medical Assistant. In addition, this course includes discussion of the components of effective client/staff communication, both verbal and nonverbal. Beginning front office activities such as scheduling, insurance, billing and patient/client education methods are covered. Practical application activities are integrated throughout this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1340",
+    "title": "Comm and Industrial Wiring II",
+    "credits": 3,
+    "description": "An advanced approach to various methods of installing commercial and industrial wiring methods, AC cable, EMT, rigid metallic conduit, PVC, flexible and surface raceway. Lab requirements include cutting, bending, installing conduit, wiring commercial and industrial apparatus.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PLMB",
+    "number": "2172",
+    "title": "Safety Applications",
+    "credits": 2,
+    "description": "Identify methods used to establish work zone safety with various work areas.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1110",
+    "title": "Introduction & Safety",
+    "credits": 1,
+    "description": "This course provides an overview of the Building Technology Specialist occupational area. Topics include basic safety, fire prevention and health information to prepare individuals entering the work force.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1090B",
+    "title": "Radiographic Pathology",
+    "credits": 2,
+    "description": "A study of various pathological terminologies, conditions, injuries, tissues, systemic diseases and their relevance to radiographic procedures",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "SOCL",
+    "number": "2120",
+    "title": "Social Problems",
+    "credits": 3,
+    "description": "A course designed to provide an examination of the major social problems in society with an emphasis on how these problems are interrelated and the role of society in their creation and perpetuation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2150",
+    "title": "Networking I",
+    "credits": 3,
+    "description": "This course is an introduction and is a foundation networking course that will cover the following topics: media and topologies, protocols and standards, network implementation, and network support.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2720",
+    "title": "Intro to Programmable Logic",
+    "credits": 2,
+    "description": "An introduction to the uses and applications of logic technology. The course utilizes test equipment and schematic diagrams to troubleshoot and repair circuits while practicing safety procedures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1070",
+    "title": "Intro to Protection",
+    "credits": 1,
+    "description": "A brief overview of principles and concepts of radiation, units of detection, measurements, exposure monitoring, dose equivalents and radiation limiting devices. Provides new students with knowledge of radiation protection as they begin clinical rotations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1330",
+    "title": "Differentials",
+    "credits": 2,
+    "description": "This course includes identifying the parts of drive lines and differentials for medium/heavy duty trucks and heavy equipment. Live work will be a part of this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1141",
+    "title": "Engines II",
+    "credits": 3,
+    "description": "This course is a continuation of Engines I, but covers heavy-duty diesel engines. Students gain knowledge in operation, troubleshooting, rebuilding and tuning all types of diesel engines. Workincludes disassembly, assembly, injection timing and adjustment common to diesel engines used in the transportation and industrial industries.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1030",
+    "title": "Business English",
+    "credits": 3,
+    "description": "Business English is designed to guide college students in developing the vital communication skills that are necessary to succeed in the modern workplace. It is also a study of English grammar and usage as applied to business documents and applications.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1420",
+    "title": "Judicial Process",
+    "credits": 3,
+    "description": "This course examines the role, function, and structure of the courts and their relationship to the criminal justice system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "1020",
+    "title": "Elementary French II",
+    "credits": 3,
+    "description": "FREN 1010 is designed to develop and strengthen the oral and written communication, reading, and listening skills learned in FREN 1010. Students will be exposed to the language as a means of communication in order to develop communicative language ability. Therefore, your instructor will speak mainly French in class, and English will be kept to a minimum.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1411",
+    "title": "SMAW - Fillet Weld",
+    "credits": 3,
+    "description": "Safely setup and operate Shielded Metal Arc Welding (SMAW) equipment with practice of single and multi-pass fillet welds in the flat, horizontal, vertical, and overhead positions using various electrodes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2410",
+    "title": "Basic Mill I",
+    "credits": 4,
+    "description": "A basic course to manufacture parts using milling machines and accessories. Topics include types of milling machines, accessories, parts, and controls; milling to length, squaring part, milling set-ups, associated cutting tool, and calculating proper feeds and speeds; realigning a vertical milling head, squaring up a milling vise, manufacturing 3-D parts, manufacturing mechanical parts that include, key-seats; indexing procedures using rotary table and dividing heads.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "1214",
+    "title": "Basic Fundamentals in PN",
+    "credits": 4,
+    "description": "The student is introduced to the basic concepts of the adult population including measurements of physiological statistics and documentation of these findings, basic nutritional intake/output, proper use of body mechanics, bed-making, and infection control. Theory and supervised skills lab experiences focus on providing basic nursing skills to meet the physiological, psychosocial, socio-cultural, and spiritual needs of clients in various health care environments. Infection control, communication and interpersonal skills, safety procedures and clients’ rights are presented as part of this course. Omnibus Budget Reconciliation Act (OBRA) guidelines are presented as an application of the nursing process in the management of clients with health alterations. Concepts essential for the safe performance of nursing procedures and for the prevention of illness and/or the transfer of disease to others are discussed. Modes of microbe transmission, isolations techniques and infection control measures are taught. Health care environments utilized include long term care facilities, skilled nursing facilities. This course includes 20-hour skills lab experience and a 40-hour clinical component. Note: Students must pass both the theory and clinical components of this course with at least 80% to progress in the Practical Nursing program. Students must earn 70% or better to test for the nurse assistant certification exam as directed by the Louisiana Department of Health.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1025",
+    "title": "General Biology Lab II",
+    "credits": 1,
+    "description": "Laboratory exercises for systematically studying laboratory safety practices, hierarchical classification, mechanisms of evolution, prokaryotic cell structure and function, characteristics of eukaryotic organisms including protists, fungi, plants, invertebrates, vertebrates, and ecology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "1130",
+    "title": "Appl of Nursing Health Assessm",
+    "credits": 1,
+    "description": "Provides students opportunity to practice skills related to focused and regional body system assessments.Prerequisites: Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_text": "Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2540",
+    "title": "Logic Functions",
+    "credits": 2,
+    "description": "An introduction to the uses and applications of logic technology. The course utilizes test equipment and schematic diagrams to troubleshoot and repair circuits while practicing safety procedures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "1015",
+    "title": "College Algebra",
+    "credits": 3,
+    "description": "This course is designed as an overview of the study of families of functions and their graphs. Topics covered include in-depth treatment of solving equations and inequalities; function properties and graphs; inverse functions; linear, quadratic, polynomial, rational, exponential and logarithmic functions with applications; systems of equations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1405",
+    "title": "Fund. of Pharm. Tech Math",
+    "credits": 2,
+    "description": "This course is a review of basic mathematics as well as use of systems of measurements, dosage calculations, concentrations and dilutions involving pharmaceutical calculations. This course teaches the pharmacy technician student the essential pharmacy calculations that are performed in a a pharmacy setting. The primary objective is to develop problem solving skills, including how to use information from written prescriptions, hospital medication orders, and drug product labels emphasizing pharmacy calculations that are used on a daily basis in retail and institutional pharmacies. Business terms and business math skills essential to pharmacy practice including inventory and purchasing, profit margins, and inventory control are also covered in this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2115",
+    "title": "Advanced Client/Server",
+    "credits": 3,
+    "description": "This course introduces students to planning, designing, and deploying a physical and logical Windows Server enterprise and Active Domain Services infrastructures including the network services. The students will learn how to plan and implement some of the advanced features available in Windows Server.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "2010B",
+    "title": "Anatomy and Physiology II",
+    "credits": 2,
+    "description": "The study of the function and structure of muscular, circulatory, endocrine, reproductive, nervous and respiratory systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "2010",
+    "title": "Intermediate French I",
+    "credits": 3,
+    "description": "Completion and review of basic elements of grammar. Introduction of reading material of moderate difficulty.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "1050",
+    "title": "Intro to Information Tech.",
+    "credits": 3,
+    "description": "This course is designed to provide students with the skills and best practices necessary to be successful in the Information Technology program, as well as, within business and industry. It focuses on building a solid, concise foundations in the fundamentals of information systems through the most recent research, references, and examples in the field.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2103",
+    "title": "Animal Nursing II",
+    "credits": 3,
+    "description": "This course will further develop clinical skills including but not limited to: radiographic positioning and acquisition, emergency and critical care, sample collection, and advanced technical skills.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "FREN",
+    "number": "2020",
+    "title": "Intermediate French II",
+    "credits": 3,
+    "description": "A course with emphasis on proficiency in reading and continuation of grammar review.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "2200",
+    "title": "Robotics II",
+    "credits": 3,
+    "description": "This course provides further exploration of industrial robot operations, programming and automation for multitasking applications, teaching robots in complex assembly environments, sensors, vision, payloads, motion control and factory integration principles. During this course students complete the requirements for NC3 Applied Robotics, which includes programming and troubleshooting a robot assembly workcell.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1310",
+    "title": "Patient/Hlth Navig Clinical II",
+    "credits": 1,
+    "description": "This course will provide the clinical experiences for entry-level patient navigators. Students will attend clinical experience in which they will shadow various healthcare personel in patient navigator roles in the inpatient, outpatient, and insurance settings. The students will experience the following areas during their clinical experience: Discharge planning, Insurance Navigators, and Clinic Population Health departments by specialty (must experience a minimum of 2 different clinic specialties).",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1110",
+    "title": "Environmental Biology",
+    "credits": 3,
+    "description": "This course will provide students the opportunity to learn about human interactions and the effects of those interactions on the natural environment. Topics include population ecology and human demography, nonrenewable and renewable energy, air quality and pollution, climate change, nutrient cycles, water quality, and environmental policies.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2231",
+    "title": "Intro to Aluminum Welding Proc",
+    "credits": 3,
+    "description": "An introduction to the principles of Gas Metal Arc Welding Aluminum (GMAWA) components and consumable identification including the safe setup ofequipment and practice of welding fillet and groove welds in the flat, horizontal, vertical, and overhead positions. Emphasis on lean manufacturing, energy efficiency, distortion control and quality inspection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HSOM",
+    "number": "1030",
+    "title": "Medical Terminology II",
+    "credits": 3,
+    "description": "HSOM 1030 is a continuation of HSOM 1020. It covers the respiratory system, blood system, lymphatic and immune systems, musculoskeletal system, oncology, radiology, nuclear medicine and radiation therapy, pharmacology, and psychiatry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ARTS",
+    "number": "1010",
+    "title": "Survey of World Art History I",
+    "credits": 3,
+    "description": "This course is the chronological study of the visual arts from the Pre-historic to the Pre-Renaissance and introduces the origins and the historical development of art including sculpture, painting, and architecture. Additionally, we will look at the various geographic, economic, cultural, social, and religious aspects which influence its appearance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "2120",
+    "title": "Introduction To Marine Safety",
+    "credits": 3,
+    "description": "This course indoctrinates students to a comprehensive maritime safety culture. Personal conduct, awareness and knowledge focused on understanding the laws and liabilities associated with employment in the industry is emphasized to ensure marine safety competencies and compliance.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1601",
+    "title": "Comm Techniques in Healthcare",
+    "credits": 3,
+    "description": "This course introduces effective and therapeutic communication (written and verbal) skills essential for the student to be successful in a variety of healthcare professions. Communication principles will be presented with subsequent examples, scenarios and role-playing to assist the student in mastering the communication techniques necessary for healthcare providers to deliver quality care. Specific areas such as the communication process, verbal & non-verbal communication skills, professional behavior, interviewing techniques, adapting to client disabilities (ADA), effective client teaching skills, multicultural and ethnic sensitivity, writing skills and use of electronic communication are included.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2200",
+    "title": "Digital Tele Health",
+    "credits": 1,
+    "description": "This course is designed to equip patient navigators with the essential knowledge and skills needed to navigate the dynamic landscape of digital telehealth and health informatics. As the healthcare industry increasingly integrates technology to enhance patient care and streamline healthcare delivery, patient navigators play a crucial role in ensuring seamless communication and support for patients. This course will include an introduction to telehealth and its impact on healthcare delivery, various telehealth modalities (virtual visits, remote monitoring, teleconsultations, etc.), basic health informatics and its role in managing health information, electronic health records, and digital tools for patient navigation. Legal and ethical aspects of telehealth and health informatics, privacy regulations, data security, and patient confidentiality in the digital healthcare space will be taught. This course will explore cultural competence in telehealth and how to develop cultural competence in the context of digital healthcare delivery in a diverse and multicultural patient population. This course will cover patient empowerment and engagement for active patient participation in healthcare through digital tools with strategies for promoting patient engagement and adherence to telehealth interventions. The student will learn to identify common challenges and barriers in adoption of telehealth and how to problem-solve and develop strategies to address obstacles. This course will also briefly explore current trends and innovations in digital health.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2210",
+    "title": "GTAW - Basic Multi-Joint",
+    "credits": 3,
+    "description": "An introduction to the principals of Gas Tungsten Arc Welding (GTAW), component and consumable identification including the safe setup of equipment and practice of welding beads (fillet welds), and groove welds in the flat, vertical, horizontal, and overhead positions using carbon steel consumables.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1104",
+    "title": "Technical Drafting",
+    "credits": 3,
+    "description": "The application of the principles and methods for creating machine and section drawing, dimensioning and mechanical components.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "2315",
+    "title": "Anatomy & Physiology LAB II",
+    "credits": 1,
+    "description": "A course designed to utilize a series of laboratory exercises to illustrate the course material in BIOL 2300. This course includes anatomical and physiological studies of the endocrine, cardiovascular, respiratory, digestive, excretory, and reproductive systems, as well as dissections.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Pharmacy Technician program. Dean of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2310",
+    "title": "Basic Lathe I",
+    "credits": 4,
+    "description": "This course teaches the types of lathes, accessories, parts and controls. Topics include to calculate proper feeds and speeds, facing, turning, drilling, reaming, and boring operations; sharpening cutting tools, manufacturing mechanical parts, boring, taper-turning, and thread cutting; learning how to use steady rest, follow rest, and taper attachment; and learning the use of index-able carbide tooling.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2420",
+    "title": "Basic Mill II",
+    "credits": 3,
+    "description": "Perform multi-angular set-ups, gear cutting, advanced indexing operations and other advanced cutting operations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1220",
+    "title": "Electrical Raceways",
+    "credits": 3,
+    "description": "An introduction to various methods of installing AC cable, EMT, rigid metallic conduit, PVC, flexible and surface raceway. Lab requirements include cutting, bending, and installing conduit.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1530",
+    "title": "System Protection",
+    "credits": 2,
+    "description": "This course is an introduction to power system components and power system protection. Topics include protection of generators and motors, protection of transformers and reactors, and protection of transmission lines.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1204",
+    "title": "Pipe Drafting",
+    "credits": 3,
+    "description": "The application of various industry standards to drawings and schematics utilized in process manufacturing, including piping components, equipment, structural systems and industry codes and practices. 2D AutoCAD and AutoCAD Plant 3D will be utilized in this course. Course concepts based on the Society of Piping Engineers and Designers credentialing exam.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1219",
+    "title": "Meat Identification & Fabricat",
+    "credits": 3,
+    "description": "Identification and fabrication of meat, seafood, and poultry. Selection, procurement, and preparation of products in commercial food service.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "2545",
+    "title": "Network Security",
+    "credits": 3,
+    "description": "This course is designed to provide an overview and understanding of established cyber security strategy as well as provide students with the opportunity to engage in strategic decision making in the context of cyber security. The course will assess current threats in varying contexts including conducting a threat or vulnerability assessment for a non-profit or government service organization, as well as evaluate current methodology and approaches to pave the way for the development and implementation of cyber security strategy at the organization or corporate level.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "2140",
+    "title": "Applied Basic Lead. Skills II",
+    "credits": 1,
+    "description": "The practical application of the skills and knowledge taught during MILS 2130. Practical exercise designed to teach the student leadership via light infantry squad and platoon tactics. The leader in the conduct of an ambush patrol.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2540",
+    "title": "InternshipPart I:Culinary Cafe",
+    "credits": 5,
+    "description": "Experiential course involving all facets of food preparation and operations in a culinary enterprise. Instructor approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "1361",
+    "title": "Pharmacology Applications",
+    "credits": 2,
+    "description": "Medical math is an integral component of this course. The terminology and principles of medication administration are presented in this course. Drug classifications and their effect on the various body systems are presented. Specific drugs in each classification are emphasized according to expected effects, side effects, and adverse effects. Routes of drug administration and variables that influence drug action are covered including dangerous drug interactions and nursing implications related to each drug. Safety precautions which will help to decrease the incidence of errors in medication administration are stressed. Advanced medication calculations will be required to demonstrate knowledge of safe dosing parameters. The nursing process is utilized to assess the client’s learning needs and effects of all pharmacological interventions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1130",
+    "title": "Child Guidance and Behaviors",
+    "credits": 3,
+    "description": "Typical, age-related behavior patterns, child guidance practices and their consequences; techniques and procedures for successful management.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1210",
+    "title": "Adm Procedures Med Offices",
+    "credits": 3,
+    "description": "This course is a discussion of the components of effective client/staff communication, both verbal and nonverbal. Beginning front office activities in a medical office such as scheduling, insurance, billing, using and maintaining office equipment, legal and ethical issues in the medical office, maintaining patient records, and patient/client education methods are covered. Practical application activities are integrated throughout this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNUR",
+    "number": "1004",
+    "title": "Practical Nursing Intersession",
+    "credits": 2,
+    "description": "This course is designed to assist students in transitioning to nursing to gain necessary skills for success in the Practical Nursing program. Course content includes: medical abbreviations, study skills, reading comprehension, and test taking skills. The course will also include basic arithmetic needed for healthcare workers: fundamental numerical operations of addition, subtraction, multiplication, and division of whole numbers, fractions, and decimals. This course also assists the student in acquiring a better understanding of percent, ratio and proportion, and measurements.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "INTE",
+    "number": "1950",
+    "title": "Intro to Cloud Computing",
+    "credits": 3,
+    "description": "This course introduces students to cloud computing while evaluating and assessing the business and technical benefits of cloud computing, gain the foundation to analyze cloud applications for use within an organization.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1210",
+    "title": "Intro To The Power Industry",
+    "credits": 3,
+    "description": "This course will study the history behind electrical utility industry. Students will study how the electrical system in the United States was established and how Thomas Edison and George Westinghouse, Jr. influenced the development of electrical systems. Students will also learn how the electrical industry was first regulated and how regulation of the industry has changed as well as learning specific employability skills. Students will also gain knowledge of how the electrical industry is currently being \"re-regulated\" to encourage competition and gain knowledge of the system operations and marketing of electricity. Finally, this course will teach how the electrical industry is segmented into utility sectors, such as investor owned, Federal owned, publicly owned and cooperatively owned utilities.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1115",
+    "title": "Gen Chemistry I Lab",
+    "credits": 1,
+    "description": "This laboratory course is designed to illustrate the material studied in CHEM 1100. Students will participate in experiments that involve mass/volume measurement and relationships, yield and stoichiometry, calorimetry and thermochemistry, and the manipulation and measurement of gases.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2114",
+    "title": "FCAW Pipe 6G",
+    "credits": 4,
+    "description": "Safely setup and operate Flux Core Arc Welding pipe (FCAW-Pipe) equipment, proper assembly of a 6G(R) - 45° fixed position pipe joint with/without a restriction ring, proper weld quality, safe setup of equipment and practice welding a 6G(R) pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1601",
+    "title": "Basic Electrical Fundamentals",
+    "credits": 5,
+    "description": "An introductory course in the basic concepts in D.C. and A.C. automotive electricity. Topics include Ohm’s Law, series and parallel circuits, Kirchhoff’s Voltage and Current Laws, Thevenin’s equivalent circuits, and A.C. power generation.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2220",
+    "title": "Air Conditioning",
+    "credits": 3,
+    "description": "This course covers the physical and chemical laws governing the principles of refrigera-tion. The basic cycle and components will be covered. Applications will include alternate refrigerants, trans-ferring, evacuation and system reprocessing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1410",
+    "title": "Advanced Database Mgmt",
+    "credits": 3,
+    "description": "A further study of database applications including advanced concepts such as action queries, switchboards, custom toolbars and menus, converting objects to html files, and hyperlinks.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1214",
+    "title": "Nursing Assistant Skills Appli",
+    "credits": 1,
+    "description": "The student will perform, demonstrate, and practice a minimum of 45 hours of basic nursing assistant care in approved facilities, to include a minimum of 40 hours of long term care, under the supervision of NTCC faculty. The application of the nursing process will be used in meeting biological, psychosocial, cultural, and spiritual needs of geriatric clients in selected environments. Major components included are rehabilitative care and support of death with dignity utilizing therapeutic and preventive measures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1150",
+    "title": "HVAC Introduction",
+    "credits": 3,
+    "description": "This course is designed to provide information needed to prepare individuals to enter the Air Conditioning and Refrigeration Industry. Topics include: Basic safety, fire prevention and health, inventory control, stock management, licensing, certification requirements, and basic business management practices.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1000",
+    "title": "Introduction to Computers",
+    "credits": 2,
+    "description": "An introductory study of computer system components, operating system environments., Internet concepts, and security issues. Includes a hands-on study emphasizing computer hardware and various operating systems features.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "1501",
+    "title": "Maritime Life",
+    "credits": 3,
+    "description": "Students are introduced to maritime careers and the maritime culture. The introduction to maritime studies is designed to familiarize students with the dynamic cultural and natural resources of the maritime environment. Students will gain knowledge and understanding of maritime environments with an emphasis on safety. Regulations and requirements for maritime employability are a required component of this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2220",
+    "title": "GTAW - PIPE 5G",
+    "credits": 4,
+    "description": "An introduction to the principals of Gas Tungsten Arc Welding of Pipe (GTAW-Pipe) in the 5G horizontal fixed position, proper assembly of a 5G pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G horizontal fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "1401",
+    "title": "Suspension & Steering Systems",
+    "credits": 4,
+    "description": "A comprehensive study of suspension systems with emphasis on wheel alignment and suspension rebuilding. Topics include principles of geometry necessary to understand the procedures and methods for diagnosis and alignment of steering systems and servicing automotive tire and wheel assemblies including rotating, balancing, and repair.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "1120",
+    "title": "Applied Lead. Develop Lab I",
+    "credits": 1,
+    "description": "The practical application of skills and knowledge taught during MS 1110. Laboratory develops importance of team building and individual contribution to mission accomplishment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2113",
+    "title": "FCAW Pipe 2G",
+    "credits": 4,
+    "description": "Safely setup and operate Flux Core Arc Welding pipe (FCAW-Pipe) equipment, proper assembly of a 2G – vertical fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 2G pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1540",
+    "title": "Advanced Word Processing",
+    "credits": 3,
+    "description": "Hands-on application of advanced word processing, with emphasis on features and commands using current version of word processing software.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "1120",
+    "title": "Introduction to Corrections",
+    "credits": 3,
+    "description": "A study of the history, philosophy, theories, and practices involved in treatment of convicted law violators. Focus is given to roles of correctional system as it relates to other components of the criminal justice system.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2130",
+    "title": "Brakes",
+    "credits": 4,
+    "description": "The course includes nomenclature, theory of operation, and ser-vice procedure for medium/heavy duty truck braking systems to include air and hydraulics.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1310",
+    "title": "Pole Climbing",
+    "credits": 4,
+    "description": "This course is designed to provide instruction on climbing a utility pole safely using the latest OSHA fall resistant requirements. At the completion of this course, you will be able to safely ascend and descend a utility pole using gaffs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MILS",
+    "number": "2110",
+    "title": "Basic Lead. Skills Develop. I",
+    "credits": 2,
+    "description": "Must be taken concurrently with MILS 2120. Discussion of leadership and its application to communication skills and human relations. Practical application of military writing--draft and edit military correspondence. Introduction to military briefings. Application of small unit tactics; individual and squad movement techniques--the responsibility of the leader.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2523",
+    "title": "Mental Illness/Psychiatric Nur",
+    "credits": 2,
+    "description": "This course is the study of the client experiencing emotional, mental and social alterations utilizing the nursing process approach with integrated pharmacology and application of life span principles. Geriatric considerations are addressed. Utilizing a nursing process approach, the student will perform applicable practical nursing clinical skills to clients in mental health facilities under the supervision and at the discretion of practical nursing faculty. This course includes a 30-hour clinical component.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2830",
+    "title": "Commercial Air Cond II",
+    "credits": 6,
+    "description": "This course teaches topics that will include types of commercial air conditioning systems heat loads, calculations, duct design, air filtration, and safety principles.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1230",
+    "title": "Family Relationships & Issues",
+    "credits": 3,
+    "description": "A study of the dynamics of family cycles, interpersonal relationships and application of principles of child and family development to relationships among young children, their families and teachers/ communities",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2230",
+    "title": "GTAW - Aluminum Multi-Joint",
+    "credits": 3,
+    "description": "An introduction to the principles of Gas Tungsten Arc Welding Aluminum (GTAW-A), component and consumable identification including the safe setup of equipment and practice of welding fillet and groove welds in the flat, horizontal, vertical, and overhead positions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "2600",
+    "title": "Pop Hlth/Prevention & Comm Hlt",
+    "credits": 2,
+    "description": "",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2997",
+    "title": "Special Project IV",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DRFT",
+    "number": "1201",
+    "title": "Architectural Drafting",
+    "credits": 3,
+    "description": "A study of the principles, methods and standards utilized in the design and construction of both residential and commercial buildings. The course also examines building codes (including ADA requirements) as well as environmental aspects related to the construction industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2999",
+    "title": "Cooperative Education",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1113",
+    "title": "EKG Applications",
+    "credits": 2,
+    "description": "This course introduces the student to the electrocardiogram (EKG) purposes and procedures. Students will gain knowledge regarding the normal structure and function of the heart with emphasis on the conduction system. A supervised lab portion (35 hours.) is an integral portion of this course and will allow student performance of EKG procedures. This course includes a minimum of 10 hours of clinical externship to be performed by the student under the supervision of a preceptor or course instructor in a variety of health care settings.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A Practicum provides supervised on-the-job work experience related to the student's education objectives. Students participating in Practicum do not receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1410",
+    "title": "Plumbing I",
+    "credits": 6,
+    "description": "A study of the tools, equipment, materials, and techniques used in the maintenance of plumbing systems. Emphasizes working with and joining pipe and tubing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "1231",
+    "title": "Diesel Engine Control Systems",
+    "credits": 3,
+    "description": "This course will include the identity of type and functions of fuel injectors, nozzles, and unit injectors. Also, this course includes identification and functions of vehicle computer control systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2410",
+    "title": "Practical Nursing III",
+    "credits": 6,
+    "description": "This course includes the study of nursing care provided to adult and geriatric clients experiencing alterations in genitourinary, reproductive, sensory, neurological and musculoskeletal functions, as well as essential information related to growth and development of infants, toddlers, preschool, school age, and adolescent children. Diseases and disorders common in children are covered. Included is a review of anatomy and physiology, therapeutic or modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process. This course in 120 theory hours, which includes 90 hours in med-surg and 30 in pediatrics.Requires: Successful completion of HNUR 2500, HNUR 2310, HNUR 2311. Concurrent enrollment in HNUR 2411; 2410 & 2411 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSO",
+    "number": "1100",
+    "title": "Records and Information Mgmt",
+    "credits": 3,
+    "description": "Introduction to basic records and information management. Includes the life cycle of a record, manual and electronic records management, basic filing procedures and rules. This course examines how different organizational, technological, regulatory, and cultural factors affect the strategies, practices, and tools that organizations can employ to manage electronic records. Problems of long-term preservation and con-tinuing access to electronic records are analyzed and addressed.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2300",
+    "title": "Nursing Concepts II",
+    "credits": 5,
+    "description": "Focuses on nursing care of adult clients with immunological, hematological, endocrine, musculoskeletal, gastrointestinal, and neurological disorders. Focuses on nursing care of pediatric clients and their families. Use of therapeutic drug classifications associated with the disorders.Prerequisites: Successful completion of the first three semesters of the ASN curriculum pattern.",
+    "prerequisite_text": "Successful completion of the first three semesters of the ASN curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CSSK",
+    "number": "1000",
+    "title": "College Success",
+    "credits": 1,
+    "description": "This course is designed to provide and teach strategies for the college freshman, cultivate essential academic skills, and promote understanding of the learning process. This course is recommended for all first-time freshmen and required for all students who need developmental studies courses.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "2230",
+    "title": "Medical Microbiology",
+    "credits": 3,
+    "description": "This course is designed primarily for students majoring in nursing or an allied health field. Topics include detailed prokaryotic cell structure and function, microbial metabolism, a survey of microorganisms including bacteria, fungi, algae, protozoans and helminths, and viral structure and function. Students are introduced to microbial growth and genetics, biotechnology, diseases, and the role of microbes in certain organ systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "1300",
+    "title": "Intro to Regulatory Compliance",
+    "credits": 3,
+    "description": "This course covers OSHA Standards, policies, and procedures in general industry. Topics include the OSHA General Industry Standards, general industry principles and case studies emphasizing hazard identification and standards applications. This course covers OSHA #511 – Occupational Safety and Health Standards for General Industry as well as three NC3 3M PPE certifications: Head, Face and Eye Protection, Hearing Protection and Respiratory Protection.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1140",
+    "title": "Electrical Fundamentals",
+    "credits": 2,
+    "description": "An introduction to welding equipment fundamentals of operation, polarity, equipment types, safety and systems setup including welding related equipment connection and a review of tools used in welding procedures.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1104",
+    "title": "Veterinary Medical Terminology",
+    "credits": 2,
+    "description": "This course introduces students to the professional language of the veterinary profession. History and word components will be used to emphasize proper veterinary terminology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNAV",
+    "number": "1400",
+    "title": "Chronic Disease Prev & Mgmt I",
+    "credits": 3,
+    "description": "This course is designed to provide students with an overview of the principles, strategies, and interventions related to the prevention and management of chronic diseases. Chronic diseases, such as cardiovascular diseases, diabetes, and respiratory conditions, pose significant challenges to global health, requiring multifaceted approaches for effective prevention and management. Throughout this course, students will explore the pathophysiology of chronic diseases, risk factors, and the social determinants of health that contribute to their prevalence. Emphasis will be placed on evidence-based practices for preventing the onset of chronic diseases, as well as strategies for managing and mitigating their impact on individuals and communities. The definition, classification, global burden, epidemiology, and trends in prevalence of major chronic conditions will be covered. Students will learn the risk factors and determinants of these chronic diseases and explore behavioral, environmental, genetic, and socio-economic factors contributing to chronic diseases. Students will gain understanding of the social determinants of health and their impact on disease development, as well as lifestyle modifications, health promotion, and public health initiatives aimed at preventing the onset of the disease. This course will cover community-based interventions and policy approaches to promote healthy behaviors screening programs and early detection methods for those chronic diseases, and strategies for identifying and managing pre-existing risk factors to prevent disease progression. The student will learn evidence-based approaches to the clinical management of chronic diseases, including: patient-centered care, pharmacological interventions, and interdisciplinary healthcare collaboration. The student will learn techniques for effective patient education and behavior change, while learning to promote self-management and empowerment in individuals with chronic conditions. By the end of Chronic Disease Prevention and Management I, students will have gained a solid foundation in the complexities of these stated chronic diseases, equipping them with the knowledge and skills necessary for implementing effective prevention and management strategies in diverse healthcare settings. This course covers half of the Chronic Disease Prevention and Management content. Students will need to take PNAV 1410 to complete the full content of Chronic Disease Prevention and Management.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 3,
+    "description": "Course designed for students who have demonstrated specific special needs in instruction through the Practical Nursing program. Associate Provost of Health Sciences approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "LPNU",
+    "number": "2119",
+    "title": "Medical/Surgical Nursing I",
+    "credits": 9,
+    "description": "\"Nursing theory related to the care of the perioperative client and the adult medical/surgical client experiencing alterations in respiratory, integumentary and genitourinary functions are presented. Principles of fluid and electrolytes/acid base balance are discussed as well as perioperative nursing. Appropriate pharmacological agents related to these systems and their actions, uses, and side effects are discussed. Client education on proper nutrition and diet modifications related to the use of these medications are stressed as well as proper nutrition and diet therapy necessary for health restoration and to maintain health are included in the discussions. Nursing implications for discharge planning and client education for the promotion of health are stressed. This course includes a 180-hour clinical component.The clinical portion of this course builds upon the nursing care theory and skills discussed in Nursing Fundamentals I, Nursing Fundamentals II, and Medical/Surgical Nursing Concepts I. Using the nursing process, students perform basic and increasingly advanced clinical nursing skills in appropriate health facilities under the supervision of the instructor. The student begins to use the nursing process to plan and implement safe nursing care.Note: Students must pass both the theory and clinical components of this course with 80% in each component to successfully complete the course and advance in the Practical Nursing Program.\"",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSN",
+    "number": "2100",
+    "title": "Career Mgmt & Communication",
+    "credits": 3,
+    "description": "This course provides opportunities for students to learn how to use computer networks and other traditional methods to facilitate the following tasks: compose and submit routine business messages; interact with peers on problem-solving teams; research, draft, format, and submit business reports; create and deliver business presentation; and seek and maximize job search resources. Activities in this class are designed to help achieve the following: effective communication skills and functional business knowledge.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2993",
+    "title": "Special Projects II",
+    "credits": 2,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1120",
+    "title": "Applied Bldg Technology Math",
+    "credits": 3,
+    "description": "A course covering the basic concepts of arithmetic, percentage, ratio, proportion, and plane geometry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "2996",
+    "title": "Special Projects IV",
+    "credits": 5,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2111",
+    "title": "PN Foundations w/Geri Clinical",
+    "credits": 4,
+    "description": "This course includes 95 hours of skills lab experiences that focus on providing nursing care to meet the physiological, socio-cultural, and spiritual needs of clients in various health care environments. Nursing skills progress from basic to more complex. Emphasis is placed on maintaining safety, infection control measures, and the dignity and rights of clients while providing nursing care activities. Care of clients across the lifespan is included, with special emphasis on care of the elderly. Students will perform, demonstrate, and practice a minimum of 45 hours of basic geriatric nursing care and skills in long term care facilities under the supervision of nursing faculty, and in accordance with Omnibus Budget Reconciliation Act (OBRA) guidelines. Students must demonstrate the ability to safely and correctly perform all skills in the practice lab setting in order to receive instructor approval to participate in the geriatric nursing clinical experience.Requires: Concurrent enrollment in HNUR 2110; 2110 & 2111 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BUSN",
+    "number": "1100",
+    "title": "Introduction To Business",
+    "credits": 3,
+    "description": "This course is designed to provide students with a broad introduction to the functions of business enterprises within the U.S. economic framework. Students are introduced to essential elements including terminology of business organizations, production, human resource management, marketing, accounting, and finance..",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2210A",
+    "title": "Appl of Nursing Concepts I",
+    "credits": 3,
+    "description": "Application of the nursing process in the care of selected clients with disorders associated with oxygenation, perfusion, sensory, integumentary, renal, fluid and electrolytes, acid-base, and mental health disorders. Clinical laboratory practice in health care agencies will be arranged.Prerequisites: Successful completion of first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "prerequisite_text": "Successful completion of first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "IMTV",
+    "number": "2100",
+    "title": "Marine Weather & Meteorology",
+    "credits": 3,
+    "description": "This course provides an overview of marine weather and meteorology and the practical techniques of coastal navigation with regard to wind, tides, visibility, shoal water and vessel positioning. The program utilizes a marine navigation lab and teaches techniques to plot the position of a vessel, predict tidal levels, current velocity and the effect of these forces on future vessel position.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2243",
+    "title": "Intro to Robotic Welding",
+    "credits": 3,
+    "description": "This course introduces students to robotic welding including safety, robotic welding set up and procedures, programming and comparing robotic vs manual welding.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "NURS",
+    "number": "2500",
+    "title": "Nursing Capstone: Trans to Pro",
+    "credits": 1,
+    "description": "A non-clinical course. This course provides the framework for assisting the transition from student nurse to professional registered nurse and licensure preparation. Resume development, delegation, and the Nurse Practice Act will be discussed.Prerequisites: Successful completion of first four semesters of the ASN curriculum.",
+    "prerequisite_text": "Successful completion of first four semesters of the ASN curriculum.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1101",
+    "title": "Culinary History & Development",
+    "credits": 3,
+    "description": "History and progression of world cuisines, including influences of geography, politics, religion, and cultural characteristics. Emphasis on international and regional American foodways as well as current trends and career opportunities in the foodservice industry.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CRMJ",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs.Dean of Academics approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1430",
+    "title": "Blueprint Interpretation",
+    "credits": 4,
+    "description": "An introduction to blueprint reading skills, which includes specifications and trade-related elements. The course includes making a material list from a blueprint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HEMS",
+    "number": "1300",
+    "title": "Emergency Medical Tech II",
+    "credits": 3,
+    "description": "This course includes instruction in the management and care of patients during pregnancy and childbirth, and the study of developmental and anatomical differences across the lifespan focusing on infants, children and the elderly. Instruction also includes common patient care needs of pediatric and geriatric patients in emergencies, care of persons with special needs, and discussion of air medical operations, weapons of mass destruction and terrorism. Practical application of EMR skills are included in the classroom setting.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1160",
+    "title": "Principles of Refrigeration I",
+    "credits": 3,
+    "description": "This course teaches the proper and safe use of hand tools including power tools and materials in the HVAC Industry. This course also provides for a review of HVAC and refrigeration processes and applications. Topics include: identify various types of pipe, tubing, and fittings; swaging, flaring and cutting copper tubing; set-up and use of an oxyacetylene torch set and proper soldering and brazing techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1310",
+    "title": "Cutting Processes-CAC/PAC",
+    "credits": 2,
+    "description": "An introduction to the principals of safely operating Air Carbon Arc Cutting (CAC-A) and Plasma Arc Cutting (PAC) equipment including practice cutting and gouging ferrous and non-ferrous metals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2999",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "Cooperative Education provides supervised on-the-job work experience related to the student's educational objectives. Students participating in Cooperative Education receive compensation for their work. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1210",
+    "title": "Growth/Devlop of Young Childre",
+    "credits": 3,
+    "description": "An introduction to Care and Development of Young Children as a part of total education to include the study of CLASS domains classroom organization, engaged support for learning and responsive caregiving; health and safety.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2310",
+    "title": "Practical Nursing II",
+    "credits": 6,
+    "description": "This course includes theory related to nursing care provided to adult and geriatric clients experiencing alterations in the respiratory, gastrointestinal, endocrine and integumentary function, as well as care of the adult and geriatric client with a neoplastic disorders. Included is a review of anatomy and physiology, therapeutic/modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease reviewed. Nursing care of the childbearing family through the stages of inceptions, fetal development, gestation, and delivery, including the antepartum, intrapartum, and postpartum periods, and the care of the neonate is also included. This course includes 90 theory hours of medical-surgical nursing and 30 hours of obstetric nursing.Requires: Successful completion of HNUR 2210 and HNUR 2211, and successful completion or concurrent enrollment in HNUR 2500. Concurrent enrollment in HNUR 2311; 2310 & 2311 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "1331",
+    "title": "Drywall",
+    "credits": 5,
+    "description": "A course covering the basic concepts and applications of carpentry. Includes safety, use of basic hand and power tools, and construction techniques.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CDYC",
+    "number": "1220",
+    "title": "Infant/Todd Care & Curriculum",
+    "credits": 3,
+    "description": "Designing culturally sensitive environments and education practices appropriate to developmental needs of infant/toddlers from conception to age 3, including facilities, schedules, activities, and regulations.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETT",
+    "number": "2302",
+    "title": "Large Animal Medicine",
+    "credits": 2,
+    "description": "This course covers the common diseases of large animals (horses, cattle, small ruminants, pigs) with an emphasis on the role of the veterinary technician in diagnostic tests, treatment, and client education. Fundamentals of large animal reproduction will also be covered.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "GEOL",
+    "number": "1010",
+    "title": "Physical Geology",
+    "credits": 3,
+    "description": "This course is a brief study of the Earth: its origin, its history and the dynamics of how it changes. Major topics include the structure of the earth and its dynamic systems; rocks and minerals; weathering and erosion; mass wasting; river, groundwater, glacial, shoreline and deserts systems; earthquakes and volcanoes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "PNUR",
+    "number": "1002",
+    "title": "MA to PN Prep with Math Lab",
+    "credits": 2,
+    "description": "This course is designed to assist students in transitioning into the accelerated paced MA to PN Practical Nursing Program by providing a review of necessary skills needed for success in the Practical Nursing program. Course content includes: medical terminology, anatomy and physiology, and nutrition review, vital signs, study skills, reading comprehension, and test taking skills. The course will also include basic arithmetic needed for healthcare workers, including conversions, dosage calculations, and intake and output.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1015",
+    "title": "General Biology I Lab",
+    "credits": 1,
+    "description": "Laboratory exercises for studying the principles of biology from the cellular level including biochemistry, cell biology, molecular biology, and genetics. Two hours of laboratory per week. A Laboratory fee is required for this course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1110",
+    "title": "Animal Anatomy Physiology Lab",
+    "credits": 1,
+    "description": "This lab is designed to reinforce lecture material and allow students to practice bone/joint identification and dissection of preserved specimens in order to identify major muscles and organs.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HCOR",
+    "number": "1802",
+    "title": "Professional Transitions PCT",
+    "credits": 2,
+    "description": "This course is designed to assist students in transitioning to the professional practice role. Students are expected to identify and perform skills necessary to secure employment in the healthcare industry and make immediate and future decisions regarding job choices and educational growth. Soft skills and personal attributes (such as enthusiasm, honesty, self-esteem, patience, cooperation, organization, responsibility, flexibility, sociability, motivation, and communication skills), necessary for successful employment are discussed and practiced. Patient Care Technician national certification exam preparation is included in the course.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CPTR",
+    "number": "1500",
+    "title": "Introduction to Computers",
+    "credits": 3,
+    "description": "The course prepares students to work with latest version of Microsoft Office in a career setting or for personal use. Using courseware that incorporates an accelerated, step-by-step, project-based approach, students develop an introductory-level competency in Word, Excel, Access, and PowerPoint and explore the essential features of the latest version of Windows and Internet Explorer. Students also develop an understanding of key ethical issues they face in the context of using information technology.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "2400",
+    "title": "Nutrition",
+    "credits": 3,
+    "description": "This course is designed to cover the principles of human nutrition and focuses upon the physiology and biochemistry of nutrients and the application of nutritional principles in health and wellness. Appropriate for students pursuing careers in dietetics, food sciences, nursing or other health-related professions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1210",
+    "title": "Residential Wiring",
+    "credits": 5,
+    "description": "The course includes the identification of various types of conductors in residential wiring, connections, types of boxes, parts of a breaker panel and service entrance, switches, and installation devices.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2320",
+    "title": "GMAW--Pipe 2G",
+    "credits": 4,
+    "description": "An introduction to the principles of Gas Metal Arc Welding of Pipe (GMAW-Pipe) in the 2G vertical fixed position, proper assembly of a 2G pipe joint, proper weld quality, safe setup of equipment, and practice welding a 2G vertical fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1412",
+    "title": "SMAW V Grove BU/Gouge",
+    "credits": 3,
+    "description": "Safely setup and operate Shielded Metal Arc Welding (SMAW) equipment with practice of V-Groove welds with a backing or back gouging in the flat, horizontal, vertical, and overhead positions using various electrodes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "2400",
+    "title": "Fire Protection and Prevention",
+    "credits": 3,
+    "description": "This course provides an in-depth exploration of fire prevention programs, focusing on fire inspection, code enforcement, and the application of model building standards and codes. Students will examine the legal, economic, and political aspects of the fire inspection process, as well as the essential components of plans review and public education initiatives. Emphasis is placed on understanding regulatory practices, fire-resistant construction materials, and the procedures for ensuring the safety and compliance of buildings with fire codes.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MTTC",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELEC",
+    "number": "1450",
+    "title": "Introduction to Electronics",
+    "credits": 3,
+    "description": "An introduction to solid state devices, diodes, transistors; half-wave, full-wave, and bridge rectifiers; and filters. Includes analyzing circuits in transistors, SCR, TRIAC, FET, Zener, VDR, and optical devices. The course includes testing and analyzing circuits.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2112",
+    "title": "FCAW Pipe 5G",
+    "credits": 4,
+    "description": "Safely setup and operate Flux Core Arc Welding pipe (FCAW-Pipe) equipment, proper assembly of a 5G - horizontal fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2231",
+    "title": "Welding",
+    "credits": 2,
+    "description": "The course includes practical experience in the use of oxyacetylene and shielded arc welding of steel plate in the flat position and an introduction of oxyacetylene/cutting procedures is also included.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "2997",
+    "title": "Practicum",
+    "credits": 3,
+    "description": "A practicum provides supervised on-the-job work experience related to the student’s education objectives. Students participating in practicum do no receive compensation. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "1210",
+    "title": "Electrical Fundamentals",
+    "credits": 3,
+    "description": "This course presents introduction to fundamental electrical concepts and theories as applied to the air conditioning industry. Topics include: AC and DC theory; ohms law; electric meters; electric diagrams; distribution systems; electrical panels; voltage circuits; code requirements; and safety.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "1120",
+    "title": "Intro to Construction Drawings",
+    "credits": 3,
+    "description": "This course provides instruction and review of basic construction mathematics, weld symbol interpretation, reading welding detail drawings, basic metallurgy, metal identification, and heat treatment of metals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HACR",
+    "number": "2530",
+    "title": "Residential System Design",
+    "credits": 2,
+    "description": "This course presents theory and practice of different types of residential air conditioning systems heat loads. Topics include calculations, duct design, air filtration, and safety practices.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2321",
+    "title": "GMAW--Pipe 5G",
+    "credits": 4,
+    "description": "Safely setup and operate Gas Metal Arc Welding pipe (GMAW-Pipe) equipment, proper assembly of a 5G horizontal fixed position pipe joint, proper weld quality, safe setup of equipment and practice welding a 5G horizontal fixed position pipe joint.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "VETA",
+    "number": "1109",
+    "title": "Animal Anatomy & Physiology",
+    "credits": 3,
+    "description": "This course includes physiological and anatomical systems of domestic animals. It includes discussions on the chemical basis for life, the cells, tissues, and the integument, musculoskeletal, cardiovascular, respiratory, digestive, nervous, endocrine, urinary, and reproductive systems of domestic animals.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BLDG",
+    "number": "2991",
+    "title": "Special Projects I",
+    "credits": 1,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "1500",
+    "title": "Industrial Hygiene",
+    "credits": 3,
+    "description": "This course covers essential topics of industrial hygiene regulations and best practices and procedures. Topics include chemical, physical, biological, and ergonomic hazards, permissible exposure limits (PEL), respiratory protection, engineering controls, hazard communication, sampling instrumentation, basic exposure calculations, hearing protection and workplace health programs. This course covers the OSHA #521 OSHA Guide to Industrial Hygiene.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "RADT",
+    "number": "1010",
+    "title": "Anatomy & Physiology I",
+    "credits": 2,
+    "description": "This course is the study of human anatomy and physiology including chemical composition, cells, tissues, topography and the skeletal and digestive systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "WELD",
+    "number": "2111",
+    "title": "FCAW - Groove Welds",
+    "credits": 3,
+    "description": "Safely setup and operate Flux Core Arc Welding (FCAW) equipment with practice of VGroove welds with a backing or back gouging in the flat, horizontal, vertical, and overhead positions.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AMAM",
+    "number": "1300",
+    "title": "Advanced Manufacturing I",
+    "credits": 3,
+    "description": "This course introduces students to Advanced Manufacturing with an emphasis on Industry 4.0, Precision Measuring Instruments (PMI) and an introduction to smart factory equipment.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2211",
+    "title": "Practical Nursing I Clinical",
+    "credits": 4,
+    "description": "Students will begin to utilize a nursing process approach to individualize client care, and will perform applicable practical nursing clinical skills to assign adult and/or geriatric client(s) experiencing a variety of medical/surgical and mental health disorders in approved health care and mental health care facilities under the supervision and discretion of practical nursing faculty. This course includes a 180-hour clinical component in the Med-Surg setting and 25 hours in the Mental Health setting.Requires: Concurrent enrollment in HNUR 2210; 2210 & 2211 are linked courses requiring passing grades in both to receive credit for either.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "OCSH",
+    "number": "1400",
+    "title": "Hazardous Materials Safety",
+    "credits": 3,
+    "description": "This course provides an in-depth analysis of how hazardous materials can escalate incidents or emergency events. It covers the fundamental concepts of hazardous chemicals, with a particular focus on how key elements, compounds, and mixtures can be inherently dangerous. Students will gain a thorough understanding of chemical interactions, classification systems, and strategies for managing chemical hazards in emergency situations. The course also includes research on relevant standards and emergency response practices, along with the study of widely used hazardous materials classification and labeling systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "AUTO",
+    "number": "2995",
+    "title": "Special Projects III",
+    "credits": 3,
+    "description": "A course designed for the student who has demonstrated specific special needs. Dean of Technical Education approval required.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CULN",
+    "number": "1170",
+    "title": "Essentials Dining Room Service",
+    "credits": 2,
+    "description": "A study of types of service used to enhance dining pleasure, as well as the preparation of beverages.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HNUR",
+    "number": "2310B",
+    "title": "Practical Nursing IIB",
+    "credits": 3,
+    "description": "This course includes theory related to nursing care provided to adult and geriatric clients experiencing alternations in the endocrine function, as well as care of the adult and geriatric client with a neoplastic disorder. Included is a review of anatomy and physiology, therapeutic/modified diets, commonly prescribed medications and medical treatment procedures, as well as nursing care interventions for each disease process reviewed. Nursing care of the childbearing family through the stages of inceptions, fetal development, gestation, and delivery, including the antepartum, intrapartum, and postpartum periods, and the care of the neonate is also included. This course includes 30 theory hours of medical-surgical nursing and 30 hours of obstetric nursing.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "HPHM",
+    "number": "1525",
+    "title": "Pharmacy Practice Lab II",
+    "credits": 2,
+    "description": "This course is designed to teach pharmacy technician students entry level skills and advanced level skills performed in community and institutional pharmacy settings. The objectives of this course are to provide the students with practical, hands-on experience in the duties performed by a pharmacy technician in every day pharmacy practice. This course addresses topics of instruction that include the reviewing and processing of medication orders, applications of pertinent laws, regulations and standards, calculations, extemporaneous non-sterile compounding, and medication preparation, hospital pharmacy dispensing and record keeping, medication reconciliation ,medication therapy management and briefly touches on aseptic technique and infection control.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "CHEM",
+    "number": "1100",
+    "title": "Gen Chemistry I (Sci Majors)",
+    "credits": 3,
+    "description": "First semester chemistry course designed for natural engineering or life sciences majors. Topics include nomenclature, atomic and molecular structure, chemical equations and stoichiometry, and gas laws.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "MATH",
+    "number": "0101",
+    "title": "Suppl Inst for Applied Alg",
+    "credits": 1,
+    "description": "This course serves as supplemental instruction for MATH 1001, Applied Algebra. Instruction is an introductory-level course study of solving equations and inequalities; linear and quadratic function properties, graphs and their applications; polynomial, exponential and logarithmic function properties and graphs. A grade of \"C\" or better must be earned for the student to have satisfactorily completed MATH 1001 to meet pre-requisite for MATH 1005.",
+    "prerequisite_text": "MATH1001",
+    "prerequisite_courses": [
+      "MATH1001"
+    ]
+  },
+  {
+    "prefix": "NURS",
+    "number": "1105",
+    "title": "Nursing Fundamentals",
+    "credits": 3,
+    "description": "Provides the foundation upon which all subsequent nursing courses are developed. The nurse’s role in meeting the basic human needs across the lifespan including an introduction to the nursing process and the concepts of comfort, rest, sleep, oxygenation, nutrition, and elimination.Prerequisites: Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_text": "Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "BIOL",
+    "number": "1200",
+    "title": "Gen Biology II (Science Major)",
+    "credits": 3,
+    "description": "BIOL 1200 is designed fro students planning to major in biology or other related disciplines. This course covers the details of evolution, speciation and systemics. This course covers the details of evolution, speciation and systematics. This course is a systematic study of the structure, function, ecology and relationships of organisms. This course touches on the classification of bacteria, archaea, fungi, protista, plantae, and animalia. Other topics include animal behavior, population biology and ecosystems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "DPET",
+    "number": "2140",
+    "title": "Fundamentals of Steering",
+    "credits": 3,
+    "description": "The course contains the theory of operation and service procedures for medium/heavy duty truck steering systems.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  },
+  {
+    "prefix": "ELLT",
+    "number": "1300",
+    "title": "Electric Line Safety",
+    "credits": 3,
+    "description": "Meets OSHA’s requirements for a construction industry training program. This course provides employees with best practices for some of the most common and hazardous situations on the job site.",
+    "prerequisite_text": null,
+    "prerequisite_courses": []
+  }
+]

--- a/data/la/prereqs.json
+++ b/data/la/prereqs.json
@@ -4675,6 +4675,10 @@
       "CRMJ 2603"
     ]
   },
+  "CRMJ 2996": {
+    "text": "Dean of Academics approval. A course designed for the student who has demonstrated specific special needs.",
+    "courses": []
+  },
   "CRPT 212": {
     "text": "TECH 101 (min C) and CRPT 120 (min C) and CRPT 122 (min C) and CRPT 124 (min C) and CRPT 211 (min C)",
     "courses": [
@@ -10919,10 +10923,28 @@
       "PSYC 2080"
     ]
   },
+  "MATH 0101": {
+    "text": "MATH1001",
+    "courses": [
+      "MATH1001"
+    ]
+  },
+  "MATH 0105": {
+    "text": "MATH1005",
+    "courses": [
+      "MATH1005"
+    ]
+  },
   "MATH 012L": {
     "text": "MATH 099 (min C)",
     "courses": [
       "MATH 099"
+    ]
+  },
+  "MATH 0150": {
+    "text": "MATH1500",
+    "courses": [
+      "MATH1500"
     ]
   },
   "MATH 1000": {
@@ -10931,6 +10953,12 @@
       "MATH 0099",
       "MATH 1004",
       "MATH 1006"
+    ]
+  },
+  "MATH 1001": {
+    "text": "MATH 0099; ACT Math 19+; SAT Math 460+; or Compass Algebra 40+.Emphasis on applications involving: solving equations and inequalities; function properties and graphs; linear, quadratic, polynomial, exponential and logarithmic functions. (Math)",
+    "courses": [
+      "MATH 0099"
     ]
   },
   "MATH 1003": {
@@ -12590,6 +12618,10 @@
       "BIOL 2251"
     ]
   },
+  "NURS 1105": {
+    "text": "Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "courses": []
+  },
   "NURS 1106": {
     "text": "BIOL 2213 (min C) and BIOL 2211 (min C) or BIOL 230 (min C) or BIOL 2214 (min C) and PSYC 201 (min C) or PSYC 2013 (min C) and ENGL 101 (min C) or ENGL 101H (min C) or ENGL 1013 (min C) and MATH 101 (min C) or MATH 1113 (min C) or MATH 1100 (min C) or MATH 110 (min C) or MATH 1213 (min C)",
     "courses": [
@@ -12665,6 +12697,10 @@
       "ENGL 102",
       "HSCI 115"
     ]
+  },
+  "NURS 1130": {
+    "text": "Successful completion of first semester of Associate of Science in Nursing curriculum pattern; fulfillment of Associate of Science in Nursing Program admission criteria: fulfillment of LSBN criteria.",
+    "courses": []
   },
   "NURS 1150": {
     "text": "NURS 1100 (min C) and NURS 1110 (min C) and BIOL 2103 (min C) or BIOL 2113 (min C) or BIOL 2103 (min TC) and BIOL 2101 (min C) or BIOL 2111 (min C) or BIOL 2101 (min TC)",
@@ -12904,6 +12940,10 @@
       "BIOL 2101"
     ]
   },
+  "NURS 2200A": {
+    "text": "Successful completion of the first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "courses": []
+  },
   "NURS 2201": {
     "text": "NURS 2100 (min C) or NURS 2100 (min TC) and NURS 2120 (min C) or NURS 2120 (min TC) and BIOL 2100 (min C) or BIOL 2100 (min TC) and NURS 2221 (min C) or NURS 2221 (min TC)",
     "courses": [
@@ -12963,6 +13003,10 @@
       "BIOL 2111",
       "BIOL 2101"
     ]
+  },
+  "NURS 2210A": {
+    "text": "Successful completion of first two semesters of Associate of Science in Nursing curriculum pattern.",
+    "courses": []
   },
   "NURS 222": {
     "text": "NURS 122 (min C) or NURS 132 (min C) and NURS 123 (min C) or NURS 133 (min C) and NURS 219 (min C) and NURS 220 (min C) and ENGL 201 (min C) or ENGL 202 (min C) or ENGL 203 (min C) or ENGL 204 (min C) or ENGL 205 (min C) or ENGL 206 (min C) or ENGL 207 (min C) or ENGL 208 (min C) or ENGL 211 (min C) or ENGL 215 (min C) or HIST 101 (min C) or HIST 102 (min C) or HIST 201 (min C) or HIST 202 (min C) or HIST 210 (min C) or HIST 213 (min C)",
@@ -13063,6 +13107,10 @@
       "NURS 1320"
     ]
   },
+  "NURS 2300A": {
+    "text": "Successful completion of the first three semesters of the ASN curriculum pattern.",
+    "courses": []
+  },
   "NURS 2307": {
     "text": "NURS 222 (min C) or NURS 2226 (min C) and NURS 220 (min C) or NURS 2206 (min C)",
     "courses": [
@@ -13081,6 +13129,10 @@
       "MATH 2100",
       "NURS 1150"
     ]
+  },
+  "NURS 2310A": {
+    "text": "Successful completion of first three semesters of Associate of Science in Nursing curriculum pattern or consent of the Dean of Nursing and Allied Health.",
+    "courses": []
   },
   "NURS 233": {
     "text": "NURS 219 (min C) and NURS 221 (min C)",
@@ -13124,6 +13176,10 @@
       "THEA 1013"
     ]
   },
+  "NURS 2410A": {
+    "text": "Successful completion of first four semesters of the ASN curriculum pattern.",
+    "courses": []
+  },
   "NURS 2500": {
     "text": "NURS 2300 (min C) and NURS 2310 (min P) and ARTS 1200 (min C) or ARTS 1200 (min TC) or THEA 1013 (min C)",
     "courses": [
@@ -13132,6 +13188,10 @@
       "ARTS 1200",
       "THEA 1013"
     ]
+  },
+  "NURS 2500A": {
+    "text": "Successful completion of first four semesters of the ASN curriculum.",
+    "courses": []
   },
   "NURS 267": {
     "text": "NURS 220 (min C) and NURS 223 (min C) and NURS 225 (min C)",
@@ -16724,6 +16784,10 @@
       "WELD 1600",
       "WELD 1800"
     ]
+  },
+  "WELD 2996": {
+    "text": "Dean of Technical Education approval. A review of American Welding Society certification requirements, materials and mastered student skills, compare completed records; take an AWS closed book certification exam, and prepare workmanship qualification samples according to the AWS QC10- Entry Level Welder standard",
+    "courses": []
   },
   "WELL 141": {
     "text": "WELL 101 (min C)",

--- a/lib/states/la/config.ts
+++ b/lib/states/la/config.ts
@@ -47,12 +47,19 @@ const laConfig: StateConfig = {
         scripts: ["scripts/la/scrape-lctcs-banner-ssb.ts"],
         runner: "http",
       },
+      // Northshore Technical CC — the 12th LCTCS college, not on the
+      // shared Banner SSB host. Coursedog catalog gives course metadata
+      // + 23 prereqs; the aggregator merges into prereqs.json. No
+      // section data is available publicly (LoLA SSO).
+      {
+        scripts: ["scripts/la/scrape-coursedog.ts"],
+        runner: "playwright",
+      },
     ],
+    prereqs: { source: "aggregate-from-courses" },
     // manual-only: transfers — Louisiana Board of Regents publishes annual
     // articulation PDFs at laregents.edu but no registered API portal yet.
     // Add to data/articulation-portals.json once researched.
-    // manual-only: prereqs — aggregated inline from Banner SSB course data
-    // by scripts/lib/aggregate-prereqs.ts (no separate catalog scrape).
     // manual-only: programs — Phase 6 wrapper at scripts/la/scrape-programs.ts
     // discovered 4 catalogs (Nunez courseleaf; Fletcher/SLCC/Delta acalog).
     // Operator must validate URLs + fill per-college config before running.

--- a/scripts/la/scrape-coursedog.ts
+++ b/scripts/la/scrape-coursedog.ts
@@ -1,0 +1,68 @@
+/**
+ * scrape-coursedog.ts (LA)
+ *
+ * Scrapes the Coursedog catalog for Northshore Technical Community College —
+ * the 12th LCTCS member, and the only one not on the shared Banner SSB 9
+ * host at reg-prod.ec.lctcs.edu.
+ *
+ * Northshore has no public class-section endpoint (its registration sits
+ * behind LoLA SSO), but its Coursedog catalog publishes 653 course
+ * descriptions and prerequisite text. The aggregate-prereqs script walks
+ * data/la/coursedog-catalog/*.json and merges those entries into
+ * data/la/prereqs.json so they show up in the semester planner.
+ *
+ * Tenant: northshoretechcc_banner (extracted by Playwright session capture
+ *   from catalog.northshorecollege.edu's network traffic on page load).
+ *
+ * Usage:
+ *   npx tsx scripts/la/scrape-coursedog.ts
+ *   npx tsx scripts/la/scrape-coursedog.ts --college northshore-technical-community-college
+ */
+
+import { scrapeCoursedogCatalog } from "../lib/scrape-coursedog";
+
+const COURSEDOG_COLLEGES: Record<string, string> = {
+  "northshore-technical-community-college": "catalog.northshorecollege.edu",
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeIdx = args.indexOf("--college");
+  const collegeFilter = collegeIdx >= 0 ? args[collegeIdx + 1] : undefined;
+
+  const targets = collegeFilter
+    ? { [collegeFilter]: COURSEDOG_COLLEGES[collegeFilter] }
+    : COURSEDOG_COLLEGES;
+
+  if (collegeFilter && !COURSEDOG_COLLEGES[collegeFilter]) {
+    console.error(`Unknown college: ${collegeFilter}`);
+    console.error(`Available: ${Object.keys(COURSEDOG_COLLEGES).join(", ")}`);
+    process.exit(1);
+  }
+
+  let totalCourses = 0;
+  let totalWithPrereqs = 0;
+
+  for (const [slug, domain] of Object.entries(targets)) {
+    console.log(`\n=== Scraping ${slug} (${domain}) ===`);
+    const result = await scrapeCoursedogCatalog({
+      state: "la",
+      slug,
+      catalogDomain: domain,
+    });
+    if (result.error) {
+      console.error(`  ERROR: ${result.error}`);
+      continue;
+    }
+    totalCourses += result.coursesCount;
+    totalWithPrereqs += result.withPrereqs;
+  }
+
+  console.log(`\n=== Summary ===`);
+  console.log(`  Total: ${totalCourses} courses, ${totalWithPrereqs} with prereqs`);
+}
+
+main().catch((err) => {
+  console.error("❌ LA Coursedog scrape failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

The Louisiana semester planner now resolves prerequisite chains for ~14 additional courses at **Northshore Technical Community College** (the 12th LCTCS member, which was deferred from the original LA add-state PR #707). Course catalogs at `/la/college/northshore-technical-community-college/courses` now show course descriptions for 653 NTCC catalog entries — useful for browsing even though section/schedule data is not publicly available.

There is still **no class-schedule data** for Northshore (their Banner sits behind LoLA SSO with no public guest access), so students won't see CRNs, meeting times, or instructors for NTCC sections. The course catalog + prereqs are the best public data Northshore exposes.

## What changes on the technical front

Northshore's catalog runs on **Coursedog** (tenant `northshoretechcc_banner`, catalog `t9dq4Y0UKgryFdjdmJUw`). One thin wrapper (`scripts/la/scrape-coursedog.ts`) drives the existing `scripts/lib/scrape-coursedog.ts` Playwright session capture against `catalog.northshorecollege.edu` and writes 653 course entries to `data/la/coursedog-catalog/northshore-technical-community-college.json`.

The shared aggregator at `scripts/lib/aggregate-prereqs.ts` already walks `data/{state}/coursedog-catalog/*.json` and merges into `prereqs.json` — same pattern as FL's FSCJ and a few SD/AZ/MI/NV/TX/CA/NM catalogs. So no aggregator change was needed; the new data file is automatically picked up.

Net delta:
| | Before (PR #707) | After (this PR) |
|---|---|---|
| LCTCS colleges covered | 11/12 | **12/12** |
| LA prereq entries | 2,033 | **2,047** (+14) |

## Wired to cron

The new scraper is declared in `lib/states/la/config.ts` under `scrapers.courses` (alongside the Banner SSB one) with `runner: "playwright"`. The unified `scheduled-scrape.yml` workflow picks this up from the registry; no YAML edits needed.

## Test plan

- [x] Smoke test: `npx tsx scripts/lib/scrape-coursedog.ts --smoke --domain catalog.northshorecollege.edu --slug northshore-technical-community-college --state la` → 653 courses captured, 23 with prereqs
- [x] Wrapper run produces non-empty `data/la/coursedog-catalog/northshore-technical-community-college.json`
- [x] Aggregator re-run takes prereqs from 2,033 → 2,047
- [x] Typecheck clean for LA-touched files
- [ ] After merge: verify `/la/college/northshore-technical-community-college` renders course catalog on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)
