### PR TITLE
fix(courseleaf): h1#page-title fallback + feat(la): 92 Nunez CC programs

### DIFF
--- a/data/la/programs/baton-rouge-community-college.json
+++ b/data/la/programs/baton-rouge-community-college.json
@@ -1,0 +1,9269 @@
+{
+  "college_slug": "baton-rouge-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.mybrcc.edu",
+  "scraped_at": "2026-05-29T15:19:44.601Z",
+  "programs": [
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=289",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education course in the Humanities Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1013",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1033",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1011",
+              "title": "General Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1031",
+              "title": "Biology I Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1923",
+              "title": "Introduction to Computers: Programming Logic and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2115",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1023",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1043",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1021",
+              "title": "General Biology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1041",
+              "title": "Biology II Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education Fine Arts Elective Credit Hours: 3 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1933",
+              "title": "Software Design and Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2125",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1943",
+              "title": "Software Design and Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2003",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education ENGL or HUMN Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2904",
+              "title": "Elementary Differential Equations and Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1123",
+              "title": "Chemistry I Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2113",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education Social or Behavioral Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2103",
+              "title": "Introduction to Data Structures and Algorithms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2903",
+              "title": "Object-Oriented Programming (Java)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1133",
+              "title": "Chemistry II for Science Major",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2123",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "American Sign Language Studies",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=223",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. Social Science Credits Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1003",
+              "title": "Deaf Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1013",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. Natural Science Credit Hours: 3 (first in sequence) 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. Mathematics or Analytical Reasoning Credit Hours: 3 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1023",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1033",
+              "title": "Fingerspelling and Numbers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. ENGL literature course Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. Natural Science Credit Hours: 3 (second in sequence) 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1113",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1133",
+              "title": "Introduction to Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1143",
+              "title": "ASL and English Translations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen. Ed. Social Science at the 2000 level Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "1123",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "2013",
+              "title": "English-to-ASL Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "2023",
+              "title": "ASL-to-English Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASLS",
+              "number": "2033",
+              "title": "ASLS Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biological Sciences",
+      "credential": "other",
+      "program_code": "ASLT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=261",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1033",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1031",
+              "title": "Biology I Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen Ed Humanities Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen. Ed. Fine Arts Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following based on your math placement scores: 3-5 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1223",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1235",
+              "title": "College Algebra and Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Statistics Course1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2115",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2125",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1043",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1041",
+              "title": "Biology II Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1123",
+              "title": "Chemistry I Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1121",
+              "title": "Chemistry I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following (must be a higher-level MATH than first semester): 3-5 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1223",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1235",
+              "title": "College Algebra and Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2115",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2125",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Statistics Course1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=285",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "1013",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2023",
+              "title": "American History 1865 to Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2253",
+              "title": "Ethics in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2313",
+              "title": "Police Systems and Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2613",
+              "title": "Court Systems and Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Math Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Natural Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "2013",
+              "title": "Correctional Systems and Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2213",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education course in Math/Analytical Reasoning Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "2303",
+              "title": "Criminal Justice Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCL",
+              "number": "2413",
+              "title": "Race Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Natural Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Criminal Justice electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLI",
+              "number": "2113",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2103",
+              "title": "Careers in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2413",
+              "title": "Juvenile Delinquency",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2513",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2243",
+              "title": "Crime Scene Investigation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Business",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=245",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "other",
+      "program_code": "AALT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=283",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen.-Ed. Math Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen.-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "1013",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "2013",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2213",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Introductory Statistics Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science Credit Hours: 3 (1st in sequence) 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2313",
+              "title": "Police Systems and Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Psychology or Sociology Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science Credit Hours: 3 (2nd in sequence) 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen.-Ed. History Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen.-Ed. Humanities Literature Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "2013",
+              "title": "Correctional Systems and Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "2013",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Fine Arts",
+      "credential": "other",
+      "program_code": "AALT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=221",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics/Analytical Reasoning Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Social Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science Credit Hours: 3 (first in sequence) 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics/Analytical Reasoning Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Humanities Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science Credit Hours: 3 (second in sequence) 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Concentration Core Selection Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1023",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1003",
+              "title": "Non-Western Art",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC 1013 - Music Theory I Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1013",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1413",
+              "title": "Introduction to Music Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Film",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "2003",
+              "title": "Introduction to Cinema Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Theatre",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "1013",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1153",
+              "title": "Introduction to Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1303",
+              "title": "Beginning Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1313",
+              "title": "Intermediate Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1403",
+              "title": "Beginning Ceramics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1423",
+              "title": "Introduction to Pottery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1433",
+              "title": "Intermediate Ceramics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1503",
+              "title": "Introduction to Sculpture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1513",
+              "title": "Introduction to Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2003",
+              "title": "Digital Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2023",
+              "title": "Relief Printmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2033",
+              "title": "Creative Coding for the Web",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2123",
+              "title": "Silkscreen Printmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2203",
+              "title": "Beginning Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2213",
+              "title": "Intermediate Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2313",
+              "title": "Introduction to Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2323",
+              "title": "Intermediate Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1081",
+              "title": "Classic Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1091",
+              "title": "Classic Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1203",
+              "title": "Ear Training and Sight Singing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1213",
+              "title": "Ear Training and Sight Singing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1403",
+              "title": "Songwriting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1441",
+              "title": "Jazz Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1451",
+              "title": "Jazz Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2301",
+              "title": "Studio Applied Lessons",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2313",
+              "title": "Pro Tools I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2323",
+              "title": "Pro Tools II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2441",
+              "title": "Jazz Ensemble III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2451",
+              "title": "Jazz Ensemble IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Film",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "1023",
+              "title": "Film and New Media Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2033",
+              "title": "Film &amp; New Media Production II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2043",
+              "title": "Post-Production Editing &amp; VFX",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Theatre",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THTR",
+              "number": "2103",
+              "title": "Acting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "2113",
+              "title": "Acting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "2203",
+              "title": "Stage Voice: Basic Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "2103",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2113",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1023",
+              "title": "History of Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2013",
+              "title": "Music History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2023",
+              "title": "Music History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Film",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "2013",
+              "title": "Cinema History through 1945",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2023",
+              "title": "Film History after 1945",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1113",
+              "title": "Introduction to Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1123",
+              "title": "Introduction to Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1003",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2003",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "General Science",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=263",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Mathematics Credit Hours: 3-5",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (first in sequence) Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Social Science Elective (2000 level) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Humanities Elective Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Mathematics Credit Hours: 3-5",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (second in sequence) Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (opposite from seq.) Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Business",
+      "credential": "other",
+      "program_code": "AALT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=262",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Humanities Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2213",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (first in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any PSYC or SOCL Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2103",
+              "title": "Calculus for Non-Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "2303",
+              "title": "Basic Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2223",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2113",
+              "title": "Financial Accounting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (second in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "2013",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2213",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2213",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. ENGL Literature course Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (opposite from seq.) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Free Elective (any course) Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Humanities",
+      "credential": "other",
+      "program_code": "AALT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=274",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics/Analytical Reasoning Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Social Science at the 2000 level Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (first in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics/Analytical Reasoning Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed Social Science at the 2000 level Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Humanities Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (second in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=273",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Social Science at the 2000 level Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (first in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Social Science at the 2000 level Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Humanities Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (second in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2113",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Nursing",
+      "credential": "other",
+      "program_code": "ASN",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=264",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2213",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2211",
+              "title": "Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education course in Humanities or Fine Arts Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2213",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2211",
+              "title": "Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Elective, Humanities or Fine Arts course Credit Hours: 3 * 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2223",
+              "title": "Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2221",
+              "title": "Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2113",
+              "title": "Psychology of Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1106",
+              "title": "Nursing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "2106",
+              "title": "Adult Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2124",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2103",
+              "title": "General Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2101",
+              "title": "General Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "2206",
+              "title": "Adult Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2226",
+              "title": "Maternal-Child Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "2307",
+              "title": "Adult Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2401",
+              "title": "Senior Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1303",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Elective, Humanities or Fine Arts course Credit Hours: 3 * 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Physical Science",
+      "credential": "other",
+      "program_code": "ASLT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=259",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1123",
+              "title": "Chemistry I Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1121",
+              "title": "Chemistry I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2115",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen Ed Arts Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1133",
+              "title": "Chemistry II for Science Major",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1131",
+              "title": "Chemistry II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2125",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1033",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=235",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2213",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2211",
+              "title": "Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2223",
+              "title": "Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2221",
+              "title": "Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2103",
+              "title": "General Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2101",
+              "title": "General Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HLSC 1012 - Introduction to Health Professions Credit Hours: 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLSC",
+              "number": "1103",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1023",
+              "title": "Surgical Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1021",
+              "title": "Skills Lab I Surgical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HLSC 1012 - Introduction to Health Professions Credit Hours: 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLSC",
+              "number": "1103",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2213",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2211",
+              "title": "Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2223",
+              "title": "Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2221",
+              "title": "Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2103",
+              "title": "General Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2101",
+              "title": "General Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1023",
+              "title": "Surgical Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1021",
+              "title": "Skills Lab I Surgical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURT",
+              "number": "1103",
+              "title": "Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1113",
+              "title": "Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "1122",
+              "title": "Skills Lab II Surgical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURT",
+              "number": "2103",
+              "title": "Surgical Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURT",
+              "number": "2207",
+              "title": "Practicum I Surgical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1303",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2253",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SURT",
+              "number": "2259",
+              "title": "Practicum II Surgical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved General Education Fine Arts (Elective) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Engineering",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=257",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "2115",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1123",
+              "title": "Chemistry I Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Natural Science Lab Credit Hours: 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Gen. Ed. Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "2125",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2133",
+              "title": "Engineering Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Natural Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Natural Science Lab Credit Hours: 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "2153",
+              "title": "Engineering Physics III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1032",
+              "title": "Engineering Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2953",
+              "title": "Comprehensive Electrical Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Gen Ed. Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Arts Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1052",
+              "title": "Introduction to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Gen. Ed. Social Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2453",
+              "title": "Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Gen. Ed. Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Gen. Ed. Humanities Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=265",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1003",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1503",
+              "title": "Professional Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2403",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANG",
+              "number": "2213",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2273",
+              "title": "Retail Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2003",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Mathematics/Analytical Reasoning - Choose one: 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "Introduction to Contemporary Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2113",
+              "title": "Financial Accounting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2103",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "1503",
+              "title": "Negotiations in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "1503",
+              "title": "Introduction to Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Social Science - Choose one: 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "2213",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2223",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2113",
+              "title": "Economic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2213",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2413",
+              "title": "Computer-Based Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Natural Science Elective Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business Elective - Choose one: 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "2703",
+              "title": "Introduction to Logistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2413",
+              "title": "Introduction to Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Humanities - Choose one: 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "2013",
+              "title": "American History Colonial to 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2023",
+              "title": "American History 1865 to Present",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Social Sciences",
+      "credential": "other",
+      "program_code": "AALT",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=244",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen.-Ed. Math Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (1st in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen. Ed. Social Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen. Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen.-Ed. Math/Analytical Reasoning Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Natural Science (2nd in sequence) Credit Hours: 3 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Lab Credit Hours: 0-1 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Social Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen-Ed. Humanities or History Sequence Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Teaching, Gr 1-5",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=234",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2613",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education fine Arts course Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1013",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1033",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2013",
+              "title": "Introduction to Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1123",
+              "title": "World Civilization 1500 to the Present",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1303",
+              "title": "Elementary Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2303",
+              "title": "Basic Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1023",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1043",
+              "title": "Biology II for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2123",
+              "title": "Major British Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1673",
+              "title": "Elementary Number Structure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Natural Science (Physical Science) Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "2013",
+              "title": "Teaching and Learning in Diverse Settings I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2013",
+              "title": "American History Colonial to 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2173",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1683",
+              "title": "Geometry for Elementary and Middle School Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Natural Science (Physical Science) Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "2033",
+              "title": "Teaching and Learning in Diverse Settings II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "2013",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Care and Development of Young Children",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=280",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "1103",
+              "title": "Working with Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1113",
+              "title": "Development of Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1123",
+              "title": "Preschool Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1133",
+              "title": "Infant and Toddler Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "1203",
+              "title": "Heath, Safety, and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1213",
+              "title": "Observation and Participation Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1223",
+              "title": "Child Guidance and Behaviors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1233",
+              "title": "Infant and Toddler Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1243",
+              "title": "Preschool Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1252",
+              "title": "Children With Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "2103",
+              "title": "Language and Literature Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2113",
+              "title": "Preschool Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2123",
+              "title": "Organization &amp; Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2132",
+              "title": "Family Relationships and Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2145",
+              "title": "Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2113",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education course in Natural Sciences Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education course in Humanities Credit Hours: 3 (excluding Foreign Languages and Communication/Speech)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computing and Information Systems, Application Software Development concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=296",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1013",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1235",
+              "title": "College Algebra and Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1953",
+              "title": "Society and Ethics in Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1933",
+              "title": "Software Design and Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2003",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1823",
+              "title": "Introduction to Database Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1973",
+              "title": "Emerging Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1953",
+              "title": "Society and Ethics in Computing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1943",
+              "title": "Software Design and Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2153",
+              "title": "Linux/Unix System Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2604",
+              "title": "Mobile Application Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1113",
+              "title": "World Civilization to 1500",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "2903",
+              "title": "Object-Oriented Programming (Java)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2724",
+              "title": "Web Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2103",
+              "title": "Introduction to Data Structures and Algorithms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2783",
+              "title": "Systems Analysis &amp; Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=250",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "Introduction to Contemporary Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SACSOC-accepted General Education course in Humanities Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTG",
+              "number": "1016",
+              "title": "General Maintenance Practices",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education course in the Social/Behavioral Sciences Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1023",
+              "title": "Physical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTG",
+              "number": "1026",
+              "title": "General Maintenance Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTA",
+              "number": "1216",
+              "title": "Aircraft Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTA",
+              "number": "1224",
+              "title": "Aircraft Finishes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any approved General Education course Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTA",
+              "number": "1236",
+              "title": "Aircraft Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTA",
+              "number": "1244",
+              "title": "Aircraft Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTP",
+              "number": "1116",
+              "title": "Powerplant Accessories",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTP",
+              "number": "1126",
+              "title": "Powerplant Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTP",
+              "number": "1134",
+              "title": "Reciprocating Engine Overhaul",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTP",
+              "number": "1144",
+              "title": "Turbine Engine Overhaul",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computing and Information Systems, Cybersecurity concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=294",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1013",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1033",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1923",
+              "title": "Introduction to Computers: Programming Logic and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2123",
+              "title": "Introduction to Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1933",
+              "title": "Software Design and Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1953",
+              "title": "Society and Ethics in Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2113",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2103",
+              "title": "Introduction to Computer Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "1103",
+              "title": "Install and Troubleshoot Part I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1943",
+              "title": "Software Design and Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2153",
+              "title": "Linux/Unix System Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2313",
+              "title": "Cyber and Digital Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "1113",
+              "title": "Install and Troubleshoot Part II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "2723",
+              "title": "Penetration Testing and Incident Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2753",
+              "title": "Information Assurance and Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2503",
+              "title": "PC and Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "2013",
+              "title": "Windows Server Part I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1113",
+              "title": "World Civilization to 1500",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computing and Information Systems, Cloud Computing concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=293",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1923",
+              "title": "Introduction to Computers: Programming Logic and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1953",
+              "title": "Society and Ethics in Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1113",
+              "title": "World Civilization to 1500",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1823",
+              "title": "Introduction to Database Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1933",
+              "title": "Software Design and Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2113",
+              "title": "Cloud Computing Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2103",
+              "title": "Introduction to Computer Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "1103",
+              "title": "Install and Troubleshoot Part I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1993",
+              "title": "Advanced Database Storage and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1943",
+              "title": "Software Design and Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2153",
+              "title": "Linux/Unix System Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "1113",
+              "title": "Install and Troubleshoot Part II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNET",
+              "number": "2503",
+              "title": "PC and Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1013",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "2013",
+              "title": "Windows Server Part I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2653",
+              "title": "Virtual Infrastructure: Installation and Configuration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2783",
+              "title": "Systems Analysis &amp; Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=295",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1103",
+              "title": "Blueprint Reading and Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1213",
+              "title": "Construction Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1033",
+              "title": "Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1223",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2253",
+              "title": "Mechanical and Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2103",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2013",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Gen Ed. Humanities Elective (History, Humanities, or Philosophy) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "2303",
+              "title": "Statics and Strengths of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2003",
+              "title": "Contracts and Construction Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2353",
+              "title": "Surveying and Site Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2113",
+              "title": "Economic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHSC",
+              "number": "1023",
+              "title": "Physical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2113",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "2203",
+              "title": "Construction Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2413",
+              "title": "Planning and Scheduling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2513",
+              "title": "Commercial and Industrial Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "1503",
+              "title": "Negotiations in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2313",
+              "title": "Financial Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2113",
+              "title": "Financial Accounting III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Diagnostic Medical Sonography",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=291",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2213",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2211",
+              "title": "Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2223",
+              "title": "Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2221",
+              "title": "Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1013",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLSC",
+              "number": "1103",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2253",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "1011",
+              "title": "Foundations of Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SACSCOC-accepted General Education Humanities course Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2213",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2211",
+              "title": "Anatomy &amp; Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "1011",
+              "title": "Foundations of Sonography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2223",
+              "title": "Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2221",
+              "title": "Anatomy &amp; Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1013",
+              "title": "Introduction to Concepts in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLSC",
+              "number": "1103",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2253",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SACSCOC-accepted General Education Humanities course Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "1102",
+              "title": "Physics and Instrumentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "1143",
+              "title": "Ultrasound Learning Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "1203",
+              "title": "Sonographic Sectional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "1122",
+              "title": "Abdominal Ultrasound I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "1161",
+              "title": "Ultrasound Praticum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "1182",
+              "title": "Ultrasound OB/GYN I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "SONO 1201 - Physics and Instrumentation II Credit Hours: 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "2123",
+              "title": "Abdominal Ultrasoud II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "2163",
+              "title": "Ultrasound Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "2183",
+              "title": "Ultrasound OB/GYN II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "2201",
+              "title": "Physics and Instrumentation III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SONO",
+              "number": "2302",
+              "title": "Abdominal Ultrasound III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "2403",
+              "title": "Ultrasound Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "2502",
+              "title": "Ultrasound OB/GYN III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SONO",
+              "number": "2601",
+              "title": "Comprehensive Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Process Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=256",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1013",
+              "title": "Introduction to Process Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2033",
+              "title": "Safety, Health, and Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following (GenEd Mathematics/Analytical Reasoning):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any General Education course in Mathematics Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2113",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1013",
+              "title": "Introduction to Computer Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "2013",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1312",
+              "title": "Process Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1322",
+              "title": "Process Instrumentation Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1612",
+              "title": "Process Technology I Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1622",
+              "title": "Process Technology I Equipment Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following pairs of courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHSC",
+              "number": "1023",
+              "title": "Physical Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1021",
+              "title": "Physical Science I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2113",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2111",
+              "title": "General Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTEC",
+              "number": "2073",
+              "title": "Quality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2423",
+              "title": "Process Technology II Unit Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2421",
+              "title": "Process Technology II Unit System Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2633",
+              "title": "Fluid Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following pairs of courses:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1043",
+              "title": "Chemistry for PTEC Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1041",
+              "title": "Chemistry Lab for PTEC Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1123",
+              "title": "Chemistry I Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1121",
+              "title": "Chemistry I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SACSCOC-accepted Gen-Ed. Humanities Credit Hours: 3 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2113",
+              "title": "Economic Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2213",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2223",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2432",
+              "title": "Process Technology III Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2442",
+              "title": "Process Technology III Operations Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2443",
+              "title": "Process Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTEC",
+              "number": "2913",
+              "title": "Process Technology Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Vehicle Maintenance and Repair Technologies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=231",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=233",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=260",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "1013",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "1013",
+              "title": "Introduction to Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Social Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. course in Mathematics/Analytical Reasoning Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "2013",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "1203",
+              "title": "Introduction to Legal Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "1213",
+              "title": "Introduction to Legal Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Natural Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLI",
+              "number": "2113",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2113",
+              "title": "Computers in the Law Office",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2153",
+              "title": "Litigation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2303",
+              "title": "Ethics and Paralegals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Paralegal elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SACSCOC-Accepted Gen.-Ed. Humanities Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Paralegal elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Paralegal elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Paralegal elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2903",
+              "title": "Paralegal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose from the following:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PALG",
+              "number": "2103",
+              "title": "Law Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2163",
+              "title": "Litigation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2223",
+              "title": "Real Estate Law and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2233",
+              "title": "Insurance Law and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2243",
+              "title": "Wills, Successions, and Trusts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2253",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2263",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2273",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "2283",
+              "title": "Personal Injury Law and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Note:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2133",
+              "title": "Literature and Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2303",
+              "title": "Introduction to Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2313",
+              "title": "Introduction to Poetry and Drama",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2123",
+              "title": "Major British Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2173",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2223",
+              "title": "Major World Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2403",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2323",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2503",
+              "title": "Folklore",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2483",
+              "title": "Shakespeare: The More Popular Plays",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1113",
+              "title": "World Civilization to 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1123",
+              "title": "World Civilization 1500 to the Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2003",
+              "title": "History of Roman Republic and Empire",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2013",
+              "title": "American History Colonial to 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2023",
+              "title": "American History 1865 to Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2213",
+              "title": "Modern Europe 1500-1848",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2223",
+              "title": "Modern Europe 1848 to Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMN",
+              "number": "2103",
+              "title": "World Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMN",
+              "number": "2013",
+              "title": "Africa and the Middle East",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMN",
+              "number": "2553",
+              "title": "Asia and the Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMN",
+              "number": "2753",
+              "title": "The Heroic Journey: From Classical to Contemporary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1013",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "For more information, contact the Division of Business and Law at (225) 216-8154.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Auto Body Repair Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=222",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MVSB",
+              "number": "1002",
+              "title": "Fundamentals and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MVSB",
+              "number": "1003",
+              "title": "Motor Vehicle Service Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MVSB",
+              "number": "1604",
+              "title": "Electrical Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1105",
+              "title": "Non-Structural Damage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1114",
+              "title": "Straighten, Pull, and Anchor",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLRP",
+              "number": "1218",
+              "title": "Collison Repair Appraisal",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1224",
+              "title": "Paint and Refinish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1152",
+              "title": "Auto Body Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MVSB",
+              "number": "1703",
+              "title": "Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1314",
+              "title": "Section, Cut, and Weld",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1324",
+              "title": "Auto Body Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLRP",
+              "number": "1252",
+              "title": "Auto Body Internship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=230",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1033",
+              "title": "Biology I for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1031",
+              "title": "Biology I Lab for Science Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1011",
+              "title": "Animal Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTEC",
+              "number": "1023",
+              "title": "Veterinary Office Procedures and Hospital Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1031",
+              "title": "Veterinary Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1041",
+              "title": "Animal Breeds and Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1054",
+              "title": "Animal Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1051",
+              "title": "Animal Anatomy and Physiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2103",
+              "title": "General Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2101",
+              "title": "General Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTEC",
+              "number": "1212",
+              "title": "Animal Nursing Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1232",
+              "title": "Surgical Nursing for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1353",
+              "title": "Clinical Pathology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1351",
+              "title": "Clinical Pathology I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1412",
+              "title": "Anesthesia for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1082",
+              "title": "Pharmacology for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTEC",
+              "number": "1613",
+              "title": "Imaging for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1711",
+              "title": "Exotic Animal Medicine for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "1872",
+              "title": "Clinical Externship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTEC",
+              "number": "2274",
+              "title": "Clinical Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "2414",
+              "title": "Large Animal Medicine and Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "2053",
+              "title": "Small Animal Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "2352",
+              "title": "Clinial Pathology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "2212",
+              "title": "Animal Nursing Skills II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTEC",
+              "number": "2112",
+              "title": "Laboratory Animal Medicine and Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "2512",
+              "title": "Trends in Veterinary Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTEC",
+              "number": "2574",
+              "title": "Clinical Externship III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2013",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SACSCOC-accepted General Education Humanities Elective Credit Hours: 3 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Networking",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=284",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1923",
+              "title": "Introduction to Computers: Programming Logic and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "1733",
+              "title": "Introduction to PC Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2103",
+              "title": "Introduction to Computer Networking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNET",
+              "number": "2403",
+              "title": "Desktop/Server and Networking Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNET",
+              "number": "2503",
+              "title": "PC and Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Certificate Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNET",
+              "number": "2603",
+              "title": "Wireless Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1933",
+              "title": "Software Design and Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1943",
+              "title": "Software Design and Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2003",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2103",
+              "title": "Introduction to Data Structures and Algorithms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2903",
+              "title": "Object-Oriented Programming (Java)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=242",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MVSB",
+              "number": "1002",
+              "title": "Fundamentals and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MVSB",
+              "number": "1003",
+              "title": "Motor Vehicle Service Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MVSB",
+              "number": "1604",
+              "title": "Electrical Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1404",
+              "title": "Steering and Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1504",
+              "title": "Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "1204",
+              "title": "Automatic Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1304",
+              "title": "Manual Drivetrain and Axles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1103",
+              "title": "Engine Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1614",
+              "title": "Automotive Advanced Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1152",
+              "title": "Automotive Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MVSB",
+              "number": "1703",
+              "title": "Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1806",
+              "title": "Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1252",
+              "title": "Automotive Internship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Carpentry",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=281",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "1103",
+              "title": "Introduction and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1113",
+              "title": "Building Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1125",
+              "title": "Introduction to Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1134",
+              "title": "Fundamentals of Carpentry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "1214",
+              "title": "Building Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1224",
+              "title": "Blueprint Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1234",
+              "title": "House Framing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CARP",
+              "number": "1312",
+              "title": "Commercial Blueprints",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CARP 1323 Roofing Applications Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1332",
+              "title": "Insulation and Moisture Barrier Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1343",
+              "title": "Exterior Finishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1352",
+              "title": "Commercial Framing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1363",
+              "title": "Drywall",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CARP",
+              "number": "1373",
+              "title": "Interior Finishing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=282",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "1002",
+              "title": "Basics of Skin, Scalp, and Hair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "1003",
+              "title": "Fundamental Hair Treatments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "1004",
+              "title": "Safety and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "1104",
+              "title": "Wet Hair Styling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "1203",
+              "title": "Hair Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "1302",
+              "title": "Chemical Hair Relaxing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "1405",
+              "title": "Hair Coloring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "1503",
+              "title": "Artistry of Artificial Hair",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "2003",
+              "title": "Manicuring and Pedicuring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "2103",
+              "title": "Facial Services and Make-Up",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COSM",
+              "number": "2104",
+              "title": "Permanent Waving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "2203",
+              "title": "Thermal Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "2402",
+              "title": "Electricity and Light Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COSM",
+              "number": "2504",
+              "title": "Salon Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Heavy Truck Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=292",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MVSB",
+              "number": "1002",
+              "title": "Fundamentals and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MVSB",
+              "number": "1003",
+              "title": "Motor Vehicle Service Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MVSB",
+              "number": "1604",
+              "title": "Electrical Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1404",
+              "title": "Truck Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1504",
+              "title": "Truck Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHTT",
+              "number": "1803",
+              "title": "Preventative Maintenance Inspection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1903",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1304",
+              "title": "Truck Drivetrain",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1614",
+              "title": "Truck Advanced Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1152",
+              "title": "Truck Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MVSB",
+              "number": "1703",
+              "title": "Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1103",
+              "title": "Truck Engine Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1014",
+              "title": "Truck Engine Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHTT",
+              "number": "1252",
+              "title": "Truck Internship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts and Occupations",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=287",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "1113",
+              "title": "Culinary Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1123",
+              "title": "Hospitality Industry Overview",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1133",
+              "title": "Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1143",
+              "title": "Basic Culinary Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1153",
+              "title": "Culinary Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "1213",
+              "title": "Dining Room Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CULN 1249 - Food Preparation and Service Credit Hours 9",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1233",
+              "title": "Restaurant Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULN",
+              "number": "1316",
+              "title": "Baking and Pastry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1323",
+              "title": "Regional Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1333",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULN",
+              "number": "1343",
+              "title": "La Carte",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting and Design Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=279",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORE",
+              "number": "1003",
+              "title": "Introduction to Craft Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1113",
+              "title": "Introduction to Industrial Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1123",
+              "title": "Engineering Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1013",
+              "title": "Introduction to Computer Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select one of the following (first in student’s area of interest):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "2103",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1033",
+              "title": "Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1013",
+              "title": "Introduction to Process Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRFT",
+              "number": "1213",
+              "title": "Descriptive Geometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1223",
+              "title": "Architectural Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1233",
+              "title": "Pipe Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1243",
+              "title": "Machine Design Drafting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select one of the following (second in student’s area of interest):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "2103",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1213",
+              "title": "Construction Materials and Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2033",
+              "title": "Safety, Health, and Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRFT",
+              "number": "1313",
+              "title": "Light Commercial Building Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1323",
+              "title": "Civil Drafting Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRFT",
+              "number": "1333",
+              "title": "Drafting and Design Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1113",
+              "title": "Introduction to Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1123",
+              "title": "Introduction to Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Drafting-related Elective Credit Hours: 3 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC/R Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=277",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "1113",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1123",
+              "title": "Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1133",
+              "title": "Electrical Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1143",
+              "title": "Applied Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1213",
+              "title": "Introduction to HVAC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "1229",
+              "title": "Principles of Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1234",
+              "title": "Commercial Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1245",
+              "title": "Commercial Refrigeration Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "2118",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2124",
+              "title": "Residential Heat Pumps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "NCCER Electrical Level 4",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=270",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORE",
+              "number": "1003",
+              "title": "Introduction to Craft Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1119",
+              "title": "Electrical Level 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1216",
+              "title": "Electrical Level 2 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "1226",
+              "title": "Electrical Level 2 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1316",
+              "title": "Electrical Level 3 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1326",
+              "title": "Electrical Level 3 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "1419",
+              "title": "Electrical Level 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=278",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HORT",
+              "number": "1113",
+              "title": "Introduction to Plant Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1123",
+              "title": "Native Plants of Louisiana I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1133",
+              "title": "Plant Propagation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1141",
+              "title": "Louisiana Laws and Regulations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1154",
+              "title": "Soils, Fertilizers, and Water",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1162",
+              "title": "Horticulture Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HORT",
+              "number": "1213",
+              "title": "Greenhouse Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1222",
+              "title": "Turfgrass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1232",
+              "title": "Introduction to Irrigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1244",
+              "title": "Plant Pest Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1253",
+              "title": "Native Plants of Louisiana II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1262",
+              "title": "Horticulture Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HORT",
+              "number": "1313",
+              "title": "Landscape Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1322",
+              "title": "Landscaping Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1336",
+              "title": "Landscaping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HORT",
+              "number": "1342",
+              "title": "Horticulture Lab III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "NCCER Instrumentation Level 4",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=269",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORE",
+              "number": "1003",
+              "title": "Introduction to Craft Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1119",
+              "title": "Instrumentation Level 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1216",
+              "title": "Instrumentation Level 2 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INST",
+              "number": "1226",
+              "title": "Instrumentation Level 2 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1316",
+              "title": "Instrumentation Level 3 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1326",
+              "title": "Instrumentation Level 3 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INST",
+              "number": "1419",
+              "title": "Instrumentation Level 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "NCCER Pipefitting Level 4",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=267",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORE",
+              "number": "1003",
+              "title": "Introduction to Craft Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PIPE",
+              "number": "1119",
+              "title": "Pipefitting Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PIPE",
+              "number": "1216",
+              "title": "Pipefitting Level 2 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PIPE",
+              "number": "1226",
+              "title": "Pipefitting Level 2 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PIPE",
+              "number": "1316",
+              "title": "Pipefitting Level 3 Part I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PIPE",
+              "number": "1326",
+              "title": "Pipefitting Level 3 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PIPE",
+              "number": "1419",
+              "title": "Pipefitting Level 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=224",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORE",
+              "number": "1003",
+              "title": "Introduction to Craft Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1113",
+              "title": "Welding Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1211",
+              "title": "Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1318",
+              "title": "SMAW I (Fillet Weld)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1419",
+              "title": "SMAW II (V-Groove Open/BU/Gouge, &amp; Plate 2G-4G)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1519",
+              "title": "SMAW III (Pipe Welds 2G-6G)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "2116",
+              "title": "GTAW (Pipe 26-6G)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2213",
+              "title": "FCAW (Fillet &amp; Groove Welds)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2313",
+              "title": "GMAW (Fillet &amp; Groove Welds)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Practical Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=258",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Pre-Nursing (Must be completed before entering the program)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HNUR",
+              "number": "1214",
+              "title": "Practical Nursing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "1225",
+              "title": "Anatomy and Physiology for Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HNUR",
+              "number": "1312",
+              "title": "Nutrition for Practical Nurses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "1324",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "1335",
+              "title": "Practical Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HNUR",
+              "number": "1413",
+              "title": "Practical Nursing Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "1428",
+              "title": "Medical Surgical I for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "1431",
+              "title": "Intravenous (IV) Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HNUR",
+              "number": "2115",
+              "title": "Obstetric and Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "2128",
+              "title": "Medical Surgical II for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HNUR",
+              "number": "2216",
+              "title": "Mental Health and PN Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HNUR",
+              "number": "2228",
+              "title": "Medical Surgical III for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "NCCER Millwright Level 4",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=268",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORE",
+              "number": "1003",
+              "title": "Introduction to Craft Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MILL",
+              "number": "1119",
+              "title": "Millwright Level 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MILL",
+              "number": "1216",
+              "title": "Millwright Level 2 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MILL",
+              "number": "1226",
+              "title": "Millwright Level 2 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MILL",
+              "number": "1316",
+              "title": "Millwright Level 3 Part 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MILL",
+              "number": "1326",
+              "title": "Millwright Level 3 Part 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MILL",
+              "number": "1419",
+              "title": "Millwright Level 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=238",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program of Study",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2313",
+              "title": "Financial Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2323",
+              "title": "Financial Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2103",
+              "title": "Introduction to Auditing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2213",
+              "title": "Introduction to Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2413",
+              "title": "Computer-Based Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2353",
+              "title": "Accounting Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ACCT elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ACCT elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ACCT Electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2123",
+              "title": "Introduction to Governmental and Not-for-Profit Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2513",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2613",
+              "title": "Introduction to Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Aviation Maintenance Technician, Airframe",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=220",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTG",
+              "number": "1016",
+              "title": "General Maintenance Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTG",
+              "number": "1026",
+              "title": "General Maintenance Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTA",
+              "number": "1216",
+              "title": "Aircraft Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTA",
+              "number": "1224",
+              "title": "Aircraft Finishes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTA",
+              "number": "1236",
+              "title": "Aircraft Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTA",
+              "number": "1244",
+              "title": "Aircraft Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technician, Powerplant",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=248",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTG",
+              "number": "1016",
+              "title": "General Maintenance Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTG",
+              "number": "1026",
+              "title": "General Maintenance Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTP",
+              "number": "1116",
+              "title": "Powerplant Accessories",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTP",
+              "number": "1126",
+              "title": "Powerplant Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTP",
+              "number": "1134",
+              "title": "Reciprocating Engine Overhaul",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTP",
+              "number": "1144",
+              "title": "Turbine Engine Overhaul",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film and New Media Production",
+      "credential": "other",
+      "program_code": "CTC",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=286",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "1023",
+              "title": "Film and New Media Production I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "2033",
+              "title": "Film &amp; New Media Production II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "2043",
+              "title": "Post-Production Editing &amp; VFX",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration",
+      "credential": "other",
+      "program_code": "CAS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=275",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "1503",
+              "title": "Negotiations in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1003",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one (General Education, Mathematics/Analytical Reasoning): 3 Credit Hours",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "Introduction to Contemporary Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "2103",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "1503",
+              "title": "Introduction to Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2113",
+              "title": "Financial Accounting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2313",
+              "title": "Financial Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one (General Education Social/Behavioral Science): 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "2213",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2223",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2113",
+              "title": "Economic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Customer Service and Sales",
+      "credential": "other",
+      "program_code": "CTC",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=290",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program of Study",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1003",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1503",
+              "title": "Professional Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2403",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2203",
+              "title": "Microcomputer Applications in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Enrolled Agent",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=288",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2313",
+              "title": "Financial Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2323",
+              "title": "Financial Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2613",
+              "title": "Introduction to Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2513",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2413",
+              "title": "Computer-Based Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2623",
+              "title": "Advanced Federal Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Accounting Elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2633",
+              "title": "Enrolled Agent Policies and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ACCT Electives: Choose from the following:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2123",
+              "title": "Introduction to Governmental and Not-for-Profit Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2103",
+              "title": "Introduction to Auditing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Arts",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=276",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ARTS-Lecture Any ARTS lecture elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1113",
+              "title": "Introduction to Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1153",
+              "title": "Introduction to Digital Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2003",
+              "title": "Digital Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ARTS or CSCI Any Certificate Elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "2203",
+              "title": "Beginning Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2313",
+              "title": "Introduction to Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ARTS or CSCI Any Certificate Elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ARTS or CSCI Any Certificate Elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ARTS or CSCI Any Certificate Elective Credit Hours: 3 (see below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ARTS Lecture Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1003",
+              "title": "Non-Western Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1023",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2103",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2113",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Certificate Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1003",
+              "title": "Non-Western Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1023",
+              "title": "Introduction to Visual Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "1513",
+              "title": "Introduction to Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2103",
+              "title": "Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2113",
+              "title": "Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2023",
+              "title": "Relief Printmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2123",
+              "title": "Silkscreen Printmaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2323",
+              "title": "Intermediate Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2333",
+              "title": "Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1923",
+              "title": "Introduction to Computers: Programming Logic and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1933",
+              "title": "Software Design and Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1943",
+              "title": "Software Design and Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1953",
+              "title": "Society and Ethics in Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1973",
+              "title": "Emerging Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=272",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAST",
+              "number": "1171",
+              "title": "Medical Terminology for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1152",
+              "title": "Human Body for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1162",
+              "title": "Professionalism in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1142",
+              "title": "Pharmacology Medical Assistnts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1014",
+              "title": "Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1221",
+              "title": "Clinical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAST",
+              "number": "1214",
+              "title": "Administrative Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "2132",
+              "title": "Clinical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1114",
+              "title": "Electrocardiography (EKG)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "2222",
+              "title": "Medical Assistant Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAST",
+              "number": "1171",
+              "title": "Medical Terminology for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1013",
+              "title": "Introduction to Computer Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1162",
+              "title": "Professionalism in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1142",
+              "title": "Pharmacology Medical Assistnts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1102",
+              "title": "Information Management for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1113",
+              "title": "Medical Coding I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAST",
+              "number": "1214",
+              "title": "Administrative Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1123",
+              "title": "Medical Coding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAST",
+              "number": "1224",
+              "title": "Medical Insurance and Billing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies",
+      "credential": "other",
+      "program_code": "CGS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=266",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1013",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Mathematics Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Social Science at the 2000 level Credit Hours: 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Fine Arts Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Natural Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1023",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Humanities , Mathematics/Analytical Reasoning , Natural Science , or Social Science Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Gen-Ed. Humanities Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate Elective (any course) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certificate Elective (any course) Credit Hours: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Music Studio Production",
+      "credential": "other",
+      "program_code": "CTC",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=271",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1413",
+              "title": "Introduction to Music Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "2313",
+              "title": "Pro Tools I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "2323",
+              "title": "Pro Tools II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education Requirements",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=225",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Retail Management",
+      "credential": "other",
+      "program_code": "CTS",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=255",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1003",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1503",
+              "title": "Professional Selling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2003",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MANG",
+              "number": "2213",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2273",
+              "title": "Retail Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Web Design",
+      "credential": "other",
+      "program_code": "CTC",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=228",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1513",
+              "title": "Introduction to Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "2003",
+              "title": "Digital Art",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "2033",
+              "title": "Creative Coding for the Web",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sterile Processing",
+      "credential": "other",
+      "program_code": "CTC",
+      "catalog_url": "https://catalog.mybrcc.edu/preview_program.php?catoid=3&poid=239",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLSC",
+              "number": "1204",
+              "title": "Sterile Processing Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HLSC 1012 - Introduction to Health Professions Credit Hours: 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/la/programs/fletcher-technical-community-college.json
+++ b/data/la/programs/fletcher-technical-community-college.json
@@ -2,54 +2,171 @@
   "college_slug": "fletcher-technical-community-college",
   "catalog_year": "2026-2027",
   "catalog_url": "https://catalog.fletcher.edu",
-  "scraped_at": "2026-05-29T15:05:57.492Z",
+  "scraped_at": "2026-05-29T15:19:33.783Z",
   "programs": [
     {
-      "title": "3G-4G FCAW Welder, CTC",
-      "credential": "other",
+      "title": "Accounting Technology, AAS",
+      "credential": "AAS",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=665",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=588",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
       "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1006",
+              "title": "",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "1103",
+                  "title": "Contemporary Mathematics"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, or PHIL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective (3 credit hours) - Choose from BIOL, CHEM, GEOL, or PHSC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, or SOCI",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "Core Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "WELD",
-              "number": "1100",
-              "title": "Occupational Orientation And Safety",
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Financial Accounting",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "WELD",
-              "number": "1200",
-              "title": "Oxyfuel Systems and Cutting Processes",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
+              "prefix": "ACCT",
               "number": "2110",
-              "title": "FCAW - Basic Fillet Welds",
+              "title": "Managerial Accounting",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "WELD",
-              "number": "2111",
-              "title": "FCAW Groove Welds",
+              "prefix": "ACCT",
+              "number": "2250",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2300",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2350",
+              "title": "Financial Accounting Projects",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2500",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1050",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction To Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2130",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BUSN",
+                  "number": "2451",
+                  "title": "Intergrated Career Skills"
+                }
+              ]
+            },
+            {
+              "prefix": "CPTR",
+              "number": "1100",
+              "title": "Introduction To Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1350",
+              "title": "Spreadsheet Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1250",
+              "title": "Word Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1750",
+              "title": "Database Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KYBD",
+              "number": "1100",
+              "title": "Keyboarding I",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "accounting"
     },
     {
       "title": "Administrative Office Management, AAS",
@@ -252,6 +369,53 @@
       "matched_program_slug": "business-administration"
     },
     {
+      "title": "3G-4G FCAW Welder, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=665",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1100",
+              "title": "Occupational Orientation And Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1200",
+              "title": "Oxyfuel Systems and Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2110",
+              "title": "FCAW - Basic Fillet Welds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2111",
+              "title": "FCAW Groove Welds",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "3G-4G SMAW Welder, CTC",
       "credential": "other",
       "program_code": null,
@@ -304,170 +468,6 @@
         }
       ],
       "matched_program_slug": null
-    },
-    {
-      "title": "Accounting Technology, AAS",
-      "credential": "AAS",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=588",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "General Education Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ENGL",
-              "number": "1006",
-              "title": "",
-              "credits": null,
-              "or_alternatives": [
-                {
-                  "prefix": "MATH",
-                  "number": "1103",
-                  "title": "Contemporary Mathematics"
-                }
-              ]
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, or PHIL",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Natural Science Elective (3 credit hours) - Choose from BIOL, CHEM, GEOL, or PHSC",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science Elective (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, or SOCI",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ACCT",
-              "number": "2100",
-              "title": "Financial Accounting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ACCT",
-              "number": "2110",
-              "title": "Managerial Accounting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ACCT",
-              "number": "2250",
-              "title": "Payroll Accounting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ACCT",
-              "number": "2300",
-              "title": "Intermediate Accounting I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ACCT",
-              "number": "2350",
-              "title": "Financial Accounting Projects",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ACCT",
-              "number": "2500",
-              "title": "Computerized Accounting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "1050",
-              "title": "Business Communications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "1100",
-              "title": "Introduction To Business",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "2130",
-              "title": "Personal Finance",
-              "credits": null,
-              "or_alternatives": [
-                {
-                  "prefix": "BUSN",
-                  "number": "2451",
-                  "title": "Intergrated Career Skills"
-                }
-              ]
-            },
-            {
-              "prefix": "CPTR",
-              "number": "1100",
-              "title": "Introduction To Computer Applications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1350",
-              "title": "Spreadsheet Applications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1250",
-              "title": "Word Processing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1750",
-              "title": "Database Applications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "KYBD",
-              "number": "1100",
-              "title": "Keyboarding I",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "accounting"
     },
     {
       "title": "Account Clerk, CTS",
@@ -694,10 +694,10 @@
       "matched_program_slug": "automotive-technology"
     },
     {
-      "title": "Apprentice Electrician, CTC",
+      "title": "Automotive Engine Performance Technician, CTC",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=626",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=603",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -708,37 +708,23 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "1010",
-              "title": "Introductory Craft Skills I",
+              "prefix": "AUTO",
+              "number": "1080",
+              "title": "Engine Performance I (Lecture And Lab)",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "1020",
-              "title": "Introductory Craft Skills II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1101",
-              "title": "Basic Electrical Skills I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1102",
-              "title": "Basic Electrical Skills II",
+              "prefix": "AUTO",
+              "number": "1081",
+              "title": "Engine Performance II (Lecture And Lab)",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "automotive-technology"
     },
     {
       "title": "Automotive Electrical Technician, CTS",
@@ -849,10 +835,10 @@
       "matched_program_slug": "automotive-technology"
     },
     {
-      "title": "Automotive Engine Performance Technician, CTC",
+      "title": "Apprentice Electrician, CTC",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=603",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=626",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -863,23 +849,37 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "AUTO",
-              "number": "1080",
-              "title": "Engine Performance I (Lecture And Lab)",
+              "prefix": "ELEC",
+              "number": "1010",
+              "title": "Introductory Craft Skills I",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "AUTO",
-              "number": "1081",
-              "title": "Engine Performance II (Lecture And Lab)",
+              "prefix": "ELEC",
+              "number": "1020",
+              "title": "Introductory Craft Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1101",
+              "title": "Basic Electrical Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1102",
+              "title": "Basic Electrical Skills II",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "automotive-technology"
+      "matched_program_slug": null
     },
     {
       "title": "Automotive Engine Repair Technician, CTC",
@@ -915,10 +915,10 @@
       "matched_program_slug": "automotive-technology"
     },
     {
-      "title": "Automotive Steering and Brakes, CTC",
+      "title": "Automotive Heating and Air Conditioning, CTC",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=600",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=602",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -930,15 +930,15 @@
           "courses": [
             {
               "prefix": "AUTO",
-              "number": "1040",
-              "title": "Steering And Suspension (Lecture And Lab)",
+              "number": "1010",
+              "title": "Introduction To Automotive Technology (Lecture And Lab)",
               "credits": null,
               "or_alternatives": []
             },
             {
               "prefix": "AUTO",
-              "number": "1050",
-              "title": "Brakes (Lecture And Lab)",
+              "number": "1070",
+              "title": "Heating And Air Conditioning (Lecture And Lab)",
               "credits": null,
               "or_alternatives": []
             }
@@ -993,39 +993,6 @@
               "prefix": "AUTO",
               "number": "1040",
               "title": "Steering And Suspension (Lecture And Lab)",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "automotive-technology"
-    },
-    {
-      "title": "Automotive Heating and Air Conditioning, CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=602",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "AUTO",
-              "number": "1010",
-              "title": "Introduction To Automotive Technology (Lecture And Lab)",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AUTO",
-              "number": "1070",
-              "title": "Heating And Air Conditioning (Lecture And Lab)",
               "credits": null,
               "or_alternatives": []
             }
@@ -1166,6 +1133,179 @@
       "matched_program_slug": "automotive-technology"
     },
     {
+      "title": "Business Elective Courses",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=671",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Business Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2250",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2500",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1000",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction To Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1010",
+              "title": "Service Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2010",
+              "title": "Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2140",
+              "title": "Introduction To Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2240",
+              "title": "Entrepreneurial Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1250",
+              "title": "Word Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1350",
+              "title": "Spreadsheet Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1650",
+              "title": "Desktop Publishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CINS",
+              "number": "1750",
+              "title": "Database Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2060",
+              "title": "Introduction To Logistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2080",
+              "title": "Transportation Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2200",
+              "title": "Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2290",
+              "title": "Supply Chain Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2300",
+              "title": "Warehouse And Inventory Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MANG",
+              "number": "2650",
+              "title": "Manufacturing Logistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Applied Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCSI",
+              "number": "1300",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OSYS",
+              "number": "2530",
+              "title": "Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PALG",
+              "number": "1010",
+              "title": "Introduction To Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
       "title": "Automotive Transmission Technician, CTC",
       "credential": "other",
       "program_code": null,
@@ -1190,6 +1330,39 @@
               "prefix": "AUTO",
               "number": "1030",
               "title": "Manual Drive Trains (Lecture And Lab)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Steering and Brakes, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=600",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "1040",
+              "title": "Steering And Suspension (Lecture And Lab)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "1050",
+              "title": "Brakes (Lecture And Lab)",
               "credits": null,
               "or_alternatives": []
             }
@@ -1479,179 +1652,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Business Elective Courses",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=671",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Business Electives",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ACCT",
-              "number": "2250",
-              "title": "Payroll Accounting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ACCT",
-              "number": "2500",
-              "title": "Computerized Accounting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "1000",
-              "title": "Business Law",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "1100",
-              "title": "Introduction To Business",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "1010",
-              "title": "Service Communications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "2010",
-              "title": "Human Relations",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "2140",
-              "title": "Introduction To Entrepreneurship",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
-              "number": "2240",
-              "title": "Entrepreneurial Finance",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1250",
-              "title": "Word Processing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1350",
-              "title": "Spreadsheet Applications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1650",
-              "title": "Desktop Publishing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CINS",
-              "number": "1750",
-              "title": "Database Applications",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MANG",
-              "number": "2060",
-              "title": "Introduction To Logistics",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MANG",
-              "number": "2080",
-              "title": "Transportation Management",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MANG",
-              "number": "2200",
-              "title": "Operations Management",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MANG",
-              "number": "2290",
-              "title": "Supply Chain Management",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MANG",
-              "number": "2300",
-              "title": "Warehouse And Inventory Management",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MANG",
-              "number": "2650",
-              "title": "Manufacturing Logistics",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MATH",
-              "number": "2010",
-              "title": "Applied Calculus",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MCSI",
-              "number": "1300",
-              "title": "Medical Terminology",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "OSYS",
-              "number": "2530",
-              "title": "Office Procedures",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "PALG",
-              "number": "1010",
-              "title": "Introduction To Paralegal Studies",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
       "title": "Care and Development of Young Children, AAS",
       "credential": "AAS",
       "program_code": null,
@@ -1815,6 +1815,56 @@
         }
       ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Certificate of General Studies - Cardiopulmonary Care Track, CGS",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=675",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Certificate of General Studies, CGS",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=630",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core/General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1006",
+              "title": "",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "1103",
+                  "title": "Contemporary Mathematics"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, PHIL, or SPAN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
     },
     {
       "title": "Certificate of General Studies in Nursing, CGS",
@@ -2037,56 +2087,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Certificate of General Studies - Cardiopulmonary Care Track, CGS",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=675",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [],
-      "matched_program_slug": "liberal-arts"
-    },
-    {
-      "title": "Certificate of General Studies, CGS",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=630",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core/General Education Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ENGL",
-              "number": "1006",
-              "title": "",
-              "credits": null,
-              "or_alternatives": [
-                {
-                  "prefix": "MATH",
-                  "number": "1103",
-                  "title": "Contemporary Mathematics"
-                }
-              ]
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, PHIL, or SPAN",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "liberal-arts"
-    },
-    {
       "title": "Child Care Teacher, TD",
       "credential": "other",
       "program_code": null,
@@ -2211,10 +2211,10 @@
       "matched_program_slug": null
     },
     {
-      "title": "Computer Information Systems, AAS",
-      "credential": "AAS",
+      "title": "Customer Service Representative, CTS",
+      "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=615",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=618",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -2225,147 +2225,44 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "CTEC",
-              "number": "1010",
-              "title": "Information Technology Principles",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1020",
-              "title": "Problem Solving And Programming Techniques",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1070",
-              "title": "Skills For Information Technology (IT) Success",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1080",
-              "title": "Introduction To Management Information Systems",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1120",
-              "title": "IT Hardware Support",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1140",
-              "title": "IT Software Support",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1180",
-              "title": "Help Desk Operations",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1550",
-              "title": "Network Essentials",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "1700",
-              "title": "Microsoft Windows Servers",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "2630",
-              "title": "Cloud",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "2820",
-              "title": "Information Technology Project Management",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "2870",
-              "title": "Network Security Design",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CTEC",
-              "number": "2990",
-              "title": "CTEC Internship",
-              "credits": null,
-              "or_alternatives": [
-                {
-                  "prefix": "CTEC",
-                  "number": "1040",
-                  "title": ""
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "General Education Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ENGL",
-              "number": "1006",
+              "prefix": "CPLT",
+              "number": "1000",
               "title": "",
               "credits": null,
-              "or_alternatives": [
-                {
-                  "prefix": "MATH",
-                  "number": "1103",
-                  "title": "Contemporary Mathematics"
-                }
-              ]
+              "or_alternatives": []
             },
             {
-              "prefix": "SPCH",
-              "number": "1200",
-              "title": "Public Speaking",
+              "prefix": "KYBD",
+              "number": "1100",
+              "title": "Keyboarding I",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Natural Science Elective (3 credit hours) - Choose from BIOL, CHEM, GEOL, PHSC",
+              "prefix": "BUSN",
+              "number": "1010",
+              "title": "Service Communications",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, or PHIL",
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction To Business",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science Elective (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, SOCL",
+              "prefix": "BUSN",
+              "number": "2010",
+              "title": "Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2451",
+              "title": "Intergrated Career Skills",
               "credits": null,
               "or_alternatives": []
             }
@@ -2890,10 +2787,10 @@
       "matched_program_slug": "criminal-justice"
     },
     {
-      "title": "Cybersecurity Support, CTC",
-      "credential": "other",
+      "title": "Computer Information Systems, AAS",
+      "credential": "AAS",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=620",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=615",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -2919,8 +2816,36 @@
             },
             {
               "prefix": "CTEC",
+              "number": "1070",
+              "title": "Skills For Information Technology (IT) Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
               "number": "1080",
               "title": "Introduction To Management Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "1120",
+              "title": "IT Hardware Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "1140",
+              "title": "IT Software Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "1180",
+              "title": "Help Desk Operations",
               "credits": null,
               "or_alternatives": []
             },
@@ -2933,76 +2858,97 @@
             },
             {
               "prefix": "CTEC",
-              "number": "2010",
-              "title": "Introduction To Computer-Human Interaction",
+              "number": "1700",
+              "title": "Microsoft Windows Servers",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "2630",
+              "title": "Cloud",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "2820",
+              "title": "Information Technology Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "2870",
+              "title": "Network Security Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "2990",
+              "title": "CTEC Internship",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CTEC",
+                  "number": "1040",
+                  "title": ""
+                }
+              ]
             }
           ]
