### PR TITLE
fix(me): refuse to overwrite prereqs.json with empty data when all PDFs fail

### DIFF
--- a/scripts/me/scrape-catalog-prereqs.ts
+++ b/scripts/me/scrape-catalog-prereqs.ts
@@ -383,6 +383,33 @@ async function main() {
     sorted[key] = merged[key];
   }
 
+  // Safety net: refuse to clobber a non-empty existing prereqs.json with
+  // an empty object. This catches the all-PDFs-failed mode (e.g. CI
+  // missing pdftotext, or every WordPress catalog host returning 5xx
+  // simultaneously) where the per-college try/catch silently swallows
+  // every error and we'd otherwise overwrite hundreds of good entries
+  // with `{}`. Per CLAUDE.md invariant — don't ship placeholder data.
+  if (Object.keys(sorted).length === 0 && fs.existsSync(outPath)) {
+    let existing: Record<string, PrereqEntry> = {};
+    try {
+      existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    } catch {
+      /* existing file is malformed — treat as empty */
+    }
+    if (Object.keys(existing).length > 0) {
+      console.error(
+        `\n✗ Refusing to overwrite ${Object.keys(existing).length}-entry ${outPath} with empty data.`,
+      );
+      console.error(
+        `  Every college's PDF either failed to download or failed to parse — see ⚠ lines above.`,
+      );
+      console.error(
+        `  Existing data left untouched. Investigate and re-run after fixing root cause.`,
+      );
+      process.exit(1);
+    }
+  }
+
   fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
   console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
 }


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible right now. This is a defensive guard against a future failure mode: if every Maine college's catalog PDF simultaneously becomes unreachable (CDN outage, mass WordPress upgrade, etc.), the scraper will now refuse to clobber the existing `data/me/prereqs.json` with an empty `{}` and instead exit non-zero so the cron flags it as broken.

Students currently see 948 prereqs (e.g. "ACC 122 → ACC 120 with a grade of C or higher") in the semester planner across the 6 MCCS colleges. This PR keeps those visible even if every PDF host goes down at once.

## What changes technically

The scraper wraps each college's PDF download + `pdftotext` parse in a per-college `try/catch` (deliberately — one flaky WordPress host shouldn't abort the other 5). But when **every** college fails, the per-college errors are silently swallowed and the script proceeds to write `{}` to disk, clobbering the prior 115 KB of good data with a 2-byte file.

This is exactly what produced the 3 consecutive empty ticks on 2026-05-27/28 (run IDs `26483745820`, `26531661568`, `26549669059`): the GitHub Actions runner didn't yet have `poppler-utils` installed for the `me-prereqs` matrix leg, so every `pdftotext` call threw `Command failed: pdftotext ...`, every error was caught silently, then `✓ Wrote 0 prereqs` clobbered the artifact.

**The root-cause environmental fix already shipped:**
- PR #672 (2026-05-28 02:48Z) added `me` to the workflow's poppler install conditional
- PR #696 (2026-05-28 18:57Z) made the install unconditional for all matrix entries

So the next cron tick will be green regardless. This PR is **just the safety net** so the next "all sites down" event doesn't blank the file again.

Mirrors the safety net added to `scripts/hi/scrape-transfer-uhdad.ts` in #782. Per CLAUDE.md invariant: *"Student data never runs through prod with fake values. If a scraper fails, leave the existing data untouched rather than substitute placeholder courses."*

## Test plan

- [x] Full run locally produces 948 prereqs (same as before — guard is opt-in only when sorted.length === 0 AND existing file is non-empty)
- [x] Typecheck — clean
- [ ] Next me-prereqs cron tick after merge should write the same 948 entries (or thereabouts as catalogs evolve) cleanly, with no environmental errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
