### PR TITLE
feat(search-intent): deterministic follow-up questions for every answer type

### DIFF
--- a/lib/search-intent/answer/__tests__/no-answer.test.ts
+++ b/lib/search-intent/answer/__tests__/no-answer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildFollowups, makeNoAnswer } from "../no-answer";
+
+describe("makeNoAnswer", () => {
+  it("returns a NoAnswer of the correct shape", () => {
+    const a = makeNoAnswer({ reason: "missing-entity", message: "msg" });
+    expect(a.type).toBe("none");
+    expect(a.reason).toBe("missing-entity");
+    expect(a.message).toBe("msg");
+  });
+
+  it("populates default followups when none provided", () => {
+    const a = makeNoAnswer({ reason: "missing-entity", message: "msg" });
+    expect(Array.isArray(a.followups)).toBe(true);
+    expect(a.followups!.length).toBeGreaterThan(0);
+    for (const f of a.followups!) {
+      expect(typeof f).toBe("string");
+      expect(f.length).toBeGreaterThan(0);
+      // No leftover template placeholders.
+      expect(f).not.toMatch(/\{.*\}/);
+    }
+  });
+
+  it("respects an explicit followups override", () => {
+    const a = makeNoAnswer({
+      reason: "out-of-scope",
+      message: "msg",
+      followups: ["custom one?", "custom two?"],
+    });
+    expect(a.followups).toEqual(["custom one?", "custom two?"]);
+  });
+
+  it("passes through optional suggestions", () => {
+    const a = makeNoAnswer({
+      reason: "no-state-data",
+      message: "msg",
+      suggestions: ["try VA", "try MA"],
+    });
+    expect(a.suggestions).toEqual(["try VA", "try MA"]);
+  });
+});
+
+describe("buildFollowups (NoAnswer)", () => {
+  it("returns deterministic templates per reason", () => {
+    expect(buildFollowups("missing-entity")).toEqual(
+      buildFollowups("missing-entity"),
+    );
+    expect(buildFollowups("out-of-scope")).toEqual(
+      buildFollowups("out-of-scope"),
+    );
+  });
+
+  it("returns at least one concrete question per reason", () => {
+    const reasons = [
+      "missing-entity",
+      "no-state-data",
+      "out-of-scope",
+      "intent-not-supported",
+    ] as const;
+    for (const r of reasons) {
+      const list = buildFollowups(r);
+      expect(list.length).toBeGreaterThan(0);
+      for (const q of list) {
+        expect(q).toMatch(/\?$/); // must look like a question
+      }
+    }
+  });
+});

--- a/lib/search-intent/answer/eligibility.ts
+++ b/lib/search-intent/answer/eligibility.ts
@@ -18,35 +18,33 @@ import type {
   CollegeEligibility,
   EligibilityAnswer,
 } from "./types";
+import { makeNoAnswer } from "./no-answer";
 
 export async function lookupEligibility(
   intent: EligibilityIntent,
   state: string,
 ): Promise<Answer> {
   if (!isValidState(state)) {
-    return {
-      type: "none",
+    return makeNoAnswer({
       reason: "no-state-data",
       message: `We don't have data for state "${state}".`,
-    };
+    });
   }
 
   if (intent.topic === "veteran") {
-    return {
-      type: "none",
+    return makeNoAnswer({
       reason: "no-state-data",
       message:
         "We don't track veteran-specific tuition data. Contact your state's Department of Veterans Services or your college's veteran-services office.",
-    };
+    });
   }
 
   const institutions = loadInstitutions(state);
   if (institutions.length === 0) {
-    return {
-      type: "none",
+    return makeNoAnswer({
       reason: "no-state-data",
       message: `We don't have audit-policy data for ${state.toUpperCase()} yet.`,
-    };
+    });
   }
 
   const cfg = getStateConfig(state);

--- a/lib/search-intent/answer/index.ts
+++ b/lib/search-intent/answer/index.ts
@@ -11,6 +11,7 @@ import { lookupEligibility } from "./eligibility";
 import { lookupPathway } from "./pathway";
 import { lookupPrereqs } from "./prereqs";
 import { lookupTransfer } from "./transfer";
+import { makeNoAnswer } from "./no-answer";
 
 export type { Answer, SourceCitation } from "./types";
 
@@ -124,11 +125,10 @@ export async function lookupAnswer(
     case "eligibility":
       return lookupEligibility(intent, state);
     case "course":
-      return {
-        type: "none",
+      return makeNoAnswer({
         reason: "intent-not-supported",
         message: "Use the course search results below.",
-      };
+      });
     case "unknown":
       return lookupUnknown(intent.raw, state);
   }
@@ -167,12 +167,11 @@ async function lookupUnknown(raw: string, state: string): Promise<Answer> {
       return pathwayAnswer;
     }
   }