-        }
-      ],
-      "matched_program_slug": "computer-science"
-    },
-    {
-      "title": "Criminal Justice, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=616",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
+        },
         {
           "name": "General Education Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "CRJU",
-              "number": "1010",
-              "title": "Introduction To Criminal Justice",
+              "prefix": "ENGL",
+              "number": "1006",
+              "title": "",
               "credits": null,
-              "or_alternatives": []
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "1103",
+                  "title": "Contemporary Mathematics"
+                }
+              ]
             },
             {
-              "prefix": "CRJU",
-              "number": "2030",
-              "title": "Criminal Law",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CRJU",
-              "number": "2630",
-              "title": "Introduction To Corrections",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CRJU",
-              "number": "2610",
-              "title": "Criminal Justice Ethics",
+              "prefix": "SPCH",
+              "number": "1200",
+              "title": "Public Speaking",
               "credits": null,
               "or_alternatives": []
             },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "CRJU XXXX - Criminal Justice Elective 3 Credit Hour(s)",
+              "title": "Natural Science Elective (3 credit hours) - Choose from BIOL, CHEM, GEOL, PHSC",
               "credits": null,
               "or_alternatives": []
             },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "CRJU XXXX - Criminal Justice Elective 3 Credit Hour(s)",
+              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, or PHIL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, SOCL",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "criminal-justice"
+      "matched_program_slug": null
     },
     {
       "title": "Cybersecurity Defender, CTS",
@@ -3101,71 +3047,71 @@
       "matched_program_slug": "computer-science"
     },
     {
-      "title": "Customer Service Representative, CTS",
+      "title": "Criminal Justice, CTS",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=618",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=616",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
       "requirement_groups": [
         {
-          "name": "Core Courses",
+          "name": "General Education Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "CPLT",
-              "number": "1000",
-              "title": "",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "KYBD",
-              "number": "1100",
-              "title": "Keyboarding I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUSN",
+              "prefix": "CRJU",
               "number": "1010",
-              "title": "Service Communications",
+              "title": "Introduction To Criminal Justice",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "BUSN",
-              "number": "1100",
-              "title": "Introduction To Business",
+              "prefix": "CRJU",
+              "number": "2030",
+              "title": "Criminal Law",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "BUSN",
-              "number": "2010",
-              "title": "Human Relations",
+              "prefix": "CRJU",
+              "number": "2630",
+              "title": "Introduction To Corrections",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "BUSN",
-              "number": "2451",
-              "title": "Intergrated Career Skills",
+              "prefix": "CRJU",
+              "number": "2610",
+              "title": "Criminal Justice Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CRJU XXXX - Criminal Justice Elective 3 Credit Hour(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CRJU XXXX - Criminal Justice Elective 3 Credit Hour(s)",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "criminal-justice"
     },
     {
-      "title": "Diesel Mechanic Apprentice, CTC",
+      "title": "Cybersecurity Support, CTC",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=643",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=620",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -3176,37 +3122,44 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "DESL",
-              "number": "1121",
-              "title": "Safety Fundamentals for Diesel-Powered Equipment",
+              "prefix": "CTEC",
+              "number": "1010",
+              "title": "Information Technology Principles",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "DESL",
-              "number": "1131",
-              "title": "Intro to Diesel-Powered Equipment and Applied Industrial Skills",
+              "prefix": "CTEC",
+              "number": "1020",
+              "title": "Problem Solving And Programming Techniques",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "DESL",
-              "number": "1141",
-              "title": "Diesel Engine Identification and Operating Principles",
+              "prefix": "CTEC",
+              "number": "1080",
+              "title": "Introduction To Management Information Systems",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "DESL",
-              "number": "1241",
-              "title": "Diesel Engine Systems",
+              "prefix": "CTEC",
+              "number": "1550",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEC",
+              "number": "2010",
+              "title": "Introduction To Computer-Human Interaction",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "computer-science"
     },
     {
       "title": "Diesel Mechanic, CTS",
@@ -3422,53 +3375,6 @@
       "matched_program_slug": "computer-science"
     },
     {
-      "title": "Drafting Technology, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=678",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "DRFT",
-              "number": "1007",
-              "title": "Drafting Fundamentals",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "DRFT",
-              "number": "2007",
-              "title": "Advanced Drafting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CADD",
-              "number": "1005",
-              "title": "CAD Fundamentals",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CADD",
-              "number": "2005",
-              "title": "Advanced CAD",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Domestic A/C & Refrigeration, CTS",
       "credential": "other",
       "program_code": null,
@@ -3558,10 +3464,10 @@
       "matched_program_slug": null
     },
     {
-      "title": "Energy Production Technologies, TD",
+      "title": "Diesel Mechanic Apprentice, CTC",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=813",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=643",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -3572,107 +3478,77 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "EPTN",
-              "number": "1030",
-              "title": "Process Diagrams",
+              "prefix": "DESL",
+              "number": "1121",
+              "title": "Safety Fundamentals for Diesel-Powered Equipment",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EPTN",
-              "number": "1050",
-              "title": "Petroleum Computational Methods",
+              "prefix": "DESL",
+              "number": "1131",
+              "title": "Intro to Diesel-Powered Equipment and Applied Industrial Skills",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EPTN",
-              "number": "1300",
-              "title": "Applied Electricity And Industrial Instrumentation I",
+              "prefix": "DESL",
+              "number": "1141",
+              "title": "Diesel Engine Identification and Operating Principles",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EPTN",
-              "number": "1310",
-              "title": "Energy Production Technologies Equipment I",
+              "prefix": "DESL",
+              "number": "1241",
+              "title": "Diesel Engine Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting Technology, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=678",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRFT",
+              "number": "1007",
+              "title": "Drafting Fundamentals",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EPTN",
-              "number": "1320",
-              "title": "Energy Production Technologies Equipment II",
+              "prefix": "DRFT",
+              "number": "2007",
+              "title": "Advanced Drafting",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EPTN",
-              "number": "1400",
-              "title": "Fluid Mechanics",
+              "prefix": "CADD",
+              "number": "1005",
+              "title": "CAD Fundamentals",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EPTN",
-              "number": "1500",
-              "title": "Offshore Safety And Compliance",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "1600",
-              "title": "Oil And Gas Production I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "1610",
-              "title": "Oil And Gas Production II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "2000",
-              "title": "Planning And Management",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "2100",
-              "title": "Introduction To Deep Water Systems And Technology",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "2200",
-              "title": "Production Safety Systems",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "2300",
-              "title": "Applied Electricity And Industrial Instrumentation II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "2400",
-              "title": "Introduction to Plant Operations",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "EPTN",
-              "number": "2500",
-              "title": "Pathways to Energy Careers",
+              "prefix": "CADD",
+              "number": "2005",
+              "title": "Advanced CAD",
               "credits": null,
               "or_alternatives": []
             }
@@ -3839,10 +3715,10 @@
       "matched_program_slug": null
     },
     {
-      "title": "FCAW Pipe Welder, CTC",
+      "title": "Energy Production Technologies, TD",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=666",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=813",
       "total_credits": null,
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
@@ -3853,222 +3729,107 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "WELD",
-              "number": "1100",
-              "title": "Occupational Orientation And Safety",
+              "prefix": "EPTN",
+              "number": "1030",
+              "title": "Process Diagrams",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "WELD",
-              "number": "1200",
-              "title": "Oxyfuel Systems and Cutting Processes",
+              "prefix": "EPTN",
+              "number": "1050",
+              "title": "Petroleum Computational Methods",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "WELD",
-              "number": "2111",
-              "title": "FCAW Groove Welds",
+              "prefix": "EPTN",
+              "number": "1300",
+              "title": "Applied Electricity And Industrial Instrumentation I",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "WELD",
-              "number": "2112",
-              "title": "FCAW 6GR Pipe",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Heating, Ventilation, Air Conditioning, and Refrigeration (HVACR), TD",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=596",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "HVAC",
-              "number": "1150",
-              "title": "HVAC Introduction",
+              "prefix": "EPTN",
+              "number": "1310",
+              "title": "Energy Production Technologies Equipment I",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1160",
-              "title": "Principles Of Refrigeration I",
+              "prefix": "EPTN",
+              "number": "1320",
+              "title": "Energy Production Technologies Equipment II",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1170",
-              "title": "Principles Of Refrigeration II",
+              "prefix": "EPTN",
+              "number": "1400",
+              "title": "Fluid Mechanics",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1180",
-              "title": "Principles Of Refrigeration III",
+              "prefix": "EPTN",
+              "number": "1500",
+              "title": "Offshore Safety And Compliance",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1210",
-              "title": "Electrical Fundamentals",
+              "prefix": "EPTN",
+              "number": "1600",
+              "title": "Oil And Gas Production I",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1220",
-              "title": "Electrical Components",
+              "prefix": "EPTN",
+              "number": "1610",
+              "title": "Oil And Gas Production II",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1230",
-              "title": "Electrical Motors",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1240",
-              "title": "Applied Electricity And Troubleshooting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1410",
-              "title": "Domestic Refrigeration",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1420",
-              "title": "Room Air Conditioners",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "2510",
-              "title": "Residential Central Air Conditioning",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "2520",
-              "title": "Residential Central Air Conditioning II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "2530",
-              "title": "Residential System Design",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "2540",
-              "title": "Residential Heating I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "2550",
-              "title": "Residential Heating II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "2560",
-              "title": "Residential Heat Pumps",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Elective/Other Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "CLCR",
+              "prefix": "EPTN",
               "number": "2000",
-              "title": "Career Preparation",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "HVAC Helper I, CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=594",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "HVAC",
-              "number": "1150",
-              "title": "HVAC Introduction",
+              "title": "Planning And Management",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1160",
-              "title": "Principles Of Refrigeration I",
+              "prefix": "EPTN",
+              "number": "2100",
+              "title": "Introduction To Deep Water Systems And Technology",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1170",
-              "title": "Principles Of Refrigeration II",
+              "prefix": "EPTN",
+              "number": "2200",
+              "title": "Production Safety Systems",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "HVAC",
-              "number": "1180",
-              "title": "Principles Of Refrigeration III",
+              "prefix": "EPTN",
+              "number": "2300",
+              "title": "Applied Electricity And Industrial Instrumentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPTN",
+              "number": "2400",
+              "title": "Introduction to Plant Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPTN",
+              "number": "2500",
+              "title": "Pathways to Energy Careers",
               "credits": null,
               "or_alternatives": []
             }
@@ -4216,113 +3977,51 @@
       "matched_program_slug": "business-administration"
     },
     {
-      "title": "General Studies, AGS",
+      "title": "FCAW Pipe Welder, CTC",
       "credential": "other",
       "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=631",
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=666",
       "total_credits": null,
       "gpa_minimum": null,
-      "description": null,
+      "description": "Powered by Modern Campus Catalog™.",
       "requirement_groups": [
         {
-          "name": "Core/General Education Courses",
+          "name": "Core Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "MATH",
-              "number": "1103",
-              "title": "Contemporary Mathematics",
-              "credits": null,
-              "or_alternatives": [
-                {
-                  "prefix": "ENGL",
-                  "number": "1006",
-                  "title": ""
-                }
-              ]
-            },
-            {
-              "prefix": "ENGL",
-              "number": "1020",
-              "title": "English Composition II",
+              "prefix": "WELD",
+              "number": "1100",
+              "title": "Occupational Orientation And Safety",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, or PHIL",
+              "prefix": "WELD",
+              "number": "1200",
+              "title": "Oxyfuel Systems and Cutting Processes",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Fine Art Elective (3 credit hours) - Choose from ARTS, MUSC, THEA",
+              "prefix": "WELD",
+              "number": "2111",
+              "title": "FCAW Groove Welds",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Natural Science Elective (6 credit hours) - Choose TWO courses from BIOL, CHEM, GEOL, or PHSC",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science Elective (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, or SOCL",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CPLT",
-              "number": "1000",
-              "title": "",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Enrichment Electives",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "MATH",
-              "number": "1223",
-              "title": "Trigonometry",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Natural Science Enrichment (3 credit hours) - Choose from BIOL, CHEM, GEOL, or PHSC",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Fine Arts or Humanities Enrichment (3 credit hours) - Choose from ENGL, HIST, PHIL, SPAN, ARTS, MUSC, THEA, or SPCH",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science Enrichment (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, or SOCL",
+              "prefix": "WELD",
+              "number": "2112",
+              "title": "FCAW 6GR Pipe",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": null
     },
     {
       "title": "General Education Course Categories and Matrix",
@@ -4939,6 +4638,382 @@
       "matched_program_slug": null
     },
     {
+      "title": "General Studies, AGS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=631",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core/General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "Contemporary Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENGL",
+                  "number": "1006",
+                  "title": ""
+                }
+              ]
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (3 credit hours) - Choose from ENGL, HIST, or PHIL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Art Elective (3 credit hours) - Choose from ARTS, MUSC, THEA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Elective (6 credit hours) - Choose TWO courses from BIOL, CHEM, GEOL, or PHSC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, or SOCL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPLT",
+              "number": "1000",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Enrichment Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1223",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science Enrichment (3 credit hours) - Choose from BIOL, CHEM, GEOL, or PHSC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts or Humanities Enrichment (3 credit hours) - Choose from ENGL, HIST, PHIL, SPAN, ARTS, MUSC, THEA, or SPCH",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Enrichment (3 credit hours) - Choose from CRJU, ECON, GEOG, POLI, PSYC, or SOCL",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "HVAC Helper I, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=594",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVAC",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1160",
+              "title": "Principles Of Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1170",
+              "title": "Principles Of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1180",
+              "title": "Principles Of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating, Ventilation, Air Conditioning, and Refrigeration (HVACR), TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=596",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVAC",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1160",
+              "title": "Principles Of Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1170",
+              "title": "Principles Of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1180",
+              "title": "Principles Of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1210",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1220",
+              "title": "Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1230",
+              "title": "Electrical Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1240",
+              "title": "Applied Electricity And Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1410",
+              "title": "Domestic Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1420",
+              "title": "Room Air Conditioners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2510",
+              "title": "Residential Central Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2520",
+              "title": "Residential Central Air Conditioning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2530",
+              "title": "Residential System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2540",
+              "title": "Residential Heating I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2550",
+              "title": "Residential Heating II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2560",
+              "title": "Residential Heat Pumps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective/Other Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLCR",
+              "number": "2000",
+              "title": "Career Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC Helper II, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=595",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVAC",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1160",
+              "title": "Principles Of Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1170",
+              "title": "Principles Of Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1180",
+              "title": "Principles Of Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1210",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1220",
+              "title": "Electrical Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1230",
+              "title": "Electrical Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1240",
+              "title": "Applied Electricity And Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Industrial/Commercial Electrician, TD",
       "credential": "other",
       "program_code": null,
@@ -5077,6 +5152,53 @@
       "matched_program_slug": null
     },
     {
+      "title": "Instrumentation Apprentice, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=634",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INST",
+              "number": "1100",
+              "title": "Core: Introduction To Basic Construction Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1101",
+              "title": "Instrumentation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1102",
+              "title": "Instrumentation Apprentice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1103",
+              "title": "Instrumentation Apprentice II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Instrumentation Technician, CTS",
       "credential": "other",
       "program_code": null,
@@ -5143,327 +5265,6 @@
               "prefix": "INST",
               "number": "1302",
               "title": "Electrical Wiring And Controllers",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "HVAC Helper II, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=595",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "HVAC",
-              "number": "1150",
-              "title": "HVAC Introduction",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1160",
-              "title": "Principles Of Refrigeration I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1170",
-              "title": "Principles Of Refrigeration II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1180",
-              "title": "Principles Of Refrigeration III",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1210",
-              "title": "Electrical Fundamentals",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1220",
-              "title": "Electrical Components",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1230",
-              "title": "Electrical Motors",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HVAC",
-              "number": "1240",
-              "title": "Applied Electricity And Troubleshooting",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Instrumentation Apprentice, CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=634",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "INST",
-              "number": "1100",
-              "title": "Core: Introduction To Basic Construction Skills",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1101",
-              "title": "Instrumentation Fundamentals",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1102",
-              "title": "Instrumentation Apprentice",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1103",
-              "title": "Instrumentation Apprentice II",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Instrumentation Technology, TD",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=636",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "INST",
-              "number": "1100",
-              "title": "Core: Introduction To Basic Construction Skills",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1101",
-              "title": "Instrumentation Fundamentals",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1102",
-              "title": "Instrumentation Apprentice",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1103",
-              "title": "Instrumentation Apprentice II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1201",
-              "title": "Instrumentation Technician I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1202",
-              "title": "Instrumentation Technician II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1301",
-              "title": "Control And Detection Devices",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1302",
-              "title": "Electrical Wiring And Controllers",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1401",
-              "title": "Instrumentation Calibration And Troubleshooting",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1402",
-              "title": "Digital Control Systems",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "INST",
-              "number": "1501",
-              "title": "Industrial Applications I (Lab)",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Other Required Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "CLCR",
-              "number": "2000",
-              "title": "Career Preparation",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "OR",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CLCR",
-              "number": "2050",
-              "title": "On-The-Job-Learning",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Intermediate Welder, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=668",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "WELD",
-              "number": "1100",
-              "title": "Occupational Orientation And Safety",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "1200",
-              "title": "Oxyfuel Systems and Cutting Processes",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "1410",
-              "title": "SMAW- Basic Beads",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "1411",
-              "title": "SMAW - Fillet Weld",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "1412",
-              "title": "SMAW - V-Groove",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "1500",
-              "title": "Basic Blueprint, Metallurgy, &amp; Weld Symbols",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "2110",
-              "title": "FCAW - Basic Fillet Welds",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "2111",
-              "title": "FCAW Groove Welds",
               "credits": null,
               "or_alternatives": []
             }
@@ -6647,6 +6448,205 @@
       "matched_program_slug": null
     },
     {
+      "title": "Instrumentation Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=636",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INST",
+              "number": "1100",
+              "title": "Core: Introduction To Basic Construction Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1101",
+              "title": "Instrumentation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1102",
+              "title": "Instrumentation Apprentice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1103",
+              "title": "Instrumentation Apprentice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1201",
+              "title": "Instrumentation Technician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1202",
+              "title": "Instrumentation Technician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1301",
+              "title": "Control And Detection Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1302",
+              "title": "Electrical Wiring And Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1401",
+              "title": "Instrumentation Calibration And Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1402",
+              "title": "Digital Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1501",
+              "title": "Industrial Applications I (Lab)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLCR",
+              "number": "2000",
+              "title": "Career Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLCR",
+              "number": "2050",
+              "title": "On-The-Job-Learning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Intermediate Welder, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=668",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1100",
+              "title": "Occupational Orientation And Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1200",
+              "title": "Oxyfuel Systems and Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1410",
+              "title": "SMAW- Basic Beads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1411",
+              "title": "SMAW - Fillet Weld",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1412",
+              "title": "SMAW - V-Groove",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1500",
+              "title": "Basic Blueprint, Metallurgy, &amp; Weld Symbols",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2110",
+              "title": "FCAW - Basic Fillet Welds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2111",
+              "title": "FCAW Groove Welds",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Louisiana Transfer Associate of Science, ASLT",
       "credential": "AS",
       "program_code": null,
@@ -7359,6 +7359,93 @@
       "matched_program_slug": null
     },
     {
+      "title": "Machine Operator, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=641",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTTC",
+              "number": "1001",
+              "title": "Material, Measurement, And Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTTC",
+              "number": "1006",
+              "title": "Introduction To Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTTC",
+              "number": "1007",
+              "title": "Intro To Milling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTTC",
+              "number": "2940",
+              "title": "Advanced Manual Machining",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Shop Helper, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=640",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTTC",
+              "number": "1001",
+              "title": "Material, Measurement, And Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTTC",
+              "number": "1006",
+              "title": "Introduction To Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTTC",
+              "number": "1007",
+              "title": "Intro To Milling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Machine Tool Technology, TD",
       "credential": "other",
       "program_code": null,
@@ -7577,133 +7664,6 @@
               "prefix": "CLCR",
               "number": "2050",
               "title": "On-The-Job-Learning",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Machine Operator, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=641",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "MTTC",
-              "number": "1001",
-              "title": "Material, Measurement, And Safety",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MTTC",
-              "number": "1006",
-              "title": "Introduction To Lathe",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MTTC",
-              "number": "1007",
-              "title": "Intro To Milling",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MTTC",
-              "number": "2940",
-              "title": "Advanced Manual Machining",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Machine Shop Helper, CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=640",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "MTTC",
-              "number": "1001",
-              "title": "Material, Measurement, And Safety",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MTTC",
-              "number": "1006",
-              "title": "Introduction To Lathe",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MTTC",
-              "number": "1007",
-              "title": "Intro To Milling",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Medical Clinical Assistant, CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=646",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "CMCA",
-              "number": "1010",
-              "title": "Medical Clinical Assistant I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CMCA",
-              "number": "1020",
-              "title": "Medical Clinical Assistant II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CMCA",
-              "number": "1030",
-              "title": "Medical Clinical Assistant III",
               "credits": null,
               "or_alternatives": []
             }
