### PR TITLE
feat(ut): scrape SLCC programs — 132 plans, closes documented ceiling

### DIFF
--- a/data/ut/programs/salt-lake-community-college.json
+++ b/data/ut/programs/salt-lake-community-college.json
@@ -1,0 +1,20124 @@
+{
+  "college_slug": "salt-lake-community-college",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.slcc.edu",
+  "scraped_at": "2026-05-29T19:32:20.836Z",
+  "programs": [
+    {
+      "title": "Advanced Emergency Medical Technician: Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12988",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEEM",
+              "number": "1202",
+              "title": "Advanced Emergency Medical Technicians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12764",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (36 credits)",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMFG",
+              "number": "1100",
+              "title": "Orientation to Advanced Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "1190",
+              "title": "First Year Advanced Manufacturing Apprenticeship Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "1210",
+              "title": "Advanced Manufacturing Principles I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "2240",
+              "title": "Technology and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "2290",
+              "title": "Second Year Advanced Manufacturing Apprenticeship Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "2390",
+              "title": "Third Year Advanced Manufacturing Apprenticeship Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2260",
+              "title": "Machine Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2340",
+              "title": "Manufacturing Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFET",
+              "number": "2410",
+              "title": "Quality Concepts and Statistical Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMFG",
+              "number": "1250",
+              "title": "Electrical Fundamentals for Advanced Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "1260",
+              "title": "Mechanical and Electrical Assembly",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "1700",
+              "title": "Industrial Printing - InDesign",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "2220",
+              "title": "Tools and Their Uses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMFG",
+              "number": "2340",
+              "title": "Automation &amp; Industrial Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1500",
+              "title": "Manual Machine Shop Theory and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1600",
+              "title": "CNC Programming and CNC Machining Theory and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2990",
+              "title": "Special Topics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1117",
+              "title": "Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1190",
+              "title": "Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "1005",
+              "title": "Related Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace/Aviation Technology Maintenance: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12482",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (72 Credits)",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTT",
+              "number": "1120",
+              "title": "Generals I - Aviation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1140",
+              "title": "Generals II - Aviation Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1220",
+              "title": "Airframe Systems I - Sheet Metal &amp; Non-Metallic Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1240",
+              "title": "Airframe Systems II - Aircraft Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1260",
+              "title": "Airframe Systems III - Aircraft Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "2320",
+              "title": "Airframe Systems IV - Airframe Inspection &amp; Rotorcraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "2340",
+              "title": "Powerplant Systems I - Reciprocating Engine System Accessories",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "2420",
+              "title": "Powerplant Systems II - Reciprocating Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "2440",
+              "title": "Powerplant Systems III - Turbine Engines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aircraft Electronics: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12727",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (17 Credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMTT",
+              "number": "1390",
+              "title": "Aircraft Electronics Technician, NCATT Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1400",
+              "title": "Aircraft Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1405",
+              "title": "Aircraft Electronics Technician, NCATT Endorsements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1410",
+              "title": "FCC General Radiotelephone Operator License Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMTT",
+              "number": "1420",
+              "title": "Advanced Aircraft Electronic Systems/Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language: AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12483",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "A.A. Degree Language Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1020",
+              "title": "Beginning American Sign Language II (LN)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2010",
+              "title": "Intermediate American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2020",
+              "title": "Intermediate American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2020",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (20 credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1010",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1020",
+              "title": "Beginning American Sign Language II (LN)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2010",
+              "title": "Intermediate American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2020",
+              "title": "Intermediate American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2100",
+              "title": "Proficiency Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "1300",
+              "title": "Conversation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1900",
+              "title": "Special Studies in ASL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2030",
+              "title": "ASL Fingerspelling &amp; Numbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2040",
+              "title": "ASL Depiction/Visual Gestural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2300",
+              "title": "ASL Conversation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2700",
+              "title": "Introduction to ASL Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2900",
+              "title": "Special Topics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (7 credits)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language/English Interpreting: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12484",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (59 credits)",
+          "credits_required": 59,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "2030",
+              "title": "ASL Fingerspelling &amp; Numbers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2040",
+              "title": "ASL Depiction/Visual Gestural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2100",
+              "title": "Proficiency Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "2700",
+              "title": "Introduction to ASL Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1000",
+              "title": "Introduction to ASL/English Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1100",
+              "title": "Connections to Community I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1110",
+              "title": "Connections to Community II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1200",
+              "title": "Interpreting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1300",
+              "title": "Ethics/Professional Standards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1400",
+              "title": "Interpreting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1500",
+              "title": "Comparative Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "1600",
+              "title": "Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2100",
+              "title": "Connections to Community III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2200",
+              "title": "ASL/English Interpreting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2400",
+              "title": "ASL/English Interpreting IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2600",
+              "title": "Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2910",
+              "title": "Educational Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2920",
+              "title": "VRS Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTR",
+              "number": "2930",
+              "title": "Community Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of: (may also be used to fulfill the General Education AR requirement)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DANC",
+              "number": "1010",
+              "title": "Dance and Culture (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1070",
+              "title": "Film and Culture (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1033",
+              "title": "Acting I-Basic Acting (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of: (may also be used to fulfill the General Education HU requirement)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1020",
+              "title": "Principles of Public Speaking (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1050",
+              "title": "Introduction to Reading Diverse Culture (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2200",
+              "title": "Americanization: Ethnicity, Power and Privilege (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2050",
+              "title": "Ethics and Values in the Contemporary World (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of: (may also be used to fulfill the General Education SS requirement)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1040",
+              "title": "Language and Culture: Introduction to Linguistic Anthropology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1010",
+              "title": "Introduction to Criminal Justice (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2110",
+              "title": "Interpersonal Communication (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1400",
+              "title": "Study of Disabilities (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Apprenticeship Heating, Cooling & Refrigeration (HVAC): AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12497",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (40 Credits)",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVAC",
+              "number": "1110",
+              "title": "HVAC I A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1120",
+              "title": "HVAC IB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1210",
+              "title": "HVAC IIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "1220",
+              "title": "HVAC IIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2310",
+              "title": "HVAC IIIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2320",
+              "title": "HVAC IIIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2410",
+              "title": "HVAC IVA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "2420",
+              "title": "HVAC IVB",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Electrical Independent Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12495",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (46 credits)",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEEL",
+              "number": "1110",
+              "title": "Electrician Apprentice IA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1120",
+              "title": "Electrician Apprentice IB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1210",
+              "title": "Electrician Apprentice IIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1220",
+              "title": "Electrician Apprentice IIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1310",
+              "title": "Electrician Apprentice IIIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1320",
+              "title": "Electrician Apprentice IIIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1410",
+              "title": "Electrician Apprentice IVA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1420",
+              "title": "Electrician Apprentice IVB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ELI 2XXX (Journeyman License): 22 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Plumber Independent Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12501",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (46 credits)",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEPL",
+              "number": "1110",
+              "title": "Plumbing IA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1120",
+              "title": "Plumbing IB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1210",
+              "title": "Plumbing IIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1220",
+              "title": "Plumbing IIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1310",
+              "title": "Plumbing IIIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1320",
+              "title": "Plumbing IIIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1410",
+              "title": "Plumbing IVA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1420",
+              "title": "Plumbing IVB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PLI 2XXX (Journeyman License): 22 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Apprenticeship Facilities Maintenance Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12496",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (30 Credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMTA",
+              "number": "1110",
+              "title": "Maintenance Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMTA",
+              "number": "1120",
+              "title": "Maintenance Electricity II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMTA",
+              "number": "1210",
+              "title": "Maintenance HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMTA",
+              "number": "1220",
+              "title": "Maintenance Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMTA",
+              "number": "2310",
+              "title": "Maintenance Constr/Mechanic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMTA",
+              "number": "2320",
+              "title": "Maintenance Pipefitting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (5 Credits Minimum)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMTA",
+              "number": "2410",
+              "title": "Mntnc. Welding/Trowel Trades",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Collision Repair and Refinishing: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12509",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (50 Credits)",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "1100",
+              "title": "Metallurgy/Nonstructural Parts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "1111",
+              "title": "Non-structural Skill/Appl Dev",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "1200",
+              "title": "Struct. Analysis/Damage Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "1211",
+              "title": "Structural Damage Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1100",
+              "title": "Automotive Refinishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1111",
+              "title": "Refinishing Skill Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1200",
+              "title": "Advanced Auto Refinishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1211",
+              "title": "Advanced Skill Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1230",
+              "title": "Auto Color and Design Theory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Architecture: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12506",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (34 Credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARCH",
+              "number": "1010",
+              "title": "Design Contexts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "1630",
+              "title": "Basic Architectural Communication I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "1632",
+              "title": "Basic Architectural Communication II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2010",
+              "title": "Design Ecologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2030",
+              "title": "Basic Architectural Communication III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2212",
+              "title": "Survey of World Architecture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2213",
+              "title": "Survey of World Architecture II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2630",
+              "title": "Design Foundations Workshop (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2632",
+              "title": "Advanced Architectural Design Workshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "2634",
+              "title": "Design Fundamentals Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I (QL)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12571",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAM",
+              "number": "1010",
+              "title": "Essential Skills and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1020",
+              "title": "Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1030",
+              "title": "Hydraulics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1040",
+              "title": "Industrial Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1050",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1060",
+              "title": "Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1070",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1080",
+              "title": "Applied System Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Emphasis Advanced Programmable Logic Controllers",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAM",
+              "number": "2010",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "2025",
+              "title": "HMI Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "2040",
+              "title": "PLC Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "2080",
+              "title": "PLC Capstone Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Emphasis Process Control Level/Flow",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAM",
+              "number": "1520",
+              "title": "Process Control Level/Flow",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1580",
+              "title": "Process Capstone Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "2200",
+              "title": "Troubleshooting Automated Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Emphasis Motor Control Systems",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAM",
+              "number": "1610",
+              "title": "Electric Motor Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1680",
+              "title": "Motor Capstone Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "2200",
+              "title": "Troubleshooting Automated Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Collision Repair: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12512",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (32 Credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "1100",
+              "title": "Metallurgy/Nonstructural Parts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "1111",
+              "title": "Non-structural Skill/Appl Dev",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "1200",
+              "title": "Struct. Analysis/Damage Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "1211",
+              "title": "Structural Damage Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "1120",
+              "title": "Math for Industry (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Communication (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Human Relations (HR)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Refinishing: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12514",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (34 Credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AR",
+              "number": "1100",
+              "title": "Automotive Refinishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1111",
+              "title": "Refinishing Skill Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1200",
+              "title": "Advanced Auto Refinishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1211",
+              "title": "Advanced Skill Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AR",
+              "number": "1230",
+              "title": "Auto Color and Design Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "Introduction to College Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "1120",
+              "title": "Math for Industry (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose any approved Human Relations (HR) course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12775",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAU",
+              "number": "1060",
+              "title": "Safety and Introduction to Automotive Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAU",
+              "number": "1155",
+              "title": "Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAU",
+              "number": "1400",
+              "title": "Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAU",
+              "number": "1500",
+              "title": "Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAU",
+              "number": "1600",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAU",
+              "number": "1800",
+              "title": "Engine Performance I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Biology: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12517",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Core Courses (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1615",
+              "title": "College Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2030",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2035",
+              "title": "Genetics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Emphasis Courses (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Anatomy and Physiology Emphasis Required Courses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Integrative Biology Emphasis Required Courses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1620",
+              "title": "College Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1625",
+              "title": "College Biology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2025",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1620",
+              "title": "College Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1625",
+              "title": "College Biology II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2025",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2060",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2065",
+              "title": "Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2220",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2225",
+              "title": "Ecology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2327",
+              "title": "Instr. Exp. in Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2335",
+              "title": "Beginning Human Donor Dissection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2345",
+              "title": "Intermediate Human Donor Dissection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2355",
+              "title": "Advanced Human Donor Dissection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2900",
+              "title": "Special Topics in Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2990",
+              "title": "Independent Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2315",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2320",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2325",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1060",
+              "title": "Trigonometry (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2040",
+              "title": "Statistics for Applied Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2015",
+              "title": "College Physics Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2020",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2025",
+              "title": "College Physics Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2225",
+              "title": "Physics for Sci &amp; Eng Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Behavioral Health Technician: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12788",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (22 credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SW",
+              "number": "1010",
+              "title": "Social Work and Social Welfare: The Profession and Institution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2100",
+              "title": "Human Behavior in the Social Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2715",
+              "title": "Introduction to Dynamics of Addiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2720",
+              "title": "Case Management and Mental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2750",
+              "title": "Ethics and the Social Work Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2940",
+              "title": "Social Work and Behavioral Health Technician Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2990",
+              "title": "Practice for Behavioral Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SW",
+              "number": "2850",
+              "title": "Foundations of Trauma-Informed Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2890",
+              "title": "Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12703",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (27 Credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1050",
+              "title": "Foundations of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1010",
+              "title": "Introduction to Business (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "2010",
+              "title": "Business Computer Proficiency - Spreadsheets and Databases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Microeconomics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1600",
+              "title": "Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2050",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2070",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2500",
+              "title": "Management Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1030",
+              "title": "Introduction To Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (18 Credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Brick Mason: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12735",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEBL",
+              "number": "1110",
+              "title": "Bricklayer IA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEBL",
+              "number": "1120",
+              "title": "Bricklayer IB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEBL",
+              "number": "1210",
+              "title": "Bricklayer IIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEBL",
+              "number": "1220",
+              "title": "Bricklayer IIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEBL",
+              "number": "1310",
+              "title": "Bricklayer IIIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEBL",
+              "number": "1320",
+              "title": "Bricklayer IIIB",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12518",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTEC",
+              "number": "1010",
+              "title": "Engineering Life: Fundamentals of Biotechnology (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "1200",
+              "title": "Introductory Biotechnology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "1500",
+              "title": "Applied Molecular Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "2000",
+              "title": "Biotechnology Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "2020",
+              "title": "Biomolecular Separation and Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "2030",
+              "title": "Cell Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "2040",
+              "title": "Statistics for Applied Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2060",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2065",
+              "title": "Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2315",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2320",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2325",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2015",
+              "title": "College Physics Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2020",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2025",
+              "title": "College Physics Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12521",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 Credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2010",
+              "title": "Survey of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2020",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1010",
+              "title": "Introduction to Business (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2200",
+              "title": "Business Communications (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "2010",
+              "title": "Business Computer Proficiency - Spreadsheets and Databases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Microeconomics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1600",
+              "title": "Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2040",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business: AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12520",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 Credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2010",
+              "title": "Survey of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2020",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1010",
+              "title": "Introduction to Business (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2200",
+              "title": "Business Communications (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "2010",
+              "title": "Business Computer Proficiency - Spreadsheets and Databases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Microeconomics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1600",
+              "title": "Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2040",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (4 credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cabinetmaking and Furniture Construction: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12556",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 Credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "1220",
+              "title": "Woodworking &amp; Millwork I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1340",
+              "title": "Cabinetmaking &amp; Renewable Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1530",
+              "title": "Furniture Design &amp; Construction I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2530",
+              "title": "Furniture Design &amp; Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2340",
+              "title": "Cabinetmaking &amp; Renewable Materials II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2220",
+              "title": "Woodworking &amp; Millwork II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2710",
+              "title": "Computer Applications for Cabinetmaking &amp; Woodworking",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ARCH",
+                  "number": "1310",
+                  "title": "Intro. to AutoCAD"
+                }
+              ]
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "1110",
+              "title": "Birth of a Flute (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1200",
+              "title": "Personal Projects",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1350",
+              "title": "Wood Finishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2530",
+              "title": "Furniture Design &amp; Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2720",
+              "title": "CNC Operations in Cabinetmaking &amp; Woodworking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemistry: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12530",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (34 Credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2315",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2320",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2325",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2225",
+              "title": "Physics for Sci &amp; Eng Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (Minimum 1 credit)",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Preparatory Electives for Rigorous Program Coursework:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1010",
+              "title": "Introductory Chemistry (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1060",
+              "title": "Trigonometry (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1080",
+              "title": "Precalculus (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Preparatory Electives for Rigorous Upper-Division Coursework:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1250",
+              "title": "Introduction to Chemical and Instrumental Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2900",
+              "title": "Special Projects in Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEM",
+              "number": "2010",
+              "title": "Writing a Research Proposal",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Advanced Math Electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2210",
+              "title": "Multivariate Calculus: Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2250",
+              "title": "Differential Eq/Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Biochemistry Electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "College Biology I (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1615",
+              "title": "College Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2025",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2030",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2035",
+              "title": "Genetics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVS",
+              "number": "1400",
+              "title": "Environmental Science (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVS",
+              "number": "1405",
+              "title": "Environmental Science Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2600",
+              "title": "Survey of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2040",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Chemical Engineering Electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "2800",
+              "title": "Fundamentals of Process Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2300",
+              "title": "Engineering Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Geology Electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1110",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1115",
+              "title": "Physical Geology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Chemistry Teaching Electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1010",
+              "title": "Orientation to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2150",
+              "title": "Intro to Multicultural Ed.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Clinical Laboratory Assistant: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12618",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required courses (13 credits)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TECL",
+              "number": "1010",
+              "title": "Introduction to Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECL",
+              "number": "1020",
+              "title": "Administrative Healthcare Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECL",
+              "number": "1030",
+              "title": "Basic Healthcare Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECL",
+              "number": "1040",
+              "title": "Clinical Lab Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1080",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1410",
+              "title": "Workplace Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Machinist Technician: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12794",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEMT",
+              "number": "1003",
+              "title": "CNC Technician Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1015",
+              "title": "Machining Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1120",
+              "title": "CNC Mill Basic Operation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1220",
+              "title": "CNC Lathe Basic Operation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1510",
+              "title": "Geometric Dimensioning and Tolerancing Basic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Driver’s License-Class A: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12654",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TECD",
+              "number": "1100",
+              "title": "Commercial Drivers License – Class A",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Studies: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12533",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 Credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1020",
+              "title": "Principles of Public Speaking (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2110",
+              "title": "Interpersonal Communication (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2270",
+              "title": "Argumentation (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1500",
+              "title": "Media and Society (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2050",
+              "title": "Perspectives in Communication (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Elements of Effective Communication (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1080",
+              "title": "Conflict Management &amp; Diversity (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1130",
+              "title": "Journalism &amp; Media Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1500",
+              "title": "Media and Society (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1560",
+              "title": "Radio Performance &amp; Production (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1800",
+              "title": "Digital Media Tools/Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1900",
+              "title": "Special Studies/ Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2000",
+              "title": "Communication CO-OP/Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2050",
+              "title": "Perspectives in Communication (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2120",
+              "title": "Team Decision Mkg &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2150",
+              "title": "Intercultural Communication (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2170",
+              "title": "Organizational Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2200",
+              "title": "Video Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2250",
+              "title": "Television Studio Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2300",
+              "title": "Public Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2400",
+              "title": "Social Media Tools and Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2500",
+              "title": "Elements and Issue of Digital Media (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2510",
+              "title": "Documentary Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2570",
+              "title": "Introduction to Visual Communication (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2600",
+              "title": "Production for Student Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2900",
+              "title": "Special Projects",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any other COMM designated course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Concrete Masonry Apprenticeship: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12776",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TECN",
+              "number": "1000",
+              "title": "Concrete Masonry 1A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECN",
+              "number": "1100",
+              "title": "Concrete Masonry 1B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECN",
+              "number": "1200",
+              "title": "Concrete Masonry 2A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECN",
+              "number": "1210",
+              "title": "Concrete Masonry 2B",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12795",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Fundamentals of Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1410",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2420",
+              "title": "Algorithms &amp; Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "1030",
+              "title": "Foundations of Computing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Science Elective Recommendations:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2430",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2450",
+              "title": "Software Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2810",
+              "title": "Computer Architecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Data Science Elective Recommendations:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2500",
+              "title": "Data Wrangling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "1550",
+              "title": "SQL Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Software Development Elective Recommendations:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2370",
+              "title": "C++ Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "1250",
+              "title": "Network Routing and Switching I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "1430",
+              "title": "Internet &amp; XHTML Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "2440",
+              "title": "Web Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional Transfer Course Elective Recommendations:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "College Biology I (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1010",
+              "title": "Engineering Math Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2550",
+              "title": "Applied Probability &amp; Statistics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1080",
+              "title": "Precalculus (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2200",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2210",
+              "title": "Multivariate Calculus: Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2270",
+              "title": "Elementary Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2015",
+              "title": "College Physics Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Construction Laborer: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12756",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Music: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12790",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (34 credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "0990",
+              "title": "Recital Attendance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1110",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1120",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1130",
+              "title": "Sight Singing/Ear Training I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1140",
+              "title": "Sight Singing/Ear Training II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1150",
+              "title": "Group Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1160",
+              "title": "Group Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1200",
+              "title": "Introduction to the Music Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1300",
+              "title": "Money &amp; Creative Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1520",
+              "title": "Music Composition I (Introduction to Electronic Music Composition)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2110",
+              "title": "Music Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2130",
+              "title": "Sight Singing/Ear Training III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2500",
+              "title": "Music Production Group",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2540",
+              "title": "Sampling, Synthesis &amp; Sound Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Performance Ensemble (Must be taken 2 times) – see list below for acceptable performance ensemble courses. An audition may be required for some ensembles.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (22-26 Credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Recording Technology Emphasis",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete all the following courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1530",
+              "title": "Music Recording Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1550",
+              "title": "Musical Acoustics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1560",
+              "title": "Music Mixing Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2580",
+              "title": "Audio Production and Mixing for Live Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1310",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose one of the following courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2065",
+              "title": "Motion Picture Sound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2570",
+              "title": "Game Audio Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1100",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1100",
+              "title": "Introduction to Music Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2550",
+              "title": "Music Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2120",
+              "title": "Music Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2140",
+              "title": "Sight Singing/Ear Training IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1060",
+              "title": "Songwriting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2200",
+              "title": "Artist Promotion and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2530",
+              "title": "Jingles and Music for Commercials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Composition/Songwriting Emphasis",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1050",
+              "title": "Songwriting &amp; Creative Process (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1060",
+              "title": "Songwriting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1540",
+              "title": "Music Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2120",
+              "title": "Music Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2140",
+              "title": "Sight Singing/Ear Training IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2350",
+              "title": "Conducting Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2510",
+              "title": "Music Composition for Games and Interactive Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2520",
+              "title": "Music Scoring For Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2530",
+              "title": "Jingles and Music for Commercials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1310",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1100",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1100",
+              "title": "Introduction to Music Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2550",
+              "title": "Music Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2200",
+              "title": "Artist Promotion and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1550",
+              "title": "Musical Acoustics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Performance Emphasis",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1050",
+              "title": "Songwriting &amp; Creative Process (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2120",
+              "title": "Music Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2140",
+              "title": "Sight Singing/Ear Training IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2200",
+              "title": "Artist Promotion and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2350",
+              "title": "Conducting Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1310",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1100",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1100",
+              "title": "Introduction to Music Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2550",
+              "title": "Music Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1060",
+              "title": "Songwriting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2530",
+              "title": "Jingles and Music for Commercials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1550",
+              "title": "Musical Acoustics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management and Sustainable Building: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12555",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Core Courses (22 Credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "1130",
+              "title": "OSHA 30 for Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1410",
+              "title": "Construction Materials &amp; Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1450",
+              "title": "Construction Print Reading &amp; Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1660",
+              "title": "Civil Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2640",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2670",
+              "title": "Building Codes &amp; Inspections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2810",
+              "title": "Construction Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2820",
+              "title": "Construction Systems and Standards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2870",
+              "title": "Construction Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (24 Credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARCH",
+              "number": "1632",
+              "title": "Basic Architectural Communication II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "1310",
+              "title": "Intro. to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1450",
+              "title": "Basic CAD for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1100",
+              "title": "Construction Math (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1220",
+              "title": "Woodworking &amp; Millwork I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1320",
+              "title": "Building Construction I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1330",
+              "title": "Interior Finishes I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1340",
+              "title": "Cabinetmaking &amp; Renewable Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1530",
+              "title": "Furniture Design &amp; Construction I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2220",
+              "title": "Woodworking &amp; Millwork II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2320",
+              "title": "Building Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2330",
+              "title": "Interior Finishes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2340",
+              "title": "Cabinetmaking &amp; Renewable Materials II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2530",
+              "title": "Furniture Design &amp; Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2710",
+              "title": "Computer Applications for Cabinetmaking &amp; Woodworking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2720",
+              "title": "CNC Operations in Cabinetmaking &amp; Woodworking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1120",
+              "title": "Acoustic Guitar Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "1010",
+              "title": "Introduction to Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "1030",
+              "title": "Surveying Field Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2060",
+              "title": "Ethics and Liability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2160",
+              "title": "Land Boundary Law I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Community Health and Leadership: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12771",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2010",
+              "title": "Health and Diseases: Introduction to Epidemiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2500",
+              "title": "Community-Engaged Public Health: Introduction to the Social Determinants of Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2800",
+              "title": "Healthcare Systems and Public Policy",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HLTH",
+                  "number": "1500",
+                  "title": "Lifetime Wellness and Fitness"
+                }
+              ]
+            },
+            {
+              "prefix": "HS",
+              "number": "1010",
+              "title": "Introduction to Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2050",
+              "title": "Ethical, Social, and Legal Issues in Health Care (HR)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12554",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (22 Credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "1130",
+              "title": "OSHA 30 for Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1410",
+              "title": "Construction Materials &amp; Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1450",
+              "title": "Construction Print Reading &amp; Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1660",
+              "title": "Civil Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2640",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2670",
+              "title": "Building Codes &amp; Inspections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2810",
+              "title": "Construction Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2820",
+              "title": "Construction Systems and Standards",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2870",
+              "title": "Construction Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "1110",
+              "title": "Birth of a Flute (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1320",
+              "title": "Building Construction I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1330",
+              "title": "Interior Finishes I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1340",
+              "title": "Cabinetmaking &amp; Renewable Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2320",
+              "title": "Building Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2330",
+              "title": "Interior Finishes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2340",
+              "title": "Cabinetmaking &amp; Renewable Materials II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12558",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (15 Credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1010",
+              "title": "Introduction to Criminal Justice (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1330",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1340",
+              "title": "Criminal Investigations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1350",
+              "title": "Introduction to Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2350",
+              "title": "Laws of Evidence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1220",
+              "title": "Justice, Peace and Conflict Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1300",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1900",
+              "title": "Special Studies in CJ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2000",
+              "title": "Criminal Justice Co-op",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2020",
+              "title": "Criminal Justice Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2300",
+              "title": "Introduction to Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2330",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2340",
+              "title": "Forensic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2410",
+              "title": "Introduction to Victimology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2450",
+              "title": "Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2460",
+              "title": "Psychological Profiling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2470",
+              "title": "Introduction to Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2480",
+              "title": "Crime Scene Investigation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2500",
+              "title": "Social Violence &amp; Change: Gangs, Genocide, Revolution, War &amp; Violence Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2510",
+              "title": "Psychology of Criminal Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2540",
+              "title": "Careers in Criminal Justice, Law, and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2570",
+              "title": "Justice for All",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2920",
+              "title": "Special Topics in CJ",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12559",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (15 Credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1010",
+              "title": "Introduction to Criminal Justice (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1330",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1340",
+              "title": "Criminal Investigations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1350",
+              "title": "Introduction to Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2350",
+              "title": "Laws of Evidence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "1220",
+              "title": "Justice, Peace and Conflict Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1300",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "1900",
+              "title": "Special Studies in CJ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2000",
+              "title": "Criminal Justice Co-op",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2020",
+              "title": "Criminal Justice Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2300",
+              "title": "Introduction to Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2330",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2340",
+              "title": "Forensic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2410",
+              "title": "Introduction to Victimology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2450",
+              "title": "Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2460",
+              "title": "Psychological Profiling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2470",
+              "title": "Introduction to Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2480",
+              "title": "Crime Scene Investigation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2500",
+              "title": "Social Violence &amp; Change: Gangs, Genocide, Revolution, War &amp; Violence Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2510",
+              "title": "Psychology of Criminal Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2540",
+              "title": "Careers in Criminal Justice, Law, and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2570",
+              "title": "Justice for All",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "2920",
+              "title": "Special Topics in CJ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete any college course numbered 1000 or above.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Dental Hygiene: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12562",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2060",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2065",
+              "title": "Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "Elementary Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1115",
+              "title": "Elementary Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "Introduction to College Writing (WC)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "1010",
+                  "title": "Intermediate Algebra (QS)"
+                }
+              ]
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Elements of Effective Communication (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1020",
+              "title": "Scientific Foundations of Human Nutrition (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Intro to Sociology (SS)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "1010",
+                  "title": "General Psychology (SS)"
+                }
+              ]
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (53 Credits)",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DH",
+              "number": "1050",
+              "title": "Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1060",
+              "title": "Dental Radiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1100",
+              "title": "Dental Hygiene Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1110",
+              "title": "Clinical Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1140",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1150",
+              "title": "Dental Materials Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1330",
+              "title": "Head and Neck Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1340",
+              "title": "Dental Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1350",
+              "title": "Dental Embryology/Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1400",
+              "title": "Dental Hygiene Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1410",
+              "title": "Clinical Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1540",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "1640",
+              "title": "Compromised Patient Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2050",
+              "title": "General and Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2200",
+              "title": "Dental Hygiene Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2210",
+              "title": "Clinical Dental Hygiene III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2220",
+              "title": "Community Dental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2340",
+              "title": "Local Anesthesia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2341",
+              "title": "Local Anesthesia Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2450",
+              "title": "Periodontology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2600",
+              "title": "Dental Hygiene Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2610",
+              "title": "Clinical Dental Hygiene IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DH",
+              "number": "2800",
+              "title": "Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12561",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "1110",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1120",
+              "title": "Introduction to Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1210",
+              "title": "Food and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1300",
+              "title": "Food Preparation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1900",
+              "title": "Sustainable Food Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2000",
+              "title": "Culinary Arts Co-op",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2410",
+              "title": "Purchasing and Storeroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2420",
+              "title": "Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2425",
+              "title": "Baking I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2520",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2610",
+              "title": "Menu Marketing &amp; Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2620",
+              "title": "Culinary Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2680",
+              "title": "Catering Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Required for the Baking Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "2430",
+              "title": "Baking II - Artisan Breads &amp; Pastries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2440",
+              "title": "Baking III - Classic European Tortes &amp; Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Required for the Culinary Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "1400",
+              "title": "Food Preparation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1500",
+              "title": "Food Preparation III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses Baking Track (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "1200",
+              "title": "Cuisine &amp; Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1299",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1330",
+              "title": "Wine Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1400",
+              "title": "Food Preparation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1500",
+              "title": "Food Preparation III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2225",
+              "title": "Mediterranean Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2235",
+              "title": "Latin American Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2330",
+              "title": "French Wine Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2450",
+              "title": "Classic &amp; Contemporary Cake Decorating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2470",
+              "title": "Classic Chocolates &amp; Confections",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses Culinary Track (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "1200",
+              "title": "Cuisine &amp; Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1299",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1330",
+              "title": "Wine Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2225",
+              "title": "Mediterranean Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2235",
+              "title": "Latin American Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2330",
+              "title": "French Wine Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2430",
+              "title": "Baking II - Artisan Breads &amp; Pastries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2440",
+              "title": "Baking III - Classic European Tortes &amp; Restaurant Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2450",
+              "title": "Classic &amp; Contemporary Cake Decorating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2470",
+              "title": "Classic Chocolates &amp; Confections",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cultural Resource Management: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12487",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 Credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "1030",
+              "title": "World Prehistory: An Introduction (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2030",
+              "title": "Introduction to Archaeology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2969",
+              "title": "Cultural Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2530",
+              "title": "Historical Archaeology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2950",
+              "title": "Archaeology Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "2341",
+              "title": "Fundamentals of Archaeology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1800",
+              "title": "Mapping Our Changing World (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2500",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2950",
+              "title": "Archival Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Diesel Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12698",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses: (25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEDT",
+              "number": "1010",
+              "title": "Introduction to Diesel Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEDT",
+              "number": "1100",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEDT",
+              "number": "1200",
+              "title": "Steering and Suspension",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEDT",
+              "number": "1300",
+              "title": "Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEDT",
+              "number": "1400",
+              "title": "Drivetrain",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEDT",
+              "number": "1600",
+              "title": "Engines I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEDT",
+              "number": "1610",
+              "title": "Engines II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Systems Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12563",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (52 Credits)",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First complete the Diesel Technology: Technical Certificate (SL Tech)(CTE) (25 credits), then complete the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DST",
+              "number": "1265",
+              "title": "Drivetrains Gear Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DST",
+              "number": "2045",
+              "title": "Advanced Engines &amp; Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DST",
+              "number": "2065",
+              "title": "Advanced Engines &amp; Electronics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DST",
+              "number": "2145",
+              "title": "Heavy Duty. Hydraulic Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DST",
+              "number": "2165",
+              "title": "Heavy Duty Hydraulic Functions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DST",
+              "number": "2265",
+              "title": "Heavy Duty. Electrical Lighting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "1005",
+              "title": "Related Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Economics: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12565",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 Credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "1740",
+              "title": "Economic History of  U.S. (AI)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Microeconomics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2020",
+              "title": "Principles of Macroeconomics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "1100",
+              "title": "Applied Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "1010",
+              "title": "Economics as a Social Science (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Labor Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2990",
+              "title": "Special Studies in Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1090",
+              "title": "College Algebra-Business (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1100",
+              "title": "Calculus Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Students must take at least one (1) “ECON” course.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12566",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (7 Credits)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "1010",
+              "title": "Orientation to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1500",
+              "title": "Lifespan Human Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1230",
+              "title": "Adolescent Growth &amp; Dev.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1000",
+              "title": "Education Program First Year Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1003",
+              "title": "EDU Scholarship Cohort",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (20 Credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "1400",
+              "title": "Study of Disabilities (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1900",
+              "title": "Individual Studies in Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2000",
+              "title": "CO-OP Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2010",
+              "title": "Intro. to Special Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2011",
+              "title": "Inclusive Classrooms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2030",
+              "title": "Research/Inquiry in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2110",
+              "title": "Ed Psych Learning &amp; Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2150",
+              "title": "Intro to Multicultural Ed.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1200",
+              "title": "Introduction to Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2330",
+              "title": "Children`s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2430",
+              "title": "Chican* and Latin* Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1230",
+              "title": "Adolescent Growth &amp; Dev.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2645",
+              "title": "Early Childhood Integrated Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Mathematical Reasoning for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2020",
+              "title": "Mathematical Reasoning for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "EARLY CHILDHOOD K-3 EDUCATION OPTION",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "1900",
+              "title": "Individual Studies in Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2000",
+              "title": "CO-OP Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2010",
+              "title": "Intro. to Special Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2330",
+              "title": "Children`s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2500",
+              "title": "Child Development: Birth-Eight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2600",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2620",
+              "title": "Creative Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2645",
+              "title": "Early Childhood Integrated Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Mathematical Reasoning for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2020",
+              "title": "Mathematical Reasoning for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ELEMENTARY EDUCATION OPTION",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "1900",
+              "title": "Individual Studies in Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2000",
+              "title": "CO-OP Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2010",
+              "title": "Intro. to Special Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2011",
+              "title": "Inclusive Classrooms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2030",
+              "title": "Research/Inquiry in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2110",
+              "title": "Ed Psych Learning &amp; Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2150",
+              "title": "Intro to Multicultural Ed.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2330",
+              "title": "Children`s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2430",
+              "title": "Chican* and Latin* Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2500",
+              "title": "Child Development: Birth-Eight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2600",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2645",
+              "title": "Early Childhood Integrated Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Mathematical Reasoning for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2020",
+              "title": "Mathematical Reasoning for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1010",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPECIAL EDUCATION OPTION",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "2010",
+              "title": "Intro. to Special Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This course is required for the Special Education option",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "1900",
+              "title": "Individual Studies in Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2000",
+              "title": "CO-OP Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2030",
+              "title": "Research/Inquiry in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2150",
+              "title": "Intro to Multicultural Ed.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2330",
+              "title": "Children`s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2430",
+              "title": "Chican* and Latin* Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2500",
+              "title": "Child Development: Birth-Eight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2600",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2645",
+              "title": "Early Childhood Integrated Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Mathematical Reasoning for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2020",
+              "title": "Mathematical Reasoning for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "1010",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECONDARY EDUCATION OPTION",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "1900",
+              "title": "Individual Studies in Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2000",
+              "title": "CO-OP Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2011",
+              "title": "Inclusive Classrooms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2110",
+              "title": "Ed Psych Learning &amp; Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2150",
+              "title": "Intro to Multicultural Ed.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2430",
+              "title": "Chican* and Latin* Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "STUDENT CHOICE in secondary major subject (see academic advisor for a specific list of courses based on chosen major)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Earth and Environmental Science: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12791",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses for All Emphases (7 credits)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENVS",
+              "number": "1400",
+              "title": "Environmental Science (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2500",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Emphasis Courses (32 Credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Apprenticeship: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12783",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEEL",
+              "number": "1110",
+              "title": "Electrician Apprentice IA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1120",
+              "title": "Electrician Apprentice IB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1210",
+              "title": "Electrician Apprentice IIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1220",
+              "title": "Electrician Apprentice IIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1310",
+              "title": "Electrician Apprentice IIIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1320",
+              "title": "Electrician Apprentice IIIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1410",
+              "title": "Electrician Apprentice IVA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEEL",
+              "number": "1420",
+              "title": "Electrician Apprentice IVB",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Engineering Essentials: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12796",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (29 credits)",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Fundamentals of Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2180",
+              "title": "Electronics Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "1000",
+              "title": "Introduction to Electrical Engineering and Lab Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "Introduction to College Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Technical Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1010",
+              "title": "Engineering Math Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1060",
+              "title": "Trigonometry (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1030",
+              "title": "IPC-A-610 Certification: Acceptability of Electronic Assemblies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1040",
+              "title": "Electronics Assembly and Soldering",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Design Manufacturing Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12590",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (36 Credits)",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDDT",
+              "number": "1010",
+              "title": "Introduction to Engineering and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1050",
+              "title": "Engineering Graphics – Introduction, Principles &amp; Applications using 3D CAD Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1500",
+              "title": "Manual Machine Shop Theory and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2160",
+              "title": "Statics and Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2340",
+              "title": "Manufacturing Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2350",
+              "title": "Manufacturing Processes Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2460",
+              "title": "Product Design &amp; Development Using CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2540",
+              "title": "Geometric Dimension &amp; Tolerance Using 3D CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1140",
+              "title": "AC and DC Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1060",
+              "title": "Trigonometry (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2010",
+              "title": "Intermediate College Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Product Design Engineering Technology (PDET) EMPHASIS COURSES (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDDT",
+              "number": "1100",
+              "title": "Advanced AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1600",
+              "title": "CNC Programming and CNC Machining Theory and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2180",
+              "title": "Electronics Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "2710",
+              "title": "3D Modeling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCCT",
+              "number": "2650",
+              "title": "Product Design Fundamentals - Rapid Prototyping via Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFET",
+              "number": "2410",
+              "title": "Quality Concepts and Statistical Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mechanical Engineering Technology (MET) EMPHASIS COURSES (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MCCT",
+              "number": "2650",
+              "title": "Product Design Fundamentals - Rapid Prototyping via Additive Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1010",
+              "title": "Introductory Chemistry (PS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Manufacturing Engineering Technology (MFET) EMPHASIS COURSES (17 credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "2170",
+              "title": "Industrial Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFET",
+              "number": "2410",
+              "title": "Quality Concepts and Statistical Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "1005",
+              "title": "Related Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12708",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 Credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEET",
+              "number": "1030",
+              "title": "IPC-A-610 Certification: Acceptability of Electronic Assemblies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1040",
+              "title": "Electronics Assembly and Soldering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1060",
+              "title": "DC Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1070",
+              "title": "AC Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1080",
+              "title": "Analog Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1090",
+              "title": "Digital Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1110",
+              "title": "Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1190",
+              "title": "Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1200",
+              "title": "Certified Electronics Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Design/Drafting Technology: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12587",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Assembly Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12573",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEET",
+              "number": "1010",
+              "title": "Basic Electronics Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1020",
+              "title": "Mechanical Assembly",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1030",
+              "title": "IPC-A-610 Certification: Acceptability of Electronic Assemblies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1050",
+              "title": "Through-Hole Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1055",
+              "title": "Surface Mount Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select one from the following courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1130",
+              "title": "IPC-J-STD-001 Certification: Requirements for Electronic Assemblies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEET",
+              "number": "1140",
+              "title": "IPC-WHMA-A-620 Certification: Cable and Wire Harness Assemblies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician: Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12992",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEEM",
+              "number": "1011",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Drafting and Manufacturing Technology: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12591",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21-22 Credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "Introduction to College Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1010",
+              "title": "Introduction to Engineering and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1050",
+              "title": "Engineering Graphics – Introduction, Principles &amp; Applications using 3D CAD Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1500",
+              "title": "Manual Machine Shop Theory and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1600",
+              "title": "CNC Programming and CNC Machining Theory and Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1070",
+              "title": "Robotics in the World (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1140",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering: APE",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12745",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGR",
+              "number": "1010",
+              "title": "Engineering Math Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1015",
+              "title": "Engineering Math Techniques Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2210",
+              "title": "Multivariate Calculus: Calculus III",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MATH",
+                  "number": "2250",
+                  "title": "Differential Eq/Linear Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (26-44 credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Chemical Engineering Option (37 credits)",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "2800",
+              "title": "Fundamentals of Process Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2315",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1040",
+              "title": "Engineering Computing in Python, Excel and VBA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2300",
+              "title": "Engineering Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2460",
+              "title": "Numerical Methods in Python",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2550",
+              "title": "Applied Probability &amp; Statistics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2950",
+              "title": "Engineering Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2225",
+              "title": "Physics for Sci &amp; Eng Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "These additional courses are not required but are suggested and are accepted at the University of Utah as program electives in the BS Chemical Engineering program. (The University of Utah is the only USHE institution with a BS Chemical Engineering program.) If students decide to take these courses, they may not be eligible for financial aid because they are not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2025",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2320",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2325",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Civil/Environmental Engineering Option (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CEEN",
+              "number": "1100",
+              "title": "Introduction to Civil and Environmental Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CEEN",
+              "number": "1400",
+              "title": "Computer-Aided Design for Civil Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CEEN",
+              "number": "2320",
+              "title": "Engineering Economics and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CEEN",
+              "number": "2750",
+              "title": "Computational Methods for Civil Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2010",
+              "title": "Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2140",
+              "title": "Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2550",
+              "title": "Applied Probability &amp; Statistics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2950",
+              "title": "Engineering Seminar",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CHEM",
+                  "number": "1215",
+                  "title": "General Chemistry Lab I"
+                },
+                {
+                  "prefix": "CEEN",
+                  "number": "2240",
+                  "title": "Surveying for Civil Engineers"
+                },
+                {
+                  "prefix": "CHEM",
+                  "number": "1220",
+                  "title": "General Chemistry II"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This additional course is not required but is recommended for students transferring to Utah State University. If students decide to take this course, it may not be eligible for financial aid because it is not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information.:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2300",
+              "title": "Engineering Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This additional course is not required but is recommended for students transferring to Southern Utah University, Utah State University, or Utah Valley University. If students decide to take this course, it may not be eligible for financial aid because it is not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2030",
+              "title": "Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Engineering Option (43 credits)",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Fundamentals of Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1410",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2420",
+              "title": "Algorithms &amp; Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "2430",
+              "title": "Discrete Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "1000",
+              "title": "Introduction to Electrical Engineering and Lab Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "1270",
+              "title": "Introduction to Electrical Circuits I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2260",
+              "title": "Fundamentals of Electrical Circuits II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2280",
+              "title": "Fundamentals of Engineering Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2700",
+              "title": "Fundamentals of Digital System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1500",
+              "title": "Applied Ethics for Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CHEM",
+                  "number": "1215",
+                  "title": "General Chemistry Lab I"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This additional course is not required but is suggested and is accepted at the University of Utah for ECE 3530. If students decide to take this course, it may not be eligible for financial aid because it is not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2550",
+              "title": "Applied Probability &amp; Statistics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electrical Engineering Option (43 credits)",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Fundamentals of Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1410",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "1000",
+              "title": "Introduction to Electrical Engineering and Lab Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "1270",
+              "title": "Introduction to Electrical Circuits I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2260",
+              "title": "Fundamentals of Electrical Circuits II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2280",
+              "title": "Fundamentals of Engineering Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2700",
+              "title": "Fundamentals of Digital System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1500",
+              "title": "Applied Ethics for Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CHEM",
+                  "number": "1215",
+                  "title": "General Chemistry Lab I"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This additional course is not required but is suggested and is accepted at the University of Utah for ECE 3530. If students decide to take this course, it may not be eligible for financial aid because it is not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2550",
+              "title": "Applied Probability &amp; Statistics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Material Science Engineering Option (26 credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1040",
+              "title": "Engineering Computing in Python, Excel and VBA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "1820",
+              "title": "Fundamentals of Microscopy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2160",
+              "title": "Elements of Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2165",
+              "title": "Introduction to Materials Science and Engineering Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CHEM",
+                  "number": "2310",
+                  "title": "Organic Chemistry I"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Mechanical Engineering Option (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "2210",
+              "title": "Electrical Engineering for Non-Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1030",
+              "title": "Engineering Computing in MATLAB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1500",
+              "title": "Applied Ethics for Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2010",
+              "title": "Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2030",
+              "title": "Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2300",
+              "title": "Engineering Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2450",
+              "title": "Numerical Methods in MATLAB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2550",
+              "title": "Applied Probability &amp; Statistics for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEEN",
+              "number": "1000",
+              "title": "Introduction to Design in Engineering Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEEN",
+              "number": "1005",
+              "title": "Introduction to Design in Engineering Systems Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEEN",
+              "number": "2650",
+              "title": "Manufacturing Engineering &amp; Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEEN",
+              "number": "2655",
+              "title": "Engineering Manufacturing Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2160",
+              "title": "Elements of Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This additional course is not required but is recommended for students transferring to Weber State University,Utah State University, or Utah Valley University. If students decide to take this course, it may not be eligible for financial aid because it is not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information.:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2140",
+              "title": "Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This additional course is not required but is recommended for students transferring to to Utah State University. If students decide to take this course, it may not be eligible for financial aid because it is not explicitly required for the program of study. Contact your academic advisor and/or the Office of Financial Aid for more information :",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2165",
+              "title": "Introduction to Materials Science and Engineering Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Exercise Science / Kinesiology: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12749",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1615",
+              "title": "College Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1105",
+              "title": "Principles of Cardiorespiratory Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1110",
+              "title": "Principles of Strength Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1115",
+              "title": "Principles of Flexibility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2500",
+              "title": "Introduction to Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (14 credits)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1620",
+              "title": "College Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1110",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1125",
+              "title": "Cooking &amp; Baking Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2315",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2100",
+              "title": "Principles of Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2200",
+              "title": "Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2250",
+              "title": "Exercise Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2400",
+              "title": "Exercise and Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2415",
+              "title": "Functional Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2425",
+              "title": "Evaluation and Assessment of Fitness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2430",
+              "title": "Designing Training Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2450",
+              "title": "Personal Trainer Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2455",
+              "title": "Certification Exam Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2600",
+              "title": "Sport and American Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2800",
+              "title": "Sport Pedagogy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2900",
+              "title": "Special Topics in Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1200",
+              "title": "First Aid and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1500",
+              "title": "Lifetime Wellness and Fitness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "2100",
+              "title": "Fitness Motiv./Behav Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1060",
+              "title": "Trigonometry (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1020",
+              "title": "Scientific Foundations of Human Nutrition (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1030",
+              "title": "Introduction to Dietetics and Nutrition Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1245",
+              "title": "Concepts in Food Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2020",
+              "title": "Nutrition for the Life Cycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2030",
+              "title": "Nutrition for Fitness and Sport",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2900",
+              "title": "Special Topics in Nutrition/Dietetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2101",
+              "title": "Social Psychology of Outdoor Adventure, Parks &amp; Recreation (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English Studies: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=13252",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "Critical Introduction to Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "Diversity in American Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2701",
+              "title": "Introduction to Literary History, Pre-1800",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2702",
+              "title": "Introduction to Literary History, Post-1800",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1200",
+              "title": "Introduction to Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1830",
+              "title": "Literary Magazine Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2030",
+              "title": "Language in US Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Introduction to Folklore (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2250",
+              "title": "Imaginative Writing (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2260",
+              "title": "Intro to Writing Poetry (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2270",
+              "title": "Intro to Writing Fiction (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2280",
+              "title": "Intro to Creative Nonfiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2290",
+              "title": "Intro Novel Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2300",
+              "title": "Intro to Shakespeare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2330",
+              "title": "Children`s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2630",
+              "title": "Contemporary World Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2640",
+              "title": "Writing and Social Justice (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2700",
+              "title": "Introduction to Critical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2701",
+              "title": "Introduction to Literary History, Pre-1800",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2702",
+              "title": "Introduction to Literary History, Post-1800",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2760",
+              "title": "Gender &amp; Cultural Studies (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2830",
+              "title": "Diverse Women Writers (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2850",
+              "title": "Intro to Queer Studies (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Family and Human Studies: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12598",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (30 Credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Elements of Effective Communication (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1020",
+              "title": "Principles of Public Speaking (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1030",
+              "title": "Quantitative Reasoning (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1380",
+              "title": "Financial Mathematics (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1500",
+              "title": "Lifespan Human Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2500",
+              "title": "Child Development: Birth-Eight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2600",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2620",
+              "title": "Creative Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2800",
+              "title": "Practicum Teaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2820",
+              "title": "Teaching Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "2010",
+              "title": "Intro. to Special Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1900",
+              "title": "Individual Studies in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2000",
+              "title": "Co-op Education in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2020",
+              "title": "Special Studies-CDA Completion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2300",
+              "title": "Administration of Early Childhood Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2340",
+              "title": "Creating Environments for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2400",
+              "title": "Couple and Family Relationships (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2550",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2570",
+              "title": "Growth &amp; Dev. of Children 6-12",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1900",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film Production Technician: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12602",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (49 credits)",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1310",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1190",
+              "title": "Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1513",
+              "title": "Stagecraft for Theatre &amp; Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1045",
+              "title": "Beginning Film Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1055",
+              "title": "Intermediate Film Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1510",
+              "title": "Documentary Film Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1075",
+              "title": "Screenwriting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2015",
+              "title": "Film Directing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2045",
+              "title": "Commercial Film Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2075",
+              "title": "Advanced Video Editing And Postproduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2510",
+              "title": "Documentary Film Production II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2065",
+              "title": "Motion Picture Sound",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2715",
+              "title": "Cinematography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1095",
+              "title": "Intro to Virtual Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2115",
+              "title": "Film Directing 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (4 Credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1800",
+              "title": "Digital Media Tools/Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1100",
+              "title": "Acting for Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2250",
+              "title": "Television Studio Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1023",
+              "title": "Introduction to Film (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1070",
+              "title": "Film and Culture (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1900",
+              "title": "Independent Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2500",
+              "title": "Bootcamp: Advanced Film Production Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2750",
+              "title": "Film Prod. Techn. Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1223",
+              "title": "Stage Make-up",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "2900",
+              "title": "Special Topics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1190",
+              "title": "Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1310",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1513",
+              "title": "Stagecraft for Theatre &amp; Film",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Family and Human Studies: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12596",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 or 16 Credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Early Childhood Education Track (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FHS",
+              "number": "1500",
+              "title": "Lifespan Human Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2500",
+              "title": "Child Development: Birth-Eight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2600",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2620",
+              "title": "Creative Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "0010",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Family and Human Development Track (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FHS",
+              "number": "1500",
+              "title": "Lifespan Human Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2400",
+              "title": "Couple and Family Relationships (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2450",
+              "title": "Introduction to Human Sexuality (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (11 or 15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Early Childhood Education Track (11 credits)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "2010",
+              "title": "Intro. to Special Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2140",
+              "title": "Technology in the Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1900",
+              "title": "Individual Studies in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2000",
+              "title": "Co-op Education in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2020",
+              "title": "Special Studies-CDA Completion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2180",
+              "title": "Home, School &amp; Comm. Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2300",
+              "title": "Administration of Early Childhood Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2340",
+              "title": "Creating Environments for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2400",
+              "title": "Couple and Family Relationships (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2550",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2570",
+              "title": "Growth &amp; Dev. of Children 6-12",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2645",
+              "title": "Early Childhood Integrated Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2900",
+              "title": "Special Topics in FHS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Family and Human Development Track (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FHS",
+              "number": "1230",
+              "title": "Adolescent Growth &amp; Dev.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1900",
+              "title": "Individual Studies in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2000",
+              "title": "Co-op Education in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2550",
+              "title": "Infant and Toddler Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2570",
+              "title": "Growth &amp; Dev. of Children 6-12",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2600",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2610",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2645",
+              "title": "Early Childhood Integrated Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2900",
+              "title": "Special Topics in FHS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fashion Design and Development: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12599",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (35 credits)",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FASH",
+              "number": "1010",
+              "title": "Introduction to Fashion (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1050",
+              "title": "Fashion Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1100",
+              "title": "Pattern Drafting Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1210",
+              "title": "Fashion Illustration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1250",
+              "title": "Textiles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1500",
+              "title": "Beginning Sewing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1505",
+              "title": "Intermediate Sewing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1610",
+              "title": "Knitwear Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1660",
+              "title": "Pattern Drafting Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "2030",
+              "title": "Advanced Sewing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "2150",
+              "title": "Draping Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "2450",
+              "title": "Fashion Design &amp; Technical Design Portfolio Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies: AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12610",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program Electives (29 credits)",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Fitness Technician: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12609",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (44 Credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EXSC",
+              "number": "1105",
+              "title": "Principles of Cardiorespiratory Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1110",
+              "title": "Principles of Strength Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1115",
+              "title": "Principles of Flexibility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2200",
+              "title": "Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2250",
+              "title": "Exercise Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2400",
+              "title": "Exercise and Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2415",
+              "title": "Functional Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2425",
+              "title": "Evaluation and Assessment of Fitness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2430",
+              "title": "Designing Training Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2450",
+              "title": "Personal Trainer Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2500",
+              "title": "Introduction to Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1200",
+              "title": "First Aid and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1500",
+              "title": "Lifetime Wellness and Fitness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "2100",
+              "title": "Fitness Motiv./Behav Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1020",
+              "title": "Scientific Foundations of Human Nutrition (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2030",
+              "title": "Nutrition for Fitness and Sport",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "College Biology I (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1615",
+              "title": "College Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1620",
+              "title": "College Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1110",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1125",
+              "title": "Cooking &amp; Baking Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2100",
+              "title": "Principles of Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2455",
+              "title": "Certification Exam Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2600",
+              "title": "Sport and American Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2800",
+              "title": "Sport Pedagogy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2900",
+              "title": "Special Topics in Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1350",
+              "title": "Intro to Yoga Teacher Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1355",
+              "title": "Yoga Teacher Training II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1360",
+              "title": "Yoga Teacher Training III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1365",
+              "title": "Yoga Teacher Training IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "1370",
+              "title": "Yoga Teacher Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1060",
+              "title": "Trigonometry (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1600",
+              "title": "Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2020",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2050",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1030",
+              "title": "Introduction to Dietetics and Nutrition Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1245",
+              "title": "Concepts in Food Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2020",
+              "title": "Nutrition for the Life Cycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2900",
+              "title": "Special Topics in Nutrition/Dietetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2101",
+              "title": "Social Psychology of Outdoor Adventure, Parks &amp; Recreation (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2300",
+              "title": "Internship in Outdoor Adventure, Parks &amp; Recreation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2320",
+              "title": "Recreation Programming and Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Firefighter: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=13767",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEFF",
+              "number": "1100",
+              "title": "Introduction to Fire",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEFF",
+              "number": "1200",
+              "title": "Firefighter",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEFF",
+              "number": "1300",
+              "title": "Introduction to Fire Command",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEFF",
+              "number": "1310",
+              "title": "Advanced Vehicle Rescue",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEFF",
+              "number": "1320",
+              "title": "Advanced Rope Rescue",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Design & Development: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12675",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1620",
+              "title": "Intro to Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1630",
+              "title": "Computer Graphics Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1680",
+              "title": "Game Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2680",
+              "title": "Game Assets &amp; Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "1350",
+              "title": "Apps and Applets: an Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "2630",
+              "title": "3D Modeling &amp; Sculpting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2640",
+              "title": "3D Animation &amp; Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2570",
+              "title": "Game Audio Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12611",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program Electives (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Geographic Information Systems and Drones: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12614",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (31 Credits)",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "1800",
+              "title": "Mapping Our Changing World (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2100",
+              "title": "Cartography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2400",
+              "title": "Data Acquisition &amp; Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2500",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2550",
+              "title": "Fundamentals of Drones",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2600",
+              "title": "Python for GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2750",
+              "title": "Remote Sensing and GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2800",
+              "title": "Web GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2880",
+              "title": "Mapping with Drones",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2920",
+              "title": "Spatial Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATMO",
+              "number": "1010",
+              "title": "Severe and Hazardous Weather (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMO",
+              "number": "1020",
+              "title": "Climate Change (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMO",
+              "number": "2100",
+              "title": "Air Pollution &amp; Atmospheric Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMO",
+              "number": "2200",
+              "title": "Mountain Weather &amp; Climate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVS",
+              "number": "1400",
+              "title": "Environmental Science (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1010",
+              "title": "Introduction to Geology (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1110",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1220",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "2350",
+              "title": "Field Studies in Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1000",
+              "title": "Earth&#039;s Environments (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1300",
+              "title": "World Geography (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1400",
+              "title": "Human Geography (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Natural Disasters (PS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geographic Information Systems: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12701",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 Credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "1800",
+              "title": "Mapping Our Changing World (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2100",
+              "title": "Cartography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2400",
+              "title": "Data Acquisition &amp; Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2500",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2600",
+              "title": "Python for GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2750",
+              "title": "Remote Sensing and GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2800",
+              "title": "Web GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2920",
+              "title": "Spatial Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Communications: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12672",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1200",
+              "title": "InDesign Software",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (13-16 Credits)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Communications: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12664",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1200",
+              "title": "InDesign Software",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Management: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12767",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (22 Credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "2010",
+              "title": "Survey of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1120",
+              "title": "Introduction to Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "2010",
+              "title": "Business Computer Proficiency - Spreadsheets and Databases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "1200",
+              "title": "Food &amp; Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2400",
+              "title": "Event Planning for Tourist Destinations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2500",
+              "title": "Tourism Accommodations &amp; Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2040",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "1110",
+              "title": "Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1200",
+              "title": "Cuisine &amp; Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1210",
+              "title": "Food and Beverage Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1320",
+              "title": "Fundamentals of Cost Control (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1330",
+              "title": "Wine Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2330",
+              "title": "French Wine Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "2410",
+              "title": "Purchasing and Storeroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "2000",
+              "title": "Hospitality Management Co-Op",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2020",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1040",
+              "title": "Ethics at Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1600",
+              "title": "Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2020",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2050",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2070",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2080",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1030",
+              "title": "Introduction To Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1910",
+              "title": "Event Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1960",
+              "title": "Professionalism in Business (HR)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Humanities: AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12778",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "A.A. Language Requirement (4 Credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (12 Credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Foundations Course (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "2950",
+              "title": "Archival Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "1010",
+              "title": "Introduction to the Humanities (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 Credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Humanities Exploration (9 Credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Introduction to Folklore (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "Critical Introduction to Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "Diversity in American Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2630",
+              "title": "Contemporary World Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1500",
+              "title": "World History to 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1510",
+              "title": "World History Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2200",
+              "title": "Americanization: Ethnicity, Power and Privilege (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "1900",
+              "title": "Special Studies in Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "2310",
+              "title": "Great Books I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "2900",
+              "title": "Special Topics in Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LANG",
+              "number": "1010",
+              "title": "1st Semester Language",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Introduction to Philosophy (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2350",
+              "title": "Principles of the Philosophy of Religion (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RELS",
+              "number": "2600",
+              "title": "World Religions (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RELS",
+              "number": "2400",
+              "title": "America&#039;s Religious Landscape (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Tracks (9 Credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (17 Credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12780",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEIT",
+              "number": "1050",
+              "title": "Career &amp; Workplace Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1100",
+              "title": "Introduction to Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1170",
+              "title": "Computer Networks I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1200",
+              "title": "A+ Core I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1210",
+              "title": "A+ Core II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1300",
+              "title": "Linux Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2200",
+              "title": "Security+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (4 credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEIT",
+              "number": "1000",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1110",
+              "title": "Introduction to Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1400",
+              "title": "Introduction to Cloud",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1800",
+              "title": "Certification Test Prep I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1810",
+              "title": "Certification Test Prep II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2170",
+              "title": "Computer Networks II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Humanities: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12779",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (12 Credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Foundations Course (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "2950",
+              "title": "Archival Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "1010",
+              "title": "Introduction to the Humanities (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 Credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Humanities Exploration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2210",
+              "title": "Introduction to Folklore (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2600",
+              "title": "Critical Introduction to Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "Diversity in American Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2630",
+              "title": "Contemporary World Literature (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1500",
+              "title": "World History to 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1510",
+              "title": "World History Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2200",
+              "title": "Americanization: Ethnicity, Power and Privilege (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "1900",
+              "title": "Special Studies in Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "2310",
+              "title": "Great Books I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "2320",
+              "title": "Great Books II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUMA",
+              "number": "2900",
+              "title": "Special Topics in Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Introduction to Philosophy (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2350",
+              "title": "Principles of the Philosophy of Religion (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RELS",
+              "number": "2600",
+              "title": "World Religions (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RELS",
+              "number": "2400",
+              "title": "America&#039;s Religious Landscape (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interior Design: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12625",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (47 Credits)",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTD",
+              "number": "1010",
+              "title": "Intro to Interior Design (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1050",
+              "title": "Professional Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1100",
+              "title": "Drafting and Space Utilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1200",
+              "title": "Color for Interiors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1250",
+              "title": "Digital Graphics for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1270",
+              "title": "Survey of Furniture &amp; Architectural Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1300",
+              "title": "Drawing for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1450",
+              "title": "Basic CAD for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1950",
+              "title": "Materials and Resources for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2200",
+              "title": "Construction Techniques and Residential Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2300",
+              "title": "Lighting Design &amp; Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2350",
+              "title": "Space Planning &amp; Commercial Codes for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2370",
+              "title": "Fundamentals of Revit",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2400",
+              "title": "Kitchen and Bath Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2600",
+              "title": "Business Practices of Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2700",
+              "title": "Interior Design Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTD",
+              "number": "1020",
+              "title": "Applying Feng Shui in Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1750",
+              "title": "Design Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2000",
+              "title": "Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2150",
+              "title": "Sustainable Interiors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2380",
+              "title": "Advanced Digital Rendering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2450",
+              "title": "Advanced Kitchen &amp; Bath Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2800",
+              "title": "Historic Preservation and Restoration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2900",
+              "title": "Independent Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "1010",
+              "title": "Design Contexts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "International Studies: AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=13254",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (29 credits)",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "For Utah State University",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "1010",
+              "title": "Introduction to Cultural Anthropology: Culture and the Human Experience (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1500",
+              "title": "World History to 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "1510",
+              "title": "World History Since 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1300",
+              "title": "World Geography (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2100",
+              "title": "Introduction to International Politics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2200",
+              "title": "Introduction to Comparative Politics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "For Utah State University",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "1000",
+              "title": "Earth&#039;s Environments (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1400",
+              "title": "Human Geography (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1800",
+              "title": "Mapping Our Changing World (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTL",
+              "number": "2240",
+              "title": "Latin American Epistemologies: Knowledge, Power, and Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "2120",
+              "title": "Sacred Traditions: Anthropology of Religion (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVACR Technician: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12657",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAC",
+              "number": "1010",
+              "title": "Introduction to Air Conditioning, Heating and Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "1100",
+              "title": "HVACR Electrical Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "1120",
+              "title": "Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "1140",
+              "title": "Basic Refrigeration Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "1160",
+              "title": "Basic Installation Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "1510",
+              "title": "Air Distribution Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAC",
+              "number": "1520",
+              "title": "Carbon Steel Piping Practices and Refrigerant Certification",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Journalism & Digital Media: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12532",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 Credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1130",
+              "title": "Journalism &amp; Media Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1500",
+              "title": "Media and Society (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1800",
+              "title": "Digital Media Tools/Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2110",
+              "title": "Interpersonal Communication (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2250",
+              "title": "Television Studio Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2400",
+              "title": "Social Media Tools and Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2600",
+              "title": "Production for Student Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1560",
+              "title": "Radio Performance &amp; Production (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2200",
+              "title": "Video Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1560",
+              "title": "Radio Performance &amp; Production (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2000",
+              "title": "Communication CO-OP/Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2050",
+              "title": "Perspectives in Communication (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2200",
+              "title": "Video Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2250",
+              "title": "Television Studio Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2300",
+              "title": "Public Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2500",
+              "title": "Elements and Issue of Digital Media (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2510",
+              "title": "Documentary Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2570",
+              "title": "Introduction to Visual Communication (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2600",
+              "title": "Production for Student Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any other COMM course or related media course with prior departmental approval.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Officer: Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12991",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TELE",
+              "number": "1030",
+              "title": "Law Enforcement Officer",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Low Voltage Technician Apprenticeship: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12784",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TELV",
+              "number": "1000",
+              "title": "Introduction to Information &amp; Communication Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "1100",
+              "title": "BICSI Installer 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "1200",
+              "title": "Building Industry Consulting Services International (BICSI) Installer 2, Copper",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "1300",
+              "title": "Building Industry Consulting Services International (BICSI) Installer 2, Optical Fiber",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "1400",
+              "title": "Building Industry Consulting Services International (BICSI) Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "2000",
+              "title": "Electronic Systems and Access Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "2100",
+              "title": "IT and Wireless Applications &amp; Test Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "2200",
+              "title": "Audiovisual (AV) Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TELV",
+              "number": "2300",
+              "title": "Low Voltage Building Automation Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Master Automobile Service Technician: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12510",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (48 Credits)",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First complete the Automotive Technology: Technical Certificate (SL Tech) (CTE) (24 credits), then complete the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2120",
+              "title": "Automotive Automatic Transmission/Transaxle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2130",
+              "title": "Automotive Manual Drivetrain &amp; Axles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2160",
+              "title": "Automotive Electrical/Electronic Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2170",
+              "title": "Heating, Ventilation, and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2260",
+              "title": "Automotive Electrical/Electronic Systems III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "2285",
+              "title": "Automotive Engine &amp; Emission Controls II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machining Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12797",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEMT",
+              "number": "1000",
+              "title": "Manufacturing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1100",
+              "title": "Mill Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1150",
+              "title": "CNC Mill Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1200",
+              "title": "Lathe Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1250",
+              "title": "CNC Lathe Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1310",
+              "title": "CNC Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12763",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (28 Credits)",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEMA",
+              "number": "1010",
+              "title": "Introduction to Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1020",
+              "title": "Medical Office I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1030",
+              "title": "Medical Office II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1040",
+              "title": "Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1050",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1060",
+              "title": "Clinical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1080",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1150",
+              "title": "Medical Assistant Laboratory Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1210",
+              "title": "Assisting with Medical Specialties I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1220",
+              "title": "Assisting with Medical Specialties II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1410",
+              "title": "Workplace Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1900",
+              "title": "Medical Assistant Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMA",
+              "number": "1910",
+              "title": "Medical Assistant Externship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12633",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (26 Credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2210",
+              "title": "Multivariate Calculus: Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2270",
+              "title": "Elementary Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2280",
+              "title": "Ordinary Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2200",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2225",
+              "title": "Physics for Sci &amp; Eng Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1040",
+              "title": "Engineering Computing in Python, Excel and VBA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Fundamentals of Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1410",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (2 credits)",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Medical Coding & Billing: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12620",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses: (25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEMC",
+              "number": "1051",
+              "title": "Medical Insurance Billing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1060",
+              "title": "Medical Insurance Billing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1070",
+              "title": "Medical Office Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1110",
+              "title": "Coding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1121",
+              "title": "Coding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1131",
+              "title": "Coding III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1140",
+              "title": "Coding IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1250",
+              "title": "Medical Terminology and Anatomy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1260",
+              "title": "Medical Terminology and Anatomy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMC",
+              "number": "1900",
+              "title": "Coding Certification Exam Prep",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "MIDI: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12642",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (15 Credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1300",
+              "title": "Money &amp; Creative Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1520",
+              "title": "Music Composition I (Introduction to Electronic Music Composition)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1540",
+              "title": "Music Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two semesters of:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2500",
+              "title": "Music Production Group",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1050",
+              "title": "Songwriting &amp; Creative Process (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1060",
+              "title": "Songwriting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1530",
+              "title": "Music Recording Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1550",
+              "title": "Musical Acoustics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1560",
+              "title": "Music Mixing Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2510",
+              "title": "Music Composition for Games and Interactive Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2520",
+              "title": "Music Scoring For Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2540",
+              "title": "Sampling, Synthesis &amp; Sound Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2550",
+              "title": "Music Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Micro-/Nanotechnology: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12585",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (26 Credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "1000",
+              "title": "Introduction to Electrical Engineering and Lab Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "1050",
+              "title": "Introduction to Nanotechnology (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2050",
+              "title": "Nano II - Properties of Nanomaterials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "1820",
+              "title": "Fundamentals of Microscopy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2000",
+              "title": "Cooperative Education In Material Science Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2320",
+              "title": "Introduction to Scanning Probe Microscopy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2330",
+              "title": "Introduction to Scanning Electron Microscopy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTEC",
+              "number": "1010",
+              "title": "Engineering Life: Fundamentals of Biotechnology (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1250",
+              "title": "Introduction to Chemical and Instrumental Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1110",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "1115",
+              "title": "Physical Geology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2160",
+              "title": "Elements of Material Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSE",
+              "number": "2165",
+              "title": "Introduction to Materials Science and Engineering Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1010",
+              "title": "Elementary Physics (PS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mortuary Science: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12638",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any Written Communication (WC) course [ENGL 1010 with APA referencing recommended]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1250",
+              "title": "Small Business Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1010",
+              "title": "Introduction to Mortuary Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete a job shadow as outlined on the Mortuary Science admissions page.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (50-51 credits)",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "1250",
+              "title": "Small Business Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2050",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1010",
+              "title": "Introduction to Mortuary Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1100",
+              "title": "Dynamics of Grief, Death and Dying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1200",
+              "title": "Microbiological Studies for Mortuary Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1300",
+              "title": "Pathology for Funeral Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1400",
+              "title": "Embalming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1405",
+              "title": "Embalming I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1500",
+              "title": "Anatomic Principles for Mortuary Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1600",
+              "title": "Thanatochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2330",
+              "title": "Funeral Service Psychology and Counseling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2400",
+              "title": "Embalming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2405",
+              "title": "Embalming II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2600",
+              "title": "Restorative Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2605",
+              "title": "Restorative Art Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2700",
+              "title": "Mortuary Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2730",
+              "title": "Funeral Home Management and Merchandising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2750",
+              "title": "Funeral Directing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2755",
+              "title": "Funeral Directing Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "2770",
+              "title": "National Board Exam Professional Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: A minimum of 67 credit hours is required to complete this degree. Students who complete the General Education and program requirements above in less than 67 credit hours will be required to take additional General Education courses to reach this minimum.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Recording Technology: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12643",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (28 Credits)",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1300",
+              "title": "Money &amp; Creative Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1520",
+              "title": "Music Composition I (Introduction to Electronic Music Composition)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1530",
+              "title": "Music Recording Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1550",
+              "title": "Musical Acoustics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1560",
+              "title": "Music Mixing Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2580",
+              "title": "Audio Production and Mixing for Live Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two semesters of:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2500",
+              "title": "Music Production Group",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12639",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (25 Credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "0990",
+              "title": "Recital Attendance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1110",
+              "title": "Music Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1120",
+              "title": "Music Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1130",
+              "title": "Sight Singing/Ear Training I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1140",
+              "title": "Sight Singing/Ear Training II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1150",
+              "title": "Group Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1160",
+              "title": "Group Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1200",
+              "title": "Introduction to the Music Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2110",
+              "title": "Music Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2120",
+              "title": "Music Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2130",
+              "title": "Sight Singing/Ear Training III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2140",
+              "title": "Sight Singing/Ear Training IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2350",
+              "title": "Conducting Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1310",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Emphasis (9-11 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Performance Emphasis-Additional Required Courses (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following First-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1765",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following Second-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2765",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One Sophomore Recital:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2700",
+              "title": "Sophomore Recital",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Private Applied Instruction classes can be repeated for credit to meet these requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Composition Emphasis-Additional Required Courses (10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1520",
+              "title": "Music Composition I (Introduction to Electronic Music Composition)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1540",
+              "title": "Music Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following First-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1712",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1722",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1732",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1742",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1752",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1762",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1765",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1772",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following Second-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2712",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2722",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2732",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2742",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2752",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2762",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2765",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2772",
+              "title": "Private Lessons: Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Private Applied Instruction classes can be repeated for credit to meet these requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music Education Emphasis-Additional Required Courses (10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1700",
+              "title": "Introduction to Music Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following First-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1712",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1722",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1732",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1742",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1752",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1762",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1765",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1772",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following Second-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2712",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2722",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2732",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2742",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2752",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2762",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2765",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2772",
+              "title": "Private Lessons: Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Private Applied Instruction classes can be repeated for credit to meet these requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Commercial Music Emphasis-Additional Required Courses (11 credits)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1300",
+              "title": "Money &amp; Creative Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1050",
+              "title": "Songwriting &amp; Creative Process (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1520",
+              "title": "Music Composition I (Introduction to Electronic Music Composition)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2200",
+              "title": "Artist Promotion and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following First-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1712",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1722",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1732",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1742",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1752",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1762",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1765",
+              "title": "Private Lessons: Woodwinds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1772",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Two of the following Second-Year Private Applied Instruction Courses:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2712",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2715",
+              "title": "Private Lessons: Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2722",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2725",
+              "title": "Private Lessons: Strings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2732",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2735",
+              "title": "Private Lessons:  Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2742",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2745",
+              "title": "Private Lessons: Brass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2752",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2755",
+              "title": "Private Lessons:  Voice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2762",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2765",
+              "title": "Private Lessons: Winds",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2772",
+              "title": "Private Lessons: Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "2775",
+              "title": "Private Lessons:  Percussion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Private Applied Instruction classes can be repeated for credit to meet these requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking and Cybersecurity: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=13768",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEIT",
+              "number": "1050",
+              "title": "Career &amp; Workplace Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1100",
+              "title": "Introduction to Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1170",
+              "title": "Computer Networks I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1200",
+              "title": "A+ Core I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1210",
+              "title": "A+ Core II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1300",
+              "title": "Linux Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1400",
+              "title": "Introduction to Cloud",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2170",
+              "title": "Computer Networks II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2200",
+              "title": "Security+",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEIT",
+              "number": "1000",
+              "title": "Information Technology Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1110",
+              "title": "Introduction to Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1150",
+              "title": "Cisco CCNA Introduction to Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1160",
+              "title": "Cisco CCNA Switching, Routing, and Wireless Essentials (SRWE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1800",
+              "title": "Certification Test Prep I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "1810",
+              "title": "Certification Test Prep II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2150",
+              "title": "CCNA Enterprise Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2250",
+              "title": "Ethical Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2270",
+              "title": "Cybersecurity Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2300",
+              "title": "Linux+",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEIT",
+              "number": "2920",
+              "title": "Special Projects II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Non-Destructive Testing - Eddy Current: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12645",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (17 Credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NDT",
+              "number": "1110",
+              "title": "Intro./Non-Destructive Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1120",
+              "title": "Magnetic Particle I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1121",
+              "title": "Magnetic Particle I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1210",
+              "title": "Liquid Penetrant I &amp; II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1211",
+              "title": "Liquid Penetrant I &amp; II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1122",
+              "title": "Eddy Current I Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1123",
+              "title": "Eddy Current I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1222",
+              "title": "Eddy Current II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1223",
+              "title": "Eddy Current II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "1260",
+              "title": "Blueprint for Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Non-Destructive Testing - Radiography: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12646",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (20-23 Credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NDT",
+              "number": "1110",
+              "title": "Intro./Non-Destructive Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1120",
+              "title": "Magnetic Particle I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1121",
+              "title": "Magnetic Particle I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1210",
+              "title": "Liquid Penetrant I &amp; II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1211",
+              "title": "Liquid Penetrant I &amp; II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1130",
+              "title": "Radiation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1132",
+              "title": "Radiography I Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1133",
+              "title": "Radiography I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1232",
+              "title": "Radiography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1233",
+              "title": "Radiography II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "1260",
+              "title": "Blueprint for Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Non-Destructive Testing - Ultrasonics: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12647",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (20-23 Credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NDT",
+              "number": "1110",
+              "title": "Intro./Non-Destructive Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1120",
+              "title": "Magnetic Particle I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1121",
+              "title": "Magnetic Particle I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1210",
+              "title": "Liquid Penetrant I &amp; II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1211",
+              "title": "Liquid Penetrant I &amp; II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1114",
+              "title": "Ultrasonics I Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1115",
+              "title": "Ultrasonics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1213",
+              "title": "Ultrasonics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1214",
+              "title": "Ultrasonics II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "1260",
+              "title": "Blueprint for Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Assistant: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12617",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TENA",
+              "number": "1100",
+              "title": "Nursing Assistant",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12648",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "Elementary Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1115",
+              "title": "Elementary Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (42 Credits)",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "1001",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1101",
+              "title": "Fundamentals of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1102",
+              "title": "Nursing Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1103",
+              "title": "Health Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1111",
+              "title": "Introduction to Clinical Judgement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1201",
+              "title": "Medical Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1202",
+              "title": "Nursing Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1203",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1211",
+              "title": "Medical Surgical Nursing I Clinical Judgement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2301",
+              "title": "Medical Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2302",
+              "title": "Nursing Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2303",
+              "title": "Obstetric and Pediatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2311",
+              "title": "Medical Surgical Nursing II Clinical Judgement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2313",
+              "title": "Obstetric and Pediatric Clinical Judgement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2401",
+              "title": "Medical Surgical Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2402",
+              "title": "Nursing Pharmacology IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2403",
+              "title": "Transition to Professional Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2404",
+              "title": "Preparation for the NCLEX RN Exam",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2411",
+              "title": "Medical Surgical Nursing III Clinical Judgement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2413",
+              "title": "Transition to Professional Nursing Practice, Clinical Judgement Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (13 credits)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Optional Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "1204",
+              "title": "LPN NCLEX Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1214",
+              "title": "LPN NCLEX Prep Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1900",
+              "title": "Independent Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "2304",
+              "title": "LPN to RN Bridge",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Non-Destructive Testing: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12644",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (50 Credits)",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "2100",
+              "title": "Technical Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1110",
+              "title": "Intro./Non-Destructive Testing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1114",
+              "title": "Ultrasonics I Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1115",
+              "title": "Ultrasonics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1120",
+              "title": "Magnetic Particle I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1121",
+              "title": "Magnetic Particle I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1122",
+              "title": "Eddy Current I Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1123",
+              "title": "Eddy Current I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1130",
+              "title": "Radiation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1132",
+              "title": "Radiography I Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1133",
+              "title": "Radiography I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1210",
+              "title": "Liquid Penetrant I &amp; II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1211",
+              "title": "Liquid Penetrant I &amp; II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1213",
+              "title": "Ultrasonics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1214",
+              "title": "Ultrasonics II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1222",
+              "title": "Eddy Current II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1223",
+              "title": "Eddy Current II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1230",
+              "title": "Codes and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1232",
+              "title": "Radiography II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1233",
+              "title": "Radiography II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NDT",
+              "number": "1234",
+              "title": "Advanced NDT Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "1005",
+              "title": "Related Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "1260",
+              "title": "Blueprint for Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12649",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any Written Communication (WC) course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "OTA",
+                  "number": "1040",
+                  "title": "Anatomy and Physiology for Occupational Therapy"
+                },
+                {
+                  "prefix": "COMM",
+                  "number": "1010",
+                  "title": "Elements of Effective Communication (CM)"
+                },
+                {
+                  "prefix": "PSY",
+                  "number": "1100",
+                  "title": "Lifespan Human Growth and Development (SS)"
+                }
+              ]
+            },
+            {
+              "prefix": "OTA",
+              "number": "1020",
+              "title": "Intro to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (69 Credits)",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "1100",
+              "title": "Functional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1105",
+              "title": "Functional Anatomy Supervised Instruction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1120",
+              "title": "OT Modalities I Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1130",
+              "title": "OT Modalities I Lecture/Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1140",
+              "title": "Physical Dysfunction Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1150",
+              "title": "Physical Dysfunction Lec/Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1170",
+              "title": "Physical Dysfunction Fieldwork I Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1180",
+              "title": "OT Domain &amp; Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1210",
+              "title": "OT Professional Issues I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1220",
+              "title": "OT Modalities II Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1230",
+              "title": "OT Modalities II Lecture/Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1240",
+              "title": "Physical Dysfunction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1250",
+              "title": "Physical Dysfunction II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1270",
+              "title": "Pediatrics Fieldwork I Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1280",
+              "title": "Pediatric/Adolescence Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1290",
+              "title": "Pediatric/Adolescence Supervised Instruction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2310",
+              "title": "OT Professional Issues II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2320",
+              "title": "OT Modalities III Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2330",
+              "title": "Modalities III Lecture/Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2340",
+              "title": "Psychosocial Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2350",
+              "title": "Geriatrics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2370",
+              "title": "Psychosocial/Geriatric Fieldwork I Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2450",
+              "title": "Fieldwork Experience II Part 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "2460",
+              "title": "Fieldwork Experience II Part 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Outdoor Adventure Parks and Recreation: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12772",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAPR",
+              "number": "2101",
+              "title": "Social Psychology of Outdoor Adventure, Parks &amp; Recreation (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2105",
+              "title": "Fall Outdoor Related Activity in Outdoor Adventure, Parks &amp; Recreation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2106",
+              "title": "Spring Outdoor Related Activities in Outdoor Adventure, Parks &amp; Recreation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2300",
+              "title": "Internship in Outdoor Adventure, Parks &amp; Recreation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "2320",
+              "title": "Recreation Programming and Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "1600",
+              "title": "Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2050",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEF",
+              "number": "1120",
+              "title": "Introduction to Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENVS",
+              "number": "1400",
+              "title": "Environmental Science (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2100",
+              "title": "Principles of Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2455",
+              "title": "Certification Exam Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2600",
+              "title": "Sport and American Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "2800",
+              "title": "Sport Pedagogy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1800",
+              "title": "Mapping Our Changing World (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLAC",
+              "number": "1350",
+              "title": "Scuba I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLAC",
+              "number": "1520",
+              "title": "Hiking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLAC",
+              "number": "1527",
+              "title": "Rock Climbing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLAC",
+              "number": "1550",
+              "title": "Mountain Biking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLAC",
+              "number": "1610",
+              "title": "Skiing/Snowboarding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLAC",
+              "number": "1923",
+              "title": "Exercise for Persons with Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1105",
+              "title": "Principles of Cardiorespiratory Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1110",
+              "title": "Principles of Strength Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXSC",
+              "number": "1115",
+              "title": "Principles of Flexibility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLTH",
+              "number": "2100",
+              "title": "Fitness Motiv./Behav Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2020",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2030",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1020",
+              "title": "Scientific Foundations of Human Nutrition (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2030",
+              "title": "Nutrition for Fitness and Sport",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2060",
+              "title": "Principles of Outdoor Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "1024",
+              "title": "Ski Lift Maintenance Level 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAPR",
+              "number": "1980",
+              "title": "Wilderness First Responder",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2300",
+              "title": "Introduction to Environmental Ethics (HU)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12650",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (30 Credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LS",
+              "number": "1010",
+              "title": "Introduction to Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1020",
+              "title": "Introduction to Civil Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1030",
+              "title": "Paralegal Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1040",
+              "title": "Introduction to Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1060",
+              "title": "Computer Essentials for Paralegals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1070",
+              "title": "Criminal Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2040",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2070",
+              "title": "Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2080",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2000",
+              "title": "Legal Studies CO-OP",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2010",
+              "title": "Paralegal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LS",
+              "number": "1500",
+              "title": "Contracts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1510",
+              "title": "Bankruptcy and Collections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1520",
+              "title": "Wills, Probate and Estates",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1530",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1540",
+              "title": "Immigration Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1550",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1560",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1570",
+              "title": "Torts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1580",
+              "title": "Hollywood and the Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1590",
+              "title": "Business Organizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2000",
+              "title": "Legal Studies CO-OP",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2010",
+              "title": "Paralegal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2050",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "2100",
+              "title": "Certification Preparation for Paralegals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "2080",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technician: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12781",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (17 credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEPT",
+              "number": "1110",
+              "title": "Introduction to Pharmacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPT",
+              "number": "1120",
+              "title": "Community Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPT",
+              "number": "1130",
+              "title": "Institutional Pharmacy Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPT",
+              "number": "1210",
+              "title": "Advanced Pharmacy Technician Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPT",
+              "number": "1290",
+              "title": "Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Photography Foundation: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12773",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1310",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1340",
+              "title": "Photographic Light 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1380",
+              "title": "Photography 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives Courses (2-4 credits)",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art Electives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1070",
+              "title": "Creative Printmaking (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1200",
+              "title": "InDesign Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1110",
+              "title": "Foundation I Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1135",
+              "title": "Printing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1320",
+              "title": "Photographic Vision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1540",
+              "title": "Beginning Painting-Oil",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1620",
+              "title": "Intro to Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1630",
+              "title": "Computer Graphics Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2412",
+              "title": "Illustrator Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2440",
+              "title": "Web Site Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2200",
+              "title": "Video Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Film Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLM",
+              "number": "1045",
+              "title": "Beginning Film Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12651",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any Written Communication (WC) course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "1100",
+                  "title": "Lifespan Human Growth and Development (SS)"
+                }
+              ]
+            },
+            {
+              "prefix": "PTA",
+              "number": "1010",
+              "title": "Intro to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (61 Credits)",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "2010",
+              "title": "Principles of Functional and Neuro Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2015",
+              "title": "Application of Functional Anatomy in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2100",
+              "title": "Patient Care Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2110",
+              "title": "Implementation of Patient Care Skills in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2200",
+              "title": "Therapeutic Modalities and Integumentary Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2210",
+              "title": "Implementation of Therapeutic Modalities in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2300",
+              "title": "Principles of Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2310",
+              "title": "Implementation of Therapeutic Exercise in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2350",
+              "title": "Data Collection for the PTA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2360",
+              "title": "Implementation of Data Collection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2400",
+              "title": "Musculoskeletal Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2410",
+              "title": "Therapeutic Interventions for Musculoskeletal Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2450",
+              "title": "Neurological Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2460",
+              "title": "Therapeutic Interventions for Neurological Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2510",
+              "title": "Special Disorders and Populations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2520",
+              "title": "Therapeutic Interventions for Special Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2530",
+              "title": "Gerontology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2540",
+              "title": "Special Disorders &amp; Populations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2550",
+              "title": "Rehabilitation Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2600",
+              "title": "Clinical Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2700",
+              "title": "Clinical Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2710",
+              "title": "Clinical Internship III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2750",
+              "title": "Seminar for the PTA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2850",
+              "title": "Special Studies for the PTA",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Apprenticeship: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12785",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEPL",
+              "number": "1110",
+              "title": "Plumbing IA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1120",
+              "title": "Plumbing IB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1210",
+              "title": "Plumbing IIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1220",
+              "title": "Plumbing IIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1310",
+              "title": "Plumbing IIIA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1320",
+              "title": "Plumbing IIIB",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1410",
+              "title": "Plumbing IVA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPL",
+              "number": "1420",
+              "title": "Plumbing IVB",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12652",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (36 Credits)",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2210",
+              "title": "Multivariate Calculus: Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2250",
+              "title": "Differential Eq/Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2270",
+              "title": "Elementary Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1090",
+              "title": "Pathways to Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "1100",
+              "title": "Introductory Mathematics for Physics and Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2225",
+              "title": "Physics for Sci &amp; Eng Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2500",
+              "title": "Introduction to Computer Methods in Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2710",
+              "title": "Introductory Modern Physics for Scientists and Engineers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Power Equipment and Motorcycle Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12793",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (24 Credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEPM",
+              "number": "1010",
+              "title": "PE Engine Fundamentals, Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPM",
+              "number": "1020",
+              "title": "Adv PE Engine Systems, Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPM",
+              "number": "1030",
+              "title": "PE and Motorcycle Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPM",
+              "number": "1040",
+              "title": "Motorcycles, Drive, S&amp;S System",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=13255",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLS",
+              "number": "1100",
+              "title": "Introduction to U.S. Government &amp; Politics (AI)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2100",
+              "title": "Introduction to International Politics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2200",
+              "title": "Introduction to Comparative Politics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2300",
+              "title": "Political Ideologies (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2700",
+              "title": "Introduction to Public Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12798",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Current Certified Nursing Assistant License [An EMT License or MA certification may be considered in place of a CNA license]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2110",
+              "title": "Form and Functions of the Human Body I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2111",
+              "title": "Form and Functions of the Human Body II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: ​BIOL 1610 /BIOL 1615 , although not required for the program, are required pre-requisites for selective admissions course requirements (BIOL 2320/BIOL 2325 and BIOL 2420/BIOL 2425). Students may transfer BIOL 2320/2325 and BIOL 2420/2425 equivalents with appropriate grades without completing BIOL 1610/1615. Similarly, CHEM 1110 is a required pre-requisite for BIOL 2420/BIOL 2425.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEMA",
+              "number": "1080",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1010",
+              "title": "Fundamentals of Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1100",
+              "title": "Medical-Surgical Nursing Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1160",
+              "title": "Introduction to Practical Nursing Clinical Judgement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1165",
+              "title": "Empowering Communities: The Role of LPNs in Public Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1200",
+              "title": "Introduction to Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1205",
+              "title": "Practical Nursing Clinical Judgement II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1300",
+              "title": "Comprehensive Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "1460",
+              "title": "Geriatric Nursing: Enhancing Quality of Life",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "2260",
+              "title": "Pharmacology II: Advanced Pharmacology for the Practical Nurse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPN",
+              "number": "2560",
+              "title": "NCLEX Prep for LPN",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Program Note",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "College Biology I (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1615",
+              "title": "College Biology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "Elementary Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1115",
+              "title": "Elementary Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "Introduction to College Writing (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any Written Communication (WC) course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1001",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "Lifespan Human Growth and Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Pre-Health Sciences: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12685",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "Elementary Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1115",
+              "title": "Elementary Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "General Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (20 credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Cell Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2025",
+              "title": "Cell Biology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2030",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2035",
+              "title": "Genetics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2060",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2065",
+              "title": "Microbiology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2327",
+              "title": "Instr. Exp. in Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1120",
+              "title": "Elementary Bioorganic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "General Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2310",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2315",
+              "title": "Organic Chemistry Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2320",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2325",
+              "title": "Organic Chemistry Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2040",
+              "title": "Statistics for Applied Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2015",
+              "title": "College Physics Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2210",
+              "title": "Physics for Science &amp; Engineering I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2215",
+              "title": "Physics for Sci &amp; Eng Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2020",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2025",
+              "title": "College Physics Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2220",
+              "title": "Physics for Science &amp; Engineering II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2225",
+              "title": "Physics for Sci &amp; Eng Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "1001",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "1020",
+              "title": "Scientific Foundations of Human Nutrition (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUTR",
+              "number": "2020",
+              "title": "Nutrition for the Life Cycle",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "One of the following four classes can be used as a program elective only if it has not already been used to fulfill the (SS) General Education requirement:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "Lifespan Human Growth and Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "1500",
+              "title": "Lifespan Human Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Intro to Sociology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "A maximum of 4 credits from the following can be applied toward program electives:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTEC",
+              "number": "1010",
+              "title": "Engineering Life: Fundamentals of Biotechnology (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MORT",
+              "number": "1010",
+              "title": "Introduction to Mortuary Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "1020",
+              "title": "Intro to Occupational Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1010",
+              "title": "Intro to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1010",
+              "title": "Intro to Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1010",
+              "title": "Introduction to Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Sales: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12774",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (17 credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKTG",
+              "number": "1030",
+              "title": "Introduction To Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1300",
+              "title": "Business Presentations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1480",
+              "title": "Sales",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1960",
+              "title": "Professionalism in Business (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1500",
+              "title": "Contracts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2110",
+              "title": "Interpersonal Communication (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12656",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any Written Communication (WC) course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1010",
+              "title": "Intro to Radiologic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (55 Credits)",
+          "credits_required": 55,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADS",
+              "number": "1020",
+              "title": "Rad. Anatomy &amp; Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1030",
+              "title": "Radiographic Imaging I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1040",
+              "title": "Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1050",
+              "title": "Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1110",
+              "title": "Radiation Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1120",
+              "title": "Rad. Anatomy &amp; Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1130",
+              "title": "Radiographic Imaging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1140",
+              "title": "Clinical Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1220",
+              "title": "Rad. Anatomy &amp; Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "1240",
+              "title": "Clinical Education III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2010",
+              "title": "Image Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2020",
+              "title": "Rad. Anatomy &amp; Procedures IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2030",
+              "title": "Radiographic Imaging III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2040",
+              "title": "Clinical Education IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2050",
+              "title": "Advanced Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2060",
+              "title": "Radiobiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2100",
+              "title": "Comprehensive Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2110",
+              "title": "Radiographic Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2120",
+              "title": "Sectional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADS",
+              "number": "2140",
+              "title": "Clinical Education V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12655",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (6 Credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2010",
+              "title": "Psy as a Science &amp; Profession",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "Lifespan Human Growth and Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2250",
+              "title": "Personality Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2300",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2500",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2710",
+              "title": "Brain and Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Respiratory Therapy: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12724",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any Written Communication (WC) course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1010",
+              "title": "Intermediate Algebra (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "Elementary Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1010",
+              "title": "Introduction to Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (51 Credits)",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1010",
+              "title": "Introduction to Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1300",
+              "title": "Cardiopulmonary Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1310",
+              "title": "Respiratory Physical Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1320",
+              "title": "Respiratory Therapy Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1330",
+              "title": "Respiratory Therapy Modalities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2420",
+              "title": "Human Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2425",
+              "title": "Human Physiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1400",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1420",
+              "title": "Adult Mechanical Ventilation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1430",
+              "title": "Respiratory Therapy Modalities II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1440",
+              "title": "Respiratory Therapy Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2210",
+              "title": "Advanced Cardiopulmonary Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2130",
+              "title": "Respiratory Therapy Modalities III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2140",
+              "title": "Respiratory Therapy Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2100",
+              "title": "Perinatal and Pediatric Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2220",
+              "title": "Application of Respiratory Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2240",
+              "title": "Respiratory Therapy Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Robotics Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12757",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEAM",
+              "number": "1010",
+              "title": "Essential Skills and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1050",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1205",
+              "title": "Robotics Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1210",
+              "title": "Introduction to Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1220",
+              "title": "Robot Handling Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEAM",
+              "number": "1230",
+              "title": "Robotics Vision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Small Unmanned Aerial Systems: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12751",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEOG",
+              "number": "2500",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2550",
+              "title": "Fundamentals of Drones",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2750",
+              "title": "Remote Sensing and GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2880",
+              "title": "Mapping with Drones",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2920",
+              "title": "Spatial Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social & Behavioral Sciences: AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12787",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (13 credits)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Pathways Course (1 course)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FHS",
+              "number": "1500",
+              "title": "Lifespan Human Development (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Intro to Sociology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Research Foundations Course (1 course)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "2030",
+              "title": "Research/Inquiry in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "2010",
+              "title": "Psy as a Science &amp; Profession",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2015",
+              "title": "Doing Sociology: Intro to Social Research",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (20 credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social & Behavioral Sciences: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12786",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "General Social & Behavioral Science Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "ANTHROPOLOGY (ANTH) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "ECONOMICS (ECON) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "EDUCATION (EDU) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "ENVIRONMENTAL JUSTICE STUDIES (ENVS) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "ENVS Electives (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATMO",
+              "number": "1010",
+              "title": "Severe and Hazardous Weather (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMO",
+              "number": "2100",
+              "title": "Air Pollution &amp; Atmospheric Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATMO",
+              "number": "2200",
+              "title": "Mountain Weather &amp; Climate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "Intro Conservation Biol (LS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "2200",
+              "title": "Business Communications (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CEEN",
+              "number": "1100",
+              "title": "Introduction to Civil and Environmental Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1020",
+              "title": "Principles of Public Speaking (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1130",
+              "title": "Journalism &amp; Media Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1500",
+              "title": "Media and Society (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2570",
+              "title": "Introduction to Visual Communication (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPS",
+              "number": "1000",
+              "title": "Creative Problem Solving-Pers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPS",
+              "number": "1010",
+              "title": "Creative Problem Solving-Team",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTEL",
+              "number": "1010",
+              "title": "Leadership &amp; Team Building (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEF",
+              "number": "1900",
+              "title": "Sustainable Food Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "1010",
+              "title": "Economics as a Social Science (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2010",
+              "title": "Principles of Microeconomics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGMT",
+              "number": "1040",
+              "title": "Clean Energy Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1030",
+              "title": "Writing in Professions (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1820",
+              "title": "Publication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2030",
+              "title": "Language in US Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2280",
+              "title": "Intro to Creative Nonfiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2310",
+              "title": "Intro to Digital Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2400",
+              "title": "Introduction to Ethnic Studies (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2430",
+              "title": "Chican* and Latin* Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2900",
+              "title": "Special Topics in Ethnic Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2999",
+              "title": "Ethnic Studies CLAC (Cultures and Languages Across the Curriculum)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FASH",
+              "number": "1050",
+              "title": "Fashion Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1000",
+              "title": "Earth&#039;s Environments (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1300",
+              "title": "World Geography (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1400",
+              "title": "Human Geography (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1700",
+              "title": "Natural Disasters (PS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "1800",
+              "title": "Mapping Our Changing World (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2550",
+              "title": "Fundamentals of Drones",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2800",
+              "title": "Web GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "2150",
+              "title": "Sustainable Interiors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1040",
+              "title": "Introduction to Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "1530",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1030",
+              "title": "Introduction To Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "1070",
+              "title": "Advertising &amp; Promotions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1040",
+              "title": "Intro to Statistics (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2050",
+              "title": "Ethics and Values in the Contemporary World (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1250",
+              "title": "Reasoning and Rational Decision-Making (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1100",
+              "title": "Introduction to U.S. Government &amp; Politics (AI)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1900",
+              "title": "Special Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2100",
+              "title": "Introduction to International Politics (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2300",
+              "title": "Political Ideologies (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "2700",
+              "title": "Introduction to Public Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2100",
+              "title": "Human Behavior in the Social Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Intro to Sociology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2015",
+              "title": "Doing Sociology: Intro to Social Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "2630",
+              "title": "Race and Ethnicity (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2020",
+              "title": "Public Land Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2100",
+              "title": "Land Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2160",
+              "title": "Land Boundary Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2170",
+              "title": "Land Boundary Law II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "2200",
+              "title": "Public Records",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ETHNIC STUDIES (ETHS) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "FAMILY & HUMAN STUDIES (FHS) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENDER STUDIES (GNDR) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "POLITICAL SCIENCE (POLS) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "PSYCHOLOGY (PSY) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SOCIAL JUSTICE STUDIES (SJS) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SOCIOLOGY (SOC) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SOCIAL WORK (SW) Emphasis (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12659",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (12 Credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "1010",
+              "title": "Intro to Sociology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1010",
+              "title": "General Psychology (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "1010",
+              "title": "Social Work and Social Welfare: The Profession and Institution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2100",
+              "title": "Human Behavior in the Social Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (12 Credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SW",
+              "number": "1900",
+              "title": "Independent Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2715",
+              "title": "Introduction to Dynamics of Addiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2720",
+              "title": "Case Management and Mental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2750",
+              "title": "Ethics and the Social Work Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2850",
+              "title": "Foundations of Trauma-Informed Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2890",
+              "title": "Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2900",
+              "title": "Special Topics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2910",
+              "title": "Introduction to Professional Skills for Substance Use Disorder Counseling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2935",
+              "title": "Introduction to Addictions Counseling for SUDC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2940",
+              "title": "Social Work and Behavioral Health Technician Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2950",
+              "title": "Introduction to Neurobiology of Addiction for SUDC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2990",
+              "title": "Practice for Behavioral Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2410",
+              "title": "African American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2420",
+              "title": "Asian American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2430",
+              "title": "Chican* and Latin* Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETHS",
+              "number": "2440",
+              "title": "Native American Experiences (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FHS",
+              "number": "2400",
+              "title": "Couple and Family Relationships (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "1010",
+              "title": "Introduction to Cultural Anthropology: Culture and the Human Experience (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Only one ETHS course will count towards the elective credit requirement.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Special Function Officer: Technical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12990",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TELE",
+              "number": "1010",
+              "title": "Special Function Officer",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Substance Use Disorder Counselor: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12789",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (19 Credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SW",
+              "number": "2715",
+              "title": "Introduction to Dynamics of Addiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2910",
+              "title": "Introduction to Professional Skills for Substance Use Disorder Counseling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2935",
+              "title": "Introduction to Addictions Counseling for SUDC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2950",
+              "title": "Introduction to Neurobiology of Addiction for SUDC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2960",
+              "title": "Substance Use Disorder Counselor Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2990",
+              "title": "Practice for Behavioral Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SW",
+              "number": "2850",
+              "title": "Foundations of Trauma-Informed Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2890",
+              "title": "Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sustainable Building Construction: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12557",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (11 credits)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMGT",
+              "number": "1130",
+              "title": "OSHA 30 for Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1410",
+              "title": "Construction Materials &amp; Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1450",
+              "title": "Construction Print Reading &amp; Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1660",
+              "title": "Civil Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARCH",
+              "number": "1310",
+              "title": "Intro. to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDDT",
+              "number": "1040",
+              "title": "Introduction to AutoCAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTD",
+              "number": "1450",
+              "title": "Basic CAD for Interior Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1100",
+              "title": "Construction Math (QS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1220",
+              "title": "Woodworking &amp; Millwork I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1320",
+              "title": "Building Construction I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1330",
+              "title": "Interior Finishes I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1340",
+              "title": "Cabinetmaking &amp; Renewable Materials I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "1530",
+              "title": "Furniture Design &amp; Construction I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2220",
+              "title": "Woodworking &amp; Millwork II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2320",
+              "title": "Building Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2330",
+              "title": "Interior Finishes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2340",
+              "title": "Cabinetmaking &amp; Renewable Materials II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2530",
+              "title": "Furniture Design &amp; Construction II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2710",
+              "title": "Computer Applications for Cabinetmaking &amp; Woodworking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMGT",
+              "number": "2720",
+              "title": "CNC Operations in Cabinetmaking &amp; Woodworking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "1010",
+              "title": "Introduction to Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SVT",
+              "number": "1030",
+              "title": "Surveying Field Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12768",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Selective Admissions Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any Written Communication (WC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1035",
+              "title": "Quantitative Reasoning with Integrated Algebra (QL)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "Lifespan Human Growth and Development (SS)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "1010",
+                  "title": ""
+                },
+                {
+                  "prefix": "COMM",
+                  "number": "1010",
+                  "title": "Elements of Effective Communication (CM)"
+                }
+              ]
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "2050",
+              "title": "Ethical, Social, and Legal Issues in Health Care (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses (53 Credits)",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2320",
+              "title": "Human Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2325",
+              "title": "Human Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HS",
+              "number": "1100",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1010",
+              "title": "Surgical Technology Basics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1015",
+              "title": "Surgical Technology Basics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1020",
+              "title": "Surgical Technology Principles &amp; Practices I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "1025",
+              "title": "Surgical Technology Principles and Practices II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2010",
+              "title": "Introduction to Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2015",
+              "title": "Introduction to Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2020",
+              "title": "Advanced Surgical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2025",
+              "title": "Comprehensive Surgical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2030",
+              "title": "Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2040",
+              "title": "Clinical Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SURG",
+              "number": "2050",
+              "title": "Surgical Technology Professional Preparedness",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Theatre: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12760",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (16 Credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THEA",
+              "number": "1160",
+              "title": "Technical Theatre I-Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1513",
+              "title": "Technical Theatre I-Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "2540",
+              "title": "Introduction to Stage Lighting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1190",
+              "title": "Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "2203",
+              "title": "Costume Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "2513",
+              "title": "Design for Stage and Screen",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Arts: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12663",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (17 credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THEA",
+              "number": "1033",
+              "title": "Acting I-Basic Acting (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1160",
+              "title": "Technical Theatre I-Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1190",
+              "title": "Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1223",
+              "title": "Stage Make-up",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1513",
+              "title": "Technical Theatre I-Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "1713",
+              "title": "Script Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video or Radio Production: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12534",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (45 Credits minimum)",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1130",
+              "title": "Journalism &amp; Media Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1500",
+              "title": "Media and Society (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1560",
+              "title": "Radio Performance &amp; Production (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1800",
+              "title": "Digital Media Tools/Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2000",
+              "title": "Communication CO-OP/Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2200",
+              "title": "Video Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2400",
+              "title": "Social Media Tools and Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2500",
+              "title": "Elements and Issue of Digital Media (CM)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2570",
+              "title": "Introduction to Visual Communication (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2600",
+              "title": "Production for Student Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "1515",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2110",
+              "title": "Interpersonal Communication (SS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2300",
+              "title": "Public Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2400",
+              "title": "Social Media Tools and Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1900",
+              "title": "Special Studies/ Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1310",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2440",
+              "title": "Web Site Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1520",
+              "title": "Music Composition I (Introduction to Electronic Music Composition)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1530",
+              "title": "Music Recording Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1560",
+              "title": "Music Mixing Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2250",
+              "title": "Television Studio Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2600",
+              "title": "Production for Student Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2510",
+              "title": "Documentary Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1020",
+              "title": "Principles of Public Speaking (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2050",
+              "title": "Perspectives in Communication (HU)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2150",
+              "title": "Intercultural Communication (CM)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Art & Design - Animation: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12665",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (17 credits)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1620",
+              "title": "Intro to Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1630",
+              "title": "Computer Graphics Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1670",
+              "title": "Character Animation Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2630",
+              "title": "3D Modeling &amp; Sculpting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2640",
+              "title": "3D Animation &amp; Rigging",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1110",
+              "title": "Foundation I Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1260",
+              "title": "Figure Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1660",
+              "title": "Storyboarding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1680",
+              "title": "Game Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2110",
+              "title": "Foundation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2260",
+              "title": "Advanced Figure Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2480",
+              "title": "Digital Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSIS",
+              "number": "1350",
+              "title": "Apps and Applets: an Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Fundamentals of Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1410",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives (4 credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Art & Design - Fine Arts: AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12792",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (26 Credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1110",
+              "title": "Foundation I Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1130",
+              "title": "3D Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1260",
+              "title": "Figure Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1310",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2110",
+              "title": "Foundation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2520",
+              "title": "Advanced Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2540",
+              "title": "Advanced Painting - Oil",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (7 credits)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1070",
+              "title": "Creative Printmaking (AR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1240",
+              "title": "Screen Printing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1250",
+              "title": "Airbrush",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1530",
+              "title": "Beginning Painting-Watercolor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1540",
+              "title": "Beginning Painting-Oil",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1560",
+              "title": "Head Studies-Portrait Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1580",
+              "title": "Landscape Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2210",
+              "title": "Illustration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2260",
+              "title": "Advanced Figure Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2480",
+              "title": "Digital Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2530",
+              "title": "Advanced Painting - Watercolor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2560",
+              "title": "Figure Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2200",
+              "title": "Video Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Visual Art & Design - Motion Graphics: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12676",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (20 Credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1110",
+              "title": "Foundation I Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1620",
+              "title": "Intro to Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1630",
+              "title": "Computer Graphics Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1660",
+              "title": "Storyboarding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2620",
+              "title": "Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2640",
+              "title": "3D Animation &amp; Rigging",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Web Graphic Design: Academic Certificate",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12677",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (26 Credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1200",
+              "title": "InDesign Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1230",
+              "title": "Typography &amp; Layout",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1630",
+              "title": "Computer Graphics Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2440",
+              "title": "Web Site Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2490",
+              "title": "Animation, Game &amp; Web Design Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2580",
+              "title": "Interactive Design &amp; Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2550",
+              "title": "User Interface Design (UI Design)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses (3 Credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Welding Fabrication & Inspection: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12678",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (54 Credits)",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First complete the Welding Technology Technical Certificate (27 credits), then complete the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "2260",
+              "title": "Industrial Blueprint and CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2234",
+              "title": "Automated Welding and Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2235",
+              "title": "Automated Welding and Fabrication Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2236",
+              "title": "Advanced Welding and Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2237",
+              "title": "Advanced Welding and Fabrication Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2244",
+              "title": "Combination Plate Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2245",
+              "title": "Combination Plate Welding Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2246",
+              "title": "Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "2247",
+              "title": "Pipe Welding Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Visual Art: AAS",
+      "credential": "AAS",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12670",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses for All Emphases (14 credits)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1110",
+              "title": "Foundation I Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1120",
+              "title": "Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1150",
+              "title": "Art Foundation Seminar (HR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1280",
+              "title": "Photoshop Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1310",
+              "title": "Photography 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Welding Technology: Technical Certificate (SL Tech)",
+      "credential": "certificate",
+      "program_code": "CTE",
+      "catalog_url": "https://catalog.slcc.edu/preview_program.php?catoid=28&poid=12628",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Required Courses (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEWT",
+              "number": "1000",
+              "title": "Introduction to Welding and Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1010",
+              "title": "Measurement Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1020",
+              "title": "Welding Symbols and Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1040",
+              "title": "Welding Inspection and Welding Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1111",
+              "title": "Shielded Metal Arc Welding (SMAW) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1112",
+              "title": "Shielded Metal Arc Welding (SMAW) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1133",
+              "title": "Shielded Metal Arc Welding (SMAW) III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1211",
+              "title": "Gas Tungsten Arc Welding (GTAW) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1212",
+              "title": "Gas Tungsten Arc Welding (GTAW) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1311",
+              "title": "Gas Metal Arc Welding (GMAW) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1312",
+              "title": "Gas Metal Arc Welding (GMAW) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1333",
+              "title": "Gas Metal Arc Welding (GMAW) III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1365",
+              "title": "Related Machining Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1411",
+              "title": "Flux Cored Arc Welding (FCAW) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1412",
+              "title": "Flux Cored Arc Welding (FCAW) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1430",
+              "title": "Flux Cored Arc Welding (FCAW) III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Program Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEWT",
+              "number": "1055",
+              "title": "Oxy Fuel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/ut/programs/snow-college.json
+++ b/data/ut/programs/snow-college.json
@@ -2,7 +2,7 @@
   "college_slug": "snow-college",
   "catalog_year": "",
   "catalog_url": "https://catalog.snow.edu/programs/",
-  "scraped_at": "2026-05-28T22:04:07.903Z",
+  "scraped_at": "2026-05-29T19:32:11.198Z",
   "programs": [
     {
       "title": "Accounting (AS) — Certificate",
@@ -52,67 +52,6 @@
       "matched_program_slug": "accounting"
     },
     {
-      "title": "Advanced Networking and Cybersecurity (Certificate) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/advanced-networking-cer/",
-      "total_credits": 20,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": 20,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "CIS",
-              "number": "1600",
-              "title": "Introduction to Networks",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CIS",
-              "number": "1605",
-              "title": "Switching, Routing, and Wireless Essentials",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CIS",
-              "number": "2320",
-              "title": "Penetration Test Fundamentals",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CIS",
-              "number": "2410",
-              "title": "Cybersecurity System Analyst",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CIS",
-              "number": "2600",
-              "title": "Scaling Networks in the Enterprise",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CIS",
-              "number": "2605",
-              "title": "Wide Area Networking Fundamentals",
-              "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "computer-science"
-    },
-    {
       "title": "Advanced Emergency Medical Technician (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -131,6 +70,74 @@
               "number": "1200",
               "title": "AEMT - Advanced Emergency Medical Technician",
               "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agribusiness (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/agribusiness-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGBS",
+              "number": "1010",
+              "title": "Fundamentals of Animal Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "1200",
+              "title": "Agribusiness Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "2020",
+              "title": "Introduction to Agricultural Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1060",
+              "title": "QuickBooks for Small Business",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "2010",
+              "title": "Financial Accounting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "2030",
+              "title": "Managerial Analysis & Decision Making",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "1830",
+              "title": "Agriculture Computer Applications and Direct Marketing",
+              "credits": 0,
               "or_alternatives": []
             }
           ]
@@ -340,72 +347,65 @@
       "matched_program_slug": null
     },
     {
-      "title": "Agribusiness (AS) — Certificate",
+      "title": "Advanced Networking and Cybersecurity (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/agribusiness-as/",
-      "total_credits": null,
+      "catalog_url": "https://catalog.snow.edu/programs/advanced-networking-cer/",
+      "total_credits": 20,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
         {
           "name": "Recommended Course Sequence",
-          "credits_required": null,
+          "credits_required": 20,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "AGBS",
-              "number": "1010",
-              "title": "Fundamentals of Animal Science",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "1200",
-              "title": "Agribusiness Foundations",
+              "prefix": "CIS",
+              "number": "1600",
+              "title": "Introduction to Networks",
               "credits": 3,
               "or_alternatives": []
             },
             {
-              "prefix": "AGBS",
-              "number": "2020",
-              "title": "Introduction to Agricultural Economics",
-              "credits": 0,
+              "prefix": "CIS",
+              "number": "1605",
+              "title": "Switching, Routing, and Wireless Essentials",
+              "credits": 3,
               "or_alternatives": []
             },
             {
-              "prefix": "BUS",
-              "number": "1060",
-              "title": "QuickBooks for Small Business",
-              "credits": 0,
+              "prefix": "CIS",
+              "number": "2320",
+              "title": "Penetration Test Fundamentals",
+              "credits": 4,
               "or_alternatives": []
             },
             {
-              "prefix": "ACCT",
-              "number": "2010",
-              "title": "Financial Accounting",
-              "credits": 0,
+              "prefix": "CIS",
+              "number": "2410",
+              "title": "Cybersecurity System Analyst",
+              "credits": 4,
               "or_alternatives": []
             },
             {
-              "prefix": "AGBS",
-              "number": "2030",
-              "title": "Managerial Analysis & Decision Making",
-              "credits": 0,
+              "prefix": "CIS",
+              "number": "2600",
+              "title": "Scaling Networks in the Enterprise",
+              "credits": 3,
               "or_alternatives": []
             },
             {
-              "prefix": "AGBS",
-              "number": "1830",
-              "title": "Agriculture Computer Applications and Direct Marketing",
-              "credits": 0,
+              "prefix": "CIS",
+              "number": "2605",
+              "title": "Wide Area Networking Fundamentals",
+              "credits": 3,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "computer-science"
     },
     {
       "title": "Agribusiness (AAS) — Associate of Science",
@@ -1150,32 +1150,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Business (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/business-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "BUS",
-              "number": "1010",
-              "title": "Introduction to Business",
-              "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
       "title": "Biology (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -1221,6 +1195,32 @@
         }
       ],
       "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/business-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "1010",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
     },
     {
       "title": "Business (ASB) — Associate of Science",
@@ -1591,60 +1591,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Chemical Engineering (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/chemical-engineering-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "CHEM",
-              "number": "1210",
-              "title": "Principles of Chemistry I PS",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1215",
-              "title": "Principles of Chemistry Lab I",
-              "credits": 1,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1220",
-              "title": "Principles of Chemistry II PS",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1225",
-              "title": "Principles of Chemistry Lab II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MATH",
-              "number": "1210",
-              "title": "Calculus I",
-              "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "engineering"
-    },
-    {
       "title": "Chemistry (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -1704,6 +1650,67 @@
         }
       ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Child Development (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/child-development-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HFST",
+              "number": "1500",
+              "title": "Human Development SS (same as PSY 1100)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "2500",
+              "title": "Early Childhood Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "2610",
+              "title": "Guidance of Young Children",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "2400",
+              "title": "Family Relations SS",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "2620",
+              "title": "Creative Experiences for Children",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "2120",
+              "title": "Foods & Nutrition for Children",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
     },
     {
       "title": "Childcare Management (AAS) — Associate of Science",
@@ -1893,10 +1900,10 @@
       "matched_program_slug": "business-administration"
     },
     {
-      "title": "Child Development (AS) — Certificate",
+      "title": "Chemical Engineering (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/child-development-as/",
+      "catalog_url": "https://catalog.snow.edu/programs/chemical-engineering-as/",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -1907,51 +1914,44 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "HFST",
-              "number": "1500",
-              "title": "Human Development SS (same as PSY 1100)",
-              "credits": 3,
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "Principles of Chemistry I PS",
+              "credits": 4,
               "or_alternatives": []
             },
             {
-              "prefix": "HFST",
-              "number": "2500",
-              "title": "Early Childhood Development",
-              "credits": 3,
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "Principles of Chemistry Lab I",
+              "credits": 1,
               "or_alternatives": []
             },
             {
-              "prefix": "HFST",
-              "number": "2610",
-              "title": "Guidance of Young Children",
+              "prefix": "CHEM",
+              "number": "1220",
+              "title": "Principles of Chemistry II PS",
               "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "HFST",
-              "number": "2400",
-              "title": "Family Relations SS",
+              "prefix": "CHEM",
+              "number": "1225",
+              "title": "Principles of Chemistry Lab II",
               "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "HFST",
-              "number": "2620",
-              "title": "Creative Experiences for Children",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HFST",
-              "number": "2120",
-              "title": "Foods & Nutrition for Children",
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I",
               "credits": 0,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "early-childhood-education"
+      "matched_program_slug": "engineering"
     },
     {
       "title": "Civil and Environmental Engineering (AS) — Certificate",
@@ -2683,6 +2683,74 @@
       "matched_program_slug": "business-administration"
     },
     {
+      "title": "Construction Technology (Certificate) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/construction-technology-cer/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TECO",
+              "number": "1030",
+              "title": "Construction Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECO",
+              "number": "1040",
+              "title": "Advanced Carpentry Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECO",
+              "number": "1050",
+              "title": "Interior Finishes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECO",
+              "number": "1060",
+              "title": "Exterior Finishes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECO",
+              "number": "1205",
+              "title": "Cabinet Making",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECO",
+              "number": "1405",
+              "title": "Introduction to Woodworking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECO",
+              "number": "1440",
+              "title": "Fundamentals of Fine Woodworking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Cosmetology (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -2798,74 +2866,6 @@
               "prefix": "TECS",
               "number": "2950",
               "title": "Cosmetology/Hair Design/Barbering Advanced Theory and Practice",
-              "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Construction Technology (Certificate) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/construction-technology-cer/",
-      "total_credits": 30,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": 30,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "TECO",
-              "number": "1030",
-              "title": "Construction Print Reading",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TECO",
-              "number": "1040",
-              "title": "Advanced Carpentry Concepts",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TECO",
-              "number": "1050",
-              "title": "Interior Finishes",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TECO",
-              "number": "1060",
-              "title": "Exterior Finishes",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TECO",
-              "number": "1205",
-              "title": "Cabinet Making",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TECO",
-              "number": "1405",
-              "title": "Introduction to Woodworking",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TECO",
-              "number": "1440",
-              "title": "Fundamentals of Fine Woodworking",
               "credits": 3,
               "or_alternatives": []
             }
@@ -4096,6 +4096,53 @@
       "matched_program_slug": "business-administration"
     },
     {
+      "title": "Family & Consumer Science Education (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/family-consumer-science-educ-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HFST",
+              "number": "1140",
+              "title": "Introductory Sewing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "1240",
+              "title": "Introductory Foods",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFST",
+              "number": "1245",
+              "title": "Introductory Foods Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "1210",
+              "title": "Personal & Consumer Finance SS",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Exercise Science (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -4156,53 +4203,6 @@
               "number": "2425",
               "title": "Human Physiology Lab",
               "credits": 1,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Family & Consumer Science Education (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/family-consumer-science-educ-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "HFST",
-              "number": "1140",
-              "title": "Introductory Sewing",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HFST",
-              "number": "1240",
-              "title": "Introductory Foods",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "HFST",
-              "number": "1245",
-              "title": "Introductory Foods Lab",
-              "credits": 1,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUS",
-              "number": "1210",
-              "title": "Personal & Consumer Finance SS",
-              "credits": 0,
               "or_alternatives": []
             }
           ]
@@ -4663,60 +4663,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Geology (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/geology-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "GEO",
-              "number": "1010",
-              "title": "Survey of Geology PSand Survey of Geology Lab LB",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "GEO",
-              "number": "1110",
-              "title": "Physical Geology PSand Physical Geology Lab LB",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "GEO",
-              "number": "1220",
-              "title": "Historical Geologyand Historical Geology Lab",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1210",
-              "title": "Principles of Chemistry I PS",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "MATH",
-              "number": "1210",
-              "title": "Calculus I",
-              "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Health Professions (AS Meta-Major) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -4825,10 +4771,10 @@
       "matched_program_slug": "history"
     },
     {
-      "title": "Humanities (AA Meta-Major) — Certificate",
+      "title": "Geology (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/humanities-aa/",
+      "catalog_url": "https://catalog.snow.edu/programs/geology-as/",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -4839,72 +4785,37 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ARTH",
-              "number": "2710",
-              "title": "Art History Survey I",
+              "prefix": "GEO",
+              "number": "1010",
+              "title": "Survey of Geology PSand Survey of Geology Lab LB",
               "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "ARTH",
-              "number": "2720",
-              "title": "Art History Survey II",
+              "prefix": "GEO",
+              "number": "1110",
+              "title": "Physical Geology PSand Physical Geology Lab LB",
               "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "ENGL",
-              "number": "2510",
-              "title": "American Literature I HU",
+              "prefix": "GEO",
+              "number": "1220",
+              "title": "Historical Geologyand Historical Geology Lab",
               "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "ENGL",
-              "number": "2520",
-              "title": "American Literature II HU",
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "Principles of Chemistry I PS",
               "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "ENGL",
-              "number": "2610",
-              "title": "British Literature I HU",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ENGL",
-              "number": "2620",
-              "title": "British Literature II HU",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ENGL",
-              "number": "2700",
-              "title": "Introduction to Critical Literature/Theory",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "PHIL",
-              "number": "1000",
-              "title": "Introduction to Philosophy HU",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "PHIL",
-              "number": "1250",
-              "title": "Reasoning and Rational Decision-Making HU",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "PHIL",
-              "number": "2050",
-              "title": "Ethics and Values HU",
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I",
               "credits": 0,
               "or_alternatives": []
             }
@@ -5038,6 +4949,95 @@
       "matched_program_slug": null
     },
     {
+      "title": "Humanities (AA Meta-Major) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/humanities-aa/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTH",
+              "number": "2710",
+              "title": "Art History Survey I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "2720",
+              "title": "Art History Survey II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2510",
+              "title": "American Literature I HU",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2520",
+              "title": "American Literature II HU",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2610",
+              "title": "British Literature I HU",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2620",
+              "title": "British Literature II HU",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2700",
+              "title": "Introduction to Critical Literature/Theory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1000",
+              "title": "Introduction to Philosophy HU",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1250",
+              "title": "Reasoning and Rational Decision-Making HU",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "2050",
+              "title": "Ethics and Values HU",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "HVACR Technician (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -5112,74 +5112,6 @@
               "number": "2500",
               "title": "Sheet Metal",
               "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Industrial Technology (AAS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/industrial-technology-aas/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "BUS",
-              "number": "1170",
-              "title": "Human Relations in Organizations SS",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AT",
-              "number": "1715",
-              "title": "Applied Technical Math",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUS",
-              "number": "1010",
-              "title": "Introduction to Business",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUS",
-              "number": "1020",
-              "title": "Computer Technology and Applications",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUS",
-              "number": "1060",
-              "title": "QuickBooks for Small Business",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUS",
-              "number": "1270",
-              "title": "Strategic Selling IE",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BUS",
-              "number": "1300",
-              "title": "Social Media Marketing",
-              "credits": 0,
               "or_alternatives": []
             }
           ]
@@ -5270,87 +5202,66 @@
       "matched_program_slug": "computer-science"
     },
     {
-      "title": "Machining Technology (Certificate) — Certificate",
+      "title": "Industrial Technology (AAS) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/machining-technology-cer/",
-      "total_credits": 30,
+      "catalog_url": "https://catalog.snow.edu/programs/industrial-technology-aas/",
+      "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
         {
           "name": "Recommended Course Sequence",
-          "credits_required": 30,
+          "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "TEMT",
-              "number": "1000",
-              "title": "Manufacturing Fundamentals",
-              "credits": 3,
+              "prefix": "BUS",
+              "number": "1170",
+              "title": "Human Relations in Organizations SS",
+              "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "TEMT",
-              "number": "1100",
-              "title": "Mill Concepts",
-              "credits": 3,
+              "prefix": "AT",
+              "number": "1715",
+              "title": "Applied Technical Math",
+              "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "TEMT",
-              "number": "1150",
-              "title": "CNC Mill Concepts",
-              "credits": 3,
+              "prefix": "BUS",
+              "number": "1010",
+              "title": "Introduction to Business",
+              "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "TEMT",
-              "number": "1200",
-              "title": "Lathe Concepts",
-              "credits": 3,
+              "prefix": "BUS",
+              "number": "1020",
+              "title": "Computer Technology and Applications",
+              "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "TEMT",
-              "number": "1250",
-              "title": "CNC Lathe Concepts",
-              "credits": 3,
+              "prefix": "BUS",
+              "number": "1060",
+              "title": "QuickBooks for Small Business",
+              "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "TEMT",
+              "prefix": "BUS",
+              "number": "1270",
+              "title": "Strategic Selling IE",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
               "number": "1300",
-              "title": "CNC Mill Programming",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEMT",
-              "number": "1350",
-              "title": "CNC Lathe Programming",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEMT",
-              "number": "1565",
-              "title": "Advanced Print Reading",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEMT",
-              "number": "2000",
-              "title": "Process Control",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEMT",
-              "number": "2300",
-              "title": "Multi-Axis",
-              "credits": 3,
+              "title": "Social Media Marketing",
+              "credits": 0,
               "or_alternatives": []
             }
           ]
@@ -5584,44 +5495,93 @@
       "matched_program_slug": "business-administration"
     },
     {
-      "title": "Mathematics (AS) — Certificate",
+      "title": "Machining Technology (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/mathematics-as/",
-      "total_credits": null,
+      "catalog_url": "https://catalog.snow.edu/programs/machining-technology-cer/",
+      "total_credits": 30,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
         {
           "name": "Recommended Course Sequence",
-          "credits_required": null,
+          "credits_required": 30,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "MATH",
-              "number": "1210",
-              "title": "Calculus I",
-              "credits": 5,
+              "prefix": "TEMT",
+              "number": "1000",
+              "title": "Manufacturing Fundamentals",
+              "credits": 3,
               "or_alternatives": []
             },
             {
-              "prefix": "MATH",
-              "number": "1220",
-              "title": "Calculus II",
-              "credits": 0,
+              "prefix": "TEMT",
+              "number": "1100",
+              "title": "Mill Concepts",
+              "credits": 3,
               "or_alternatives": []
             },
             {
-              "prefix": "MATH",
-              "number": "2270",
-              "title": "Linear Algebra",
-              "credits": 0,
+              "prefix": "TEMT",
+              "number": "1150",
+              "title": "CNC Mill Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1200",
+              "title": "Lathe Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1250",
+              "title": "CNC Lathe Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1300",
+              "title": "CNC Mill Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1350",
+              "title": "CNC Lathe Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "1565",
+              "title": "Advanced Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "2000",
+              "title": "Process Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEMT",
+              "number": "2300",
+              "title": "Multi-Axis",
+              "credits": 3,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "mathematics"
+      "matched_program_slug": null
     },
     {
       "title": "Mechanical and Industrial Engineering (AS) — Certificate",
@@ -5664,10 +5624,10 @@
       "matched_program_slug": "engineering"
     },
     {
-      "title": "Music (AS) — Certificate",
+      "title": "Mathematics (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/music-as/",
+      "catalog_url": "https://catalog.snow.edu/programs/mathematics-as/",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -5678,23 +5638,30 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "MUSC",
-              "number": "1110",
-              "title": "Music Theory I",
-              "credits": 3,
+              "prefix": "MATH",
+              "number": "1210",
+              "title": "Calculus I",
+              "credits": 5,
               "or_alternatives": []
             },
             {
-              "prefix": "MUSC",
-              "number": "1130",
-              "title": "Sight Singing/Ear Training I",
-              "credits": 1,
+              "prefix": "MATH",
+              "number": "1220",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2270",
+              "title": "Linear Algebra",
+              "credits": 0,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Medical Assisant (Certificate) — Certificate",
@@ -5799,6 +5766,86 @@
               "number": "1910",
               "title": "Medical Assistant Externship II",
               "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/music-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUSC",
+              "number": "1110",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "1130",
+              "title": "Sight Singing/Ear Training I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nail Technician (Certificate) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/nail-technology-cer/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TENT",
+              "number": "1110",
+              "title": "Nail Technician I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TENT",
+              "number": "1200",
+              "title": "Nail Technician II Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TENT",
+              "number": "1600",
+              "title": "Advanced Techniques Class/Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TENT",
+              "number": "1610",
+              "title": "Nail Technician Business Basics",
+              "credits": 1,
               "or_alternatives": []
             }
           ]
@@ -6064,45 +6111,45 @@
       "matched_program_slug": null
     },
     {
-      "title": "Nail Technician (Certificate) — Certificate",
+      "title": "Natural Resources (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/nail-technology-cer/",
-      "total_credits": 9,
+      "catalog_url": "https://catalog.snow.edu/programs/natural-resources-as/",
+      "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
         {
           "name": "Recommended Course Sequence",
-          "credits_required": 9,
+          "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "TENT",
-              "number": "1110",
-              "title": "Nail Technician I",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TENT",
-              "number": "1200",
-              "title": "Nail Technician II Clinical",
+              "prefix": "NR",
+              "number": "1010",
+              "title": "Introduction to Natural Resources",
               "credits": 2,
               "or_alternatives": []
             },
             {
-              "prefix": "TENT",
-              "number": "1600",
-              "title": "Advanced Techniques Class/Lab",
-              "credits": 2,
+              "prefix": "BIOL",
+              "number": "1010",
+              "title": "General Biology LSand General Biology Lab LB",
+              "credits": 0,
               "or_alternatives": []
             },
             {
-              "prefix": "TENT",
+              "prefix": "BIOL",
+              "number": "1420",
+              "title": "Environmental Biology LSand Environmental Biology Lab LB",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
               "number": "1610",
-              "title": "Nail Technician Business Basics",
-              "credits": 1,
+              "title": "Biology I LSand Biology I Laboratory LB",
+              "credits": 0,
               "or_alternatives": []
             }
           ]
@@ -6345,79 +6392,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Natural Resources (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/natural-resources-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "NR",
-              "number": "1010",
-              "title": "Introduction to Natural Resources",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BIOL",
-              "number": "1010",
-              "title": "General Biology LSand General Biology Lab LB",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BIOL",
-              "number": "1420",
-              "title": "Environmental Biology LSand Environmental Biology Lab LB",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BIOL",
-              "number": "1610",
-              "title": "Biology I LSand Biology I Laboratory LB",
-              "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Networking and Cybersecurity (AAS) — Associate of Science",
-      "credential": "AS",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/networking-cybersecurity-aas/",
-      "total_credits": 60,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": 60,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "MATH",
-              "number": "1050",
-              "title": "College Algebra MA",
-              "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "computer-science"
-    },
-    {
       "title": "Networking and Cybersecurity (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -6457,6 +6431,32 @@
               "number": "2310",
               "title": "Cybersecurity Essentials",
               "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Networking and Cybersecurity (AAS) — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/networking-cybersecurity-aas/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1050",
+              "title": "College Algebra MA",
+              "credits": 0,
               "or_alternatives": []
             }
           ]
@@ -6856,6 +6856,46 @@
       "matched_program_slug": null
     },
     {
+      "title": "Outdoor Leadership and Entrepreneurship (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/outdoor-leadershipentrepren-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OLE",
+              "number": "1000",
+              "title": "Introduction to Outdoor Leadership SS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLE",
+              "number": "1010",
+              "title": "Outdoor Leadership Business & Careers IE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLE",
+              "number": "2000",
+              "title": "Outdoor Skills IE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Outdoor Leadership (Certificate) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -6937,46 +6977,6 @@
               "number": "2750",
               "title": "River/Water Technical Leadership",
               "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Outdoor Leadership and Entrepreneurship (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/outdoor-leadershipentrepren-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "OLE",
-              "number": "1000",
-              "title": "Introduction to Outdoor Leadership SS",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "OLE",
-              "number": "1010",
-              "title": "Outdoor Leadership Business & Careers IE",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "OLE",
-              "number": "2000",
-              "title": "Outdoor Skills IE",
-              "credits": 3,
               "or_alternatives": []
             }
           ]
@@ -7224,6 +7224,39 @@
       "matched_program_slug": null
     },
     {
+      "title": "Phlebotomy (Certificate) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/phlebotomy-cer/",
+      "total_credits": 3,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEPH",
+              "number": "1010",
+              "title": "Phlebotomy I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEPH",
+              "number": "1020",
+              "title": "Phlebotomy II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Physical Education Teaching (AS) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -7256,39 +7289,6 @@
               "number": "1020",
               "title": "Scientific Foundations of Nutrition LS",
               "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Phlebotomy (Certificate) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/phlebotomy-cer/",
-      "total_credits": 3,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "TEPH",
-              "number": "1010",
-              "title": "Phlebotomy I",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEPH",
-              "number": "1020",
-              "title": "Phlebotomy II",
-              "credits": 1,
               "or_alternatives": []
             }
           ]
@@ -7574,6 +7574,177 @@
       "matched_program_slug": null
     },
     {
+      "title": "Precision Agriculture (Certificate) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/precision-agriculture-cer/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGTM",
+              "number": "2900",
+              "title": "Farm Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "1997",
+              "title": "Agriculture Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGTM",
+              "number": "1210",
+              "title": "Small Engines Power Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGTM",
+              "number": "1000",
+              "title": "Introduction to Plant Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGTM",
+              "number": "1050",
+              "title": "Farm Machinery Maintenance, Management and Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGTM",
+              "number": "1330",
+              "title": "Agricultural Chemicals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "1830",
+              "title": "Agriculture Computer Applications and Direct Marketing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGTM",
+              "number": "2600",
+              "title": "Drones in Agriculture and Associated Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "2020",
+              "title": "Introduction to Agricultural Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "2030",
+              "title": "Managerial Analysis & Decision Making",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGTM",
+              "number": "2500",
+              "title": "Irrigation Systems Equipment Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Veterinary (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/preveterinary-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1610",
+              "title": "Biology I LS",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1615",
+              "title": "Biology I Laboratory LB",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "2200",
+              "title": "Anatomy & Physiology of Domestic Animals IE",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGBS",
+              "number": "2205",
+              "title": "Anatomy & Physiology of Domestic Animals Lab IE",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "Elementary Chemistry PS",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1115",
+              "title": "Elementary Chemistry Lab LB",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1210",
+              "title": "Principles of Chemistry I PS",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1215",
+              "title": "Principles of Chemistry Lab I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Pre-Engineering (APE) — Associate of Science",
       "credential": "AS",
       "program_code": null,
@@ -7850,177 +8021,6 @@
         }
       ],
       "matched_program_slug": "engineering"
-    },
-    {
-      "title": "Precision Agriculture (Certificate) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/precision-agriculture-cer/",
-      "total_credits": 28,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": 28,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "AGTM",
-              "number": "2900",
-              "title": "Farm Safety",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "1997",
-              "title": "Agriculture Internship I",
-              "credits": 1,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGTM",
-              "number": "1210",
-              "title": "Small Engines Power Systems",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGTM",
-              "number": "1000",
-              "title": "Introduction to Plant Science",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGTM",
-              "number": "1050",
-              "title": "Farm Machinery Maintenance, Management and Operation",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGTM",
-              "number": "1330",
-              "title": "Agricultural Chemicals and Applications",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "1830",
-              "title": "Agriculture Computer Applications and Direct Marketing",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGTM",
-              "number": "2600",
-              "title": "Drones in Agriculture and Associated Computer Applications",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "2020",
-              "title": "Introduction to Agricultural Economics",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "2030",
-              "title": "Managerial Analysis & Decision Making",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGTM",
-              "number": "2500",
-              "title": "Irrigation Systems Equipment Maintenance and Repair",
-              "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Pre-Veterinary (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/preveterinary-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "BIOL",
-              "number": "1610",
-              "title": "Biology I LS",
-              "credits": 4,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "BIOL",
-              "number": "1615",
-              "title": "Biology I Laboratory LB",
-              "credits": 1,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "2200",
-              "title": "Anatomy & Physiology of Domestic Animals IE",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "AGBS",
-              "number": "2205",
-              "title": "Anatomy & Physiology of Domestic Animals Lab IE",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1110",
-              "title": "Elementary Chemistry PS",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1115",
-              "title": "Elementary Chemistry Lab LB",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1210",
-              "title": "Principles of Chemistry I PS",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "CHEM",
-              "number": "1215",
-              "title": "Principles of Chemistry Lab I",
-              "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
     },
     {
       "title": "Psychology (AS) — Certificate",
@@ -8547,46 +8547,6 @@
       "matched_program_slug": "business-administration"
     },
     {
-      "title": "Social Work (AS) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/social-work-as/",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "SW",
-              "number": "1010",
-              "title": "Social Work as a Profession",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "SW",
-              "number": "2100",
-              "title": "Understanding Human Behavior and the Social Environment",
-              "credits": 3,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "SW",
-              "number": "2400",
-              "title": "Diverse Populations",
-              "credits": 3,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Social Sciences (AS Meta-Major) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -8674,6 +8634,46 @@
               "prefix": "POLS",
               "number": "2100",
               "title": "Introduction to International Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work (AS) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/social-work-as/",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SW",
+              "number": "1010",
+              "title": "Social Work as a Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2100",
+              "title": "Understanding Human Behavior and the Social Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "2400",
+              "title": "Diverse Populations",
               "credits": 3,
               "or_alternatives": []
             }
@@ -9442,179 +9442,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Welding Technology (Certificate) — Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.snow.edu/programs/welding-technology-cer/",
-      "total_credits": 30,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Recommended Course Sequence",
-          "credits_required": 30,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "TEWT",
-              "number": "1000",
-              "title": "Introduction to Welding and Cutting",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1010",
-              "title": "Measurement Systems",
-              "credits": 1,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1111",
-              "title": "Shielded Metal Arc Welding (SMAW) I",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1112",
-              "title": "Shielded Metal Arc Welding (SMAW) II",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1211",
-              "title": "Gas Tungsten Arc Welding (GTAW) I",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1212",
-              "title": "Gas Tungsten Arc Welding (GTAW) II",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1311",
-              "title": "Gas Metal Arc Welding (GMAW) I",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1411",
-              "title": "Flux Cored Arc Welding (FCAW) I",
-              "credits": 2,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1020",
-              "title": "Welding Symbols/Print Reading",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1070",
-              "title": "Weld Inspection & Testing",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1312",
-              "title": "Gas Metal Arc Welding (GMAW) II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1412",
-              "title": "Flux Cored Arc Welding (FCAW) II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1610",
-              "title": "Metal Fabrication I",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "1615",
-              "title": "Metal Fabrication II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2100",
-              "title": "Specialized Shielded Metal Arc Welding (SMAW) I",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2110",
-              "title": "Specialized Shielded Metal Arc Welding (SMAW) II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2200",
-              "title": "Specialized Gas Tungsten Arc Welding (GTAW) I",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2210",
-              "title": "Specialized Gas Tungsten Arc Welding (GTAW) II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2300",
-              "title": "Specialized Gas Metal Arc Welding (GMAW) I",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2310",
-              "title": "Specialized Gas Metal Arc Welding (GMAW) II",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2400",
-              "title": "Specialized Flux Cored Arc Welding (FCAW) I",
-              "credits": 0,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "TEWT",
-              "number": "2410",
-              "title": "Specialized Flux Cored Welding (FCAW) II",
-              "credits": 0,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "welding"
-    },
-    {
       "title": "Visual and Performing Arts (AS Meta-Majors) — Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -9994,6 +9821,179 @@
         }
       ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology (Certificate) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.snow.edu/programs/welding-technology-cer/",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEWT",
+              "number": "1000",
+              "title": "Introduction to Welding and Cutting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1010",
+              "title": "Measurement Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1111",
+              "title": "Shielded Metal Arc Welding (SMAW) I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1112",
+              "title": "Shielded Metal Arc Welding (SMAW) II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1211",
+              "title": "Gas Tungsten Arc Welding (GTAW) I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1212",
+              "title": "Gas Tungsten Arc Welding (GTAW) II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1311",
+              "title": "Gas Metal Arc Welding (GMAW) I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1411",
+              "title": "Flux Cored Arc Welding (FCAW) I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1020",
+              "title": "Welding Symbols/Print Reading",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1070",
+              "title": "Weld Inspection & Testing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1312",
+              "title": "Gas Metal Arc Welding (GMAW) II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1412",
+              "title": "Flux Cored Arc Welding (FCAW) II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1610",
+              "title": "Metal Fabrication I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "1615",
+              "title": "Metal Fabrication II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2100",
+              "title": "Specialized Shielded Metal Arc Welding (SMAW) I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2110",
+              "title": "Specialized Shielded Metal Arc Welding (SMAW) II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2200",
+              "title": "Specialized Gas Tungsten Arc Welding (GTAW) I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2210",
+              "title": "Specialized Gas Tungsten Arc Welding (GTAW) II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2300",
+              "title": "Specialized Gas Metal Arc Welding (GMAW) I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2310",
+              "title": "Specialized Gas Metal Arc Welding (GMAW) II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2400",
+              "title": "Specialized Flux Cored Arc Welding (FCAW) I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEWT",
+              "number": "2410",
+              "title": "Specialized Flux Cored Welding (FCAW) II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
     },
     {
       "title": "Writing and Rhetoric (Certificate) — Certificate",

--- a/lib/states/ut/config.ts
+++ b/lib/states/ut/config.ts
@@ -60,18 +60,14 @@ const utConfig: StateConfig = {
     //   tools at transferut.com but they don't expose a public API; see
     //   the manual TODOs in the PR description for the fallback path.
     prereqs: { source: "aggregate-from-courses" },
-    // programs — Snow College's CourseLeaf catalog scraped via
-    //   scripts/ut/scrape-programs.ts (119 programs across 7 award
-    //   types). SLCC's catalog platform was not detected by the
-    //   Phase-6 probe and remains in the documentedCeilings.programs
-    //   gap below.
+    // programs — Snow College (CourseLeaf) + Salt Lake Community
+    //   College (Acalog) both scraped via scripts/ut/scrape-programs.ts.
+    //   119 Snow programs + 132 SLCC programs.
     programs: [{ scripts: ["scripts/ut/scrape-programs.ts"], runner: "http" }],
   },
   documentedCeilings: {
     transfers:
       "Utah's transfer portal (transferut.com) doesn't expose a public API. SLCC and Snow publish individual course-equivalency tables on their registrar sites but these are not machine-readable. Tracking as a known ceiling rather than substituting placeholder data.",
-    programs:
-      "Salt Lake Community College's catalog platform was not detected by the Phase-6 auto-discovery probe (acalog / courseleaf / smartcatalogiq / coursedog / cleancatalog all returned no match across the 5 candidate URLs). Snow College's CourseLeaf catalog is fully scraped; SLCC programs remain a gap pending separate investigation.",
   },
 };
 

--- a/scripts/ut/scrape-programs.ts
+++ b/scripts/ut/scrape-programs.ts
@@ -13,6 +13,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import { scrapeAcalogPrograms } from "../lib/scrape-acalog-programs.js";
 import { scrapeCourseleafPrograms } from "../lib/scrape-courseleaf-programs.js";
 
 async function run(
@@ -50,6 +51,33 @@ async function main() {
       collegeSlug: "snow-college",
       baseUrl: "https://catalog.snow.edu",
       programIndexPath: "/programs/",
+    }),
+  );
+
+  // salt-lake-community-college (acalog)
+  //
+  // The Phase-6 auto-discovery probe missed SLCC's catalog because it
+  // tried `salt.edu` (wrong domain — SLCC is `slcc.edu`). Manually
+  // verified 2026-05-29 that catalog.slcc.edu is Acalog: the
+  // `/preview_program.php` URL redirects to `index.php?catoid=28` and
+  // the sidebar exposes nav links `?navoid=9697` (Degrees and
+  // Certificates) + `?navoid=9720` (Programs Listed Alphabetically).
+  //
+  // catoid is pinned to 28 (current catalog as of probe). Auto-discover
+  // returned an old archive (catoid=3) whose navoid IDs don't match the
+  // ones used by the live current catalog. The navoids 9697 + 9720
+  // were sampled from catoid=28's sidebar nav, so they must be paired
+  // with that catoid.
+  // 9720 is the comprehensive alphabetical index — preferred. 9697 is
+  // also included so degree/certificate groupings the alphabetical
+  // index sometimes skips are picked up.
+  await run("salt-lake-community-college", () =>
+    scrapeAcalogPrograms({
+      collegeSlug: "salt-lake-community-college",
+      baseUrl: "https://catalog.slcc.edu",
+      catoidFallback: 28,
+      programNavoids: [9720, 9697],
+      autoDiscoverCatoid: false,
     }),
   );
 }


### PR DESCRIPTION
## What changes for someone using the site

`/ut/college/salt-lake-community-college/programs` now lists **132 degree, certificate, and associate plans** sourced from SLCC's Acalog catalog — previously the page rendered the documented-ceiling empty state. Snow's page (119 programs) was already live.

Practical examples now reachable from the pathway-intent search:

- **Nursing AAS** — 32 courses across 4 requirement groups
- **Practical Nursing certificate** — 26 courses, 3 groups
- **Computer Science AS** — 33 courses across 2 groups
- **Nursing Assistant certificate**, full credential mix (34 AAS, 34 AS, 6 AA, 57 certificates)

## What changes on the technical front

Closes the SLCC programs gap that was tracked as `documentedCeilings.programs` in [lib/states/ut/config.ts](https://github.com/rohan-c0de/cc-coursemap/blob/main/lib/states/ut/config.ts) after PR #712. The auto-add-state Phase-6 probe had missed SLCC's catalog because it probed `salt.edu` (wrong domain — SLCC is `slcc.edu`).

Manual re-probe found `catalog.slcc.edu` is **Acalog** (`/preview_program.php` redirects to `index.php?catoid=28`; sidebar exposes `?navoid=9697` and `?navoid=9720`). One entry added to the existing `scripts/ut/scrape-programs.ts` wrapper using the shared `scrapeAcalogPrograms` template.

Two implementation details worth flagging:

1. **`autoDiscoverCatoid: false`** — Acalog's auto-discover heuristic returned `catoid=3` (an old archived catalog) whose navoid IDs don't match the live structure. Pinning to `catoid=28` (current catalog year 2026-2027) so the navoid IDs resolve. When SLCC publishes a new catalog year, the catoid needs to be re-pinned (this is the same operational burden every Acalog-using state has).
2. **navoid=9697 returned 0 programs** but is kept in the navoid list as a backstop. It's currently a category-header page rather than a program-listing page; future catalog years may shift the schema.

The matcher hit 40/132 (30%) on canonical program slugs. The rest use SLCC-specific naming like `"Nursing Assistant: Technical Certificate (SL Tech)"` with embedded campus tags — typical for an institution with a unique credential taxonomy.

`documentedCeilings.programs` removed from the config (no longer accurate). `snow-college.json` shows ~1,250 lines of churn — that's CourseLeaf rescrape-ordering drift (same data, different JSON ordering between runs); cron does this on every tick.

## Test plan

After merge + Vercel redeploy:
- [ ] `https://communitycollegepath.com/ut/college/salt-lake-community-college/programs` lists 132 programs
- [ ] `/ut/college/snow-college/programs` still renders 119 (no regression)
- [ ] Pathway-intent search ("how do I become a nurse?") now surfaces SLCC's Nursing AAS as a result

🤖 Generated with [Claude Code](https://claude.com/claude-code)
