### PR TITLE
hotfix(ca): import AnyNode from domhandler in scrape-losrios

### DIFF
--- a/scripts/ca/scrape-losrios.ts
+++ b/scripts/ca/scrape-losrios.ts
@@ -35,6 +35,9 @@
  */
 
 import * as cheerio from "cheerio";
+// AnyNode is exported from domhandler (cheerio's underlying DOM lib) but
+// isn't re-exported as `cheerio.AnyNode` in cheerio 1.2 — import directly.
+import type { AnyNode } from "domhandler";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -262,7 +265,7 @@ interface ParsedCard {
   classSection: string;
 }
 
-function parseCard($: cheerio.CheerioAPI, article: cheerio.AnyNode, term: TermSpec): ParsedCard | null {
+function parseCard($: cheerio.CheerioAPI, article: AnyNode, term: TermSpec): ParsedCard | null {
   const $a = $(article);
 
   // Subject + number + title


### PR DESCRIPTION
## What changes for someone using the site

Nothing. Pure build-fix — production Vercel deploys are currently failing typecheck and this unblocks them.

## What broke and why

Production Vercel builds started failing at `c9b4a5f` (the CSS-pipeline PR #738) with:

```
./scripts/ca/scrape-losrios.ts:265:60
Type error: Namespace '"…/node_modules/cheerio/dist/esm/index"' has no exported
member 'AnyNode'.
```

The error was **latent on main** — two peer scrapers (`scripts/lib/scrape-courseleaf-programs.ts` and `scripts/lib/scrape-smartcatalogiq-programs.ts`) already had the fix and an explanatory comment ("`AnyNode` is exported from domhandler … isn't re-exported as `cheerio.AnyNode` in cheerio 1.2 — import directly."). The Los Rios scraper missed the pattern when it was first written.

Vercel's TypeScript incremental cache was apparently masking the error on earlier deploys. PR #738 changed `package.json` (added `@tailwindcss/cli` + `concurrently`, removed `@tailwindcss/postcss`), which invalidated the cache and forced a full re-typecheck on the next build — surfacing the latent error.

## What's in the fix

One import added, one type annotation changed — mirrors the exact pattern used by the two peer scrapers:

```ts
import type { AnyNode } from "domhandler";
// …
function parseCard($: cheerio.CheerioAPI, article: AnyNode, term: TermSpec): ParsedCard | null {
```

No runtime behavior change.

## Test plan

- [ ] After merge, Vercel build for the merge commit succeeds (the `test`/`typecheck` job no longer flags `scripts/ca/scrape-losrios.ts:265`)
- [ ] Prod site renders identically — this is a typecheck-only fix, no runtime path touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