@@ -7947,39 +7907,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Nurse Aide (Nursing), CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=651",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "NURS",
-              "number": "1000",
-              "title": "Basic Nursing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "NURS",
-              "number": "1080",
-              "title": "Health Assessment For Nurses",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "nursing"
-    },
-    {
       "title": "Medical Laboratory Technician, AAS",
       "credential": "AAS",
       "program_code": null,
@@ -8213,6 +8140,46 @@
       "matched_program_slug": null
     },
     {
+      "title": "Medical Clinical Assistant, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=646",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMCA",
+              "number": "1010",
+              "title": "Medical Clinical Assistant I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMCA",
+              "number": "1020",
+              "title": "Medical Clinical Assistant II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMCA",
+              "number": "1030",
+              "title": "Medical Clinical Assistant III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Medical Office Assistant, CTC",
       "credential": "other",
       "program_code": null,
@@ -8265,6 +8232,39 @@
         }
       ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Nurse Aide (Nursing), CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=651",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "1000",
+              "title": "Basic Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1080",
+              "title": "Health Assessment For Nurses",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
     },
     {
       "title": "Nursing Assistant, CTC",
@@ -8504,67 +8504,6 @@
       "matched_program_slug": "nursing"
     },
     {
-      "title": "Phlebotomy, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=657",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "HPHL",
-              "number": "1110",
-              "title": "Introduction To Health Care",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HPHL",
-              "number": "1010",
-              "title": "Phlebotomy Principles",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HPHL",
-              "number": "1021",
-              "title": "Phlebotomy Techniques Lecture",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HPHL",
-              "number": "1022",
-              "title": "Phlebotomy Techniques Lab &amp; Clinical Experiences",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HPHL",
-              "number": "1120",
-              "title": "Body Structure And Function",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HPHL",
-              "number": "1130",
-              "title": "Phlebotomy Capstone Course",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Office Assistant, CTS",
       "credential": "other",
       "program_code": null,
@@ -8799,123 +8738,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Practical Nursing, TD",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=659",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses, starting Fall 2025",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "LPNU",
-              "number": "1005",
-              "title": "PN Anatomy &amp; Physiology",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "1203",
-              "title": "Practical Nursing Perspectives",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "1214",
-              "title": "Basic Fundamentals in Practical Nursing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "1223",
-              "title": "Advanced Fundamentals in Practical Nursing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "1234",
-              "title": "Basic Pharmacology",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "1262",
-              "title": "Basic Nutrition for Practical Nursing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2119",
-              "title": "Medical Surgical Nursing I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2124",
-              "title": "Advanced Pharmacology and IV Therapy",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2229",
-              "title": "Medical Surgical Nursing II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2338",
-              "title": "Medical Surgical Nursing III",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2342",
-              "title": "Transitions to Professional Practice for the Practical Nurse",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2413",
-              "title": "Mental Health Nursing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2423",
-              "title": "Maternal and Women&#039;s Health Nursing",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "LPNU",
-              "number": "2433",
-              "title": "Pediatric Nursing",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "nursing"
-    },
-    {
       "title": "Practical Nursing to Associate of Science in Nursing (LPN to ASN), AS",
       "credential": "AS",
       "program_code": null,
@@ -9050,6 +8872,123 @@
       "matched_program_slug": "nursing"
     },
     {
+      "title": "Practical Nursing, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=659",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses, starting Fall 2025",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPNU",
+              "number": "1005",
+              "title": "PN Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "1203",
+              "title": "Practical Nursing Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "1214",
+              "title": "Basic Fundamentals in Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "1223",
+              "title": "Advanced Fundamentals in Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "1234",
+              "title": "Basic Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "1262",
+              "title": "Basic Nutrition for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2119",
+              "title": "Medical Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2124",
+              "title": "Advanced Pharmacology and IV Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2229",
+              "title": "Medical Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2338",
+              "title": "Medical Surgical Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2342",
+              "title": "Transitions to Professional Practice for the Practical Nurse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2413",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2423",
+              "title": "Maternal and Women&#039;s Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPNU",
+              "number": "2433",
+              "title": "Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
       "title": "Production Helper, CTC",
       "credential": "other",
       "program_code": null,
@@ -9095,6 +9034,142 @@
               "prefix": "EPTN",
               "number": "2500",
               "title": "Pathways to Energy Careers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=657",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPHL",
+              "number": "1110",
+              "title": "Introduction To Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPHL",
+              "number": "1010",
+              "title": "Phlebotomy Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPHL",
+              "number": "1021",
+              "title": "Phlebotomy Techniques Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPHL",
+              "number": "1022",
+              "title": "Phlebotomy Techniques Lab &amp; Clinical Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPHL",
+              "number": "1120",
+              "title": "Body Structure And Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPHL",
+              "number": "1130",
+              "title": "Phlebotomy Capstone Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Residential Electrician, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=627",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "1010",
+              "title": "Introductory Craft Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1020",
+              "title": "Introductory Craft Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1101",
+              "title": "Basic Electrical Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1102",
+              "title": "Basic Electrical Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1201",
+              "title": "Residential Electrician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1202",
+              "title": "Residential Electrician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1203",
+              "title": "Electrical Raceways And Fittings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1204",
+              "title": "Conduit Bending",
               "credits": null,
               "or_alternatives": []
             }