-  return {
-    type: "none",
+  return makeNoAnswer({
     reason: "out-of-scope",
     message:
       "I'm not sure what you're asking. Try a course code (like ENG 111), 'prereqs for BIO 256', or 'does ENG 111 transfer to GMU'.",
-  };
+  });
 }
 
 const FIELD_STOP_WORDS = new Set([

--- a/lib/search-intent/answer/no-answer.ts
+++ b/lib/search-intent/answer/no-answer.ts
@@ -1,0 +1,65 @@
+// NoAnswer helpers — deterministic followup question suggestions.
+//
+// Every NoAnswer surface in the search-intent system flows through
+// `makeNoAnswer()` so the UI always gets a predictable shape with sensible
+// "where to go next" suggestions. Templates are reason-keyed so a
+// student staring at a dead-end card has at least two concrete questions
+// they can click instead of having to re-think their query from scratch.
+//
+// Pure templating — no LLM, no Date.now(), no Math.random(). Same input
+// always produces the same suggestions.
+
+import type { NoAnswer } from "./types";
+
+/**
+ * Build a NoAnswer with default `followups` keyed off the reason. Callers
+ * may pass through their own `suggestions` (free-form text shown in the
+ * card body) and/or override `followups` when they have intent-specific
+ * questions in mind.
+ */
+export function makeNoAnswer(parts: {
+  reason: NoAnswer["reason"];
+  message: string;
+  suggestions?: string[];
+  followups?: string[];
+}): NoAnswer {
+  return {
+    type: "none",
+    reason: parts.reason,
+    message: parts.message,
+    suggestions: parts.suggestions,
+    followups: parts.followups ?? buildFollowups(parts.reason),
+  };
+}
+
+/**
+ * Default follow-up questions for each NoAnswer reason. Kept generic
+ * because we don't have a course/university to template against — these
+ * are the "what now?" prompts a student would actually ask.
+ */
+export function buildFollowups(reason: NoAnswer["reason"]): string[] {
+  switch (reason) {
+    case "missing-entity":
+      return [
+        "What courses are available?",
+        "How do I find a transfer-friendly course?",
+      ];
+    case "no-state-data":
+      return [
+        "Which states do you have data for?",
+        "How do I apply to a community college?",
+      ];
+    case "out-of-scope":
+      return [
+        "What courses are available?",
+        "How do I apply to a community college?",
+      ];
+    case "intent-not-supported":
+      // Course-search NoAnswer — the UI shows the results grid below, so
+      // pointing students at related questions keeps the page useful.
+      return [
+        "What are the prereqs for a course I'm looking at?",
+        "Does my course transfer to a 4-year university?",
+      ];
+  }
+}

--- a/lib/search-intent/answer/transfer.ts
+++ b/lib/search-intent/answer/transfer.ts
@@ -28,6 +28,7 @@ import type {
   TransferEquivalency,
 } from "./types";
 import { courseExists, resolveUniversity } from "./validate";
+import { makeNoAnswer } from "./no-answer";
 import { subjectName } from "../../subjects";
 
 const MAX_ALTERNATIVES = 5;
@@ -48,18 +49,16 @@ export async function lookupTransfer(
       const msg = destName
         ? `Showing ${name} courses — pick one to check if it transfers to ${destName}.`
         : `Showing ${name} courses — pick one to check transfer equivalency.`;
-      return {
-        type: "none",
+      return makeNoAnswer({
         reason: "missing-entity",
         message: msg,
-      };
+      });
     }
-    return {
-      type: "none",
+    return makeNoAnswer({
       reason: "missing-entity",
       message:
         "Which course are you asking about? Try 'Does ENG 111 transfer to GMU?'",
-    };
+    });
   }
 
   // Validate course exists in this state.


### PR DESCRIPTION
## What changes for someone using the site

**Nothing visible yet.** The search-intent JSON response (`/api/search-intent/...`) now includes a `followups` array on every answer type — including the dead-end NoAnswer cases like \"we don't have data for that state\" or \"which course did you mean?\". The UI doesn't render this field yet; the AnswerCard work that turns these strings into clickable pills is a separate PR (PR E in the search-intent enhancement plan). This PR is part of a 4-PR set (B–E) and lands the data shape ahead of the UI so the two can ship independently.

If you call the API directly today, you'll see arrays like:

```json
{"type":"none","reason":"missing-entity","message":"Which course are you asking about?",
 "followups":["What courses are available?","How do I find a transfer-friendly course?"]}
```

## What changes on the technical front

PR D of the search-intent enhancement plan. The Transfer / Prereqs / Eligibility / Pathway answer builders already populated their own `followups` arrays from earlier work (templates per status, e.g. \"What are the prereqs for {course}?\"). The gap was **NoAnswer**: five separate `return { type: \"none\", reason: ..., message: ... }` sites across `transfer.ts`, `eligibility.ts`, and `index.ts` all built NoAnswer inline without setting `followups`.

Added `lib/search-intent/answer/no-answer.ts` with:
- `makeNoAnswer({ reason, message, suggestions?, followups? })` — single construction helper
- `buildFollowups(reason)` — deterministic templates per reason (`missing-entity`, `no-state-data`, `out-of-scope`, `intent-not-supported`)

Replaced all five inline `{ type: \"none\", ... }` literals with `makeNoAnswer(...)`. Each call site can still override `followups` if it has intent-specific suggestions in mind.

Pure string templating — no LLM call, no `Date.now()`, no `Math.random()`. The same intent + state always produces the same followups so the search-intent eval harness stays deterministic.

## Files changed

- `lib/search-intent/answer/no-answer.ts` — new helper
- `lib/search-intent/answer/__tests__/no-answer.test.ts` — new tests (shape, defaults, override behavior, no leftover `{placeholder}` text, every default ends with `?`)
- `lib/search-intent/answer/transfer.ts` — route 2 NoAnswer sites through `makeNoAnswer`
- `lib/search-intent/answer/eligibility.ts` — route 3 NoAnswer sites through `makeNoAnswer`
- `lib/search-intent/answer/index.ts` — route the 2 `course` / `unknown` fallbacks through `makeNoAnswer`

Did **not** touch: the classifier (PR B), the UI (`AnswerCard.tsx`, `app/[state]/courses/*` — PR E), or `pathway.ts` (PR C owns pathway followups).

## Test plan

- [x] `npx vitest run lib/search-intent/` — 135 / 135 pass
- [x] `npx tsc --noEmit` on touched files — no new errors (pre-existing unrelated errors in `scripts/ca/`)
- [ ] After PR E (UI) lands, click through a few queries on a state landing page and confirm followup pills render under each answer card variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)