### PR TITLE
hotfix: remove duplicate ndInstitutions import — unblocks all Vercel deploys

### DIFF
--- a/lib/institutions.ts
+++ b/lib/institutions.ts
@@ -46,7 +46,6 @@ import utInstitutions from "@/data/ut/institutions.json";
 import waInstitutions from "@/data/wa/institutions.json";
 import coInstitutions from "@/data/co/institutions.json";
 import ndInstitutions from "@/data/nd/institutions.json";
-import ndInstitutions from "@/data/nd/institutions.json";
 
 // Double-cast via `unknown` because the JSON-inferred types narrow some fields
 // to `null` where `Institution` expects a concrete type (e.g. `minimum_age` is
@@ -96,7 +95,6 @@ const REGISTRY: Record<string, Institution[]> = {
   ut: utInstitutions as unknown as Institution[],
   wa: waInstitutions as unknown as Institution[],
   co: coInstitutions as unknown as Institution[],
-  nd: ndInstitutions as unknown as Institution[],
   nd: ndInstitutions as unknown as Institution[],
 };
 


### PR DESCRIPTION
## What changes for someone using the site

**Every Vercel production deploy for the past ~30 minutes has been failing**, so the live site is frozen on commit \`cc94748\` (Lone Star, 30+ min ago) even though many PRs have merged since. That's why \`/ca/transfer\` is still broken — my hotfix #781 never actually shipped. This PR removes a 2-line duplicate that breaks \`next build\` and unblocks all the stuck deploys.

After this merges + redeploys: every PR that's been stacking up (including #781's transfer fix) will finally take effect, and \`/ca/transfer\` should work.

## What changes on the technical front

PR #773 (ND auto-add-state, commit \`defdd45\`) accidentally added the same line twice in \`lib/institutions.ts\`:

\`\`\`diff
 import ndInstitutions from "@/data/nd/institutions.json";
-import ndInstitutions from "@/data/nd/institutions.json";   // duplicate
\`\`\`

\`\`\`diff
   nd: ndInstitutions as unknown as Institution[],
-  nd: ndInstitutions as unknown as Institution[],          // duplicate
 };
\`\`\`

This produces \`error TS2300: Duplicate identifier 'ndInstitutions'\` and \`error TS1117: An object literal cannot have multiple properties with the same name\` — fatal to \`next build\`. Vercel's been silently failing every deploy since.

## Verification

- [x] \`git diff\` shows only the two duplicate lines removed
- [ ] **Post-merge:** confirm Vercel's next deploy goes green (it should — this is the only thing standing in its way), then verify \`/ca/transfer\` renders normally (which requires #781's perf fix that's already in main)

## Follow-up suggestion

A CI gate that runs \`npm run typecheck\` on every PR would have caught this at the auto-add-state PR stage. The existing Test job runs typecheck but apparently isn't required for merge — making it required would prevent this class of regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)