@@ -9474,81 +9549,6 @@
               "prefix": "RADT",
               "number": "2080",
               "title": "Radiographic Clinical Education V",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Residential Electrician, CTS",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=627",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "1010",
-              "title": "Introductory Craft Skills I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1020",
-              "title": "Introductory Craft Skills II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1101",
-              "title": "Basic Electrical Skills I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1102",
-              "title": "Basic Electrical Skills II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1201",
-              "title": "Residential Electrician I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1202",
-              "title": "Residential Electrician II",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1203",
-              "title": "Electrical Raceways And Fittings",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "1204",
-              "title": "Conduit Bending",
               "credits": null,
               "or_alternatives": []
             }
@@ -9958,121 +9958,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Technical Studies, AAS",
-      "credential": "AAS",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=662",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "CPXX 1XXX - Approved Computer Elective 3 Credit Hour(s)",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ENGL",
-              "number": "1006",
-              "title": "English Composition I: Enhanced Writing Corequisite Model",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ENGL",
-              "number": "1010",
-              "title": "English Composition I",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MATH",
-              "number": "1214",
-              "title": "College Algebra",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MATH",
-              "number": "1213",
-              "title": "College Algebra",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities (GER) 3 Credit Hour(s)",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Natural Science (GER) 3 Credit Hour(s)",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science (GER) 3 Credit Hour(s)",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "TIG Pipe Welder, CTC",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=667",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": "Powered by Modern Campus Catalog™.",
-      "requirement_groups": [
-        {
-          "name": "Core Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "WELD",
-              "number": "1512",
-              "title": "Pipe 6G",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "2220",
-              "title": "GTAW - Pipe 5G",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "WELD",
-              "number": "2222",
-              "title": "GTAW- Pipe 6G",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Technical Studies - Practical Nursing Track, AAS",
       "credential": "AAS",
       "program_code": null,
@@ -10318,6 +10203,121 @@
         }
       ],
       "matched_program_slug": "welding"
+    },
+    {
+      "title": "TIG Pipe Welder, CTC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=667",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1512",
+              "title": "Pipe 6G",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2220",
+              "title": "GTAW - Pipe 5G",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2222",
+              "title": "GTAW- Pipe 6G",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.fletcher.edu/preview_program.php?catoid=6&poid=662",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CPXX 1XXX - Approved Computer Elective 3 Credit Hour(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1006",
+              "title": "English Composition I: Enhanced Writing Corequisite Model",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1214",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities (GER) 3 Credit Hour(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science (GER) 3 Credit Hour(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science (GER) 3 Credit Hour(s)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
     },
     {
       "title": "Word Processor Operator, CTS",

--- a/data/la/programs/nunez-community-college.json
+++ b/data/la/programs/nunez-community-college.json
@@ -1,0 +1,9729 @@
+{
+  "college_slug": "nunez-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.nunez.edu/programs/",
+  "scraped_at": "2026-05-29T19:29:06.701Z",
+  "programs": [
+    {
+      "title": "Application Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/application-fundamentals-certificate-technical-studies/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1600",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1610",
+              "title": "Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1620",
+              "title": "Presentations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1630",
+              "title": "Databases",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1640",
+              "title": "DataTasking,Email,Collab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2600",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2610",
+              "title": "Advanced Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace Manufacturing Technology, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/aerospace-manufacturing-technology/aerospace-manufacturing-technology-technical-diploma/",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2900",
+              "title": "Job Readiness Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1000",
+              "title": "Introduction to Aerospace",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1040",
+              "title": "Intro to Elec.& Elec. Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1050",
+              "title": "Fluid Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1210",
+              "title": "Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1500",
+              "title": "Hoist & Crane Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1760",
+              "title": "Adv Electro & Electri Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1780",
+              "title": "Intro Mech Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2510",
+              "title": "Welding Aero Manuf",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2700",
+              "title": "Advanced Mechanical Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2770",
+              "title": "Surface Prep, Coatings & Adhes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2780",
+              "title": "Composite Materials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2790",
+              "title": "Fabrication Aero Manuf",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace Manufacturing Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/aerospace-manufacturing-technology/aerospace-manufacturing-technology-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept ((or higher))",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1000",
+              "title": "Physical Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1200",
+              "title": "Physical Science II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "General Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2900",
+              "title": "Job Readiness Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1000",
+              "title": "Introduction to Aerospace",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1040",
+              "title": "Intro to Elec.& Elec. Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1050",
+              "title": "Fluid Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1210",
+              "title": "Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1500",
+              "title": "Hoist & Crane Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1760",
+              "title": "Adv Electro & Electri Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1780",
+              "title": "Intro Mech Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2510",
+              "title": "Welding Aero Manuf",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2700",
+              "title": "Advanced Mechanical Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2770",
+              "title": "Surface Prep, Coatings & Adhes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2780",
+              "title": "Composite Materials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2790",
+              "title": "Fabrication Aero Manuf",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/business-fundamentals-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1330",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Aerospace Manufacturing Technology, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/aerospace-manufacturing-technology/aerospace-manufacturing-technology-cts/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1000",
+              "title": "Introduction to Aerospace",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1040",
+              "title": "Intro to Elec.& Elec. Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1760",
+              "title": "Adv Electro & Electri Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "1780",
+              "title": "Intro Mech Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARST",
+              "number": "2700",
+              "title": "Advanced Mechanical Assembly",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Information Technology, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/business-information-technology-technical-diploma/",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1600",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1610",
+              "title": "Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1620",
+              "title": "Presentations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1630",
+              "title": "Databases",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1640",
+              "title": "DataTasking,Email,Collab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2600",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2610",
+              "title": "Advanced Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Advanced Application Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/advanced-application-fundamentals-certificate-technical-studies/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2620",
+              "title": "Advanced Databases",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2630",
+              "title": "MS Windows OS Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2640",
+              "title": "Networking & Security Fund.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2650",
+              "title": "Web Development Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2660",
+              "title": "Software Dev Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2670",
+              "title": "Config. & Supporting Windows",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud Computing Foundations, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/cloud-computing-certificate-technical-studies/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCOM",
+              "number": "1001",
+              "title": "Intro to Information Technolog",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1002",
+              "title": "PC Hardware and Software Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1004",
+              "title": "Intro to Programming&Scripting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1021",
+              "title": "Fund of AWS Cloud Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1023",
+              "title": "Intro to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1027",
+              "title": "Windows Client Server 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1030",
+              "title": "Linux Desktop & Server OS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1033",
+              "title": "Intermediate Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1037",
+              "title": "Windows Client Server 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCOM",
+              "number": "1045",
+              "title": "Introduction to Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Databases, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/databases-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1630",
+              "title": "Databases",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2620",
+              "title": "Advanced Databases",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Microsoft OS, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/microsoft-os-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2630",
+              "title": "MS Windows OS Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2640",
+              "title": "Networking & Security Fund.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2670",
+              "title": "Config. & Supporting Windows",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/software-development-certificate-technical-studies/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2650",
+              "title": "Web Development Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2660",
+              "title": "Software Dev Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2670",
+              "title": "Config. & Supporting Windows",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spreadsheets, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/spreadsheets-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1610",
+              "title": "Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2610",
+              "title": "Advanced Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Word Processing, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-information-technology/word-processing-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1600",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2600",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Clerk, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/accounting-clerk-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1500",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Management, Associate of Applied Science (Accounting Concentration) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/accounting-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2700",
+              "title": "Foundations of Strategic Mgmt",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2750",
+              "title": "Business Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1500",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2200",
+              "title": "Personal Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2180",
+              "title": "Intro to Govt & Non-Profit Acc",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2330",
+              "title": "Auditing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1400",
+              "title": "Business Math with Excel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1610",
+              "title": "Spreadsheets",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2000",
+              "title": "Principles of Marketing",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, Associate of Applied Science (Business Administration Concentration) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/business-admin-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2700",
+              "title": "Foundations of Strategic Mgmt",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2750",
+              "title": "Business Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2000",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2150",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1900",
+              "title": "Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Managerial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1330",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1400",
+              "title": "Business Math with Excel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1500",
+              "title": "Starting Your Own Business",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1530",
+              "title": "Retailing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1700",
+              "title": "Principles of Real Estate",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1710",
+              "title": "LA Real Estate Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Fundamentals, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/business-fundamentals-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1400",
+              "title": "Business Math with Excel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1600",
+              "title": "Word Processing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1610",
+              "title": "Spreadsheets",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2610",
+              "title": "Advanced Spreadsheets",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1620",
+              "title": "Presentations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OADM",
+              "number": "1500",
+              "title": "Administrtv Office Procedures",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OFCR",
+              "number": "1450",
+              "title": "Speed-Building Strategies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OFCR",
+              "number": "2100",
+              "title": "Advanced Typing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OFCR",
+              "number": "1400",
+              "title": "College Keyboarding",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, Associate of Applied Science (Entrepreneurship/Small Business Concentration) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/entrepr-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2700",
+              "title": "Foundations of Strategic Mgmt",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2750",
+              "title": "Business Internship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1500",
+              "title": "Starting Your Own Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2000",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2500",
+              "title": "Financing for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1175",
+              "title": "Customer Service,Sales,Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1330",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1400",
+              "title": "Business Math with Excel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1530",
+              "title": "Retailing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2200",
+              "title": "Business Law",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship/Small Business Management, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/entrepreneurship-certificate-technical-studies/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1400",
+              "title": "Business Math with Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1500",
+              "title": "Starting Your Own Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1510",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2000",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2500",
+              "title": "Financing for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Payroll and Timekeeping Clerk, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/payroll-timekeeping-clerk-career-technical-certificate/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1500",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2200",
+              "title": "Personal Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Real Estate Sales, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-management/real-estate-sales-career-technical-certificate/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1700",
+              "title": "Principles of Real Estate",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1710",
+              "title": "LA Real Estate Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Concentration, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-technology/accounting-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1500",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2180",
+              "title": "Intro to Govt & Non-Profit Acc",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2200",
+              "title": "Personal Income Tax",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2330",
+              "title": "Auditing Principles",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1610",
+              "title": "Spreadsheets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Administration Concentration, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-technology/business-administration-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2000",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2150",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2999",
+              "title": "Business Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FINA",
+              "number": "2010",
+              "title": "Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1330",
+              "title": "Personal Finance",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "College Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1700",
+              "title": "Finite Math",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Technology, Certificate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-technology/business-technology-certificate-applied-science/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship Concentration, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-technology/entrepreneurship-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2100",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1500",
+              "title": "Starting Your Own Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1510",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1520",
+              "title": "Marketing for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2200",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2500",
+              "title": "Financing for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2999",
+              "title": "Business Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hotel, Restaurant, and Tourism Admin, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-technology/hotel-restaurant-tourism-admin-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1800",
+              "title": "Introduction to Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2800",
+              "title": "Lodging Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hotel, Restaurant, and Tourism Concentration, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/business-technology/hotel-restaurant-tourism-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1800",
+              "title": "Introduction to Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2100",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2150",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2800",
+              "title": "Lodging Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2820",
+              "title": "Marktng for Hospitality & Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2890",
+              "title": "Found.of Strat. Mgmt for Hospi",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1020",
+              "title": "Basic Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Care and Development of Young Children, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/care-development-young-children/care-development-young-children-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2200",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2100",
+              "title": "Human Growth and Development",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1050",
+              "title": "Intro to Care&Dev of Yng Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1110",
+              "title": "Observation & Participation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2300",
+              "title": "Lit & Lang Dev in Early Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2980",
+              "title": "Practicum",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Care and Development of Young Children, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/care-development-young-children/care-development-young-children-technical-diploma/",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2100",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2200",
+              "title": "Child Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1050",
+              "title": "Intro to Care&Dev of Yng Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1110",
+              "title": "Observation & Participation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1120",
+              "title": "Health,Safety&Nutr for Yng Chl",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1300",
+              "title": "Intro to Children w/Exception",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1350",
+              "title": "Including Children with Autism",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1810",
+              "title": "Math & Science in Early Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2130",
+              "title": "Infant & Toddler Curr Developm",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2730",
+              "title": "Curr & Teach Mat in Early Chld",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2300",
+              "title": "Lit & Lang Dev in Early Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2850",
+              "title": "Guiding & Managing Child Behav",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "2980",
+              "title": "Practicum",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Teaching Skills, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/care-development-young-children/early-childhood-teaching-skills-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDYC",
+              "number": "1015",
+              "title": "Strengthening the CDYC I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1025",
+              "title": "Strengthening the CDYC II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDYC",
+              "number": "1035",
+              "title": "Strengthening the CDYC III",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Carpentry, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/carpentry/carpentry-certificate-technical-studies/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1030",
+              "title": "Carpentry 1",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1050",
+              "title": "Carpentry 2",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Coastal Restoration, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/coastal-restoration-certificate-technical-studies/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2200",
+              "title": "Louisiana Wetlands Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1013",
+              "title": "Coastal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2020",
+              "title": "Field & Research Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2410",
+              "title": "Coastal Restoration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "1030",
+              "title": "Environmental Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "1010",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Coastal Studies and GIS Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/coastal-studies-gis-technology-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1201",
+              "title": "World Regional Geography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1202",
+              "title": "World Regional Geography II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1100",
+              "title": "General Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2100",
+              "title": "Louisiana History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2200",
+              "title": "Louisiana Wetlands Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1013",
+              "title": "Coastal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1114",
+              "title": "Computer Graphs & Maps",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1123",
+              "title": "Fundamentals of Mapping & GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2133",
+              "title": "Remote Sensing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2143",
+              "title": "GIS Theories and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2153",
+              "title": "Remote Sensing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "1030",
+              "title": "Environmental Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Coastal Studies and GIS Technology, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/coastal-studies-gis-technology-technical-diploma/",
+      "total_credits": 47,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1201",
+              "title": "World Regional Geography I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1202",
+              "title": "World Regional Geography II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1100",
+              "title": "General Biology Iand General Biology I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2100",
+              "title": "Louisiana History",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2200",
+              "title": "Louisiana Wetlands Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1013",
+              "title": "Coastal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1114",
+              "title": "Computer Graphs & Maps",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1123",
+              "title": "Fundamentals of Mapping & GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2133",
+              "title": "Remote Sensing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2143",
+              "title": "GIS Theories and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2153",
+              "title": "Remote Sensing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "1030",
+              "title": "Environmental Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Coastal Surveying Skills, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/coastal-survey-skills-career-technical-certificate/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSTL",
+              "number": "2323",
+              "title": "Introduction to sUAS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1313",
+              "title": "Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1311",
+              "title": "Surveying Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2333",
+              "title": "Hydrographic Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRDT",
+              "number": "1030",
+              "title": "Basic CADD",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "GIS & Facilities Planning Program, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/gis-facilities-planning-program-certificate-technical-studies/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENVN",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1114",
+              "title": "Computer Graphs & Maps",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1123",
+              "title": "Fundamentals of Mapping & GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2133",
+              "title": "Remote Sensing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2143",
+              "title": "GIS Theories and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2163",
+              "title": "Master Planning for Fed Fac",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "GIS Technology, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/gis-technology-certificate-technical-studies/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2200",
+              "title": "Louisiana Wetlands Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1114",
+              "title": "Computer Graphs & Maps",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1123",
+              "title": "Fundamentals of Mapping & GIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2133",
+              "title": "Remote Sensing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2143",
+              "title": "GIS Theories and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2153",
+              "title": "Remote Sensing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wastewater Plant Operator, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/wastewater-plant-operator-career-technical-certificate/",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSTL",
+              "number": "1243",
+              "title": "Wastewater Treatment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1253",
+              "title": "Wastewater Collection I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Plant Operator, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/coastal-studies-gis-technology/water-plant-operator-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSTL",
+              "number": "1213",
+              "title": "Water Treatment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1223",
+              "title": "Water Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "1233",
+              "title": "Water Distribution I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baker, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/culinary-arts-culinary-entrepreneurship/baker-career-technical-certificate/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "1000",
+              "title": "Introduction to Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1020",
+              "title": "Basic Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1050",
+              "title": "Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1500",
+              "title": "Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1600",
+              "title": "Advanced Baking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/culinary-arts-culinary-entrepreneurship/culinary-arts-certificate-technical-studies/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "1000",
+              "title": "Introduction to Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1020",
+              "title": "Basic Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1050",
+              "title": "Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1100",
+              "title": "Culinary Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1030",
+              "title": "Nutrition for Food Service Prs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1500",
+              "title": "Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1750",
+              "title": "Meat, Poultry, and Seafood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1800",
+              "title": "Soups, Stocks, and Sauces",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1900",
+              "title": "Garde Manger Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2900",
+              "title": "International Cuisine",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Entrepreneurship, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/culinary-arts-culinary-entrepreneurship/culinary-entrepreneurship-technical-diploma/",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "1000",
+              "title": "Introduction to Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1020",
+              "title": "Basic Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1050",
+              "title": "Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1100",
+              "title": "Culinary Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1030",
+              "title": "Nutrition for Food Service Prs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1500",
+              "title": "Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2700",
+              "title": "Food Service Management I & II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1750",
+              "title": "Meat, Poultry, and Seafood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1800",
+              "title": "Soups, Stocks, and Sauces",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1900",
+              "title": "Garde Manger Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2730",
+              "title": "Food Service Management III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2750",
+              "title": "FSM IV- Hosp & Rest Mgmt",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2850",
+              "title": "Culinary Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2900",
+              "title": "International Cuisine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1500",
+              "title": "Starting Your Own Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1520",
+              "title": "Marketing for Entrepreneurs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinarian, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/culinary-arts-culinary-entrepreneurship/entry-level-cook-career-technical-certificate/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "1000",
+              "title": "Introduction to Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1020",
+              "title": "Basic Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1050",
+              "title": "Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1500",
+              "title": "Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1800",
+              "title": "Soups, Stocks, and Sauces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Service Manager, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/culinary-arts-culinary-entrepreneurship/food-service-manager-career-technical-certificate/",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "1050",
+              "title": "Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "1100",
+              "title": "Culinary Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1030",
+              "title": "Nutrition for Food Service Prs",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2700",
+              "title": "Food Service Management I & II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2730",
+              "title": "Food Service Management III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "2750",
+              "title": "FSM IV- Hosp & Rest Mgmt",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity and Information Assurance, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/cyber-security/cybersecurity-and-information-assurance-associate-applied-science/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1203",
+              "title": "Applied Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1213",
+              "title": "Applied Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1000",
+              "title": "Info. Technology Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1100",
+              "title": "Problem Solv. & Prog Technique",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1200",
+              "title": "Skills for Info Tech. Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1300",
+              "title": "Introduction to Scripting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1400",
+              "title": "IT Hardware Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1500",
+              "title": "IT Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1600",
+              "title": "Linux Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1700",
+              "title": "Network Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1800",
+              "title": "Microsoft Windows Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1900",
+              "title": "CCNA I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2000",
+              "title": "Advanced Network Topics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2100",
+              "title": "Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2200",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2300",
+              "title": "Network Security Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2400",
+              "title": "CSCI Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1010",
+              "title": "Ethics in Info. Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1910",
+              "title": "CCNA II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1920",
+              "title": "CCNA III",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Security Professional, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/cyber-security/cybersecurity-and-information-assurance-information-systems-security-professional-cts/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1000",
+              "title": "Info. Technology Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1100",
+              "title": "Problem Solv. & Prog Technique",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1200",
+              "title": "Skills for Info Tech. Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1400",
+              "title": "IT Hardware Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1500",
+              "title": "IT Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1700",
+              "title": "Network Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2500",
+              "title": "Network Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2300",
+              "title": "Network Security Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Security, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/cyber-security/network-security-ctc/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSCI",
+              "number": "1400",
+              "title": "IT Hardware Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1500",
+              "title": "IT Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "1700",
+              "title": "Network Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSCI",
+              "number": "2300",
+              "title": "Network Security Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/electrical-construction/electrical-construction-aas/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1000",
+              "title": "Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1000",
+              "title": "Electrical Construction I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1010",
+              "title": "NCCER Instrument Level I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1010",
+              "title": "Electrical Construction II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1020",
+              "title": "NCCER Instrument Level II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2000",
+              "title": "Electrical Construction III",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2010",
+              "title": "Electrical Construction IV",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction - Advanced, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/electrical-construction/electrical-construction-advanced-certificate-technical-studies/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "2000",
+              "title": "Electrical Construction III",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "2010",
+              "title": "Electrical Construction IV",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/electrical-construction/electrical-construction-certificate-technical-studies/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1000",
+              "title": "Electrical Construction I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1010",
+              "title": "Electrical Construction II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services Education - Paramedic, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/emergency-medical-services-education/emergency-medical-services-paramedic-certificate-technical-studies/",
+      "total_credits": 37,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1010",
+              "title": "Intro Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1020",
+              "title": "Intro Anatomy & Physiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1200",
+              "title": "Principles of Paramedic Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1210",
+              "title": "Princ. of Paramedic Care Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1300",
+              "title": "Cardiac & Resp Emergencies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1310",
+              "title": "Cardiac & Resp Emerg Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1320",
+              "title": "Paramedic Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1500",
+              "title": "Medical Emergencies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1510",
+              "title": "Medical Emergencies Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1520",
+              "title": "Paramedic Internship II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2200",
+              "title": "Special Populations in EMS",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2210",
+              "title": "Special Populations in EMS lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2220",
+              "title": "Paramedic Internship III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2300",
+              "title": "Trauma Emergencies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2310",
+              "title": "Trauma Emergencies Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2320",
+              "title": "Paramedic Field Practicum I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2400",
+              "title": "EMS Operations&Paramedic Rev",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2420",
+              "title": "Paramedic Field Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "EMT - Advanced, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/emergency-medical-services-education/emt-advanced-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMSE",
+              "number": "1100",
+              "title": "Adv Emergency Med Technician",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1120",
+              "title": "Adv Emerg Med Tech Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "EMT - Basic, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/emergency-medical-services-education/emt-basic-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMSE",
+              "number": "1020",
+              "title": "Emergency Medical Technician I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1021",
+              "title": "Emergency Medical Tech II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1030",
+              "title": "Emergency Med Tech Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1031",
+              "title": "Emergency Medical Tech II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1040",
+              "title": "Emergency Med Tech Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of General Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/general-studies/associate-general-studies/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Emergency Medical Services Education - Paramedic, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/emergency-medical-services-education/paramedic-associate-of-applied-science/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1010",
+              "title": "Intro Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1020",
+              "title": "Intro Anatomy & Physiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1190",
+              "title": "Math for Allied Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1203",
+              "title": "Applied Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2100",
+              "title": "Anthropology of Sex and Gender",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1200",
+              "title": "World Regional Geography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "1100",
+              "title": "American Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "2610",
+              "title": "Constitutional Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1100",
+              "title": "Introduction to Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1130",
+              "title": "Psychology of Personal Adjustm",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "1100",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "1510",
+              "title": "Sociology of Sexual Behavior",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "2100",
+              "title": "Social Problems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "2220",
+              "title": "Drug Abuse",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1500",
+              "title": "Nutrition and Diet Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2050",
+              "title": "Genetics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1003",
+              "title": "Gen, Organic & Biochemistry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "1010",
+              "title": "Environmental Hlth and Safety",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "1030",
+              "title": "Environmental Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2150",
+              "title": "Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1100",
+              "title": "Intro to Philosophy",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1130",
+              "title": "World Religions",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2200",
+              "title": "Ethics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1010",
+              "title": "History of Western Civ I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2100",
+              "title": "Louisiana History",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "1010",
+              "title": "Elementary French I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1010",
+              "title": "Elementary Spanish I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1020",
+              "title": "Emergency Medical Technician I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1030",
+              "title": "Emergency Med Tech Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1021",
+              "title": "Emergency Medical Tech II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1031",
+              "title": "Emergency Medical Tech II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1040",
+              "title": "Emergency Med Tech Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1200",
+              "title": "Principles of Paramedic Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1210",
+              "title": "Princ. of Paramedic Care Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1300",
+              "title": "Cardiac & Resp Emergencies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1310",
+              "title": "Cardiac & Resp Emerg Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1320",
+              "title": "Paramedic Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1500",
+              "title": "Medical Emergencies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1510",
+              "title": "Medical Emergencies Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "1520",
+              "title": "Paramedic Internship II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2200",
+              "title": "Special Populations in EMS",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2210",
+              "title": "Special Populations in EMS lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2220",
+              "title": "Paramedic Internship III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2300",
+              "title": "Trauma Emergencies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2310",
+              "title": "Trauma Emergencies Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2320",
+              "title": "Paramedic Field Practicum I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2400",
+              "title": "EMS Operations&Paramedic Rev",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSE",
+              "number": "2420",
+              "title": "Paramedic Field Practicum II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certificate of General Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/general-studies/certificate-general-studies/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Heating, Air Conditioning, and Refrigeration, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/heating-air-conditioning-refrigeration-hacr/aas/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1160",
+              "title": "Principles of Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1170",
+              "title": "Principles of Refrigeration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1210",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1220",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1230",
+              "title": "Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1180",
+              "title": "Princip. of Refrigeration III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1240",
+              "title": "Applied Electricity& Troublesh",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1410",
+              "title": "Domestic Refrigeration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1420",
+              "title": "Room Air Conditioners",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2510",
+              "title": "Residential Central A/C",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2520",
+              "title": "Residential Central A/C II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2530",
+              "title": "Residential System Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2540",
+              "title": "Residential Heating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2560",
+              "title": "Residential Heat Pumps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2900",
+              "title": "Job Readiness Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Domestic Refrigeration Helper II, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/heating-air-conditioning-refrigeration-hacr/domestic-refrigeration-helper-ii-certificate-technical-studies/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1160",
+              "title": "Principles of Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1170",
+              "title": "Principles of Refrigeration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1210",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1220",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1230",
+              "title": "Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1180",
+              "title": "Princip. of Refrigeration III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1240",
+              "title": "Applied Electricity& Troublesh",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1410",
+              "title": "Domestic Refrigeration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1420",
+              "title": "Room Air Conditioners",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Refrigeration Helper I, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/heating-air-conditioning-refrigeration-hacr/refrigeration-helper-i-certificate-technical-studies/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1160",
+              "title": "Principles of Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1170",
+              "title": "Principles of Refrigeration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1210",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1220",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1230",
+              "title": "Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating, Air Conditioning, and Refrigeration, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/heating-air-conditioning-refrigeration-hacr/heating20air-condtioning-and-refrigeration-technical-diploma/",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HACR",
+              "number": "1150",
+              "title": "HVAC Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1160",
+              "title": "Principles of Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1170",
+              "title": "Principles of Refrigeration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1210",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1220",
+              "title": "Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1230",
+              "title": "Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1180",
+              "title": "Princip. of Refrigeration III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1240",
+              "title": "Applied Electricity& Troublesh",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1410",
+              "title": "Domestic Refrigeration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "1420",
+              "title": "Room Air Conditioners",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2510",
+              "title": "Residential Central A/C",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2520",
+              "title": "Residential Central A/C II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2530",
+              "title": "Residential System Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2540",
+              "title": "Residential Heating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HACR",
+              "number": "2560",
+              "title": "Residential Heat Pumps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2900",
+              "title": "Job Readiness Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Instrumentation, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/instrumentation-technician/instrumentation-aas/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1000",
+              "title": "Physical Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1010",
+              "title": "NCCER Instrument Level I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1000",
+              "title": "Electrical Construction I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1020",
+              "title": "NCCER Instrument Level II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1010",
+              "title": "Electrical Construction II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1030",
+              "title": "NCCER Instrument Level III",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1040",
+              "title": "NCCER Instrument Level IV",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Instrumentation Skills, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/instrumentation-technician/instrumentation-skills-career-technical-certificate/",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1010",
+              "title": "NCCER Instrument Level I",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Instrumentation Helper, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/instrumentation-technician/instrumentation-helper-certificate-technical-studies/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1010",
+              "title": "NCCER Instrument Level I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1020",
+              "title": "NCCER Instrument Level II",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "NCCER Instrumentation and Electrical, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/instrumentation-technician/nccer-instrumentation-and-electrical-technical-diploma/",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNST",
+              "number": "1000",
+              "title": "Introduction to Construction",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1010",
+              "title": "NCCER Instrument Level I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1000",
+              "title": "Electrical Construction I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1020",
+              "title": "NCCER Instrument Level II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "1010",
+              "title": "Electrical Construction II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1030",
+              "title": "NCCER Instrument Level III",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1040",
+              "title": "NCCER Instrument Level IV",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "NCCER Instrumentation - Advanced, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/instrumentation-technician/nccer-instrumentation-advanced-certificate-technical-studies/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INST",
+              "number": "1030",
+              "title": "NCCER Instrument Level III",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INST",
+              "number": "1040",
+              "title": "NCCER Instrument Level IV",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer Degree, Biological Sciences Concentration, Associate of Science — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/louisiana-transfer-degree/biological-sciences-concentration-associate-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "College Trigonometry",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2100",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2020",
+              "title": "Survey of English Lit II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2110",
+              "title": "Poetry and Drama",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2220",
+              "title": "Intro to African American Lit",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Intro to Women's Literature",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "World Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "World Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1100",
+              "title": "General Biology Iand General Biology I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1200",
+              "title": "General Biology IIand General Biology II Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "General Chemistry Iand General Chemistry I Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2000",
+              "title": "Microbiologyand Microbiology Laboratory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1200",
+              "title": "General Chemistry IIand General Chemistry II Lab",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer Degree, Business Concentration, Associate of Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/louisiana-transfer-degree/business-concentration-associate-arts/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2020",
+              "title": "Survey of English Lit II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2110",
+              "title": "Poetry and Drama",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2220",
+              "title": "Intro to African American Lit",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Intro to Women's Literature",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "World Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "World Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2150",
+              "title": "Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2200",
+              "title": "Argumentation and Debate",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2400",
+              "title": "Principles of Fin Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2150",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Louisiana Transfer Degree, Fine Arts Concentration, Associate of Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/louisiana-transfer-degree/fine-arts-concentration-associate-arts/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2020",
+              "title": "Survey of English Lit II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2110",
+              "title": "Poetry and Drama",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2220",
+              "title": "Intro to African American Lit",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Intro to Women's Literature",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "World Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "World Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2150",
+              "title": "Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "2200",
+              "title": "Argumentation and Debate",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1200",
+              "title": "Introduction to Fine Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1013",
+              "title": "Music Appreciation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "2400",
+              "title": "Survey of Visual Arts to 1400",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "2410",
+              "title": "Survey of Vis. Arts from 1400",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1400",
+              "title": "Survey of Music Med. to Class.",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1500",
+              "title": "Survey Music fr Rom to Pres",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1300",
+              "title": "Introduction to Acting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "2110",
+              "title": "Advanced Acting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1000",
+              "title": "Introduction to Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1010",
+              "title": "Sculpture Fundamentals",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1150",
+              "title": "Figure Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1600",
+              "title": "Introduction to Painting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1700",
+              "title": "Introduction to Ceramics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1800",
+              "title": "Digital Photography",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1850",
+              "title": "Introduction to Digital Art",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1900",
+              "title": "Intro to Printmaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "2100",
+              "title": "Intermediate Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "2500",
+              "title": "Watercolor",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Louisiana Transfer Degree, Humanities Concentration, Associate of Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/louisiana-transfer-degree/humanities-concentration-associate-arts/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2020",
+              "title": "Survey of English Lit II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2030",
+              "title": "Major British Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2110",
+              "title": "Poetry and Drama",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2220",
+              "title": "Intro to African American Lit",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Intro to Women's Literature",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "World Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "World Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer Degree, Physical Sciences Concentration, Associate of Science — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/louisiana-transfer-degree/physical-sciences-concentration-associate-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1400",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2020",
+              "title": "Survey of English Lit II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2110",
+              "title": "Poetry and Drama",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2220",
+              "title": "Intro to African American Lit",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Intro to Women's Literature",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "World Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "World Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1100",
+              "title": "General Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "General Chemistry Iand General Chemistry I Laband General Chemistry IIand General Chemistry II Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "General Physics Iand General Physics I Laboratoryand General Physics IIand General Physics II Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Calculus I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2100",
+              "title": "Calculus II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer Degree, Social Sciences Concentration, Associate of Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/louisiana-transfer-degree/social-sciences-concentration-associate-arts/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2020",
+              "title": "Survey of English Lit II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2110",
+              "title": "Poetry and Drama",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2220",
+              "title": "Intro to African American Lit",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2240",
+              "title": "Intro to Women's Literature",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "World Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "World Literature II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Technology: Medical Office Management Concentration, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/medical-coding-billing/business-technology-medical-office-management-concentration-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1100",
+              "title": "General Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2300",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2310",
+              "title": "Human Anatomy & Phys I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2400",
+              "title": "Human Anatomy & Phys II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2410",
+              "title": "Human Anatomy & Phys II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1020",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1030",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1110",
+              "title": "Basic CPT Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2010",
+              "title": "Legal Aspects of Medical Ofc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2050",
+              "title": "Medical Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2090",
+              "title": "Advanced Medical Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2150",
+              "title": "Reimbursement/Patient Billing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2600",
+              "title": "Human Disease for Allied Hlth",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2700",
+              "title": "Basic ICD-10CM Coding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Billing and Coding, Certificate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/medical-coding-billing/medical-billing-coding-certificate-applied-science/",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1010",
+              "title": "Intro Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1020",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1030",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1110",
+              "title": "Basic CPT Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2010",
+              "title": "Legal Aspects of Medical Ofc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2050",
+              "title": "Medical Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2090",
+              "title": "Advanced Medical Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2150",
+              "title": "Reimbursement/Patient Billing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2700",
+              "title": "Basic ICD-10CM Coding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certified Nursing Assistant, CNA, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/nursing-nursing-assistant/certified-nursing-assistant-cna-career-technical-certificate/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "1000",
+              "title": "Nursing Assistant",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1020",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1030",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing - Limited Enrollment, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/nursing-nursing-assistant/practical-nursing-limited-enrollment-technical-diploma/",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 56,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "1011",
+              "title": "Fundamentals of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1020",
+              "title": "Fund of Nursing I Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1030",
+              "title": "Med-Surg Nursing I Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1040",
+              "title": "Med-Surg Nursing I Clinical",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1051",
+              "title": "Med-Surg Nursing II Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1500",
+              "title": "Pharmacology and Math Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1060",
+              "title": "Med-Surg Nursing II Clinical",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1210",
+              "title": "Intravenous Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1090",
+              "title": "Mental Health Nursing Theory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1150",
+              "title": "Mental Health Nursing Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1100",
+              "title": "Maternal/Newborn NursingTheory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1110",
+              "title": "Maternal/Newborn Nurs Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1115",
+              "title": "Nursing Care of Children Thry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1125",
+              "title": "Nursing Care of Child.Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1130",
+              "title": "PN Professionalism &Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1135",
+              "title": "PN Prof & Leadership Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1010",
+              "title": "Intro Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1500",
+              "title": "Nutrition and Diet Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paralegal Skills, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/paralegal-studies/paralegal-skills-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PARL",
+              "number": "1000",
+              "title": "Intro to Law and the Para Prof",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1100",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2000",
+              "title": "Case Analysis and Writing",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Assistant, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/paralegal-studies/paralegal-studies-certificate-technical-studies/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1000",
+              "title": "Intro to Law and the Para Prof",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1025",
+              "title": "Technology in the Law Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1050",
+              "title": "Litigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1100",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1300",
+              "title": "Legal Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2000",
+              "title": "Case Analysis and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1200",
+              "title": "Business Associations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1500",
+              "title": "Constitutional Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2050",
+              "title": "Evidence",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2100",
+              "title": "The Law of Torts and Prod Liab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2150",
+              "title": "Insurance Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2200",
+              "title": "Contracts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2250",
+              "title": "Criminal Procedure",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2300",
+              "title": "Domestic Law and Litigation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2350",
+              "title": "Special Topics: Discovery",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2400",
+              "title": "Legal Drafting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2500",
+              "title": "Paralegal Practicum",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2600",
+              "title": "Notary Public Law & Prep",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OADM",
+              "number": "1510",
+              "title": "Legal Typing",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/paralegal-studies/paralegal-studies-associate-arts/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1200",
+              "title": "Survey of Mathematical Concept (or higher)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Survey of Math Cpts with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1100",
+              "title": "Fund of Effective Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "1310",
+              "title": "Interpersonal Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "1100",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2190",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1000",
+              "title": "Intro to Law and the Para Prof",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1025",
+              "title": "Technology in the Law Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1050",
+              "title": "Litigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1300",
+              "title": "Legal Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1100",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2000",
+              "title": "Case Analysis and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2500",
+              "title": "Paralegal Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1200",
+              "title": "Business Associations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "1500",
+              "title": "Constitutional Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2050",
+              "title": "Evidence",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2100",
+              "title": "The Law of Torts and Prod Liab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2150",
+              "title": "Insurance Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2200",
+              "title": "Contracts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2250",
+              "title": "Criminal Procedure",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2300",
+              "title": "Domestic Law and Litigation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2350",
+              "title": "Special Topics: Discovery",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2400",
+              "title": "Legal Drafting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PARL",
+              "number": "2600",
+              "title": "Notary Public Law & Prep",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OADM",
+              "number": "1510",
+              "title": "Legal Typing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1710",
+              "title": "LA Real Estate Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "1030",
+              "title": "Environmental Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "2610",
+              "title": "Constitutional Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "2090",
+              "title": "Criminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "2400",
+              "title": "Juvenile Delinquency",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "EKG Technician, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/patient-care-technician/ekg-technician-career-technical-certificate/",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HASC",
+              "number": "1020",
+              "title": "Intro to EKG",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1030",
+              "title": "EKG II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Patient Care Technician, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/patient-care-technician/patient-care-technician-certificate-technical-studies/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "1000",
+              "title": "Nursing Assistant",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1020",
+              "title": "Intro to EKG",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1030",
+              "title": "EKG II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1010",
+              "title": "Phlebotomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1011",
+              "title": "Phlebotomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1012",
+              "title": "Phlebotomy Clin Externship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1020",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "1030",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSOM",
+              "number": "2050",
+              "title": "Medical Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Technician, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/patient-care-technician/phlebotomy-technician-career-technical-certificate/",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HASC",
+              "number": "1010",
+              "title": "Phlebotomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1011",
+              "title": "Phlebotomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HASC",
+              "number": "1012",
+              "title": "Phlebotomy Clin Externship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Process Technology, Associate of Applied Science, Fast Track — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/process-technology-ptec/process-technology-associate-applied-science-fast-track/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "General Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1000",
+              "title": "Physical Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1110",
+              "title": "General Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1100",
+              "title": "Physical Science I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1010",
+              "title": "Intro to Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1330",
+              "title": "Process Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1331",
+              "title": "Process Instrumentation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1630",
+              "title": "Process Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1631",
+              "title": "Process Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2420",
+              "title": "Process Technology II:Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2421",
+              "title": "Process Tech II: Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2430",
+              "title": "Process Tech III: Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2431",
+              "title": "Process Tech III:OperationsLab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2440",
+              "title": "Process Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2630",
+              "title": "Fluid Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2910",
+              "title": "Process Technology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2900",
+              "title": "Job Readiness Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Process Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/process-technology-ptec/process-technology-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "General Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1000",
+              "title": "Physical Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1110",
+              "title": "General Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1100",
+              "title": "Physical Science I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Macroeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1010",
+              "title": "Intro to Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1330",
+              "title": "Process Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1331",
+              "title": "Process Instrumentation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1630",
+              "title": "Process Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1631",
+              "title": "Process Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2420",
+              "title": "Process Technology II:Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2421",
+              "title": "Process Tech II: Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2430",
+              "title": "Process Tech III: Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2431",
+              "title": "Process Tech III:OperationsLab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2630",
+              "title": "Fluid Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2440",
+              "title": "Process Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2910",
+              "title": "Process Technology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2900",
+              "title": "Job Readiness Skills",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2400",
+              "title": "Business Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Process Technology Support Technician, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/process-technology-ptec/process-technology-support-technician-certificate-technical-studies/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTEC",
+              "number": "1010",
+              "title": "Intro to Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1330",
+              "title": "Process Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1331",
+              "title": "Process Instrumentation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1630",
+              "title": "Process Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1631",
+              "title": "Process Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Process Technology, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/process-technology-ptec/process-technology-technical-diploma/",
+      "total_credits": 47,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "General Physics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1000",
+              "title": "Physical Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1110",
+              "title": "General Physics I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "1100",
+              "title": "Physical Science I Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1010",
+              "title": "Intro to Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1330",
+              "title": "Process Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1331",
+              "title": "Process Instrumentation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1630",
+              "title": "Process Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "1631",
+              "title": "Process Equipment Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "2070",
+              "title": "Quality Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2420",
+              "title": "Process Technology II:Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2421",
+              "title": "Process Tech II: Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2430",
+              "title": "Process Tech III: Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2431",
+              "title": "Process Tech III:OperationsLab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2630",
+              "title": "Fluid Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2440",
+              "title": "Process Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTEC",
+              "number": "2910",
+              "title": "Process Technology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1150",
+              "title": "Survey of Microcomputer App",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Offshore Safety and Survival, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/sustainable-energy-career-academy/offshore-safety-and-survival-career-technical-certificate/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SECA",
+              "number": "1000",
+              "title": "Offshore Basic Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1010",
+              "title": "Intro to Rescue Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1020",
+              "title": "Adv. Rescue Ops & First Aid",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wind Energy Technology, Associate of Applied Science — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/sustainable-energy-career-academy/wind-energy-technology-associate-applied-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2300",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "1010",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "1030",
+              "title": "Physical Geology Lab.",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVN",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2200",
+              "title": "Louisiana Wetlands Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1000",
+              "title": "Offshore Basic Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1010",
+              "title": "Intro to Rescue Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1020",
+              "title": "Adv. Rescue Ops & First Aid",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1030",
+              "title": "Introduction to Wind Energy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1100",
+              "title": "Intro to Mechanical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1110",
+              "title": "Basics of Electric Motors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1120",
+              "title": "Basics of Hydraulic Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1130",
+              "title": "Installation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "2000",
+              "title": "Wind Turbine Blade Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "2010",
+              "title": "WTG Hazardous Energies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "2011",
+              "title": "Managing Working at Heights",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2323",
+              "title": "Introduction to sUAS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2321",
+              "title": "Drone Surveying Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wind Turbine Mechanics and Maintenance, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/sustainable-energy-career-academy/wind-turbine-mechanics-maintenance-technical-diploma/",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2210",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2300",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2200",
+              "title": "Louisiana Wetlands Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "1010",
+              "title": "Physical Geology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "1030",
+              "title": "Physical Geology Lab.",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1000",
+              "title": "Offshore Basic Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1010",
+              "title": "Intro to Rescue Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1020",
+              "title": "Adv. Rescue Ops & First Aid",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1030",
+              "title": "Introduction to Wind Energy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1100",
+              "title": "Intro to Mechanical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1110",
+              "title": "Basics of Electric Motors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1120",
+              "title": "Basics of Hydraulic Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "1130",
+              "title": "Installation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "2000",
+              "title": "Wind Turbine Blade Repair",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "2010",
+              "title": "WTG Hazardous Energies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SECA",
+              "number": "2011",
+              "title": "Managing Working at Heights",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2323",
+              "title": "Introduction to sUAS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSTL",
+              "number": "2321",
+              "title": "Drone Surveying Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Teaching (Grades 1-5)- Associate of Science — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/teaching-grades-1-5/teaching-grades-1-5-limited-enrollment-associate-science/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1011",
+              "title": "English Composition I with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Survey of English Literature I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Reading Fiction",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Major American Writers",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1060",
+              "title": "Principles of Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1080",
+              "title": "Principles of Biology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "1010",
+              "title": "Physical Geology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1300",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1310",
+              "title": "College Algebra with Lab",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1600",
+              "title": "Elementary Number Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1630",
+              "title": "Elem Geometry & Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2000",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIAR",
+              "number": "1200",
+              "title": "Introduction to Fine Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1000",
+              "title": "Intro to Theater",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1500",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1510",
+              "title": "World History II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2010",
+              "title": "American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2020",
+              "title": "American History from 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1201",
+              "title": "World Regional Geography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1202",
+              "title": "World Regional Geography II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2000",
+              "title": "Microeconomics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1100",
+              "title": "Introduction to Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLI",
+              "number": "1100",
+              "title": "American Government",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "1100",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "2010",
+              "title": "Teac. & Learn. in Diver. Set.1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "2030",
+              "title": "Teac. & Learn. in Div. Set. 2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Combo Welding, Technical Diploma — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/welding/combo-welder-technical-diploma/",
+      "total_credits": 53,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUDV",
+              "number": "1070",
+              "title": "Living-Learning-Working Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INDT",
+              "number": "1030",
+              "title": "Industrial & Plant Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1000",
+              "title": "Introduction to Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1110",
+              "title": "Shielded Metal Arc Welding I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1200",
+              "title": "Shielded Metal Arc Welding II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1300",
+              "title": "Shielded Metal Arc Welding III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1500",
+              "title": "Field Skills for Welders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1600",
+              "title": "Gas Metal Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1800",
+              "title": "Flux-Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1900",
+              "title": "Fitting for Welders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2000",
+              "title": "Open Root Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2100",
+              "title": "SMAW Pipe I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2200",
+              "title": "SMAW Pipe II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2800",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2900",
+              "title": "Blueprint Rdng for Weld&Fabric",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Intermediate Welding, Certificate of Technical Studies — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/welding/intermediate-welding-certificate-technical-studies/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1000",
+              "title": "Introduction to Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1110",
+              "title": "Shielded Metal Arc Welding I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1200",
+              "title": "Shielded Metal Arc Welding II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1300",
+              "title": "Shielded Metal Arc Welding III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2000",
+              "title": "Open Root Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1600",
+              "title": "Gas Metal Arc Welding",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1800",
+              "title": "Flux-Cored Arc Welding",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "2100",
+              "title": "SMAW Pipe I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Shielded Metal Arc Welding, Career and Technical Certificate — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.nunez.edu/programs/welding/shielded-metal-arc-welding-career-technical-certificate/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "1000",
+              "title": "Introduction to Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1110",
+              "title": "Shielded Metal Arc Welding I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "1200",
+              "title": "Shielded Metal Arc Welding II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/la/programs/south-louisiana-community-college.json
+++ b/data/la/programs/south-louisiana-community-college.json
@@ -1,0 +1,1926 @@
+{
+  "college_slug": "south-louisiana-community-college",
+  "catalog_year": "2024-2025",
+  "catalog_url": "https://catalog.solacc.edu",
+  "scraped_at": "2026-05-29T15:19:38.281Z",
+  "programs": [
+    {
+      "title": "General Education Curriculum",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1063",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1051",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credit Hours: 45",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1031",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1048",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Major Elective XXX1 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Major Elective XXXX 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Administrative Professional Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1068",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credit Hours: 45",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Welding Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1076",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Business Office Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1067",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Application Software Development, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1045",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ASDV XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ASDV XXXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ASDV XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ASDV XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1047",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Civil, Surveying and Mapping Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1033",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Civil, Surveying and Mapping Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1034",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1052",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Diving, CTS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1070",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1025",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS or CORR XXXX Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS or CORR XXXX Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CJUS or CORR XXXX Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts and Occupations, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1053",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Powered Equipment Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1055",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts and Occupations, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1054",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media Design, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1026",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting and Design Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1035",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Total Credit Hours: 15",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media Design, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1027",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "DGMD XXXX1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting and Design Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1036",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrician: Commercial/Industrial Electrical Technician, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1056",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician Paramedic, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1065",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NREMT Certification required to continue to the second semester of the program.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician Paramedic, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1042",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NREMT Certification required to continue to the second semester of the program.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies, AGS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1028",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education/Major Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Health Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1075",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "MAJOR COURSES",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ELECTIVE REQUIREMENTS",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "see note 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "see note 6",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "see note 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "see note 6",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating, Air Conditioning & Refrigeration, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1057",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements: 45 Credit Hours",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electronics Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1037",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2 - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Marine Electronics Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1069",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electronics Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1038",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2 - Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ETRN XXXX Major Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Technology, AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1039",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credit Hours: 27",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 6 Credits:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives Requirements - Total Credit Hours: 6",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "If transferring to a 4-year college, it is recommended the student select 6 credits from BIOL 1000 or BIOL 1010, MATH 2010, MATH 2020, and PSYC 2010, otherwise select an INTC elective.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1000",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTC",
+              "number": "2070",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTC",
+              "number": "2070",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1000",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1049",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credit Hours: 45",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 - Spring¹",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 - Fall²³⁴",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 - Summer¹",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 - Spring²³⁴",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Industrial/Agriculture Mechanics Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1058",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1050",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credit Hours: 45",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 - Spring¹",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 - Fall²³⁴",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 - Summer¹",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 - Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 - Spring²³⁴",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INTE XXXX Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Louisiana Transfer - Humanities Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1023",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Physical Science Concentration, ASLT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1030",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Total Credit Hours: 41",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENGL Literature 2XXX 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEN. ED. XXX1 Humanities 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENGL Literature 2XXX 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEN. ED. XXX1 Humanities 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Louisiana Transfer - Biology Concentration, ASLT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1029",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Total Credit Hours: 39",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENGL Literature 2XXX 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credit Hours: 9",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEN.ED. XXX1 Natural/Physical Science 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GEN.ED. XXX1 Natural/Physical Science 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENGL Literature 2XXX 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Louisiana Transfer - Social Sciences Concentration, AALT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1024",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Electives: Total Credit Hours: 15",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENGL 2XXX English Literature 2XXX 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or GEN.ED. XXX1 Humanities 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1073",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Track 1 - Coding Track",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Track 2 - Clinical Track",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1074",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Track 1 - Coding Track",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Track 2 - Clinical Track",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Science, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1041",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, LPN to RN, ASN",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1071",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nondestructive Testing Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1040",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, Registered, ASN",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1043",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing, Practical, AAS and TD",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1044",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Oil and Gas Production Technology, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1060",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OGPT XXXX - Major Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1061",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding, TD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.solacc.edu/preview_program.php?catoid=22&poid=1062",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/scripts/la/scrape-programs.ts
+++ b/scripts/la/scrape-programs.ts
@@ -41,9 +41,10 @@ async function run(
 
 async function main() {
   console.log("LA program scraper");
-  // nunez-community-college (courseleaf)
+  // nunez-community-college (courseleaf) — Nunez uses /programs/ not the
+  // default /programs-study/.
   await run("nunez-community-college", () =>
-    scrapeCourseleafPrograms({ collegeSlug: "nunez-community-college", baseUrl: "https://catalog.nunez.edu" }),
+    scrapeCourseleafPrograms({ collegeSlug: "nunez-community-college", baseUrl: "https://catalog.nunez.edu", programIndexPath: "/programs/" }),
   );
 
   // fletcher-technical-community-college (acalog)
@@ -51,20 +52,22 @@ async function main() {
     scrapeAcalogPrograms({ collegeSlug: "fletcher-technical-community-college", baseUrl: "https://catalog.fletcher.edu", catoidFallback: 0, programNavoids: [], autoDiscoverCatoid: true, useSearchDiscovery: true }),
   );
 
-  // south-louisiana-community-college (acalog) — catoidFallback=22 confirmed
-  // by manual probe; auto-discovery is intermittent on this catalog.
+  // south-louisiana-community-college (acalog) — programs listed under
+  // navoid=10083 ("Programs"). Probed manually 2026-05-29.
   await run("south-louisiana-community-college", () =>
-    scrapeAcalogPrograms({ collegeSlug: "south-louisiana-community-college", baseUrl: "https://catalog.solacc.edu", catoidFallback: 22, programNavoids: [], autoDiscoverCatoid: false, useSearchDiscovery: true }),
+    scrapeAcalogPrograms({ collegeSlug: "south-louisiana-community-college", baseUrl: "https://catalog.solacc.edu", catoidFallback: 22, programNavoids: [10083], autoDiscoverCatoid: false }),
   );
 
-  // louisiana-delta-community-college (acalog) — catoidFallback=3 confirmed.
+  // louisiana-delta-community-college (acalog) — programs at navoid=46 ("All Programs").
   await run("louisiana-delta-community-college", () =>
-    scrapeAcalogPrograms({ collegeSlug: "louisiana-delta-community-college", baseUrl: "https://catalog.ladelta.edu", catoidFallback: 3, programNavoids: [], autoDiscoverCatoid: false, useSearchDiscovery: true }),
+    scrapeAcalogPrograms({ collegeSlug: "louisiana-delta-community-college", baseUrl: "https://catalog.ladelta.edu", catoidFallback: 3, programNavoids: [46], autoDiscoverCatoid: false }),
   );
 
-  // baton-rouge-community-college (acalog) — catoidFallback=3 confirmed.
+  // baton-rouge-community-college (acalog) — navoid=76 ("Programs A-Z") has
+  // 61 preview_program.php links; navoid=85 ("Programs of Study") is a
+  // navigation parent with no direct program poids.
   await run("baton-rouge-community-college", () =>
-    scrapeAcalogPrograms({ collegeSlug: "baton-rouge-community-college", baseUrl: "https://catalog.mybrcc.edu", catoidFallback: 3, programNavoids: [], autoDiscoverCatoid: false, useSearchDiscovery: true }),
+    scrapeAcalogPrograms({ collegeSlug: "baton-rouge-community-college", baseUrl: "https://catalog.mybrcc.edu", catoidFallback: 3, programNavoids: [76], autoDiscoverCatoid: false }),
   );
 }
 

--- a/scripts/lib/scrape-courseleaf-programs.ts
+++ b/scripts/lib/scrape-courseleaf-programs.ts
@@ -249,7 +249,11 @@ function parseProgramPage(
   programPath: string,
 ): ProgramRequirement[] {
   const $ = cheerio.load(html);
-  const programTitle = $("h1.page-title").first().text().trim();
+  // Support both class="page-title" (most catalogs) and id="page-title"
+  // (e.g. Nunez CC uses <h1 id="page-title">).
+  const programTitle =
+    ($("h1.page-title").first().text().trim() ||
+      $("h1#page-title").first().text().trim());
   if (!programTitle) return [];
 
   const catalogUrl = new URL(programPath, baseUrl).toString();


### PR DESCRIPTION
## What changes for someone using the site

`/la/college/nunez-community-college/programs` now renders 92 degree and certificate programs (85 AAS, 4 AA, 3 AS). Before this PR the page was empty. Combined with PRs #737 and #742, LA's total program coverage is now **284 programs across 4 colleges** (Fletcher 83, BRCC 61, SLCC 48, Nunez 92).

The parser bug this fixes also affected any other CourseLeaf catalog that uses `<h1 id="page-title">` instead of `<h1 class="page-title">`. It's a 1-line fix with no downside — `class` is still tried first, so no existing catalog's behavior changes.

## What changes on the technical front

Root cause: `parseProgramPage` in `scripts/lib/scrape-courseleaf-programs.ts` extracted the program title with `$('h1.page-title')` (CSS class selector). Most CourseLeaf catalogs write `<h1 class="page-title">`. Nunez writes `<h1 id="page-title">`. Class vs id — one char difference, totally silent failure: `programTitle` was always `""`, the early-return guard fired, every page returned an empty program list, and the scraper logged `Parsed 0 program awards across 117 pages, skipped 117`.

Fix: try both selectors, prefer class:
```ts
const programTitle =
  ($('h1.page-title').first().text().trim() ||
   $('h1#page-title').first().text().trim());
```

Nunez result: 117 paths → **92 programs** (25 skipped = 24 category nav pages with no `sc_courselist` + 1 soft-404).

## Note on Louisiana Delta CC (still 0)

Delta's `catalog.ladelta.edu` sits behind an **AWS WAF JS challenge** that returns a 1.9 KB challenge page on any plain HTTP GET to `/content.php?catoid=3&navoid=46`. The flat-fetch approach can't solve it. Would need a Playwright session — separate PR if Delta programs become a priority.

## Test plan
- [x] Nunez: 92 programs in `data/la/programs/nunez-community-college.json` (AAS 85, AA 4, AS 3)
- [x] Existing catalogs unaffected: Fletcher still 83, SLCC 48, BRCC 61
- [x] Typecheck clean
- [ ] After merge: `/la/college/nunez-community-college/programs` renders on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)