### PR TITLE
fix(mn): WAF bypass for 5 Acalog colleges — +2,116 prereqs, +156 programs

### DIFF
--- a/data/mn/prereqs.json
+++ b/data/mn/prereqs.json
@@ -1,4 +1,17854 @@
 {
+  "ADSC 1010": {
+    "text": "ADSC 1003",
+    "courses": [
+      "ADSC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ADSC 1206": {
+    "text": "ADSC 1031 and ENGL 0900",
+    "courses": [
+      "ADSC 1031",
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 1031": {
+    "text": "ARCH 1000",
+    "courses": [
+      "ARCH 1000"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 1040": {
+    "text": "ARCH 1043",
+    "courses": [
+      "ARCH 1043"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 1045": {
+    "text": "ARCH 1040",
+    "courses": [
+      "ARCH 1040"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 1058": {
+    "text": "CEST 1055",
+    "courses": [
+      "CEST 1055"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2005": {
+    "text": "ARCH 1000 and ARCH 1052",
+    "courses": [
+      "ARCH 1000",
+      "ARCH 1052"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 1052": {
+    "text": "ARCH 1040 and ARCH 1043",
+    "courses": [
+      "ARCH 1040",
+      "ARCH 1043"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2025": {
+    "text": "ARCH 1043",
+    "courses": [
+      "ARCH 1043"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2029": {
+    "text": "ARCH 2027",
+    "courses": [
+      "ARCH 2027"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2027": {
+    "text": "ARCH 2025",
+    "courses": [
+      "ARCH 2025"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2030": {
+    "text": "ARCH 1015",
+    "courses": [
+      "ARCH 1015"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2085": {
+    "text": "ARCH 1000 and ARCH 1043",
+    "courses": [
+      "ARCH 1000",
+      "ARCH 1043"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2070": {
+    "text": "ARCH 1015 and ARCH 2025",
+    "courses": [
+      "ARCH 1015",
+      "ARCH 2025"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2095": {
+    "text": "ARCH 2090",
+    "courses": [
+      "ARCH 2090"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ARCH 2055": {
+    "text": "ARCH 1002 and ARCH 1052",
+    "courses": [
+      "ARCH 1002",
+      "ARCH 1052"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "DIAG 2720": {
+    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
+    "courses": [
+      "DIAG 2600",
+      "DIAG 2620",
+      "DIAG 2640",
+      "DIAG 2660",
+      "DIAG 2680"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "DIAG 2700": {
+    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
+    "courses": [
+      "DIAG 2600",
+      "DIAG 2620",
+      "DIAG 2640",
+      "DIAG 2660",
+      "DIAG 2680"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "DIAG 2760": {
+    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
+    "courses": [
+      "DIAG 2600",
+      "DIAG 2620",
+      "DIAG 2640",
+      "DIAG 2660",
+      "DIAG 2680"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "DIAG 2740": {
+    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
+    "courses": [
+      "DIAG 2600",
+      "DIAG 2620",
+      "DIAG 2640",
+      "DIAG 2660",
+      "DIAG 2680"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "DIAG 2780": {
+    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
+    "courses": [
+      "DIAG 2600",
+      "DIAG 2620",
+      "DIAG 2640",
+      "DIAG 2660",
+      "DIAG 2680"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2005": {
+    "text": "AUTO 2145 and AUTO 2159",
+    "courses": [
+      "AUTO 2145",
+      "AUTO 2159"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2119": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2129": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2135": {
+    "text": "AUTO 1010 and AUTO 1167",
+    "courses": [
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2164": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2166": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2175": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2183": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2187": {
+    "text": "AUTO 1010 and AUTO 1167",
+    "courses": [
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2460": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167 or instructor permission",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 1167"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "AUTO 2480": {
+    "text": "AUTO 1000 , AUTO 1010 , and AUTO 2183",
+    "courses": [
+      "AUTO 1000",
+      "AUTO 1010",
+      "AUTO 2183"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BHHS 1550": {
+    "text": "BHHS 1010 and BHHS 1570",
+    "courses": [
+      "BHHS 1010",
+      "BHHS 1570"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BHHS 1570": {
+    "text": "BHHS 1010",
+    "courses": [
+      "BHHS 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BHHS 2020": {
+    "text": "BHHS 1020",
+    "courses": [
+      "BHHS 1020"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BHHS 2101": {
+    "text": "Instructor permission",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "BHHS 2050": {
+    "text": "BHHS 1010 , BHHS 1020 , BHHS 1031 , and BHHS 1040",
+    "courses": [
+      "BHHS 1010",
+      "BHHS 1020",
+      "BHHS 1031",
+      "BHHS 1040"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BHHS 2105": {
+    "text": "Instructor permission",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "BIOL 1130": {
+    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
+    "courses": [
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BIOL 2100": {
+    "text": "BIOL 1106",
+    "courses": [
+      "BIOL 1106"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BIOL 1106": {
+    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
+    "courses": [
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BMET 1301": {
+    "text": "ETEC 1151 with a grade of C or better",
+    "courses": [
+      "ETEC 1151"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BMET 1200": {
+    "text": "ETEC 1202 , ETEC 1260 , ETEC 1281 and BMET 1301",
+    "courses": [
+      "BMET 1301",
+      "ETEC 1202",
+      "ETEC 1260",
+      "ETEC 1281"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BIOL 2200": {
+    "text": "BIOL 2100",
+    "courses": [
+      "BIOL 2100"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BDAT 1010": {
+    "text": "ITEC 1006",
+    "courses": [
+      "ITEC 1006"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BMET 2012": {
+    "text": "BMET 1200 , ETEC 2276 , and ETEC 2138",
+    "courses": [
+      "BMET 1200",
+      "ETEC 2138",
+      "ETEC 2276"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BDAT 1040": {
+    "text": "BDAT 1005 and ITEC 1006",
+    "courses": [
+      "BDAT 1005",
+      "ITEC 1006"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "BDAT 2140": {
+    "text": "ITEC 1006",
+    "courses": [
+      "ITEC 1006"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 1200": {
+    "text": "ELEC 1002",
+    "courses": [
+      "ELEC 1002"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 1210": {
+    "text": "ELEC 1002",
+    "courses": [
+      "ELEC 1002"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2300": {
+    "text": "ELEC 2021 and MAIN 1200",
+    "courses": [
+      "ELEC 2021",
+      "MAIN 1200"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2330": {
+    "text": "MAIN 1100",
+    "courses": [
+      "MAIN 1100"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2350": {
+    "text": "MAIN 1200 and MAIN 1210",
+    "courses": [
+      "MAIN 1200",
+      "MAIN 1210"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2310": {
+    "text": "ELEC 1002 , ELEC 2021 , and MAIN 1100",
+    "courses": [
+      "ELEC 1002",
+      "ELEC 2021",
+      "MAIN 1100"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2320": {
+    "text": "ETEC 1250 and ETEC 1113",
+    "courses": [
+      "ETEC 1113",
+      "ETEC 1250"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2430": {
+    "text": "MAIN 2330",
+    "courses": [
+      "MAIN 2330"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2440": {
+    "text": "MACH 1251 , MAIN 2310 , MAIN 2330 , AND MAIN 2350",
+    "courses": [
+      "MACH 1251",
+      "MAIN 2310",
+      "MAIN 2330",
+      "MAIN 2350"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAIN 2400": {
+    "text": "MACH 1251 , MAIN 2310 , MAIN 2330 , and MAIN 2350",
+    "courses": [
+      "MACH 1251",
+      "MAIN 2310",
+      "MAIN 2330",
+      "MAIN 2350"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1002": {
+    "text": "MATH 0801 with a C or better or appropriate placement score",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1031": {
+    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
+    "courses": [
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1062": {
+    "text": "ELEC 1002 and MATH 1400 with a grade of C or better",
+    "courses": [
+      "ELEC 1002",
+      "MATH 1400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1081": {
+    "text": "ELEC 1021 and ELEC 1031",
+    "courses": [
+      "ELEC 1021",
+      "ELEC 1031"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1091": {
+    "text": "ELEC 1031",
+    "courses": [
+      "ELEC 1031"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1108": {
+    "text": "ELEC 1062 and ELEC 2021",
+    "courses": [
+      "ELEC 1062",
+      "ELEC 2021"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 1122": {
+    "text": "ELEC 1021",
+    "courses": [
+      "ELEC 1021"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2011": {
+    "text": "ELEC 1091",
+    "courses": [
+      "ELEC 1091"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2031": {
+    "text": "ELEC 1091",
+    "courses": [
+      "ELEC 1091"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2021": {
+    "text": "ELEC 1062 and ELEC 1091 or in the CNC Service Technician Diploma",
+    "courses": [
+      "ELEC 1062",
+      "ELEC 1091"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2041": {
+    "text": "ELEC 1062",
+    "courses": [
+      "ELEC 1062"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2061": {
+    "text": "ELEC 2011",
+    "courses": [
+      "ELEC 2011"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2072": {
+    "text": "ELEC 2021 and ELEC 2041",
+    "courses": [
+      "ELEC 2021",
+      "ELEC 2041"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ELEC 2081": {
+    "text": "ELEC 2031",
+    "courses": [
+      "ELEC 2031"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "CEST 1010": {
+    "text": "CEST 1000",
+    "courses": [
+      "CEST 1000"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "CEST 1020": {
+    "text": "CEST 1000",
+    "courses": [
+      "CEST 1000"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "CEST 2000": {
+    "text": "ARCH 2025",
+    "courses": [
+      "ARCH 2025"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "CEST 1075": {
+    "text": "CEST 1000 AND CEST 1010",
+    "courses": [
+      "CEST 1000",
+      "CEST 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "EMED 1501": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 1512": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 1515": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 1520": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 1700": {
+    "text": "EMED 1600 and EMED 1605 Or by special permission of Program Director/Medical Director",
+    "courses": [
+      "EMED 1600",
+      "EMED 1605"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "EMED 1711": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2501": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2502": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2506": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2601": {
+    "text": "EMED 2510 Or by special permission of Program Director/Medical Director",
+    "courses": [
+      "EMED 2510"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2510": {
+    "text": "EMED 1705 Or by special permission of Program Director/Medical Director",
+    "courses": [
+      "EMED 1705"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2610": {
+    "text": "EMED 2510 Or by special permission of Program Director/Medical Director",
+    "courses": [
+      "EMED 2510"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ENGL 0900": {
+    "text": "Accuplacer Reading score of 215",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2620": {
+    "text": "Permission required of Program Director/Medical Director",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "EMED 2625": {
+    "text": "Admittance into the Paramedic Program",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "ENGL 1107": {
+    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
+    "courses": [
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ENGL 1110": {
+    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
+    "courses": [
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ENGL 2105": {
+    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
+    "courses": [
+      "ENGL 0900"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 1202": {
+    "text": "ETEC 1113",
+    "courses": [
+      "ETEC 1113"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 1170": {
+    "text": "ETEC 1113 and ETEC 1250 with a grade of C or higher",
+    "courses": [
+      "ETEC 1113",
+      "ETEC 1250"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 1271": {
+    "text": "ETEC 1113 with a grade of C or higher",
+    "courses": [
+      "ETEC 1113"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 1260": {
+    "text": "ETEC 1113",
+    "courses": [
+      "ETEC 1113"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 1281": {
+    "text": "ETEC 1113 and ETEC 1250 with a grade of C or better",
+    "courses": [
+      "ETEC 1113",
+      "ETEC 1250"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2138": {
+    "text": "ETEC 1281",
+    "courses": [
+      "ETEC 1281"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2011": {
+    "text": "BMET 1301 and ETEC 1202 with a grade of C or higher",
+    "courses": [
+      "BMET 1301",
+      "ETEC 1202"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2143": {
+    "text": "ETEC 1170 and ETEC 1202 with a grade of C or higher",
+    "courses": [
+      "ETEC 1170",
+      "ETEC 1202"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2162": {
+    "text": "ETEC 1102 , ETEC 1281 , ETEC 1170 , and ETEC 1250",
+    "courses": [
+      "ETEC 1102",
+      "ETEC 1170",
+      "ETEC 1250",
+      "ETEC 1281"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2172": {
+    "text": "ETEC 1202 , ETEC 2138 , and ETEC 2162",
+    "courses": [
+      "ETEC 1202",
+      "ETEC 2138",
+      "ETEC 2162"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2177": {
+    "text": "ETEC 1202 , ETEC 2138 , and ETEC 2162",
+    "courses": [
+      "ETEC 1202",
+      "ETEC 2138",
+      "ETEC 2162"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ETEC 2276": {
+    "text": "BMET 1301 with a grade of C or higher",
+    "courses": [
+      "BMET 1301"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1200": {
+    "text": "HITM 1221",
+    "courses": [
+      "HITM 1221"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1120": {
+    "text": "HITM 1221",
+    "courses": [
+      "HITM 1221"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1210": {
+    "text": "HITM 1221 and HITM 1244",
+    "courses": [
+      "HITM 1221",
+      "HITM 1244"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1244": {
+    "text": "HITM 1221",
+    "courses": [
+      "HITM 1221"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1241": {
+    "text": "HITM 1130 and HITM 1221",
+    "courses": [
+      "HITM 1130",
+      "HITM 1221"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1250": {
+    "text": "HITM 1241",
+    "courses": [
+      "HITM 1241"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1325": {
+    "text": "HITM 1221",
+    "courses": [
+      "HITM 1221"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 1260": {
+    "text": "HITM 1130 , HITM 1230 , AND HITM 1241",
+    "courses": [
+      "HITM 1130",
+      "HITM 1230",
+      "HITM 1241"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 2240": {
+    "text": "HITM 1221",
+    "courses": [
+      "HITM 1221"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 2000": {
+    "text": "HITM 1221 and MATH 0801 or appropriate placement score",
+    "courses": [
+      "HITM 1221",
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 2245": {
+    "text": "HITM 1221 , HITM 2000 , ADSC 1171 , ADSC 1181 and MATH 0801 or appropriate placement score",
+    "courses": [
+      "ADSC 1171",
+      "ADSC 1181",
+      "HITM 1221",
+      "HITM 2000",
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 2410": {
+    "text": "HITM 2400",
+    "courses": [
+      "HITM 2400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 2430": {
+    "text": "HITM 2400",
+    "courses": [
+      "HITM 2400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HITM 2420": {
+    "text": "HITM 2400",
+    "courses": [
+      "HITM 2400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "HLTH 1205": {
+    "text": "Passed Minnesota Health Background Documentation of immunity to all required vaccinations along with TB blood tests Current American Heart Association BLS for Healthcare Provider Card Instructor approval",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2105": {
+    "text": "ITEC 1011 or instructor permission",
+    "courses": [
+      "ITEC 1011"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2120": {
+    "text": "ITEC 1006 or instructor permission",
+    "courses": [
+      "ITEC 1006"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2207": {
+    "text": "ITEC 1003",
+    "courses": [
+      "ITEC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2311": {
+    "text": "ITEC 1016",
+    "courses": [
+      "ITEC 1016"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2215": {
+    "text": "ITEC 1003 , ITEC 1006 or instructor permission",
+    "courses": [
+      "ITEC 1003",
+      "ITEC 1006"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2407": {
+    "text": "ITEC 1003",
+    "courses": [
+      "ITEC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2317": {
+    "text": "ITEC 1006 , ITEC 1011 , and ITEC 1016",
+    "courses": [
+      "ITEC 1006",
+      "ITEC 1011",
+      "ITEC 1016"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2340": {
+    "text": "ITEC 1011 and ITEC 1016 or instructor permission",
+    "courses": [
+      "ITEC 1011",
+      "ITEC 1016"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2411": {
+    "text": "ITEC 1003",
+    "courses": [
+      "ITEC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2440": {
+    "text": "ITEC 1003",
+    "courses": [
+      "ITEC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2520": {
+    "text": "ITEC 2340",
+    "courses": [
+      "ITEC 2340"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2450": {
+    "text": "ITEC 1003",
+    "courses": [
+      "ITEC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2600": {
+    "text": "ITEC 1011",
+    "courses": [
+      "ITEC 1011"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ITEC 2700": {
+    "text": "ITEC 1011",
+    "courses": [
+      "ITEC 1011"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 1105": {
+    "text": "JRBC 1005",
+    "courses": [
+      "JRBC 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 1005": {
+    "text": "ADSC 1003 or minimum typing speed of 25 wpm",
+    "courses": [
+      "ADSC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 1120": {
+    "text": "JRBC 1000 and JRBC 1005",
+    "courses": [
+      "JRBC 1000",
+      "JRBC 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 1200": {
+    "text": "JRBC 1105",
+    "courses": [
+      "JRBC 1105"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2016": {
+    "text": "JRBC 2011",
+    "courses": [
+      "JRBC 2011"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2000": {
+    "text": "JRBC 1200",
+    "courses": [
+      "JRBC 1200"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2036": {
+    "text": "JRBC 1105",
+    "courses": [
+      "JRBC 1105"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2030": {
+    "text": "JRBC 1105",
+    "courses": [
+      "JRBC 1105"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2100": {
+    "text": "JRBC 2000",
+    "courses": [
+      "JRBC 2000"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2127": {
+    "text": "JRBC 2000",
+    "courses": [
+      "JRBC 2000"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2120": {
+    "text": "JRBC 2100",
+    "courses": [
+      "JRBC 2100"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 2135": {
+    "text": "JRBC 2000",
+    "courses": [
+      "JRBC 2000"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "JRBC 3101": {
+    "text": "JRBC 1105",
+    "courses": [
+      "JRBC 1105"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1200": {
+    "text": "MACH 1101 , MACH 1106 , and MACH 1121",
+    "courses": [
+      "MACH 1101",
+      "MACH 1106",
+      "MACH 1121"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1220": {
+    "text": "MACH 1101 , MACH 1106 , and MACH 1121",
+    "courses": [
+      "MACH 1101",
+      "MACH 1106",
+      "MACH 1121"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1240": {
+    "text": "MACH 1121 and MACH 1132",
+    "courses": [
+      "MACH 1121",
+      "MACH 1132"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1266": {
+    "text": "MACH 1106 AND MATH 1171 OR MATH 1650",
+    "courses": [
+      "MACH 1106",
+      "MATH 1171",
+      "MATH 1650"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1275": {
+    "text": "MACH 1121",
+    "courses": [
+      "MACH 1121"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1251": {
+    "text": "MACH 1101 , MACH 1106 , MACH 1121 and MACH 1132",
+    "courses": [
+      "MACH 1101",
+      "MACH 1106",
+      "MACH 1121",
+      "MACH 1132"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2310": {
+    "text": "MATH 1171 , MACH 1251 , and MACH 1262",
+    "courses": [
+      "MACH 1251",
+      "MACH 1262",
+      "MATH 1171"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 1262": {
+    "text": "MACH 1101 AND MATH 1171 OR MATH 1650",
+    "courses": [
+      "MACH 1101",
+      "MATH 1171",
+      "MATH 1650"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2320": {
+    "text": "MATH 1171 , MACH 1251 , and MACH 1262",
+    "courses": [
+      "MACH 1251",
+      "MACH 1262",
+      "MATH 1171"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2351": {
+    "text": "MACH 1200 , MACH 1220 , and MACH 1240",
+    "courses": [
+      "MACH 1200",
+      "MACH 1220",
+      "MACH 1240"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2360": {
+    "text": "MACH 1231 , MACH 1240 , and MACH 1251",
+    "courses": [
+      "MACH 1231",
+      "MACH 1240",
+      "MACH 1251"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2331": {
+    "text": "MACH 1200 , MACH 1231 , and MACH 1262",
+    "courses": [
+      "MACH 1200",
+      "MACH 1231",
+      "MACH 1262"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2340": {
+    "text": "MACH 1262 AND MACH 1266",
+    "courses": [
+      "MACH 1262",
+      "MACH 1266"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2411": {
+    "text": "MACH 1220 and MACH 2360",
+    "courses": [
+      "MACH 1220",
+      "MACH 2360"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2420": {
+    "text": "MACH 2331",
+    "courses": [
+      "MACH 2331"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2440": {
+    "text": "MACH 2340",
+    "courses": [
+      "MACH 2340"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2435": {
+    "text": "MATH 1171 or MATH 1650 , MACH 2320 , MACH 2331 , and MACH 2340",
+    "courses": [
+      "MACH 2320",
+      "MACH 2331",
+      "MACH 2340",
+      "MATH 1171",
+      "MATH 1650"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2451": {
+    "text": "MACH 2310 , MACH 2331 , MACH 2331 , MACH 2340 , MACH 2351 and MACH 2360",
+    "courses": [
+      "MACH 2310",
+      "MACH 2331",
+      "MACH 2340",
+      "MACH 2351",
+      "MACH 2360"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2462": {
+    "text": "MATH 1171 or MATH 1650 , MACH 2310 , MACH 2331 , MACH 2340 , and MACH 2360",
+    "courses": [
+      "MACH 2310",
+      "MACH 2331",
+      "MACH 2340",
+      "MACH 2360",
+      "MATH 1171",
+      "MATH 1650"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MACH 2472": {
+    "text": "MATH 1171 or MATH 1650 , MACH 2320 , MACH 2331 , MACH 2340",
+    "courses": [
+      "MACH 2320",
+      "MACH 2331",
+      "MACH 2340",
+      "MATH 1171",
+      "MATH 1650"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAST 1301": {
+    "text": "ADSC 1003 or 25 words per-minute (wpm) keyboarding ablility",
+    "courses": [
+      "ADSC 1003"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAST 1603": {
+    "text": "Must complete immunizations (Refer to current Medical Assistant student handbook) Instructor approval Restricted to the following majors: Medical Assistant AAS and diploma",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "MAST 1200": {
+    "text": "HLTH 1005 , HLTH 1040 , MATH 1010 , MAST 1301 , MAST 1402 , and MAST 1603",
+    "courses": [
+      "HLTH 1005",
+      "HLTH 1040",
+      "MAST 1301",
+      "MAST 1402",
+      "MAST 1603",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAST 1402": {
+    "text": "Restricted to the following major: Medical Assistant",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "MAST 1701": {
+    "text": "HLTH 1005 , HLTH 1040 , MATH 1010 , MAST 1301 , MAST 1402 , and MAST 1603",
+    "courses": [
+      "HLTH 1005",
+      "HLTH 1040",
+      "MAST 1301",
+      "MAST 1402",
+      "MAST 1603",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAST 2702": {
+    "text": "HLTH 1005 , HLTH 1040 , MATH 1010 , MAST 1301 , MAST 1402 , and MAST 1603",
+    "courses": [
+      "HLTH 1005",
+      "HLTH 1040",
+      "MAST 1301",
+      "MAST 1402",
+      "MAST 1603",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MAST 2902": {
+    "text": "HLTH 1005 , HLTH 1040 , MATH 1010 , MAST 1200 , MAST 1301 ,MAST 1402 , MAST 1603 , MAST 1701 , and MAST 2702 Passed Minnesota Health Background, documentation of immunity to all required vaccinations along with TB blood tests, current American Heart Association BLS for Healthcare Provider Card Instructor approval",
+    "courses": [
+      "HLTH 1005",
+      "HLTH 1040",
+      "MAST 1200",
+      "MAST 1301",
+      "MAST 1402",
+      "MAST 1603",
+      "MAST 1701",
+      "MAST 2702",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1081": {
+    "text": "MATH 0801 with a C or higher or appropriate placement score",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1010": {
+    "text": "MATH 0801 with a grade of B or higher or Accuplacer Arithmetic score of 275",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 0910": {
+    "text": "MATH 0801 with a C or higher or appropriate placement score",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1400": {
+    "text": "MATH 0801 with a C or higher or appropriate placement score",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1171": {
+    "text": "MATH 0801 with a C or higher or appropriate placement score",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1090": {
+    "text": "MATH 0801 with a C or higher or appropriate placement score",
+    "courses": [
+      "MATH 0801"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1550": {
+    "text": "MATH 1081 , MATH 1400 , or appropriate placement score",
+    "courses": [
+      "MATH 1081",
+      "MATH 1400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1500": {
+    "text": "MATH 1081 , MATH 1400 , or appropriate placement score",
+    "courses": [
+      "MATH 1081",
+      "MATH 1400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1650": {
+    "text": "MATH 1081 , MATH 1400 , or appropriate placement score",
+    "courses": [
+      "MATH 1081",
+      "MATH 1400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MATH 1710": {
+    "text": "Prerequisites: MATH 1081 with a C or higher or appropriate placement score",
+    "courses": [
+      "MATH 1081"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 2035": {
+    "text": "MECH 2064 or MECH 2074 or MECH 2084 and MECH 1216",
+    "courses": [
+      "MECH 1216",
+      "MECH 2064",
+      "MECH 2074",
+      "MECH 2084"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 1235": {
+    "text": "MATH 1081 or appropriate placement score",
+    "courses": [
+      "MATH 1081"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 2055": {
+    "text": "MECH 1216 and MECH 2064 or MECH 2074 or MECH 2084",
+    "courses": [
+      "MECH 1216",
+      "MECH 2064",
+      "MECH 2074",
+      "MECH 2084"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 1245": {
+    "text": "MECH 1216 and MECH 2064 or MECH 2074 or MECH 2084",
+    "courses": [
+      "MECH 1216",
+      "MECH 2064",
+      "MECH 2074",
+      "MECH 2084"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 2045": {
+    "text": "MECH 2064 or MECH 2074 or MECH 2084 and MECH 1216",
+    "courses": [
+      "MECH 1216",
+      "MECH 2064",
+      "MECH 2074",
+      "MECH 2084"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 2080": {
+    "text": "MECH 1216 and MECH 2064 or MECH 2074 or MECH 2084",
+    "courses": [
+      "MECH 1216",
+      "MECH 2064",
+      "MECH 2074",
+      "MECH 2084"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "MECH 2090": {
+    "text": "MECH 1216 and MECH 2064 or MECH 2074 or MECH 2084",
+    "courses": [
+      "MECH 1216",
+      "MECH 2064",
+      "MECH 2074",
+      "MECH 2084"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 1007": {
+    "text": "COTA 1002",
+    "courses": [
+      "COTA 1002"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 1155": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , and HLTH 1005",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "HLTH 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 1260": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , and HLTH 1005",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "HLTH 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 1270": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , and HLTH 1005",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "HLTH 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 1290": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , and HLTH 1005",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "HLTH 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 1280": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , and HLTH 1005",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "HLTH 1005"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2330": {
+    "text": "COTA 1280 , PSYC 1406 , PSYC 1506 , ENGL 1107 or 2105 , SPCH 1200 or 1500 , and HLTH 1005",
+    "courses": [
+      "COTA 1280",
+      "ENGL 1107",
+      "HLTH 1005",
+      "PSYC 1406",
+      "PSYC 1506",
+      "SPCH 1200"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2310": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , COTA 1155 , COTA 1260 , COTA 1270 , COTA 1280 , COTA 1290 , HLTH 1005 , PSYC 1406 , PSYC 1506 , SPCH 1500 , and ENGL 1107 OR ENGL 2105",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "COTA 1155",
+      "COTA 1260",
+      "COTA 1270",
+      "COTA 1280",
+      "COTA 1290",
+      "ENGL 1107",
+      "ENGL 2105",
+      "HLTH 1005",
+      "PSYC 1406",
+      "PSYC 1506",
+      "SPCH 1500"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2350": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , COTA 1155 , COTA 1260 , COTA 1270 , COTA 1280 , COTA 1290 , HLTH 1005 , PSYC 1406 , PSYC 1506 , SPCH 1500 , and ENGL 1107 OR ENGL 2105",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "COTA 1155",
+      "COTA 1260",
+      "COTA 1270",
+      "COTA 1280",
+      "COTA 1290",
+      "ENGL 1107",
+      "ENGL 2105",
+      "HLTH 1005",
+      "PSYC 1406",
+      "PSYC 1506",
+      "SPCH 1500"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2411": {
+    "text": "COTA 2310 , COTA 2330 , COTA 2340 , COTA 2350 , and COTA 2391",
+    "courses": [
+      "COTA 2310",
+      "COTA 2330",
+      "COTA 2340",
+      "COTA 2350",
+      "COTA 2391"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2340": {
+    "text": "​COTA 1002 , COTA 1007 , COTA 1050 , COTA 1105 , COTA 1155 , COTA 1260 , COTA 1270 , COTA 1280 , COTA 1290 , HLTH 1005 , PSYC 1406 , PSYC 1506 , SPCH 1500 , and ENGL 1107 OR ENGL 2105 This course is restricted to the following major, Occupational Therapy Assistant",
+    "courses": [
+      "COTA 1002",
+      "COTA 1007",
+      "COTA 1050",
+      "COTA 1105",
+      "COTA 1155",
+      "COTA 1260",
+      "COTA 1270",
+      "COTA 1280",
+      "COTA 1290",
+      "ENGL 1107",
+      "ENGL 2105",
+      "HLTH 1005",
+      "PSYC 1406",
+      "PSYC 1506",
+      "SPCH 1500"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2391": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , COTA 1155 , COTA 1260 , COTA 1270 , COTA 1280 , COTA 1290 , HLTH 1005 , PSYC 1406 , PSYC 1506 , SPCH 1500 , and ENGL 1107 OR ENGL 2105",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "COTA 1155",
+      "COTA 1260",
+      "COTA 1270",
+      "COTA 1280",
+      "COTA 1290",
+      "ENGL 1107",
+      "ENGL 2105",
+      "HLTH 1005",
+      "PSYC 1406",
+      "PSYC 1506",
+      "SPCH 1500"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1400": {
+    "text": "Must be accepted into the Practical Nursing program for the current semester. Successful completion of ENGL 1107 , HLTH 1005 , HLTH 1040 , and MATH 1010",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1405": {
+    "text": "Must be accepted into the Practical Nursing program for the current semester. Successful completion of ENGL 1107 , HLTH 1005 , HLTH 1040 , and MATH 1010",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "COTA 2421": {
+    "text": "COTA 1002 , COTA 1050 , COTA 1105 , COTA 1155 , COTA 1260 , COTA 1270 , COTA 1280 , COTA 1290 , COTA 2310 , COTA 2330 , COTA 2340 , COTA 2350 , COTA 2391 , HLTH 1005 PSYC 1406 , PSYC 1506 , SPCH 1500 , and ENGL 1107 OR ENGL 2105",
+    "courses": [
+      "COTA 1002",
+      "COTA 1050",
+      "COTA 1105",
+      "COTA 1155",
+      "COTA 1260",
+      "COTA 1270",
+      "COTA 1280",
+      "COTA 1290",
+      "COTA 2310",
+      "COTA 2330",
+      "COTA 2340",
+      "COTA 2350",
+      "COTA 2391",
+      "ENGL 1107",
+      "ENGL 2105",
+      "HLTH 1005",
+      "PSYC 1406",
+      "PSYC 1506",
+      "SPCH 1500"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1410": {
+    "text": "Must be accepted into the Practical Nursing program for the current semester. Successful completion of ENGL 1107 , HLTH 1005 , HLTH 1040 , and MATH 1010",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1420": {
+    "text": "Must be accepted into the Practical Nursing program for the current semester. Successful completion of ENGL 1107 , HLTH 1005 , HLTH 1040 , and MATH 1010",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1432": {
+    "text": "Must be accepted into the Practical Nursing program for the current semester. Successful completion of HLTH 1005 , HLTH 1040 , ENGL 1107 , and MATH 1010",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1500": {
+    "text": "ENGL 1107 , HLTH 1005 , HLTH 1040 , MATH 1010 , NURS 1400 , NURS 1405 , NURS 1410 , NURS 1420 , and NURS 1432",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010",
+      "NURS 1400",
+      "NURS 1405",
+      "NURS 1410",
+      "NURS 1420",
+      "NURS 1432"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1515": {
+    "text": "ENGL 1107 , HLTH 1005 , HLTH 1040 , MATH 1010 , NURS 1400 , NURS 1405 , NURS 1410 , NURS 1420 ,and NURS 1432",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010",
+      "NURS 1400",
+      "NURS 1405",
+      "NURS 1410",
+      "NURS 1420",
+      "NURS 1432"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1521": {
+    "text": "ENGL 1107 , HLTH 1005 , HLTH 1040 , MATH 1010 , NURS 1400 , NURS 1405 , NURS 1410 , NURS 1420 , and NURS 1432",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010",
+      "NURS 1400",
+      "NURS 1405",
+      "NURS 1410",
+      "NURS 1420",
+      "NURS 1432"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1511": {
+    "text": "ENGL 1107 , HLTH 1005 , HLTH 1040 , MATH 1010 , NURS 1400 , NURS 1405 , NURS 1410 , NURS 1420 , and NURS 1432",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010",
+      "NURS 1400",
+      "NURS 1405",
+      "NURS 1410",
+      "NURS 1420",
+      "NURS 1432"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "PHYS 1000": {
+    "text": "MATH 1081 , MATH 1171 , MATH 1400 , or appropriate placement score",
+    "courses": [
+      "MATH 1081",
+      "MATH 1171",
+      "MATH 1400"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "NURS 1542": {
+    "text": "ENGL 1107 , HLTH 1005 , HLTH 1040 , MATH 1010 , NURS 1400 , NURS 1405 , NURS 1410 , NURS 1420 , and NURS 1432",
+    "courses": [
+      "ENGL 1107",
+      "HLTH 1005",
+      "HLTH 1040",
+      "MATH 1010",
+      "NURS 1400",
+      "NURS 1405",
+      "NURS 1410",
+      "NURS 1420",
+      "NURS 1432"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "PSYC 1606": {
+    "text": "PSYC 1406",
+    "courses": [
+      "PSYC 1406"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 1200": {
+    "text": "MACH 1121 and MACH 1132",
+    "courses": [
+      "MACH 1121",
+      "MACH 1132"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 1210": {
+    "text": "MACH 1121 and MACH 1132",
+    "courses": [
+      "MACH 1121",
+      "MACH 1132"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2300": {
+    "text": "MACH 1240",
+    "courses": [
+      "MACH 1240"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2320": {
+    "text": "MACH 1121 and QUAL 1200",
+    "courses": [
+      "MACH 1121",
+      "QUAL 1200"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2321": {
+    "text": "MACH 1121 and QUAL 1200",
+    "courses": [
+      "MACH 1121",
+      "QUAL 1200"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2310": {
+    "text": "ADSC 1171 , MATH 1550 , QUAL 1200 , and QUAL 1210",
+    "courses": [
+      "ADSC 1171",
+      "MATH 1550",
+      "QUAL 1200",
+      "QUAL 1210"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2350": {
+    "text": "ADSC 1171 , MACH 1231 , and QUAL 1200",
+    "courses": [
+      "ADSC 1171",
+      "MACH 1231",
+      "QUAL 1200"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2400": {
+    "text": "MATH 1550 and QUAL 2310",
+    "courses": [
+      "MATH 1550",
+      "QUAL 2310"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2410": {
+    "text": "QUAL 1210",
+    "courses": [
+      "QUAL 1210"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2340": {
+    "text": "MACH 1090 and MACH 1231",
+    "courses": [
+      "MACH 1090",
+      "MACH 1231"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2401": {
+    "text": "MATH 1550 and QUAL 2310",
+    "courses": [
+      "MATH 1550",
+      "QUAL 2310"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "QUAL 2430": {
+    "text": "QUAL 2300 , QUAL 2310 , QUAL 2320 , QUAL 2330 , and QUAL 2340",
+    "courses": [
+      "QUAL 2300",
+      "QUAL 2310",
+      "QUAL 2320",
+      "QUAL 2330",
+      "QUAL 2340"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "SSAC 0905": {
+    "text": "Accuplacer placement score between 215-249 and/or admissions approval",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "SSAC 0925": {
+    "text": "Accuplacer placement score between 215-249 and/or admissions approval",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "SSAC 0915": {
+    "text": "Accuplacer placement score between 215-249 and/ or admissions approval",
+    "courses": [],
+    "source": "anoka-technical-college"
+  },
+  "SURG 1005": {
+    "text": "HLTH 1040 and BIOL 2100",
+    "courses": [
+      "BIOL 2100",
+      "HLTH 1040"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "SURG 1003": {
+    "text": "HLTH 1040 and BIOL 2100",
+    "courses": [
+      "BIOL 2100",
+      "HLTH 1040"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "SURG 1037": {
+    "text": "SURG 1010 , SURG 1026 , SURG 1027 , and SURG 1035",
+    "courses": [
+      "SURG 1010",
+      "SURG 1026",
+      "SURG 1027",
+      "SURG 1035"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "SURG 2000": {
+    "text": "SURG 1010 , SURG 1026 , SURG 1027 , and SURG 1035",
+    "courses": [
+      "SURG 1010",
+      "SURG 1026",
+      "SURG 1027",
+      "SURG 1035"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1024": {
+    "text": "WELD 1012",
+    "courses": [
+      "WELD 1012"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1022": {
+    "text": "WELD 1008",
+    "courses": [
+      "WELD 1008"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1026": {
+    "text": "WELD 1012",
+    "courses": [
+      "WELD 1012"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1036": {
+    "text": "WELD 1002 , WELD 1004 , WELD 1006 , WELD 1008 , WELD 1012 , WELD 1014 , WELD 1016 , and WELD 1018",
+    "courses": [
+      "WELD 1002",
+      "WELD 1004",
+      "WELD 1006",
+      "WELD 1008",
+      "WELD 1012",
+      "WELD 1014",
+      "WELD 1016",
+      "WELD 1018"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1028": {
+    "text": "WELD 1002 , WELD 1004 , WELD 1006 , WELD 1008 , WELD 1012 , WELD 1014 , WELD 1016 , AND WELD 1018",
+    "courses": [
+      "WELD 1002",
+      "WELD 1004",
+      "WELD 1006",
+      "WELD 1008",
+      "WELD 1012",
+      "WELD 1014",
+      "WELD 1016",
+      "WELD 1018"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1034": {
+    "text": "WELD 1002 , WELD 1004 , WELD 1006 , WELD 1008 , WELD 1012 , WELD 1014 , WELD 1016 , and WELD 1018",
+    "courses": [
+      "WELD 1002",
+      "WELD 1004",
+      "WELD 1006",
+      "WELD 1008",
+      "WELD 1012",
+      "WELD 1014",
+      "WELD 1016",
+      "WELD 1018"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 1209": {
+    "text": "WELD 1022 , WELD 1024 , WELD 1026 , WELD 1028 , WELD 1034 , and WELD 1036",
+    "courses": [
+      "WELD 1022",
+      "WELD 1024",
+      "WELD 1026",
+      "WELD 1028",
+      "WELD 1034",
+      "WELD 1036"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2000": {
+    "text": "WELD 1022 , WELD 1024 , WELD 1026 , WELD 1028 , WELD 1034 , and WELD 1036",
+    "courses": [
+      "WELD 1022",
+      "WELD 1024",
+      "WELD 1026",
+      "WELD 1028",
+      "WELD 1034",
+      "WELD 1036"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2004": {
+    "text": "WELD 1022 , WELD 1024 , WELD 1026 , WELD 1028 , WELD 1034 , and WELD 1036",
+    "courses": [
+      "WELD 1022",
+      "WELD 1024",
+      "WELD 1026",
+      "WELD 1028",
+      "WELD 1034",
+      "WELD 1036"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2008": {
+    "text": "WELD 1022 , WELD 1024 , WELD 1026 , WELD 1028 , WELD 1034 , and WELD 1036",
+    "courses": [
+      "WELD 1022",
+      "WELD 1024",
+      "WELD 1026",
+      "WELD 1028",
+      "WELD 1034",
+      "WELD 1036"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2012": {
+    "text": "WELD 1209 , WELD 2000 , WELD 2004 , WELD 2006 , and WELD 2008",
+    "courses": [
+      "WELD 1209",
+      "WELD 2000",
+      "WELD 2004",
+      "WELD 2006",
+      "WELD 2008"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2014": {
+    "text": "WELD 1209 , WELD 2000 , WELD 2004 , WELD 2006 , and WELD 2008",
+    "courses": [
+      "WELD 1209",
+      "WELD 2000",
+      "WELD 2004",
+      "WELD 2006",
+      "WELD 2008"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2016": {
+    "text": "WELD 1209 , WELD 2000 , WELD 2004 , WELD 2006 , and WELD 2008",
+    "courses": [
+      "WELD 1209",
+      "WELD 2000",
+      "WELD 2004",
+      "WELD 2006",
+      "WELD 2008"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "WELD 2018": {
+    "text": "WELD 1209 , WELD 2000 , WELD 2004 , WELD 2006 , and WELD 2008",
+    "courses": [
+      "WELD 1209",
+      "WELD 2000",
+      "WELD 2004",
+      "WELD 2006",
+      "WELD 2008"
+    ],
+    "source": "anoka-technical-college"
+  },
+  "ADCS 1110": {
+    "text": "ADCS 1120 and HPER 1102",
+    "courses": [
+      "ADCS 1120",
+      "HPER 1102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 1210": {
+    "text": "ADCS 1110 , ADCS 1120 , and HPER 1102",
+    "courses": [
+      "ADCS 1110",
+      "ADCS 1120",
+      "HPER 1102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 2295": {
+    "text": "ADCS 1200 , ADCS 1210 , and ADCS 1220",
+    "courses": [
+      "ADCS 1200",
+      "ADCS 1210",
+      "ADCS 1220"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 1200": {
+    "text": "ADCS 1110 , ADCS 1120 , and HPER 1102",
+    "courses": [
+      "ADCS 1110",
+      "ADCS 1120",
+      "HPER 1102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 1120": {
+    "text": "ADCS 1110 and HPER 1102",
+    "courses": [
+      "ADCS 1110",
+      "HPER 1102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 2297": {
+    "text": "ADCS 1200 and ADCS 1210",
+    "courses": [
+      "ADCS 1200",
+      "ADCS 1210"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 1220": {
+    "text": "ADCS 1110 and ADCS 1120",
+    "courses": [
+      "ADCS 1110",
+      "ADCS 1120"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ADCS 2298": {
+    "text": "ADCS 2297",
+    "courses": [
+      "ADCS 2297"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ASL 1102": {
+    "text": "ASL 1101 or two years ASL in high school",
+    "courses": [
+      "ASL 1101"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ASL 2201": {
+    "text": "ASL 1102 or permission of instructor",
+    "courses": [
+      "ASL 1102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ASL 2202": {
+    "text": "ASL 2201 or permission of instructor",
+    "courses": [
+      "ASL 2201"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1122": {
+    "text": "ART 1121",
+    "courses": [
+      "ART 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1132": {
+    "text": "ART 1131",
+    "courses": [
+      "ART 1131"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1142": {
+    "text": "ART 1141 or ART 1241",
+    "courses": [
+      "ART 1141",
+      "ART 1241"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1145": {
+    "text": "ART 1141 , ART 1144 , or ART 1241",
+    "courses": [
+      "ART 1141",
+      "ART 1144",
+      "ART 1241"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1151": {
+    "text": "ART 1150",
+    "courses": [
+      "ART 1150"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1162": {
+    "text": "ART 1161",
+    "courses": [
+      "ART 1161"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1166": {
+    "text": "ART 1165",
+    "courses": [
+      "ART 1165"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1171": {
+    "text": "ART 1170",
+    "courses": [
+      "ART 1170"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1173": {
+    "text": "ART 1172",
+    "courses": [
+      "ART 1172"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1252": {
+    "text": "ART 1251",
+    "courses": [
+      "ART 1251"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1242": {
+    "text": "ART 1241",
+    "courses": [
+      "ART 1241"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1272": {
+    "text": "ART 1271",
+    "courses": [
+      "ART 1271"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1282": {
+    "text": "ART 1281",
+    "courses": [
+      "ART 1281"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 1291": {
+    "text": "ART 1290",
+    "courses": [
+      "ART 1290"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2121": {
+    "text": "ART 1121",
+    "courses": [
+      "ART 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2131": {
+    "text": "ART 1131",
+    "courses": [
+      "ART 1131"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2132": {
+    "text": "ART 1131",
+    "courses": [
+      "ART 1131"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2133": {
+    "text": "ART 2132",
+    "courses": [
+      "ART 2132"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2134": {
+    "text": "ART 2133",
+    "courses": [
+      "ART 2133"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2165": {
+    "text": "ART 1165 or ART 1155",
+    "courses": [
+      "ART 1155",
+      "ART 1165"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2167": {
+    "text": "ART 1165 and ART 1166",
+    "courses": [
+      "ART 1165",
+      "ART 1166"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2168": {
+    "text": "ART 1165 and ART 1166 or ART 2167",
+    "courses": [
+      "ART 1165",
+      "ART 1166",
+      "ART 2167"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2253": {
+    "text": "ART 1252 or ART 1282",
+    "courses": [
+      "ART 1252",
+      "ART 1282"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2200": {
+    "text": "ART 1107 , ART 1108 , ART 1115 , ART 1117 , ART 1141 , and ART 1170",
+    "courses": [
+      "ART 1107",
+      "ART 1108",
+      "ART 1115",
+      "ART 1117",
+      "ART 1141",
+      "ART 1170"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ART 2254": {
+    "text": "ART 1252 or ART 1282",
+    "courses": [
+      "ART 1252",
+      "ART 1282"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 1107": {
+    "text": "BIOL 1106 or equivalent",
+    "courses": [
+      "BIOL 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 1133": {
+    "text": "BIOL 1103",
+    "courses": [
+      "BIOL 1103"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 2202": {
+    "text": "BIOL 1106",
+    "courses": [
+      "BIOL 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 2114": {
+    "text": "BIOL 2113",
+    "courses": [
+      "BIOL 2113"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 2206": {
+    "text": "BIOL 1106",
+    "courses": [
+      "BIOL 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 2229": {
+    "text": "BIOL 1106 , one other BIOL course, and permission of instructor",
+    "courses": [
+      "BIOL 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BIOL 2230": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BMED 2297": {
+    "text": "Permission of program director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BMED 2400": {
+    "text": "MATH 1114",
+    "courses": [
+      "MATH 1114"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BMED 2510": {
+    "text": "BUS 1119",
+    "courses": [
+      "BUS 1119"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BMED 2520": {
+    "text": "ENGL 0950 or achievement of required score on English placement assessment",
+    "courses": [
+      "ENGL 0950"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BUS 1134": {
+    "text": "BUS 2125 or permission of instructor",
+    "courses": [
+      "BUS 2125"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BUS 1135": {
+    "text": "BUS 2125 or permission of instructor",
+    "courses": [
+      "BUS 2125"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BUS 2126": {
+    "text": "BUS 2125",
+    "courses": [
+      "BUS 2125"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BUS 2227": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BUS 2228": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "BUS 2233": {
+    "text": "BUS 1112 and BUS 2125",
+    "courses": [
+      "BUS 1112",
+      "BUS 2125"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 1020": {
+    "text": "Any of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 1061": {
+    "text": "MATH 0250 or appropriate score on math placement test AND",
+    "courses": [
+      "MATH 0250"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 1062": {
+    "text": "CHEM 1061 AND",
+    "courses": [
+      "CHEM 1061"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 2061": {
+    "text": "CHEM 1062",
+    "courses": [
+      "CHEM 1062"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 2062": {
+    "text": "CHEM 2061",
+    "courses": [
+      "CHEM 2061"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 2090": {
+    "text": "CHEM 2061 and BIOL 1106",
+    "courses": [
+      "BIOL 1106",
+      "CHEM 2061"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CHEM 2230": {
+    "text": "A college-level chemistry course with lab is required. Students must meet with the instructor and get approval prior to registration",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ICBE 1101": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CSCI 1101": {
+    "text": "MATH 0240 or appropriate score on the math placement test or equivalent",
+    "courses": [
+      "MATH 0240"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CSCI 1106": {
+    "text": "MATH 1200 or appropriate score on the math placement test",
+    "courses": [
+      "MATH 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CSCI 1125": {
+    "text": "CSCI 1106",
+    "courses": [
+      "CSCI 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CSCI 1107": {
+    "text": "CSCI 1106",
+    "courses": [
+      "CSCI 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CSCI 2100": {
+    "text": "MATH 1400",
+    "courses": [
+      "MATH 1400"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CSCI 2021": {
+    "text": "CSCI 1106",
+    "courses": [
+      "CSCI 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 1213": {
+    "text": "CNET 1212",
+    "courses": [
+      "CNET 1212"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2101": {
+    "text": "Completion of CNET 1001 & CNET 1100 or CSCI 1101 or CSCI 1106",
+    "courses": [
+      "CNET 1001",
+      "CNET 1100",
+      "CSCI 1101",
+      "CSCI 1106"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2110": {
+    "text": "CNET 1001 & CNET 1105",
+    "courses": [
+      "CNET 1001",
+      "CNET 1105"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2114": {
+    "text": "Completion of CNET 1001 or CNET 1100",
+    "courses": [
+      "CNET 1001",
+      "CNET 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2220": {
+    "text": "CNET 2110",
+    "courses": [
+      "CNET 2110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2230": {
+    "text": "CNET 2110",
+    "courses": [
+      "CNET 2110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2304": {
+    "text": "CNET 2302",
+    "courses": [
+      "CNET 2302"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2305": {
+    "text": "CNET 2302",
+    "courses": [
+      "CNET 2302"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2302": {
+    "text": "CNET 2101",
+    "courses": [
+      "CNET 2101"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2320": {
+    "text": "CNET 2305",
+    "courses": [
+      "CNET 2305"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2390": {
+    "text": "CNET 2101",
+    "courses": [
+      "CNET 2101"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "CNET 2401": {
+    "text": "Must have attended ICDN (Interconnecting Cisco Network Devices), ICRS (Introduction to Cisco Routers) or CCDA (Cisco Certified Design Associate); or must have installed at least two Cisco routers and/or switches; or taken semesters 1 & 2 from a Cisco Network Academy",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "EDUC 2215": {
+    "text": "3 credits of psychology",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 1111": {
+    "text": "MATH 0250",
+    "courses": [
+      "MATH 0250"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 1200": {
+    "text": "MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 1201": {
+    "text": "ENGR 1200",
+    "courses": [
+      "ENGR 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2218": {
+    "text": "MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2240": {
+    "text": "CHEM 1061",
+    "courses": [
+      "CHEM 1061"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2219": {
+    "text": "MATH 1400 and PHYS 1327",
+    "courses": [
+      "MATH 1400",
+      "PHYS 1327"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2221": {
+    "text": "MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2242": {
+    "text": "PHYS 1327",
+    "courses": [
+      "PHYS 1327"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2241": {
+    "text": "PHYS 1327",
+    "courses": [
+      "PHYS 1327"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGR 2243": {
+    "text": "ENGR 2241",
+    "courses": [
+      "ENGR 2241"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 0990": {
+    "text": "ENGL 0890 or achievement of the recommended score on measures used for placement",
+    "courses": [
+      "ENGL 0890"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 1121": {
+    "text": "Any of the following: College-Level Writing Placement, ENGL 1121 Placement (based upon ESL Writing Score), or ELL 0850 or ENGL 0990",
+    "courses": [
+      "ELL 0850",
+      "ENGL 0990"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 1120": {
+    "text": "Any of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2261": {
+    "text": "ENGL 1120 or ENGL 1121",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2241": {
+    "text": "ENGL 1120 or ENGL 1121",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2262": {
+    "text": "ENGL 1120 or ENGL 1121",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2263": {
+    "text": "ENGL 1120 or ENGL 1121",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2251": {
+    "text": "ENGL 1120 or ENGL 1121",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2271": {
+    "text": "ENGL 1120 or ENGL 1121",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ELL 0810": {
+    "text": "Achievement of the recommended score on the Accuplacer ESL (LOEP) test",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2281": {
+    "text": "ENGL 1120 or ENGL 1121 and at least one of the following courses: ENGL 2241 , ENGL 2251 , ENGL 2261 , ENGL 2262 , ENGL 2263 , or ENGL 2271",
+    "courses": [
+      "ENGL 1120",
+      "ENGL 1121",
+      "ENGL 2241",
+      "ENGL 2251",
+      "ENGL 2261",
+      "ENGL 2262",
+      "ENGL 2263",
+      "ENGL 2271"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ELL 0790": {
+    "text": "A qualifying score on the Accuplacer ESL (LOEP) test",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ENGL 2291": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ELL 0850": {
+    "text": "ELL 0790 or achievement of the recommended score on the Accuplacer ESL (LOEP) test",
+    "courses": [
+      "ELL 0790"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ELL 0870": {
+    "text": "ELL 0810 or achievement of the recommended score on the Accuplacer ESL (LOEP) test",
+    "courses": [
+      "ELL 0810"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2207": {
+    "text": "HPER 1200",
+    "courses": [
+      "HPER 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2210": {
+    "text": "Permission of varsity coach or athletic director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2211": {
+    "text": "Permission of varsity coach or athletic director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2208": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2215": {
+    "text": "Permission of varsity coach or athletic director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2217": {
+    "text": "Permission of varsity coach or athletic director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2218": {
+    "text": "Permission of varsity coach or athletic director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2219": {
+    "text": "Permission of varsity coach or athletic director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2296": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "HPER 2297": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "IHH 2295": {
+    "text": "Permission of course faculty",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "IHH 2290": {
+    "text": "IHH 2104",
+    "courses": [
+      "IHH 2104"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "IHH 2204": {
+    "text": "IHH 2104",
+    "courses": [
+      "IHH 2104"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "IHH 2297": {
+    "text": "Permission of course faculty",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "INTS 2291": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 0011": {
+    "text": "Any of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 0120": {
+    "text": "Any of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 0230": {
+    "text": "MATH 0080 or appropriate score on the math placement test",
+    "courses": [
+      "MATH 0080"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 0140": {
+    "text": "Any of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 0240": {
+    "text": "MATH 0080 or appropriate score on the math placement test",
+    "courses": [
+      "MATH 0080"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 0250": {
+    "text": "MATH 0230 , MATH 0240 , or appropriate score on math placement test",
+    "courses": [
+      "MATH 0230",
+      "MATH 0240"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1100": {
+    "text": "MATH 0230 , MATH 0240 , or appropriate score on math placement test",
+    "courses": [
+      "MATH 0230",
+      "MATH 0240"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1121": {
+    "text": "Any Goal 4 course with a MATH prefix or an appropriate score on the math placement test. Students should check with specific transfer programs for which Goal 4 course best meets their needs",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1114": {
+    "text": "Any of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1200": {
+    "text": "Appropriate score on the math placement test, concurrent registration in MATH 0120 , or MATH 0250",
+    "courses": [
+      "MATH 0120",
+      "MATH 0250"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1201": {
+    "text": "Appropriate score on math placement test or MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1401": {
+    "text": "MATH 1400",
+    "courses": [
+      "MATH 1400"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 2100": {
+    "text": "MATH 1400",
+    "courses": [
+      "MATH 1400"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 1210": {
+    "text": "Appropriate score on the math placement test or recommendation from MATH 0250 instructor",
+    "courses": [
+      "MATH 0250"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 2200": {
+    "text": "MATH 1401",
+    "courses": [
+      "MATH 1401"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 2201": {
+    "text": "MATH 1401",
+    "courses": [
+      "MATH 1401"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 2210": {
+    "text": "MATH 1401",
+    "courses": [
+      "MATH 1401"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 2230": {
+    "text": "MATH 1401",
+    "courses": [
+      "MATH 1401"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MATH 2220": {
+    "text": "MATH 1401",
+    "courses": [
+      "MATH 1401"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 1126": {
+    "text": "MUSC 1116 or permission of instructor",
+    "courses": [
+      "MUSC 1116"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 1127": {
+    "text": "MUSC 1117",
+    "courses": [
+      "MUSC 1117"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 1147": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 1148": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 2216": {
+    "text": "MUSC 1126 or permission of instructor",
+    "courses": [
+      "MUSC 1126"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 2217": {
+    "text": "MUSC 1127",
+    "courses": [
+      "MUSC 1127"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 2226": {
+    "text": "MUSC 2216 or permission of instructor",
+    "courses": [
+      "MUSC 2216"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MUSC 2227": {
+    "text": "MUSC 2217",
+    "courses": [
+      "MUSC 2217"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1160": {
+    "text": "BIOL 2113 , ENGL 1130 , and CHEM 1050",
+    "courses": [
+      "BIOL 2113",
+      "CHEM 1050",
+      "ENGL 1130"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1162": {
+    "text": "ENGL 1130 , BIOL 2113 , and CHEM 1050",
+    "courses": [
+      "BIOL 2113",
+      "CHEM 1050",
+      "ENGL 1130"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1165": {
+    "text": "ENGL 1130 , BIOL 2113 , and CHEM 1050",
+    "courses": [
+      "BIOL 2113",
+      "CHEM 1050",
+      "ENGL 1130"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1190": {
+    "text": "ENGL 1130 , BIOL 2113 , and CHEM 1050",
+    "courses": [
+      "BIOL 2113",
+      "CHEM 1050",
+      "ENGL 1130"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1260": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1262": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1265": {
+    "text": "NURS 1165 , NURS 1162 , ENGL 1130 , BIOL 2113 , and CHEM 1050",
+    "courses": [
+      "BIOL 2113",
+      "CHEM 1050",
+      "ENGL 1130",
+      "NURS 1162",
+      "NURS 1165"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 1290": {
+    "text": "NURS 1160 , NURS 1162 , NURS 1190 , BIOL 2113 , CHEM 1050 , and ENGL 1130",
+    "courses": [
+      "BIOL 2113",
+      "CHEM 1050",
+      "ENGL 1130",
+      "NURS 1160",
+      "NURS 1162",
+      "NURS 1190"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2360": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2362": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2390": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2460": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2700": {
+    "text": "Admission to the nursing program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2462": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2720": {
+    "text": "Admission to the nursing program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2490": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2750": {
+    "text": "Admission to the nursing program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2800": {
+    "text": "Completion of all of the following:",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2850": {
+    "text": "NURS 2700 or NURS 2720 , NURS 2750 , and BIOL 2114",
+    "courses": [
+      "BIOL 2114",
+      "NURS 2700",
+      "NURS 2720",
+      "NURS 2750"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2820": {
+    "text": "NURS 2700 or NURS 2720 , NURS 2750 , and BIOL 2114",
+    "courses": [
+      "BIOL 2114",
+      "NURS 2700",
+      "NURS 2720",
+      "NURS 2750"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2900": {
+    "text": "NURS 2800 , NURS 2820 , and NURS 2850",
+    "courses": [
+      "NURS 2800",
+      "NURS 2820",
+      "NURS 2850"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2920": {
+    "text": "NURS 2800 , NURS 2820 , and NURS 2850",
+    "courses": [
+      "NURS 2800",
+      "NURS 2820",
+      "NURS 2850"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHAR 2100": {
+    "text": "PHAR 1100",
+    "courses": [
+      "PHAR 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHAR 2110": {
+    "text": "PHAR 1100",
+    "courses": [
+      "PHAR 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "NURS 2950": {
+    "text": "NURS 2800 , NURS 2820 , and NURS 2850",
+    "courses": [
+      "NURS 2800",
+      "NURS 2820",
+      "NURS 2850"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHAR 2120": {
+    "text": "PHAR 1100",
+    "courses": [
+      "PHAR 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHAR 2297": {
+    "text": "Permission of program director",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHAR 2130": {
+    "text": "PHAR 1100",
+    "courses": [
+      "PHAR 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1020": {
+    "text": "Admission to the PTA program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1010": {
+    "text": "PTAC 1050 , PTAC 1060 , PTAC 1070 , PTAC 1080 , PTAC 1110 , and BIOL 2114",
+    "courses": [
+      "BIOL 2114",
+      "PTAC 1050",
+      "PTAC 1060",
+      "PTAC 1070",
+      "PTAC 1080",
+      "PTAC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1030": {
+    "text": "Admission to the PTA program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1050": {
+    "text": "PTAC 1020 , PTAC 1030 , PTAC 1040 , and BIOL 2113",
+    "courses": [
+      "BIOL 2113",
+      "PTAC 1020",
+      "PTAC 1030",
+      "PTAC 1040"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1040": {
+    "text": "Admission to the PTA program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1060": {
+    "text": "PTAC 1020 , PTAC 1030 , PTAC 1040 and BIOL 2113",
+    "courses": [
+      "BIOL 2113",
+      "PTAC 1020",
+      "PTAC 1030",
+      "PTAC 1040"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1070": {
+    "text": "PTAC 1020 , PTAC 1030 , PTAC 1040 and BIOL 2113",
+    "courses": [
+      "BIOL 2113",
+      "PTAC 1020",
+      "PTAC 1030",
+      "PTAC 1040"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1080": {
+    "text": "PTAC 1020 , PTAC 1030 , PTAC 1040 , and BIOL 2113",
+    "courses": [
+      "BIOL 2113",
+      "PTAC 1020",
+      "PTAC 1030",
+      "PTAC 1040"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1110": {
+    "text": "PTAC 1100 , PTAC 1020 , PTAC 1030 , and PTAC 1040",
+    "courses": [
+      "PTAC 1020",
+      "PTAC 1030",
+      "PTAC 1040",
+      "PTAC 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 1100": {
+    "text": "Admission to the PTA program",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2010": {
+    "text": "BIOL 2114 , PTAC 1050 , PTAC 1060 , PTAC 1070 , PTAC 1080 , and PTAC 1100",
+    "courses": [
+      "BIOL 2114",
+      "PTAC 1050",
+      "PTAC 1060",
+      "PTAC 1070",
+      "PTAC 1080",
+      "PTAC 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2000": {
+    "text": "BIOL 2114 , PTAC 1050 , PTAC 1060 , PTAC 1070 , PTAC 1080 , and PTAC 1100",
+    "courses": [
+      "BIOL 2114",
+      "PTAC 1050",
+      "PTAC 1060",
+      "PTAC 1070",
+      "PTAC 1080",
+      "PTAC 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2040": {
+    "text": "PTAC 2000 , PTAC 2010 , and PTAC 2015",
+    "courses": [
+      "PTAC 2000",
+      "PTAC 2010",
+      "PTAC 2015"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2050": {
+    "text": "PTAC 2000 , PTAC 2010 , and PTAC 2015",
+    "courses": [
+      "PTAC 2000",
+      "PTAC 2010",
+      "PTAC 2015"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2060": {
+    "text": "PTAC 2040 and PTAC 2050",
+    "courses": [
+      "PTAC 2040",
+      "PTAC 2050"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2015": {
+    "text": "BIOL 2114 , PTAC 1050 , PTAC 1060 , PTAC 1070 , PTAC 1080 , and PTAC 1100",
+    "courses": [
+      "BIOL 2114",
+      "PTAC 1050",
+      "PTAC 1060",
+      "PTAC 1070",
+      "PTAC 1080",
+      "PTAC 1100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2120": {
+    "text": "PTAC 2000 , PTAC 2010 , PTAC 2015 , and PTAC 2110",
+    "courses": [
+      "PTAC 2000",
+      "PTAC 2010",
+      "PTAC 2015",
+      "PTAC 2110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2110": {
+    "text": "PTAC 1050 , PTAC 1060 , PTAC 1070 , and PTAC 1080",
+    "courses": [
+      "PTAC 1050",
+      "PTAC 1060",
+      "PTAC 1070",
+      "PTAC 1080"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2130": {
+    "text": "PTAC 1030",
+    "courses": [
+      "PTAC 1030"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHYS 1317": {
+    "text": "MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PTAC 2170": {
+    "text": "PTAC 2000 , PTAC 2010 , and PTAC 2015",
+    "courses": [
+      "PTAC 2000",
+      "PTAC 2010",
+      "PTAC 2015"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHYS 1327": {
+    "text": "MATH 1400",
+    "courses": [
+      "MATH 1400"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PHYS 1328": {
+    "text": "PHYS 1327",
+    "courses": [
+      "PHYS 1327"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PRSW 2500": {
+    "text": "PRSW 2100",
+    "courses": [
+      "PRSW 2100"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 1130": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2120": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2250": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2215": {
+    "text": "3 credits of psychology",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2235": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2257": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2260": {
+    "text": "PSYC 1110 , SOC 1111 , or consent of instructor",
+    "courses": [
+      "PSYC 1110",
+      "SOC 1111"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2265": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2270": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2285": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "READ 0910": {
+    "text": "Appropriate scores on the placement measures",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "PSYC 2360": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "READ 0990": {
+    "text": "READ 0910 or appropriate score on the placement measures",
+    "courses": [
+      "READ 0910"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "SOC 2221": {
+    "text": "SOC 1111 or permission of instructor",
+    "courses": [
+      "SOC 1111"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "SOC 2261": {
+    "text": "SOC 1111 or permission of instructor",
+    "courses": [
+      "SOC 1111"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "SOC 2260": {
+    "text": "SOC 1111 , PSYC 1110 , or permission of instructor",
+    "courses": [
+      "PSYC 1110",
+      "SOC 1111"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "SOC 2291": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 1001": {
+    "text": "Therapeutic Massage Pre-Program Orientation",
+    "courses": [],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 1020": {
+    "text": "BIOL 1102 and BIOL 1104",
+    "courses": [
+      "BIOL 1102",
+      "BIOL 1104"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 1021": {
+    "text": "MASG 1001 , MASG 2102 , BIOL 1102 , and BIOL 1104",
+    "courses": [
+      "BIOL 1102",
+      "BIOL 1104",
+      "MASG 1001",
+      "MASG 2102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 1296": {
+    "text": "MASG 1001",
+    "courses": [
+      "MASG 1001"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 1022": {
+    "text": "MASG 1001 , MASG 2102 , BIOL 1102 , and BIOL 1104",
+    "courses": [
+      "BIOL 1102",
+      "BIOL 1104",
+      "MASG 1001",
+      "MASG 2102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 1023": {
+    "text": "MASG 1001 , MASG 2102 , BIOL 1102 , and BIOL 1104",
+    "courses": [
+      "BIOL 1102",
+      "BIOL 1104",
+      "MASG 1001",
+      "MASG 2102"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 2108": {
+    "text": "MASG 1020 and MASG 1021",
+    "courses": [
+      "MASG 1020",
+      "MASG 1021"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "MASG 2297": {
+    "text": "MASG 2108",
+    "courses": [
+      "MASG 2108"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "WGST 2120": {
+    "text": "PSYC 1110",
+    "courses": [
+      "PSYC 1110"
+    ],
+    "source": "anoka-ramsey-community-college"
+  },
+  "ACCT 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ACCT 1020": {
+    "text": "ACCT 1010 or ACCT 2020 or concurrently enrolled. Note: Students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "ACCT 1010",
+      "ACCT 2020"
+    ],
+    "source": "century-college"
+  },
+  "ACCT 1030": {
+    "text": "CAPL 1010 and ACCT 1010 with grades of C or higher OR CAPL 1010 and ACCT 2020 with grades of C or higher or instructor consent",
+    "courses": [
+      "ACCT 1010",
+      "ACCT 2020",
+      "CAPL 1010"
+    ],
+    "source": "century-college"
+  },
+  "ACCT 2025": {
+    "text": "ACCT 2020 with a grade of C or higher",
+    "courses": [
+      "ACCT 2020"
+    ],
+    "source": "century-college"
+  },
+  "ACCT 2035": {
+    "text": "ACCT 1010 or ACCT 2020 with a grade of C or higher",
+    "courses": [
+      "ACCT 1010",
+      "ACCT 2020"
+    ],
+    "source": "century-college"
+  },
+  "ACCT 2050": {
+    "text": "ACCT 1010 or ACCT 2020",
+    "courses": [
+      "ACCT 1010",
+      "ACCT 2020"
+    ],
+    "source": "century-college"
+  },
+  "ACCT 2099": {
+    "text": "Complete the following:",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ADCO 1060": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 1030": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 2010": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 2020": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 2030": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 2050": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 2055": {
+    "text": "ADCO 1020 with a grade of C or higher",
+    "courses": [
+      "ADCO 1020"
+    ],
+    "source": "century-college"
+  },
+  "ADCO 2781": {
+    "text": "All required addiction counseling coursework completed and instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ADCO 2782": {
+    "text": "All required addiction counseling coursework completed and instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ADM 1030": {
+    "text": "ADM 1025 or ECAD 1070 or instructor consent",
+    "courses": [
+      "ADM 1025",
+      "ECAD 1070"
+    ],
+    "source": "century-college"
+  },
+  "ADM 1035": {
+    "text": "ADM 1025 or ECAD 1070 or instructor consent",
+    "courses": [
+      "ADM 1025",
+      "ECAD 1070"
+    ],
+    "source": "century-college"
+  },
+  "ADM 1790": {
+    "text": "Instructor consent and at least one of the following ADM courses:",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ADM 2041": {
+    "text": "ADM 2010 or ADM 1010 with a grade of C or higher",
+    "courses": [
+      "ADM 1010",
+      "ADM 2010"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2020": {
+    "text": "ADM 1030 or ADM 2010",
+    "courses": [
+      "ADM 1030",
+      "ADM 2010"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2010": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2042": {
+    "text": "ADM 2010 or ADM 1010 with a grade of C or higher",
+    "courses": [
+      "ADM 1010",
+      "ADM 2010"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2060": {
+    "text": "BIOL 1020 or BIOL 1041 and ADM 1010 or ADM 2010 with grades of C or higher",
+    "courses": [
+      "ADM 1010",
+      "ADM 2010",
+      "BIOL 1020",
+      "BIOL 1041"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2050": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2075": {
+    "text": "ADM 1053 with a grade of C or higher",
+    "courses": [
+      "ADM 1053"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2780": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ADM 2077": {
+    "text": "ADM 1055 or ADM 2075 with a grade of C or higher",
+    "courses": [
+      "ADM 1055",
+      "ADM 2075"
+    ],
+    "source": "century-college"
+  },
+  "ADM 2080": {
+    "text": "ADM 2010 with a grade of C or higher",
+    "courses": [
+      "ADM 2010"
+    ],
+    "source": "century-college"
+  },
+  "ASL 1011": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ASL 1012": {
+    "text": "ASL 1011 with a grade C or higher or instructor consent",
+    "courses": [
+      "ASL 1011"
+    ],
+    "source": "century-college"
+  },
+  "ANTH 1023": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ANTH 1022": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ANTH 2061": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ANTH 2031": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1024": {
+    "text": "Course placement into college-level English and Reading or completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1021": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1022": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1032": {
+    "text": "ART 1031 or Instructor consent",
+    "courses": [
+      "ART 1031"
+    ],
+    "source": "century-college"
+  },
+  "ART 1081": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1080": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ART 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ART 2099": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ABOD 1005": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1015": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1025": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1035": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1045": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1065": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1055": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1085": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1075": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1095": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ABOD 1105": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1125": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1135": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ABOD 1115": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1015": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1025": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1005": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1035": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1045": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1055": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1105": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher; AND Permission of instructor",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1065": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1075": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1085": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 1095": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "AST 2005": {
+    "text": "AST 1005 , AST 1015 , AST 1025 , AST 1035 , AST 1045 , AST 1055 , AST 1065 , AST 1075 , AST 1085 , and AST 1095 and instructor consent",
+    "courses": [
+      "AST 1005",
+      "AST 1015",
+      "AST 1025",
+      "AST 1035",
+      "AST 1045",
+      "AST 1055",
+      "AST 1065",
+      "AST 1075",
+      "AST 1085",
+      "AST 1095"
+    ],
+    "source": "century-college"
+  },
+  "AST 2045": {
+    "text": "AST 2035 and instructor consent",
+    "courses": [
+      "AST 2035"
+    ],
+    "source": "century-college"
+  },
+  "AST 2015": {
+    "text": "AST 2005 and instructor consent",
+    "courses": [
+      "AST 2005"
+    ],
+    "source": "century-college"
+  },
+  "AST 2035": {
+    "text": "AST 2025 and instructor consent",
+    "courses": [
+      "AST 2025"
+    ],
+    "source": "century-college"
+  },
+  "AST 2025": {
+    "text": "AST 2015 and instructor consent",
+    "courses": [
+      "AST 2015"
+    ],
+    "source": "century-college"
+  },
+  "AST 2055": {
+    "text": "AST 2045 and instructor consent",
+    "courses": [
+      "AST 2045"
+    ],
+    "source": "century-college"
+  },
+  "AST 2065": {
+    "text": "AST 2055 and instructor consent",
+    "courses": [
+      "AST 2055"
+    ],
+    "source": "century-college"
+  },
+  "AST 2075": {
+    "text": "AST 2065 and instructor consent",
+    "courses": [
+      "AST 2065"
+    ],
+    "source": "century-college"
+  },
+  "AST 2085": {
+    "text": "AST 2075 and instructor consent",
+    "courses": [
+      "AST 2075"
+    ],
+    "source": "century-college"
+  },
+  "AST 2095": {
+    "text": "AST 1005 , AST 1015 , AST 1045 , AST 1085 , and AST 1095 and instructor consent",
+    "courses": [
+      "AST 1005",
+      "AST 1015",
+      "AST 1045",
+      "AST 1085",
+      "AST 1095"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1010": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1021": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1022": {
+    "text": "BIOL 1024 or concurrently enrolled. Note: Students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "BIOL 1024"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1023": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1024": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1025": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1029": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "BIOL 2028": {
+    "text": "BIOL 1020 or BIOL 1041 with a grade of C or higher",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 1041"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1041": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher. CHEM 1020 or higher with a grade of C or higher OR one year each of High School Biology AND High School Chemistry with grades of C or higher within the last three years OR Instructor consent",
+    "courses": [
+      "CHEM 1020",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 1042": {
+    "text": "BIOL 1041 with a grade of C or higher",
+    "courses": [
+      "BIOL 1041"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 2010": {
+    "text": "BIOL 1010 or BIOL 1020 or BIOL 1041 with a grade C or higher",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020",
+      "BIOL 1041"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 2031": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher. BIOL 1020 with a grade of C or higher AND CHEM 1020 with a grade of C or higher OR one year each of High School Biology AND High School Chemistry with grades of C or higher within the last three years OR instructor consent",
+    "courses": [
+      "BIOL 1020",
+      "CHEM 1020",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 2032": {
+    "text": "BIOL 2031 with a grade of C or higher",
+    "courses": [
+      "BIOL 2031"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 2996": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "BIOL 2035": {
+    "text": "BIOL 2032 with a grade of C or higher or concurrently enrolled. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "BIOL 2032"
+    ],
+    "source": "century-college"
+  },
+  "BIOL 2038": {
+    "text": "BIOL 1041 with a grade of C or higher",
+    "courses": [
+      "BIOL 1041"
+    ],
+    "source": "century-college"
+  },
+  "BMGT 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "BMGT 2060": {
+    "text": "ENGL 1021",
+    "courses": [
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "CHEM 1042": {
+    "text": "CHEM 1041 with a grade of C or higher",
+    "courses": [
+      "CHEM 1041"
+    ],
+    "source": "century-college"
+  },
+  "CRRS 1010": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CHEM 1790": {
+    "text": "CHEM 1041 with a grade of C or higher and instructor and dean consent",
+    "courses": [
+      "CHEM 1041"
+    ],
+    "source": "century-college"
+  },
+  "CHEM 2041": {
+    "text": "CHEM 1042 with a grade of C or higher",
+    "courses": [
+      "CHEM 1042"
+    ],
+    "source": "century-college"
+  },
+  "CHEM 1041": {
+    "text": "Course placement into MATH 1061 or above, or completion of MATH 0070 with a grade of C or higher. Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "MATH 0070",
+      "MATH 1061",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CHEM 2042": {
+    "text": "CHEM 2041 with a grade of C or higher",
+    "courses": [
+      "CHEM 2041"
+    ],
+    "source": "century-college"
+  },
+  "CHIN 1012": {
+    "text": "CHIN 1011",
+    "courses": [
+      "CHIN 1011"
+    ],
+    "source": "century-college"
+  },
+  "COMM 1021": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 1051": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 1031": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 1041": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 2033": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 1061": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "COMM 2071": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COMM 2790": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CAPL 1021": {
+    "text": "OFFT 1001 or instructor consent",
+    "courses": [
+      "OFFT 1001"
+    ],
+    "source": "century-college"
+  },
+  "CAPL 1025": {
+    "text": "CAPL 1010 or instructor consent",
+    "courses": [
+      "CAPL 1010"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1000": {
+    "text": "Course placement into MATH 0070 or higher, or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1021": {
+    "text": "CSCI 1020 and CAPL 1010 or instructor consent",
+    "courses": [
+      "CAPL 1010",
+      "CSCI 1020"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1022": {
+    "text": "Course placement into MATH 0070 or higher or completion of MATH 0030 with a grade of Cor higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1060": {
+    "text": "Course placement into MATH 0070 or above or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1058": {
+    "text": "Course placement into MATH 0070 or higher or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1071": {
+    "text": "Course placement into MATH 0070 or above or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1081": {
+    "text": "Course placement in MATH 1061 or above, or completion of MATH 0070 with a grade of C or higher or instructor consent",
+    "courses": [
+      "MATH 0070",
+      "MATH 1061"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 1082": {
+    "text": "CSCI 1081 with a grade of C or higher",
+    "courses": [
+      "CSCI 1081"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2006": {
+    "text": "CSCI 2005 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CSCI 2005"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2005": {
+    "text": "CSCI 1058 or CSCI 1060 or CSCI 1071 or CSCI 1081 or CSCI 1082 or instructor consent",
+    "courses": [
+      "CSCI 1058",
+      "CSCI 1060",
+      "CSCI 1071",
+      "CSCI 1081",
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2010": {
+    "text": "CSCI 1081 or instructor consent",
+    "courses": [
+      "CSCI 1081"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2016": {
+    "text": "CSCI 1082 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2014": {
+    "text": "Course placement into MATH 1081 or completion of MATH 1061 with a grade of C or higher",
+    "courses": [
+      "MATH 1061",
+      "MATH 1081"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2033": {
+    "text": "CSCI 1058 or CSCI 1060 or CSCI 1071 or CSCI 1081 or CSCI 1082 or instructor consent",
+    "courses": [
+      "CSCI 1058",
+      "CSCI 1060",
+      "CSCI 1071",
+      "CSCI 1081",
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2050": {
+    "text": "CSCI 1081 or CSCI 1082 or instructor consent",
+    "courses": [
+      "CSCI 1081",
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2051": {
+    "text": "CSCI 2050 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CSCI 2050"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2041": {
+    "text": "CSCI 1082 - Object-Oriented Programming and CSCI 2014 - Discrete Structures of Computer Science with grades of C or higher",
+    "courses": [
+      "CSCI 1082",
+      "CSCI 2014"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2061": {
+    "text": "CSCI 1082 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2091": {
+    "text": "CSCI 1081 or instructor consent",
+    "courses": [
+      "CSCI 1081"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2082": {
+    "text": "CSCI 1082 with a grade of C or higher",
+    "courses": [
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2096": {
+    "text": "CSCI 2094 or 2095 with a grade of C or higher",
+    "courses": [
+      "CSCI 2094"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2095": {
+    "text": "CSCI 1082 or instructor consent",
+    "courses": [
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2094": {
+    "text": "CSCI 1082 or instructor consent",
+    "courses": [
+      "CSCI 1082"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2211": {
+    "text": "MATH 1025 with a grade of C or higher or concurrently enrolled",
+    "courses": [
+      "MATH 1025"
+    ],
+    "source": "century-college"
+  },
+  "CSCI 2795": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "CTSA 2015": {
+    "text": "CTSA 1013 or Instructor Consent",
+    "courses": [
+      "CTSA 1013"
+    ],
+    "source": "century-college"
+  },
+  "CTSA 2017": {
+    "text": "CTSA 1013 or Instructor Consent",
+    "courses": [
+      "CTSA 1013"
+    ],
+    "source": "century-college"
+  },
+  "CTSA 2018": {
+    "text": "CTSA 1013 or Instructor Consent",
+    "courses": [
+      "CTSA 1013"
+    ],
+    "source": "century-college"
+  },
+  "CTSA 2031": {
+    "text": "CTSA 1030 or Instructor Consent",
+    "courses": [
+      "CTSA 1030"
+    ],
+    "source": "century-college"
+  },
+  "CTSA 2780": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "CTSA 2032": {
+    "text": "CTSA 1030 or Instructor Consent",
+    "courses": [
+      "CTSA 1030"
+    ],
+    "source": "century-college"
+  },
+  "COS 1007": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1000": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1010": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1028": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1020": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1033": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1040": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1031": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 1035": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of “C” or higher OR course placement into ESOL 0041 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0031 with a grade of “C” or higher and ESOL 0042 with a grade of “C” or higher and ESOL 0043 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0031",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "COS 2099": {
+    "text": "Instructor consent required",
+    "courses": [],
+    "source": "century-college"
+  },
+  "CJS 1024": {
+    "text": "ENGL 1020 or ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "CJS 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "CJS 2011": {
+    "text": "CJS 2010 or instructor consent",
+    "courses": [
+      "CJS 2010"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2012": {
+    "text": "CJS 2011 or instructor consent",
+    "courses": [
+      "CJS 2011"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2013": {
+    "text": "CJS 2012 or instructor consent",
+    "courses": [
+      "CJS 2012"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2014": {
+    "text": "CJS 2012 and instructor consent",
+    "courses": [
+      "CJS 2012"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2010": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher and placement into MATH 0070 or above or completion of MATH 0030 or MATH 0060 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "MATH 0030",
+      "MATH 0060",
+      "MATH 0070",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2084": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher; CJS 2083 with a grade of C or better or instructor consent",
+    "courses": [
+      "CJS 2083",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2093": {
+    "text": "Fifteen college credits and course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2089": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2095": {
+    "text": "Fifteen completed college credits. Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2094": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2099": {
+    "text": "CJS 1020 and CJS 2089 and instructor consent",
+    "courses": [
+      "CJS 1020",
+      "CJS 2089"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2120": {
+    "text": "CJS 2081 and ENGL 1020 with a grade of C or higher or ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "CJS 2081",
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2096": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher; CJS 2094 with a grade of C or better or instructor consent",
+    "courses": [
+      "CJS 2094",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2225": {
+    "text": "ENGL 1024 with a grade of ”C” or higher. CJS 1024 , CJS 2081 , CJS 2085 , SOC 1033 , SOC 1080 ,and SOC 2051 with grades of “C” or higher and instructor consent",
+    "courses": [
+      "CJS 1024",
+      "CJS 2081",
+      "CJS 2085",
+      "ENGL 1024",
+      "SOC 1033",
+      "SOC 1080",
+      "SOC 2051"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2230": {
+    "text": "ENGL 1024 with a grade of “C” or higher. CJS 1024 , CJS 2081 , CJS 2085 , SOC 1080 ,and SOC 2051 with grades of “C” or higher and instructor consent",
+    "courses": [
+      "CJS 1024",
+      "CJS 2081",
+      "CJS 2085",
+      "ENGL 1024",
+      "SOC 1080",
+      "SOC 2051"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2101": {
+    "text": "CJS 2081 with a grade of C or higher. Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "CJS 2081",
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2231": {
+    "text": "ENGL 1024 with a grade of “C” or higher. CJS 1024 , CJS 2081 , CJS 2085 , SOC 1033 , SOC 1080 , and SOC 2051 with grades of “C” or higher and instructor consent",
+    "courses": [
+      "CJS 1024",
+      "CJS 2081",
+      "CJS 2085",
+      "ENGL 1024",
+      "SOC 1033",
+      "SOC 1080",
+      "SOC 2051"
+    ],
+    "source": "century-college"
+  },
+  "CJS 2241": {
+    "text": "ENGL 1024 with a grade of “C” or higher. CJS 1024 , CJS 2081 , CJS 2085 , SOC 1080 , SOC 1033 , SOC 2051 with grades of C or higher and instructor consent",
+    "courses": [
+      "CJS 1024",
+      "CJS 2081",
+      "CJS 2085",
+      "ENGL 1024",
+      "SOC 1033",
+      "SOC 1080",
+      "SOC 2051"
+    ],
+    "source": "century-college"
+  },
+  "CFI 1071": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "CFI 1072": {
+    "text": "CFI 1071 with a grade of C or higher AND CFI 1205 or CSCI 1060 with a grade of C or higher OR instructor consent",
+    "courses": [
+      "CFI 1071",
+      "CFI 1205",
+      "CSCI 1060"
+    ],
+    "source": "century-college"
+  },
+  "CFI 1081": {
+    "text": "CFI 1065 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CFI 1065"
+    ],
+    "source": "century-college"
+  },
+  "CFI 1073": {
+    "text": "CFI 1083 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CFI 1083"
+    ],
+    "source": "century-college"
+  },
+  "CFI 1085": {
+    "text": "INET 1101 with a grade of C or higher or instructor consent",
+    "courses": [
+      "INET 1101"
+    ],
+    "source": "century-college"
+  },
+  "CFI 1205": {
+    "text": "CFI 1085 with a grade of C or higher OR instructor consent",
+    "courses": [
+      "CFI 1085"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2082": {
+    "text": "CFI 1081 with a grade of C or higher OR instructor consent",
+    "courses": [
+      "CFI 1081"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2072": {
+    "text": "CFI 1071 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CFI 1071"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2088": {
+    "text": "CFI 1085 and CFI 2086 with grades of C or higher OR instructor consent",
+    "courses": [
+      "CFI 1085",
+      "CFI 2086"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2200": {
+    "text": "CFI 1085 with a grade of C or higher OR instructor consent",
+    "courses": [
+      "CFI 1085"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2086": {
+    "text": "CFI 1083 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CFI 1083"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2202": {
+    "text": "CFI 1065 with a grade of C or higher or instructor consent",
+    "courses": [
+      "CFI 1065"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2201": {
+    "text": "CFI 1065 and CFI 1205 with grades of C or higher or instructor consent",
+    "courses": [
+      "CFI 1065",
+      "CFI 1205"
+    ],
+    "source": "century-college"
+  },
+  "CFI 2790": {
+    "text": "Instructor and program director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "DENA 1000": {
+    "text": "ENGL 1020 or 1021 with a grade of C or higher, and COMM 1021, COMM 1031, COMM 1041 or COMM 1051 with a grade of C or higher",
+    "courses": [
+      "COMM 1021",
+      "COMM 1031",
+      "COMM 1041",
+      "COMM 1051",
+      "ENGL 1020"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1011": {
+    "text": "ENGL 1020 or 1021 with a grade of C or higher; and COMM 1021, COMM 1031, COMM 1041 or COMM 1051 with a grade of C or high",
+    "courses": [
+      "COMM 1021",
+      "COMM 1031",
+      "COMM 1041",
+      "COMM 1051",
+      "ENGL 1020"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1022": {
+    "text": "DENA 1000 , DENA 1011 , and DENA 1012",
+    "courses": [
+      "DENA 1000",
+      "DENA 1011",
+      "DENA 1012"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1012": {
+    "text": "ENGL 1020 or 1021 with a grade of C or higher; and COMM 1021, COMM 1031, COMM 1041 or COMM 1051 with a grade of C or higher",
+    "courses": [
+      "COMM 1021",
+      "COMM 1031",
+      "COMM 1041",
+      "COMM 1051",
+      "ENGL 1020"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1021": {
+    "text": "DENA 1000 , DENA 1011 , and DENA 1012",
+    "courses": [
+      "DENA 1000",
+      "DENA 1011",
+      "DENA 1012"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1031": {
+    "text": "DENA 1000 , DENA 1011 , and DENA 1012",
+    "courses": [
+      "DENA 1000",
+      "DENA 1011",
+      "DENA 1012"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1032": {
+    "text": "DENA 1021 , DENA 1022 , DENA 1031 , DENA 1041 , and DENA 1042",
+    "courses": [
+      "DENA 1021",
+      "DENA 1022",
+      "DENA 1031",
+      "DENA 1041",
+      "DENA 1042"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1041": {
+    "text": "DENA 1000 , DENA 1011 , and DENA 1012",
+    "courses": [
+      "DENA 1000",
+      "DENA 1011",
+      "DENA 1012"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1061": {
+    "text": "DENA 1021 , DENA 1022 , DENA 1031 , DENA 1041 , and DENA 1042",
+    "courses": [
+      "DENA 1021",
+      "DENA 1022",
+      "DENA 1031",
+      "DENA 1041",
+      "DENA 1042"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1042": {
+    "text": "DENA 1000 , DENA 1011 , and DENA 1012",
+    "courses": [
+      "DENA 1000",
+      "DENA 1011",
+      "DENA 1012"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1062": {
+    "text": "DENA 1021 , DENA 1022 , DENA 1031 , DENA 1041 , and DENA 1042",
+    "courses": [
+      "DENA 1021",
+      "DENA 1022",
+      "DENA 1031",
+      "DENA 1041",
+      "DENA 1042"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1700": {
+    "text": "DENA 1021 , DENA 1022 , DENA 1031 , DENA 1041 , and DENA 1042",
+    "courses": [
+      "DENA 1021",
+      "DENA 1022",
+      "DENA 1031",
+      "DENA 1041",
+      "DENA 1042"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1063": {
+    "text": "DENA 1021 , DENA 1022 DENA 1031 , DENA 1041 , and DENA 1042",
+    "courses": [
+      "DENA 1021",
+      "DENA 1022",
+      "DENA 1031",
+      "DENA 1041",
+      "DENA 1042"
+    ],
+    "source": "century-college"
+  },
+  "DENA 1782": {
+    "text": "All dental assisting program courses must be completed. Must have HBV series of inoculations and be covered by both medical insurance and professional liability insurance. Students must be able to perform physical tasks to complete course requirements and pass a Department of Human Services background study with no restrictions",
+    "courses": [],
+    "source": "century-college"
+  },
+  "DENA 1783": {
+    "text": "All dental assisting program courses must be completed. Must have HBV series of inoculations and be covered by both medical insurance and professional liability insurance. Students must be able to perform physical tasks to complete course requirements and pass a Department of Human Services background study with no restrictions",
+    "courses": [],
+    "source": "century-college"
+  },
+  "DENH 1050": {
+    "text": "DENH 1024 , DENH 1030 , DENH 1040 , and DENH 1045",
+    "courses": [
+      "DENH 1024",
+      "DENH 1030",
+      "DENH 1040",
+      "DENH 1045"
+    ],
+    "source": "century-college"
+  },
+  "DENH 1060": {
+    "text": "DENH 1024 , DENH 1030 , DENH 1040 , and DENH 1045",
+    "courses": [
+      "DENH 1024",
+      "DENH 1030",
+      "DENH 1040",
+      "DENH 1045"
+    ],
+    "source": "century-college"
+  },
+  "DENH 1080": {
+    "text": "DENH 1030 , DENH 1040 , and DENH 1045",
+    "courses": [
+      "DENH 1030",
+      "DENH 1040",
+      "DENH 1045"
+    ],
+    "source": "century-college"
+  },
+  "DENH 1085": {
+    "text": "DENH 1021 , DENH 1024 , DENH 1030 , DENH 1040 , and DENH 1045",
+    "courses": [
+      "DENH 1021",
+      "DENH 1024",
+      "DENH 1030",
+      "DENH 1040",
+      "DENH 1045"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2005": {
+    "text": "DENH 1050 , DENH 1060 , DENH 1080 , and DENH 1085",
+    "courses": [
+      "DENH 1050",
+      "DENH 1060",
+      "DENH 1080",
+      "DENH 1085"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2010": {
+    "text": "DENH 2005",
+    "courses": [
+      "DENH 2005"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2015": {
+    "text": "DENH 2005",
+    "courses": [
+      "DENH 2005"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2030": {
+    "text": "DENH 2005",
+    "courses": [
+      "DENH 2005"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2020": {
+    "text": "DENH 2005",
+    "courses": [
+      "DENH 2005"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2035": {
+    "text": "DENH 2010 , DENH 2015 , DENH 2020 , and DENH 2030",
+    "courses": [
+      "DENH 2010",
+      "DENH 2015",
+      "DENH 2020",
+      "DENH 2030"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2040": {
+    "text": "DENH 2010 , DENH 2015 , DENH 2020 , and DENH 2030",
+    "courses": [
+      "DENH 2010",
+      "DENH 2015",
+      "DENH 2020",
+      "DENH 2030"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2070": {
+    "text": "DENH 2010 , DENH 2015 , DENH 2020 , and DENH 2030",
+    "courses": [
+      "DENH 2010",
+      "DENH 2015",
+      "DENH 2020",
+      "DENH 2030"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2060": {
+    "text": "DENH 2010 , DENH 2015 , DENH 2020 , and DENH 2030",
+    "courses": [
+      "DENH 2010",
+      "DENH 2015",
+      "DENH 2020",
+      "DENH 2030"
+    ],
+    "source": "century-college"
+  },
+  "DENH 2065": {
+    "text": "DENH 2010 , DENH 2015 , DENH 2020 , and DENH 2030",
+    "courses": [
+      "DENH 2010",
+      "DENH 2015",
+      "DENH 2020",
+      "DENH 2030"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 1045": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher OR concurrent enrollment of high school students by instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 1010": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher OR concurrent enrollment of high school students by instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 1030": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 1075": {
+    "text": "EDUC 1070",
+    "courses": [
+      "EDUC 1070"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 1060": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 1070": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher. Course placement into MATH 0070 or higher, or completion of MATH 0030 with a grade of C or higher or MATH 0060 with a grade of C or higher, or MATH 1025 or above with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "MATH 0030",
+      "MATH 0060",
+      "MATH 0070",
+      "MATH 1025",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 2060": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 2025": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher OR concurrent enrollment of high school students by instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 2070": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EDUC 2080": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EMS 1025": {
+    "text": "Currrent state EMT certification and current AHA BLS Provider certification",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMS 1790": {
+    "text": "Instructor and Dean consent. Student must also be state certified as an Emergency Medical Responder (EMR), Emergency Medical Technician (EMT), or Paramedic",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMS 2001": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMS 2003": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMS 2002": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMS 2010": {
+    "text": "EMS 1010 with current certification or a current American Heart Association (AHA) Basic Life Support (BLS) Provider certification",
+    "courses": [
+      "EMS 1010"
+    ],
+    "source": "century-college"
+  },
+  "EMS 2012": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMS 2014": {
+    "text": "Students must possess current certification or licensure as an Emergency Medical Technician (EMT), Paramedic, Registered Nurse (RN), Medical Doctor (MD), Doctor of Osteopathy (DO), Respiratory Therapist (RT), or Physician’s Assistant (PA)",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMSP 1210": {
+    "text": "EMSP 1205 with a grade of C or higher",
+    "courses": [
+      "EMSP 1205"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1215": {
+    "text": "EMSP 1210 with a grade of C or higher",
+    "courses": [
+      "EMSP 1210"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1225": {
+    "text": "EMSP 1240 and EMSP 1245 with a grade of C or higher",
+    "courses": [
+      "EMSP 1240",
+      "EMSP 1245"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1226": {
+    "text": "EMSP 1225 with a grade of C or higher",
+    "courses": [
+      "EMSP 1225"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1227": {
+    "text": "EMSP 1226 with a grade of C or higher",
+    "courses": [
+      "EMSP 1226"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1220": {
+    "text": "EMSP 1210 with a grade of C or higher",
+    "courses": [
+      "EMSP 1210"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1230": {
+    "text": "EMSP 1227 with a grade of C or higher",
+    "courses": [
+      "EMSP 1227"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1235": {
+    "text": "EMSP 1205 with a grade of C or higher",
+    "courses": [
+      "EMSP 1205"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1240": {
+    "text": "EMSP 1215 and EMSP 1220 with a grade of C or higher",
+    "courses": [
+      "EMSP 1215",
+      "EMSP 1220"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1245": {
+    "text": "EMSP 1210 with a grade of C or higher",
+    "courses": [
+      "EMSP 1210"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1255": {
+    "text": "EMSP 1215 and EMSP 1220 with a grade of C or higher",
+    "courses": [
+      "EMSP 1215",
+      "EMSP 1220"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1265": {
+    "text": "EMSP 1260 with a grade of C or higher",
+    "courses": [
+      "EMSP 1260"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1260": {
+    "text": "EMSP 1226 with a grade of C or higher",
+    "courses": [
+      "EMSP 1226"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1250": {
+    "text": "EMSP 1215 and EMSP 1220 with a grade of C or higher",
+    "courses": [
+      "EMSP 1215",
+      "EMSP 1220"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1270": {
+    "text": "EMSP 1230 and EMSP 1265 with a grade of C or higher",
+    "courses": [
+      "EMSP 1230",
+      "EMSP 1265"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1271": {
+    "text": "EMSP 1230 and EMSP 1270 with a grade of C or higher",
+    "courses": [
+      "EMSP 1230",
+      "EMSP 1270"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1272": {
+    "text": "EMSP 1240 and EMSP 1270 with a grade of C or higher",
+    "courses": [
+      "EMSP 1240",
+      "EMSP 1270"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1273": {
+    "text": "EMSP 1230 , EMSP 1255 , and EMSP 1270 with a grade of C or higher",
+    "courses": [
+      "EMSP 1230",
+      "EMSP 1255",
+      "EMSP 1270"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1275": {
+    "text": "EMSP 1270 , EMSP 1271 , EMSP 1272 , EMSP 1273 , and EMSP 1274 with a grade of C or higher",
+    "courses": [
+      "EMSP 1270",
+      "EMSP 1271",
+      "EMSP 1272",
+      "EMSP 1273",
+      "EMSP 1274"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1274": {
+    "text": "EMSP 1227 and EMSP 1270 with a grade of C or higher",
+    "courses": [
+      "EMSP 1227",
+      "EMSP 1270"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1276": {
+    "text": "EMSP 1270 , EMSP 1271 , EMSP 1272 , EMSP 1273 , and EMSP 1274 with a grade of C or higher",
+    "courses": [
+      "EMSP 1270",
+      "EMSP 1271",
+      "EMSP 1272",
+      "EMSP 1273",
+      "EMSP 1274"
+    ],
+    "source": "century-college"
+  },
+  "EMSP 1277": {
+    "text": "EMSP 1270 , EMSP 1271 , EMSP 1272 , EMSP 1273 , and EMSP 1274 with a grade of C or higher",
+    "courses": [
+      "EMSP 1270",
+      "EMSP 1271",
+      "EMSP 1272",
+      "EMSP 1273",
+      "EMSP 1274"
+    ],
+    "source": "century-college"
+  },
+  "EMS 2011": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "EMSP 1280": {
+    "text": "EMSP 1270 , EMSP 1271 , EMSP 1272 , EMSP 1273 , EMSP 1274 , EMSP 1275 , EMSP 1276 , and EMSP 1277 with a grade of C or higher",
+    "courses": [
+      "EMSP 1270",
+      "EMSP 1271",
+      "EMSP 1272",
+      "EMSP 1273",
+      "EMSP 1274",
+      "EMSP 1275",
+      "EMSP 1276",
+      "EMSP 1277"
+    ],
+    "source": "century-college"
+  },
+  "EMSB 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1146": {
+    "text": "EMSE 1141 with a grade of C or higher",
+    "courses": [
+      "EMSE 1141"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1141": {
+    "text": "EMSE 1140 with a grade of C or higher",
+    "courses": [
+      "EMSE 1140"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1148": {
+    "text": "EMSE 1141 with a grade of C or higher",
+    "courses": [
+      "EMSE 1141"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1149": {
+    "text": "EMSE 1146 with a grade of C or higher; course placement into MATH 0070 or higher or completion of MATH 0030 or MATH 0060 with a grade of C or higher, or completion of MATH 1000 with a grade of C or higher",
+    "courses": [
+      "EMSE 1146",
+      "MATH 0030",
+      "MATH 0060",
+      "MATH 0070",
+      "MATH 1000"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1154": {
+    "text": "EMSE 1149 with a grade of C or higher",
+    "courses": [
+      "EMSE 1149"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1153": {
+    "text": "EMSE 1149 with a grade of C or higher",
+    "courses": [
+      "EMSE 1149"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1160": {
+    "text": "EMSE 1154 with a grade of C or higher",
+    "courses": [
+      "EMSE 1154"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1164": {
+    "text": "EMSE 1161 with a grade of C or higher",
+    "courses": [
+      "EMSE 1161"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1161": {
+    "text": "EMSE 1160 with a grade of C or higher",
+    "courses": [
+      "EMSE 1160"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1166": {
+    "text": "EMSE 1161 with a grade of C or higher",
+    "courses": [
+      "EMSE 1161"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1175": {
+    "text": "EMSE 1170 with a grade of C or higher",
+    "courses": [
+      "EMSE 1170"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1176": {
+    "text": "EMSE 1170 with a grade of C or higher",
+    "courses": [
+      "EMSE 1170"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1170": {
+    "text": "EMSE 1148 , EMSE 1164 , and EMSE 1166 with a grade of C or higher",
+    "courses": [
+      "EMSE 1148",
+      "EMSE 1164",
+      "EMSE 1166"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1177": {
+    "text": "EMSE 1170 with a grade of C or higher",
+    "courses": [
+      "EMSE 1170"
+    ],
+    "source": "century-college"
+  },
+  "EMSE 1180": {
+    "text": "EMSE 1175 , EMSE 1176 , and EMSE 1177 with a grade of C or higher",
+    "courses": [
+      "EMSE 1175",
+      "EMSE 1176",
+      "EMSE 1177"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 1020": {
+    "text": "Course placement into college-level English OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ENGR 1080": {
+    "text": "PHYS 1081 and MATH 1081 with grades of C or higher",
+    "courses": [
+      "MATH 1081",
+      "PHYS 1081"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2060": {
+    "text": "PHYS 1081 , MATH 1081 , and CHEM 1041 with grades of C or higher",
+    "courses": [
+      "CHEM 1041",
+      "MATH 1081",
+      "PHYS 1081"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2070": {
+    "text": "PHYS 1081 and MATH 1081 and CHEM 1041 with grade C or higher",
+    "courses": [
+      "CHEM 1041",
+      "MATH 1081",
+      "PHYS 1081"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2071": {
+    "text": "CHEM 1041 and ENGR 1080 and MATH 2081 with a grade of C or higher. MATH 2082 with a grade of C or higher or concurrently enrolled",
+    "courses": [
+      "CHEM 1041",
+      "ENGR 1080",
+      "MATH 2081",
+      "MATH 2082"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2085": {
+    "text": "ENGR 1080 and MATH 1082 with grades of C or higher",
+    "courses": [
+      "ENGR 1080",
+      "MATH 1082"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2080": {
+    "text": "PHYS 1081 - Introductory Physics I and MATH 1082 - Single Variable Calculus II with grades of C or higher",
+    "courses": [
+      "MATH 1082",
+      "PHYS 1081"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2091": {
+    "text": "PHYS 1082 and MATH 1082 with grades of C or higher",
+    "courses": [
+      "MATH 1082",
+      "PHYS 1082"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2090": {
+    "text": "PHYS 1082 and MATH 1082 with grades of C or higher",
+    "courses": [
+      "MATH 1082",
+      "PHYS 1082"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2092": {
+    "text": "ENGR 2091 and MATH 1082 with grades of C or higher",
+    "courses": [
+      "ENGR 2091",
+      "MATH 1082"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2095": {
+    "text": "MATH 1081 with a grade C or higher",
+    "courses": [
+      "MATH 1081"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2790": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0950 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGR 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ECAD 1040": {
+    "text": "ECAD 1020 , ECAD 1070 ; Math placement into MATH 0070 or above OR completion MATH 0030 with a grade of C or higher",
+    "courses": [
+      "ECAD 1020",
+      "ECAD 1070",
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 1790": {
+    "text": "ECAD 1070 or ECAD 2050 or ECAD 2055 with a grade of B or higher and instructor and dean consent",
+    "courses": [
+      "ECAD 1070",
+      "ECAD 2050",
+      "ECAD 2055"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2020": {
+    "text": "ECAD 1020 or instructor consent",
+    "courses": [
+      "ECAD 1020"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2030": {
+    "text": "ECAD 1040 ; course placement into MATH 0070 or above, or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "ECAD 1040",
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2040": {
+    "text": "ECAD 1040 , ECAD 1060 and course placement into MATH 0070 /MATH 1015 or above or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "ECAD 1040",
+      "ECAD 1060",
+      "MATH 0030",
+      "MATH 0070",
+      "MATH 1015"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2050": {
+    "text": "ECAD 1020 or ENGR 1020 or instructor consent",
+    "courses": [
+      "ECAD 1020",
+      "ENGR 1020"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2070": {
+    "text": "ECAD 2040 , MATH 1015 , and PHYS 1020 or instructor consent",
+    "courses": [
+      "ECAD 2040",
+      "MATH 1015",
+      "PHYS 1020"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2053": {
+    "text": "ECAD 1020 or ENGR 1020 or instructor consent",
+    "courses": [
+      "ECAD 1020",
+      "ENGR 1020"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2075": {
+    "text": "ECAD 2053 with a grade of C or higher",
+    "courses": [
+      "ECAD 2053"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2055": {
+    "text": "ECAD 1020 or ENGR 1020 or instructor consent",
+    "courses": [
+      "ECAD 1020",
+      "ENGR 1020"
+    ],
+    "source": "century-college"
+  },
+  "ECAD 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ECAD 2080": {
+    "text": "ECAD 2040 and ECAD 2050 or ECAD 2053",
+    "courses": [
+      "ECAD 2040",
+      "ECAD 2050",
+      "ECAD 2053"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 0080": {
+    "text": "Assessment score placement in ENGL 0080 or above and assessment score placement in RDNG 0900",
+    "courses": [
+      "RDNG 0900"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 0090": {
+    "text": "Course placement into ENGL 0090 or ENGL 0950 AND completion of RDNG 0940 with a grade of C or higher OR completion of RDNG 0950 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 0950": {
+    "text": "Course placement into ENGL 0950 OR completion of RDNG 0940 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 1033 or completion of ESOL 0043 with a grade of C or higher and completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 1020": {
+    "text": "Course placement into ENGL 0950 OR completion of RDNG 0940 with a grade of C or higher OR completion of RDNG 0950 with a grade of C or higher OR course placement into ESOL 1033 or completion of ESOL 0043 with a grade of C or higher and ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 1022": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 1021": {
+    "text": "Course placement into ENGL 1021 OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of ENGL 0090 with a grade of C or higher and RDNG 0950 with a grade of C or higher OR course placement into ESOL 1033 or completion of ESOL 0043 with a grade of C or higher and ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 1024": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 1025": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 1027": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2012": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2011": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2013": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2018": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2014": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2015": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2019": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2024": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2025": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher. Completion of ENGL 1027 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ENGL 1027",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2026": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2028": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2029": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2030": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher AND instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2031": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2032": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2043": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2035": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2051": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2052": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2055": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2061": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2057": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2063": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2062": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2058": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2065": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2072": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2073": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2071": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2076": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2075": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2077": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2099": {
+    "text": "ENGL 1020 or ENGL 1021 with a grade of C or higher. Completion of three courses, including ENGL 1027, toward the creative writing certificate AND Instructor consent",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021",
+      "ENGL 1027"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2083": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ENGL 2095": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0021": {
+    "text": "Appropriate scores on the language proficiency test with background information, oral interview, and writing sample",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ESOL 0022": {
+    "text": "Appropriate scores on the language proficiency test with background information, oral interview, and writing sample. Students should take advantage of community based ABE/ESL programs and have some previous English reading, writing and speaking experience, along with some previous formal educational experiences to build basic academic skills",
+    "courses": [],
+    "source": "century-college"
+  },
+  "ESOL 0031": {
+    "text": "Placement into ESOL 0031 OR completion of ESOL 0021 with a grade of “C” or higher",
+    "courses": [
+      "ESOL 0021"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0032": {
+    "text": "Placement into ESOL 0032 OR completion of ESOL 0022 with a grade of” C” or higher",
+    "courses": [
+      "ESOL 0022"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0033": {
+    "text": "Course placement into ESOL 0033, background information, oral interview, and writing sample or ESOL 0023 with a grade of C or higher",
+    "courses": [
+      "ESOL 0023"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0042": {
+    "text": "Placement into ESOL 0042 OR completion of ESOL 0032 with a grade of “C” or higher",
+    "courses": [
+      "ESOL 0032"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0041": {
+    "text": "Placement into ESOL 0041 OR completion of ESOL 0031 with a grade of “C” or higher",
+    "courses": [
+      "ESOL 0031"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0043": {
+    "text": "Placement into ESOL 0043 OR completion of ESOL 0033 with a grade of “C” or higher",
+    "courses": [
+      "ESOL 0033"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0051": {
+    "text": "Placement into ESOL 0051 OR completion of ESOL 0041 with a grade of “C” or higher",
+    "courses": [
+      "ESOL 0041"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 1033": {
+    "text": "Placement into ESOL 1033 OR completion of ESOL 0043 with a grade of “C” or higher OR course placement into ENGL 1021 OR course placement into ENGL 0950 OR completion of RDNG 0940 with a grade of “C” or higher OR completion of RDNG 0950 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0950",
+      "ENGL 1021",
+      "ESOL 0043",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0951": {
+    "text": "Course placement into ESOL 1033 and 1035 OR completion of ESOL 0051 and ESOL 0052 with a grade of C or higher OR a placement of advanced speaking, listening, reading, and writing skills",
+    "courses": [
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 0052": {
+    "text": "Placement into ESOL 0052 OR completion of ESOL 0042 with a grade of “C” or higher",
+    "courses": [
+      "ESOL 0042"
+    ],
+    "source": "century-college"
+  },
+  "ESOL 1035": {
+    "text": "Course placement into ESOL 1035 OR completion of ESOL 0043 , ESOL 0051 , and ESOL 0052 with grades of “C” or higher OR course placement into ENGL 1021 OR completion of ENGL 0950 with a grade of “C” or higher OR completion of RDNG 0940 with a grade of “C” or higher and qualifying English Placement Exam OR completion of ENGL 0090 with a grade of “C” or higher and RDNG 0950 with a grade of “C” or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ENGL 1021",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "FACM 1033": {
+    "text": "FACM 1030",
+    "courses": [
+      "FACM 1030"
+    ],
+    "source": "century-college"
+  },
+  "FACM 2020": {
+    "text": "FACM 1033",
+    "courses": [
+      "FACM 1033"
+    ],
+    "source": "century-college"
+  },
+  "FACM 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "FRTA 2021": {
+    "text": "FRTA 1091 , FRTA 1092",
+    "courses": [
+      "FRTA 1091",
+      "FRTA 1092"
+    ],
+    "source": "century-college"
+  },
+  "FRTA 1092": {
+    "text": "FRTA 1091 and FRTA 1095",
+    "courses": [
+      "FRTA 1091",
+      "FRTA 1095"
+    ],
+    "source": "century-college"
+  },
+  "FRTA 2031": {
+    "text": "FRTA 1091 and FRTA 1092",
+    "courses": [
+      "FRTA 1091",
+      "FRTA 1092"
+    ],
+    "source": "century-college"
+  },
+  "FRTA 2011": {
+    "text": "FRTA 1091 and FRTA 1092",
+    "courses": [
+      "FRTA 1091",
+      "FRTA 1092"
+    ],
+    "source": "century-college"
+  },
+  "FRTA 2071": {
+    "text": "FRTA 1091 and FRTA 1092",
+    "courses": [
+      "FRTA 1091",
+      "FRTA 1092"
+    ],
+    "source": "century-college"
+  },
+  "FRTA 2096": {
+    "text": "FRTA 1091 , FRTA 1092 , and FRTA 1095 or equivalent state certification(s)",
+    "courses": [
+      "FRTA 1091",
+      "FRTA 1092",
+      "FRTA 1095"
+    ],
+    "source": "century-college"
+  },
+  "FRTA 2081": {
+    "text": "FRTA 2011 and FRTA 2031",
+    "courses": [
+      "FRTA 2011",
+      "FRTA 2031"
+    ],
+    "source": "century-college"
+  },
+  "GNDR 1061": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "GNDR 2061": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "GNDR 1071": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "GNDR 2099": {
+    "text": "Completion of at least three courses toward the GNDR Studies Certificate and consent of instructor. ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "GNDR 2081": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "GEOG 1021": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "GEOG 1031": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "GEOG 1023": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "GEOG 1041": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 1019": {
+    "text": "GRDP 1012",
+    "courses": [
+      "GRDP 1012"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 1790": {
+    "text": "Instructor and Dean Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "GRDP 1061": {
+    "text": "GRDP 1060",
+    "courses": [
+      "GRDP 1060"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2061": {
+    "text": "GRDP 1061",
+    "courses": [
+      "GRDP 1061"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2062": {
+    "text": "GRDP 2061",
+    "courses": [
+      "GRDP 2061"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2064": {
+    "text": "GRDP 2061",
+    "courses": [
+      "GRDP 2061"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2069": {
+    "text": "GRDP 2061",
+    "courses": [
+      "GRDP 2061"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2066": {
+    "text": "GRDP 2061",
+    "courses": [
+      "GRDP 2061"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2780": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "GRDP 2067": {
+    "text": "GRDP 1018",
+    "courses": [
+      "GRDP 1018"
+    ],
+    "source": "century-college"
+  },
+  "GRDP 2951": {
+    "text": "GRDP 1012 and GRDP 1013 or Instructor Consent",
+    "courses": [
+      "GRDP 1012",
+      "GRDP 1013"
+    ],
+    "source": "century-college"
+  },
+  "HLTH 1001": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HSCI 1001": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HSCI 1000": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HSCI 1010": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher. MN Human Services Study with no restrictions. Students must provide proof of immunization for Rubella, Mumps, Rubeola, DT or DtaP, TB screening and the Hepatitis B series",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 1042": {
+    "text": "Concurrently enrolled in HVAC 1041",
+    "courses": [
+      "HVAC 1041"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 1041": {
+    "text": "Concurrently enrolled in HVAC 1042",
+    "courses": [
+      "HVAC 1042"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 1067": {
+    "text": "FACM 1030 and HVAC 1060 with grades of C or higher",
+    "courses": [
+      "FACM 1030",
+      "HVAC 1060"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 1070": {
+    "text": "This course requires completion of HVAC 1067 or concurrently enrolled",
+    "courses": [
+      "HVAC 1067"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 1069": {
+    "text": "HVAC 1042 or instructor consent",
+    "courses": [
+      "HVAC 1042"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "HVAC 1080": {
+    "text": "Coures placement into MATH 1061 or above or completion of MATH 1015 with grade of C or higher",
+    "courses": [
+      "MATH 1015",
+      "MATH 1061"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 2020": {
+    "text": "HVAC 1041 , HVAC 1042 , HVAC 1060 , and HVAC 1067 with grades of C or higher",
+    "courses": [
+      "HVAC 1041",
+      "HVAC 1042",
+      "HVAC 1060",
+      "HVAC 1067"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 2051": {
+    "text": "HVAC 1042 or instructor consent",
+    "courses": [
+      "HVAC 1042"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 2052": {
+    "text": "HVAC 2051 or instructor consent",
+    "courses": [
+      "HVAC 2051"
+    ],
+    "source": "century-college"
+  },
+  "HVAC 2053": {
+    "text": "FACM 1030 , HVAC 1041 , HVAC 1042 , HVAC 1060 , HVAC 2051 , and HVAC 2052 with grades of C or higher",
+    "courses": [
+      "FACM 1030",
+      "HVAC 1041",
+      "HVAC 1042",
+      "HVAC 1060",
+      "HVAC 2051",
+      "HVAC 2052"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1031": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1040": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1035": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1032": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1045": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1051": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "HIST 1060": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 2041": {
+    "text": "ENGL 1020 with a grade of C or higher or ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "HIST 1061": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 2043": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "HIST 2066": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "HIST 2051": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "HIST 2053": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HIST 2780": {
+    "text": "Minimum 3 credits of college-level history, ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher and consent of instructor",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "HMG 1012": {
+    "text": "HMG 1011 or instructor consent",
+    "courses": [
+      "HMG 1011"
+    ],
+    "source": "century-college"
+  },
+  "HSER 1790": {
+    "text": "Consent of instructor and dean",
+    "courses": [],
+    "source": "century-college"
+  },
+  "HSER 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "HSER 2781": {
+    "text": "Completion of HSER 2060 with a grade of C or higher and consent of instructor",
+    "courses": [
+      "HSER 2060"
+    ],
+    "source": "century-college"
+  },
+  "HUM 1055": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "HUM 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "HUM 2061": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "HUM 2790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INDV 1791": {
+    "text": "Instructor and Dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INDV 1790": {
+    "text": "Instructor and Dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INDV 2780": {
+    "text": "Instructor and Dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INFS 1020": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "INTD 1050": {
+    "text": "INTD 1020 and INTD 1040 with grades of C or higher",
+    "courses": [
+      "INTD 1020",
+      "INTD 1040"
+    ],
+    "source": "century-college"
+  },
+  "INTD 1055": {
+    "text": "INTD 1020 and INTD 1040 with grades of C or higher",
+    "courses": [
+      "INTD 1020",
+      "INTD 1040"
+    ],
+    "source": "century-college"
+  },
+  "INTD 1040": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "INTD 1090": {
+    "text": "INTD 1020 and INTD 1040 with grades of C or higher or instructor consent",
+    "courses": [
+      "INTD 1020",
+      "INTD 1040"
+    ],
+    "source": "century-college"
+  },
+  "INTD 1790": {
+    "text": "Instructor and Dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INTD 2002": {
+    "text": "INTD 1055 and INTD 2001 with a grade of C or higher",
+    "courses": [
+      "INTD 1055",
+      "INTD 2001"
+    ],
+    "source": "century-college"
+  },
+  "INTD 2001": {
+    "text": "INTD 1020 and INTD 1040 with grades of C or higher",
+    "courses": [
+      "INTD 1020",
+      "INTD 1040"
+    ],
+    "source": "century-college"
+  },
+  "INTD 2040": {
+    "text": "INTD 1055 and INTD 2001 with grades of C or higher",
+    "courses": [
+      "INTD 1055",
+      "INTD 2001"
+    ],
+    "source": "century-college"
+  },
+  "INTD 2045": {
+    "text": "INTD 2002 with a grade of C or higher",
+    "courses": [
+      "INTD 2002"
+    ],
+    "source": "century-college"
+  },
+  "INTD 2075": {
+    "text": "INTD 1050 and INTD 2001 with grades of C or instructor consent",
+    "courses": [
+      "INTD 1050",
+      "INTD 2001"
+    ],
+    "source": "century-college"
+  },
+  "INTD 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INTD 2071": {
+    "text": "INTD 2002 and INTD 2040 with a grade of C or higher",
+    "courses": [
+      "INTD 2002",
+      "INTD 2040"
+    ],
+    "source": "century-college"
+  },
+  "INET 1201": {
+    "text": "INET 1101 with a grade of C or higher",
+    "courses": [
+      "INET 1101"
+    ],
+    "source": "century-college"
+  },
+  "INET 1202": {
+    "text": "INET 1100 with a grade of C or higher",
+    "courses": [
+      "INET 1100"
+    ],
+    "source": "century-college"
+  },
+  "INET 1203": {
+    "text": "INET 1100 with a grade of C or higher",
+    "courses": [
+      "INET 1100"
+    ],
+    "source": "century-college"
+  },
+  "INET 2101": {
+    "text": "INET 1201 with a grade of C or higher",
+    "courses": [
+      "INET 1201"
+    ],
+    "source": "century-college"
+  },
+  "INET 2099": {
+    "text": "INET 1201 and CTSA 1013 and CFI 1083 with grades of C or higher or instructor consent",
+    "courses": [
+      "CFI 1083",
+      "CTSA 1013",
+      "INET 1201"
+    ],
+    "source": "century-college"
+  },
+  "INET 2102": {
+    "text": "INET 1201 and INET 1202 with grades of C of higher or instructor consent",
+    "courses": [
+      "INET 1201",
+      "INET 1202"
+    ],
+    "source": "century-college"
+  },
+  "INET 2103": {
+    "text": "INET 1201 and INET 1202 with grades of C or higher or instructor consent",
+    "courses": [
+      "INET 1201",
+      "INET 1202"
+    ],
+    "source": "century-college"
+  },
+  "INET 2201": {
+    "text": "INET 2103 with a grade of C or higher or instructor consent",
+    "courses": [
+      "INET 2103"
+    ],
+    "source": "century-college"
+  },
+  "INET 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "INET 2202": {
+    "text": "INET 2102 and CTSA 1013 with grades of C or higher or instructor consent",
+    "courses": [
+      "CTSA 1013",
+      "INET 2102"
+    ],
+    "source": "century-college"
+  },
+  "INET 2790": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "KBD 2010": {
+    "text": "KBD 1010 , KBD 1020 , KBD 1030 , KBD 1040 , and KBD 1050 or instructor consent",
+    "courses": [
+      "KBD 1010",
+      "KBD 1020",
+      "KBD 1030",
+      "KBD 1040",
+      "KBD 1050"
+    ],
+    "source": "century-college"
+  },
+  "KBD 2030": {
+    "text": "KBD 1010 and KBD 1030 or instructor consent",
+    "courses": [
+      "KBD 1010",
+      "KBD 1030"
+    ],
+    "source": "century-college"
+  },
+  "KBD 2060": {
+    "text": "KBD 2020 or instructor consent",
+    "courses": [
+      "KBD 2020"
+    ],
+    "source": "century-college"
+  },
+  "KBD 2020": {
+    "text": "KBD 1010 and KBD 1030 or instructor consent",
+    "courses": [
+      "KBD 1010",
+      "KBD 1030"
+    ],
+    "source": "century-college"
+  },
+  "KBD 2070": {
+    "text": "KBD 2020 or instructor consent",
+    "courses": [
+      "KBD 2020"
+    ],
+    "source": "century-college"
+  },
+  "KBD 2780": {
+    "text": "KBD 1010 and KBD 1030",
+    "courses": [
+      "KBD 1010",
+      "KBD 1030"
+    ],
+    "source": "century-college"
+  },
+  "KBD 2080": {
+    "text": "KBD 1010 or instructor consent",
+    "courses": [
+      "KBD 1010"
+    ],
+    "source": "century-college"
+  },
+  "MKTG 1790": {
+    "text": "MKTG 2050 with a grade of B or higher and Instructor and dean consent",
+    "courses": [
+      "MKTG 2050"
+    ],
+    "source": "century-college"
+  },
+  "MKTG 2780": {
+    "text": "Last semester prior to graduation and instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "MKTG 2076": {
+    "text": "MKTG 2063 with a grade of “C” or higher",
+    "courses": [
+      "MKTG 2063"
+    ],
+    "source": "century-college"
+  },
+  "MATH 0030": {
+    "text": "Assessment score placement in Math 0030",
+    "courses": [],
+    "source": "century-college"
+  },
+  "MATH 1000": {
+    "text": "Assessment score placement in MATH 1000",
+    "courses": [],
+    "source": "century-college"
+  },
+  "MATH 0961": {
+    "text": "Course placement into MATH 0961",
+    "courses": [],
+    "source": "century-college"
+  },
+  "MATH 1015": {
+    "text": "Placement into MATH 1015",
+    "courses": [],
+    "source": "century-college"
+  },
+  "MATH 1025": {
+    "text": "Course placement into MATH 1025 or higher OR completion of MATH 0060 with a grade of C or higher OR MATH 0070 with a grade of C or higher OR MATH 1030 or above with a grade of C or higher OR MATH 0925 with a grade of C or higher OR concurrently enrolled in MATH 0925",
+    "courses": [
+      "MATH 0060",
+      "MATH 0070",
+      "MATH 0925",
+      "MATH 1030"
+    ],
+    "source": "century-college"
+  },
+  "MATH 1030": {
+    "text": "Course placement into MATH 1030 or higher OR completion of MATH 0060 with a grade of C or higher OR MATH 0070 with a grade of C or higher OR MATH 1025 or above with a grade of C or higher OR MATH 0930 with a grade of C or higher OR concurrently enrolled in MATH 0930",
+    "courses": [
+      "MATH 0060",
+      "MATH 0070",
+      "MATH 0930",
+      "MATH 1025"
+    ],
+    "source": "century-college"
+  },
+  "MATH 1050": {
+    "text": "MATH 0070 with a grade of C or higher, or placement into MATH 1050",
+    "courses": [
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "MATH 1061": {
+    "text": "Course placement into MATH 1061 OR completion of MATH 0070 with a grade of C or higher OR MATH 0961 with a grade of C or higher OR concurrently enrolled in MATH 0961",
+    "courses": [
+      "MATH 0070",
+      "MATH 0961"
+    ],
+    "source": "century-college"
+  },
+  "MATH 1070": {
+    "text": "MATH 1061 with a grade of “C” or higher, or placement into MATH 1070. Restriction: Credit will not be granted for both MATH 1070 and MATH 1081",
+    "courses": [
+      "MATH 1061",
+      "MATH 1081"
+    ],
+    "source": "century-college"
+  },
+  "MATH 1062": {
+    "text": "Placement into MATH 1062 or higher, or MATH 1061 with a grade of C or higher",
+    "courses": [
+      "MATH 1061"
+    ],
+    "source": "century-college"
+  },
+  "MATH 1082": {
+    "text": "MATH 1081 with a grade of C or higher",
+    "courses": [
+      "MATH 1081"
+    ],
+    "source": "century-college"
+  },
+  "MATH 2081": {
+    "text": "MATH 1082 with a grade of C or higher, or instructor consent",
+    "courses": [
+      "MATH 1082"
+    ],
+    "source": "century-college"
+  },
+  "MATH 2025": {
+    "text": "MATH 1082 with a grade of C or higher",
+    "courses": [
+      "MATH 1082"
+    ],
+    "source": "century-college"
+  },
+  "MATH 2082": {
+    "text": "MATH 1082 with a grade of C or higher, or instructor consent",
+    "courses": [
+      "MATH 1082"
+    ],
+    "source": "century-college"
+  },
+  "MEDA 1002": {
+    "text": "MEDA 1011 and MEDA 1013 with grades of C or higher",
+    "courses": [
+      "MEDA 1011",
+      "MEDA 1013"
+    ],
+    "source": "century-college"
+  },
+  "MEDA 1014": {
+    "text": "MEDA 1011 and MEDA 1013 with grades of C or higher",
+    "courses": [
+      "MEDA 1011",
+      "MEDA 1013"
+    ],
+    "source": "century-college"
+  },
+  "MEDA 1011": {
+    "text": "HLTH 1001 with a grade of C or higher and BIOL 1024 OR BIOL 2031 AND BIOL 2032 .Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "BIOL 1024",
+      "BIOL 2031",
+      "BIOL 2032",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "HLTH 1001",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "MEDA 1013": {
+    "text": "HLTH 1001 with a grade of C or higher and BIOL 1024 OR BIOL 2031 AND BIOL 2032 .Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "BIOL 1024",
+      "BIOL 2031",
+      "BIOL 2032",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "HLTH 1001",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "MEDA 1020": {
+    "text": "CAPL 1010 or CSCI 1020 with a grade of C or higher, and HLTH 1001 with a grade of C or higher. Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "CAPL 1010",
+      "CSCI 1020",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "HLTH 1001",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "MEDA 1780": {
+    "text": "All program requirements completed prior to the practicum experience and Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "MEDA 1030": {
+    "text": "BIOL 1024 OR BIOL 2031 AND BIOL 2032 ; HLTH 1001 with a grade of C or higher. Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher. Must be a current Medical Assistant, a current MEDA major, and have instructor consent",
+    "courses": [
+      "BIOL 1024",
+      "BIOL 2031",
+      "BIOL 2032",
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "HLTH 1001",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "MUSC 1075": {
+    "text": "MUSC 1070 with a grade of C or higher",
+    "courses": [
+      "MUSC 1070"
+    ],
+    "source": "century-college"
+  },
+  "MUSC 2070": {
+    "text": "MUSC 1075 with a grade of C or higher",
+    "courses": [
+      "MUSC 1075"
+    ],
+    "source": "century-college"
+  },
+  "MUSC 2075": {
+    "text": "MUSC 2070 with a grade of C or higher",
+    "courses": [
+      "MUSC 2070"
+    ],
+    "source": "century-college"
+  },
+  "NVP 1019": {
+    "text": "NVP 1012",
+    "courses": [
+      "NVP 1012"
+    ],
+    "source": "century-college"
+  },
+  "NVP 1135": {
+    "text": "NVP 1133 with a grade of C or higher",
+    "courses": [
+      "NVP 1133"
+    ],
+    "source": "century-college"
+  },
+  "NVP 1137": {
+    "text": "NVP 1133",
+    "courses": [
+      "NVP 1133"
+    ],
+    "source": "century-college"
+  },
+  "NVP 1790": {
+    "text": "Instructor and Dean Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "NVP 2131": {
+    "text": "NVP 1135 or Instructor Consent",
+    "courses": [
+      "NVP 1135"
+    ],
+    "source": "century-college"
+  },
+  "NVP 2133": {
+    "text": "NVP 1137",
+    "courses": [
+      "NVP 1137"
+    ],
+    "source": "century-college"
+  },
+  "NVP 2134": {
+    "text": "NVP 1137",
+    "courses": [
+      "NVP 1137"
+    ],
+    "source": "century-college"
+  },
+  "NVP 2137": {
+    "text": "NVP 2133",
+    "courses": [
+      "NVP 2133"
+    ],
+    "source": "century-college"
+  },
+  "NVP 2135": {
+    "text": "NVP 1135 or Instructor Consent",
+    "courses": [
+      "NVP 1135"
+    ],
+    "source": "century-college"
+  },
+  "NVP 2780": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "NVP 2139": {
+    "text": "NVP 2133 or Instructor Consent",
+    "courses": [
+      "NVP 2133"
+    ],
+    "source": "century-college"
+  },
+  "NURS 1028": {
+    "text": "Nursing Director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "NURS 2025": {
+    "text": "NURS 2300 or NURS 2310 or NURS 2320",
+    "courses": [
+      "NURS 2300",
+      "NURS 2310",
+      "NURS 2320"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2350": {
+    "text": "BIOL 1020 (or higher), CHEM 1020 (or higher), ENGL 1021, PSYC 1041 with grades of C or higher are prerequisites for acceptance into the nursing program and for this course",
+    "courses": [
+      "BIOL 1020",
+      "CHEM 1020",
+      "ENGL 1021",
+      "PSYC 1041"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2300": {
+    "text": "BIOL 1020 (or higher), CHEM 1020 (or higher), ENGL 1020 or ENGL 1021 , and PSYC 1041 with grades of C or higher",
+    "courses": [
+      "BIOL 1020",
+      "CHEM 1020",
+      "ENGL 1020",
+      "ENGL 1021",
+      "PSYC 1041"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2310": {
+    "text": "BIOL 1020 (or higher), CHEM 1020 (or higher), ENGL 1020 or ENGL 1021 , and PSYC 1041 with grades of C or higher",
+    "courses": [
+      "BIOL 1020",
+      "CHEM 1020",
+      "ENGL 1020",
+      "ENGL 1021",
+      "PSYC 1041"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2410": {
+    "text": "NURS 2300 , NURS 2310 , and NURS 2320 ; BIOL 2031 and COMM 1031 or COMM 1041 or COMM 1051 with grades of C or higher",
+    "courses": [
+      "BIOL 2031",
+      "COMM 1031",
+      "COMM 1041",
+      "COMM 1051",
+      "NURS 2300",
+      "NURS 2310",
+      "NURS 2320"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2320": {
+    "text": "BIOL 1020 (or higher), CHEM 1020 (or higher), ENGL 1020 or ENGL 1021 , and PSYC 1041 with grades of C or higher",
+    "courses": [
+      "BIOL 1020",
+      "CHEM 1020",
+      "ENGL 1020",
+      "ENGL 1021",
+      "PSYC 1041"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2400": {
+    "text": "NURS 2300 , NURS 2310 , and NURS 2320 ; BIOL 2031 and COMM 1031 or COMM 1041 or COMM 1051 with grades of C or higher",
+    "courses": [
+      "BIOL 2031",
+      "COMM 1031",
+      "COMM 1041",
+      "COMM 1051",
+      "NURS 2300",
+      "NURS 2310",
+      "NURS 2320"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2500": {
+    "text": "NURS 2400 , NURS 2410 , NURS 2420 , and BIOL 2032 with grades of C or higher",
+    "courses": [
+      "BIOL 2032",
+      "NURS 2400",
+      "NURS 2410",
+      "NURS 2420"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2420": {
+    "text": "NURS 2300 , NURS 2310 , and NURS 2320 ; BIOL 2031 and COMM 1031 or COMM 1041 or COMM 1051 with grades of C or higher",
+    "courses": [
+      "BIOL 2031",
+      "COMM 1031",
+      "COMM 1041",
+      "COMM 1051",
+      "NURS 2300",
+      "NURS 2310",
+      "NURS 2320"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2510": {
+    "text": "NURS 2400 , NURS 2410 , NURS 2420 , and BIOL 2032 with grades of C or higher",
+    "courses": [
+      "BIOL 2032",
+      "NURS 2400",
+      "NURS 2410",
+      "NURS 2420"
+    ],
+    "source": "century-college"
+  },
+  "NURS 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "NURS 2520": {
+    "text": "NURS 2400 , NURS 2410 , NURS 2420 , and BIOL 2032 with grades of C or higher",
+    "courses": [
+      "BIOL 2032",
+      "NURS 2400",
+      "NURS 2410",
+      "NURS 2420"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OFFT 2013": {
+    "text": "Completion of or concurrently enrolled in OFFT 2010. Note: Students concurrently enrolled in prerequisite course must contact Instructor or Records Office for verification to register",
+    "courses": [
+      "OFFT 2010"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2021": {
+    "text": "OFFT 2006 and OFFT 2010 wth grades of C or higher",
+    "courses": [
+      "OFFT 2006",
+      "OFFT 2010"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2006": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2012": {
+    "text": "Completion of or concurrently enrolled in OFFT 2010. Note: Students concurrently enrolled in prerequisite course must contact Instructor or Records Office for verification to register",
+    "courses": [
+      "OFFT 2010"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2030": {
+    "text": "OFFT 2006 and OFFT 2010 with grades of C or higher",
+    "courses": [
+      "OFFT 2006",
+      "OFFT 2010"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2010": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2041": {
+    "text": "CAPL 1010 and OFFT 2010 with grades of C or higher",
+    "courses": [
+      "CAPL 1010",
+      "OFFT 2010"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2044": {
+    "text": "OFFT 2041 with a grade of C or higher or instructor consent",
+    "courses": [
+      "OFFT 2041"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2031": {
+    "text": "BIOL 1024 , OFFT 2012 , OFFT 2013 , and OFFT 2050 with grades of C or higher",
+    "courses": [
+      "BIOL 1024",
+      "OFFT 2012",
+      "OFFT 2013",
+      "OFFT 2050"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2035": {
+    "text": "OFFT 2031 and OFFT 2032 with grades of C or higher",
+    "courses": [
+      "OFFT 2031",
+      "OFFT 2032"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2032": {
+    "text": "BIOL 1024 , OFFT 2012 , OFFT 2013 , and OFFT 2050 with grades of C or higher",
+    "courses": [
+      "BIOL 1024",
+      "OFFT 2012",
+      "OFFT 2013",
+      "OFFT 2050"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2050": {
+    "text": "CAPL 1010 and OFFT 2010 with grades of C or higher",
+    "courses": [
+      "CAPL 1010",
+      "OFFT 2010"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2095": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OFFT 2054": {
+    "text": "OFFT 2050 with a grade of C or higher",
+    "courses": [
+      "OFFT 2050"
+    ],
+    "source": "century-college"
+  },
+  "OFFT 2055": {
+    "text": "CAPL 1010 or instructor consent",
+    "courses": [
+      "CAPL 1010"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1010": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OFFT 2099": {
+    "text": "CAPL 1010 and CAPL 1023 or instructor consent",
+    "courses": [
+      "CAPL 1010",
+      "CAPL 1023"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1015": {
+    "text": "OPCA 1010 with a grade of C or higher or concurrently enrolled",
+    "courses": [
+      "OPCA 1010"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1020": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1025": {
+    "text": "OPCA 1015 with a grade of C or higher or concurrently enrolled",
+    "courses": [
+      "OPCA 1015"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1030": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1040": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1035": {
+    "text": "OPCA 1025 with a grade of C or higher or concurrently enrolled",
+    "courses": [
+      "OPCA 1025"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1060": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1050": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1045": {
+    "text": "OPCA 1035 with a grade of C or higher or concurrently enrolled",
+    "courses": [
+      "OPCA 1035"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1055": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1070": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1065": {
+    "text": "OPCA 1055 with a grade of C or higher, or concurrently enrolled",
+    "courses": [
+      "OPCA 1055"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1080": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1075": {
+    "text": "OPCA 1065 with a grade of C or higher, or concurrently enrolled",
+    "courses": [
+      "OPCA 1065"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1090": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1085": {
+    "text": "OPCA 1075 with a grade of C or higher, or concurrently enrolledOPCA 1075",
+    "courses": [
+      "OPCA 1075"
+    ],
+    "source": "century-college"
+  },
+  "OPCA 1110": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2020": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2010": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2030": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 1780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2040": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2050": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2080": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2060": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2090": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "OPCA 2070": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PHIL 1021": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PHIL 1025": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PHIL 1035": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PHIL 1031": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PHIL 2032": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "PHIL 2051": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 1019": {
+    "text": "PHOT 1012",
+    "courses": [
+      "PHOT 1012"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 1076": {
+    "text": "PHOT 1071 with a grade of “C” or higher",
+    "courses": [
+      "PHOT 1071"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 1078": {
+    "text": "PHOT 1076 with a grade of “C” or higher",
+    "courses": [
+      "PHOT 1076"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 1790": {
+    "text": "Instructor and Dean Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PHOT 2073": {
+    "text": "PHOT 1018 and PHOT 1071 with grades of “C” or higher",
+    "courses": [
+      "PHOT 1018",
+      "PHOT 1071"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 2071": {
+    "text": "PHOT 1078 with a grade of “C” or higher",
+    "courses": [
+      "PHOT 1078"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 2075": {
+    "text": "PHOT 1073 with a grade of “C” or higher",
+    "courses": [
+      "PHOT 1073"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 2078": {
+    "text": "PHOT 1078 and PHOT 2073 with grades of “C” or higher",
+    "courses": [
+      "PHOT 1078",
+      "PHOT 2073"
+    ],
+    "source": "century-college"
+  },
+  "PHOT 2780": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PHOT 2079": {
+    "text": "PHOT 1078 and PHOT 2073 with grades of “C” or higher",
+    "courses": [
+      "PHOT 1078",
+      "PHOT 2073"
+    ],
+    "source": "century-college"
+  },
+  "PE 2088": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 1780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2089": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2091": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2095": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2093": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2092": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2094": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2097": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2096": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PE 2098": {
+    "text": "Instructor or athletic director consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PHYS 1020": {
+    "text": "Course placement into MATH 0070 or above or completion of MATH 0030 or MATH 0060 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0060",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "PHYS 1035": {
+    "text": "Course placement into MATH 0070 or higher or completion of MATH 0030 or MATH 0060 with a grade of C or higher. Restriction: Closed to students who have completed PHYS 1030",
+    "courses": [
+      "MATH 0030",
+      "MATH 0060",
+      "MATH 0070",
+      "PHYS 1030"
+    ],
+    "source": "century-college"
+  },
+  "PHYS 1042": {
+    "text": "PHYS 1041 with a grade of C or higher",
+    "courses": [
+      "PHYS 1041"
+    ],
+    "source": "century-college"
+  },
+  "PHYS 1082": {
+    "text": "PHYS 1081 and MATH 1081",
+    "courses": [
+      "MATH 1081",
+      "PHYS 1081"
+    ],
+    "source": "century-college"
+  },
+  "PHYS 1041": {
+    "text": "Course placement into MATH 1061 or above, or completion of MATH 0070 or MATH 0090 or MATH 1015 with a grade of C or higher",
+    "courses": [
+      "MATH 0070",
+      "MATH 0090",
+      "MATH 1015",
+      "MATH 1061"
+    ],
+    "source": "century-college"
+  },
+  "PHYS 1081": {
+    "text": "Course placement into MATH 1081 or completion of MATH 1062 with a grade of C or higher",
+    "courses": [
+      "MATH 1062",
+      "MATH 1081"
+    ],
+    "source": "century-college"
+  },
+  "PHYS 2081": {
+    "text": "PHYS 1082 and MATH 1082",
+    "courses": [
+      "MATH 1082",
+      "PHYS 1082"
+    ],
+    "source": "century-college"
+  },
+  "POLS 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "POLS 1035": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "POLS 1780": {
+    "text": "POLS 1031 or POLS 1033 or concurrently enrolled and instructor consent. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "POLS 1031",
+      "POLS 1033"
+    ],
+    "source": "century-college"
+  },
+  "POLS 1040": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 1041": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 1790": {
+    "text": "Consent of instructor and dean",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PSYC 1050": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2001": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2021": {
+    "text": "PSYC 1020 with a grade of C or higher and ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021",
+      "PSYC 1020"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2002": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2030": {
+    "text": "PSYC 1020 with a grade of C or higher and ENGL 1020 or ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021",
+      "PSYC 1020"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2004": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2003": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2045": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2043": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2790": {
+    "text": "PSYC 1020 or consent of instructor; course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "PSYC 1020",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2044": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2050": {
+    "text": "MATH 1025 (preferred) or MATH 1061 or above with a grade of C or higher and PSYC 1020 with a grade of C or higher",
+    "courses": [
+      "MATH 1025",
+      "MATH 1061",
+      "PSYC 1020"
+    ],
+    "source": "century-college"
+  },
+  "PSYC 2780": {
+    "text": "Completion of one PSYC course with a grade of C or higher AND Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "PSAF 1790": {
+    "text": "PSAF 1020 and instructor and dean consent",
+    "courses": [
+      "PSAF 1020"
+    ],
+    "source": "century-college"
+  },
+  "PSAF 1032": {
+    "text": "PSAF 1031 or instructor consent",
+    "courses": [
+      "PSAF 1031"
+    ],
+    "source": "century-college"
+  },
+  "PSAF 2050": {
+    "text": "PSAF 1020 and instructor consent",
+    "courses": [
+      "PSAF 1020"
+    ],
+    "source": "century-college"
+  },
+  "RADT 1040": {
+    "text": "RADT 1020 and RADT 1031",
+    "courses": [
+      "RADT 1020",
+      "RADT 1031"
+    ],
+    "source": "century-college"
+  },
+  "RADT 1032": {
+    "text": "RADT 1020 and RADT 1031 with grades of C or higher",
+    "courses": [
+      "RADT 1020",
+      "RADT 1031"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2010": {
+    "text": "RADT 2020 , RADT 2030 and RADT 2783",
+    "courses": [
+      "RADT 2020",
+      "RADT 2030",
+      "RADT 2783"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2000": {
+    "text": "RADT 1032 , RADT 1040 and RADT 1781",
+    "courses": [
+      "RADT 1032",
+      "RADT 1040",
+      "RADT 1781"
+    ],
+    "source": "century-college"
+  },
+  "RADT 1781": {
+    "text": "RADT 1020 and RADT 1031 with grades of C or higher",
+    "courses": [
+      "RADT 1020",
+      "RADT 1031"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2020": {
+    "text": "RADT 1782 and RADT 2000",
+    "courses": [
+      "RADT 1782",
+      "RADT 2000"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2030": {
+    "text": "RADT 1782 and RADT 2000",
+    "courses": [
+      "RADT 1782",
+      "RADT 2000"
+    ],
+    "source": "century-college"
+  },
+  "RADT 1782": {
+    "text": "RADT 1032 , RADT 1040 and RADT 1781",
+    "courses": [
+      "RADT 1032",
+      "RADT 1040",
+      "RADT 1781"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2060": {
+    "text": "RADT 2010 , RADT 2090 , RADT 2100 and RADT 2784",
+    "courses": [
+      "RADT 2010",
+      "RADT 2090",
+      "RADT 2100",
+      "RADT 2784"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2090": {
+    "text": "RADT 2020 , RADT 2030 , and RADT 2783",
+    "courses": [
+      "RADT 2020",
+      "RADT 2030",
+      "RADT 2783"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2100": {
+    "text": "RADT 2020 , RADT 2030 and RADT 2783",
+    "courses": [
+      "RADT 2020",
+      "RADT 2030",
+      "RADT 2783"
+    ],
+    "source": "century-college"
+  },
+  "RDNG 0930": {
+    "text": "Course placement into RDNG 0930",
+    "courses": [],
+    "source": "century-college"
+  },
+  "RADT 2783": {
+    "text": "RADT 1782 and RADT 2000",
+    "courses": [
+      "RADT 1782",
+      "RADT 2000"
+    ],
+    "source": "century-college"
+  },
+  "RDNG 0940": {
+    "text": "Course placement into RDNG 0940",
+    "courses": [],
+    "source": "century-college"
+  },
+  "RDNG 0950": {
+    "text": "Course placement into RDNG 0950",
+    "courses": [],
+    "source": "century-college"
+  },
+  "RNEW 1507": {
+    "text": "Course placement into MATH 0070 or higher or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "RDNG 0951": {
+    "text": "A placement into RDNG 0951 with the equivalent of a student Lexile level of 950 or above",
+    "courses": [],
+    "source": "century-college"
+  },
+  "RNEW 2543": {
+    "text": "Couse placement into MATH 0070 or higher or completion of MATH 0030 with a grade of C or higher",
+    "courses": [
+      "MATH 0030",
+      "MATH 0070"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2784": {
+    "text": "RADT 2020 , RADT 2030 , and RADT 2783",
+    "courses": [
+      "RADT 2020",
+      "RADT 2030",
+      "RADT 2783"
+    ],
+    "source": "century-college"
+  },
+  "RDNG 1000": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "RADT 2785": {
+    "text": "RADT 2010 , RADT 2090 , RADT 2100 , and RADT 2784",
+    "courses": [
+      "RADT 2010",
+      "RADT 2090",
+      "RADT 2100",
+      "RADT 2784"
+    ],
+    "source": "century-college"
+  },
+  "SOC 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "SOC 1080": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "SOC 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "SOC 1033": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "SOC 1041": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "SOC 2031": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "SOC 2053": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "SOC 2051": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "SOC 2071": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "SOC 2087": {
+    "text": "ENGL 1020 with a grade of C or higher OR ENGL 1021 with a grade of C or higher",
+    "courses": [
+      "ENGL 1020",
+      "ENGL 1021"
+    ],
+    "source": "century-college"
+  },
+  "SOLR 1781": {
+    "text": "SOLR 1020 , SOLR 2030 /SOLR 2035",
+    "courses": [
+      "SOLR 1020",
+      "SOLR 2030",
+      "SOLR 2035"
+    ],
+    "source": "century-college"
+  },
+  "SOLR 1780": {
+    "text": "SOLR 1020 , SOLR 2020 , and SOLR 2025",
+    "courses": [
+      "SOLR 1020",
+      "SOLR 2020",
+      "SOLR 2025"
+    ],
+    "source": "century-college"
+  },
+  "SOLR 2035": {
+    "text": "SOLR 1020 and SOLR 1030 or consent of instructor. Concurrent enrollment in SOLR 2030",
+    "courses": [
+      "SOLR 1020",
+      "SOLR 1030",
+      "SOLR 2030"
+    ],
+    "source": "century-college"
+  },
+  "SOLR 2030": {
+    "text": "SOLR 1020 and SOLR 1030 , concurrent enrollment in SOLR 2035 or consent of instructor",
+    "courses": [
+      "SOLR 1020",
+      "SOLR 1030",
+      "SOLR 2035"
+    ],
+    "source": "century-college"
+  },
+  "SPAN 1012": {
+    "text": "SPAN 1011",
+    "courses": [
+      "SPAN 1011"
+    ],
+    "source": "century-college"
+  },
+  "SPAN 1790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "SPAN 2022": {
+    "text": "SPAN 2021",
+    "courses": [
+      "SPAN 2021"
+    ],
+    "source": "century-college"
+  },
+  "SPAN 2021": {
+    "text": "SPAN 1012",
+    "courses": [
+      "SPAN 1012"
+    ],
+    "source": "century-college"
+  },
+  "SPAN 2790": {
+    "text": "Instructor and dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "STSC 1050": {
+    "text": "Course placement into ENGL 0950 and RDNG 0950 or above OR completion of RDNG 0940 with a grade of C or higher OR course placement into ESOL 0051 and ESOL 0052 and ESOL 1033 OR completion of ESOL 0041 with a grade of C or higher and ESOL 0042 with a grade of C or higher and ESOL 0043 with a grade of C or higher",
+    "courses": [
+      "ENGL 0950",
+      "ESOL 0041",
+      "ESOL 0042",
+      "ESOL 0043",
+      "ESOL 0051",
+      "ESOL 0052",
+      "ESOL 1033",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "THTR 1013": {
+    "text": "Instructor consent, gained through audition and/or assignment of a role or technical theatre project on the Century stage",
+    "courses": [],
+    "source": "century-college"
+  },
+  "THTR 1020": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "THTR 1033": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "THTR 1071": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "THTR 1790": {
+    "text": "Instructor and Dean consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "THTR 1081": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "THTR 2780": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "THTR 2081": {
+    "text": "THTR 1020 or instructor consent. Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950",
+      "THTR 1020"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1032": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher, and instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1021": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher, and instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1035": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1065": {
+    "text": "TRIN 1021 , TRIN 1032 , and TRIN 1033 with grades of C or higher",
+    "courses": [
+      "TRIN 1021",
+      "TRIN 1032",
+      "TRIN 1033"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1051": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher; or instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1071": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher; or instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1073": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher; or instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1790": {
+    "text": "TRIN 1021 , TRIN 1032 , and TRIN 1033 with a grade of C or higher, and instructor consent",
+    "courses": [
+      "TRIN 1021",
+      "TRIN 1032",
+      "TRIN 1033"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1075": {
+    "text": "Course placement into college-level English and Reading OR completion of ENGL 0950 with a grade of C or higher OR completion of RDNG 0940 with a grade of C or higher and qualifying English Placement Exam OR completion of RDNG 0950 with a grade of C or higher and ENGL 0090 with a grade of C or higher OR completion of ESOL 0051 with a grade of C or higher and ESOL 0052 with a grade of C or higher; or instructor consent",
+    "courses": [
+      "ENGL 0090",
+      "ENGL 0950",
+      "ESOL 0051",
+      "ESOL 0052",
+      "RDNG 0940",
+      "RDNG 0950"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2021": {
+    "text": "TRIN 1021 , TRIN 1032 ,and TRIN 1033 with grades of C or higher and instructor consent",
+    "courses": [
+      "TRIN 1021",
+      "TRIN 1032",
+      "TRIN 1033"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 1083": {
+    "text": "TRIN 1021 , TRIN 1032 ,and TRIN 1033 with grades of C or higher and instructor consent",
+    "courses": [
+      "TRIN 1021",
+      "TRIN 1032",
+      "TRIN 1033"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2032": {
+    "text": "TRIN 1083 with a grade of C or higher or concurrently enrolled and instructor consent. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "TRIN 1083"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2023": {
+    "text": "TRIN 1083 with a grade of C or higher",
+    "courses": [
+      "TRIN 1083"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2035": {
+    "text": "TRIN 1083 with a grade of C or higher or concurrently enrolled. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "TRIN 1083"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2036": {
+    "text": "TRIN 1083 with a grade of C or higher, or concurrently enrolled. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "TRIN 1083"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2780": {
+    "text": "TRIN 1083 with a grade of C or higher or concurrently enrolled and instructor consent. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "TRIN 1083"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2037": {
+    "text": "TRIN 2023 with a grade of C or higher, or concurrently enrolled. Note: students concurrently enrolled in prerequisite course must contact Records Office for verification",
+    "courses": [
+      "TRIN 2023"
+    ],
+    "source": "century-college"
+  },
+  "TRIN 2790": {
+    "text": "Instructor consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "TRIN 2996": {
+    "text": "Completion of TRIN 1083 with a grade of C or higher and Instructor Consent",
+    "courses": [
+      "TRIN 1083"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 1019": {
+    "text": "WEBD 1012",
+    "courses": [
+      "WEBD 1012"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 1125": {
+    "text": "WEBD 1121 and WEBD 1123 with grades of “C” or higher",
+    "courses": [
+      "WEBD 1121",
+      "WEBD 1123"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 1790": {
+    "text": "Instructor and Dean Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "WEBD 1127": {
+    "text": "WEBD 1121 and WEBD 1123 with grades of “C” or higher",
+    "courses": [
+      "WEBD 1121",
+      "WEBD 1123"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 2121": {
+    "text": "WEBD 1125 with a grade of “C” or higher",
+    "courses": [
+      "WEBD 1125"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 2780": {
+    "text": "Instructor Consent",
+    "courses": [],
+    "source": "century-college"
+  },
+  "WEBD 2125": {
+    "text": "WEBD 2123 with a grade of “C” or higher",
+    "courses": [
+      "WEBD 2123"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 2123": {
+    "text": "WEBD 1127 with a grade of “C” or higher",
+    "courses": [
+      "WEBD 1127"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 2129": {
+    "text": "WEBD 2121 and WEBD 2123 with grades of “C” or higher",
+    "courses": [
+      "WEBD 2121",
+      "WEBD 2123"
+    ],
+    "source": "century-college"
+  },
+  "WEBD 2127": {
+    "text": "WEBD 2123 with a grade of “C” or higher",
+    "courses": [
+      "WEBD 2123"
+    ],
+    "source": "century-college"
+  },
+  "WLDG 1015": {
+    "text": "WLDG 1011 or instructor consent",
+    "courses": [
+      "WLDG 1011"
+    ],
+    "source": "century-college"
+  },
+  "WLDG 1022": {
+    "text": "WLDG 1021 or instructor consent",
+    "courses": [
+      "WLDG 1021"
+    ],
+    "source": "century-college"
+  },
+  "WLDG 1025": {
+    "text": "WLDG 1021 or instructor consent",
+    "courses": [
+      "WLDG 1021"
+    ],
+    "source": "century-college"
+  },
+  "ABCT 1212": {
+    "text": "ABCT 1111",
+    "courses": [
+      "ABCT 1111"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 1120": {
+    "text": "ABCT 1111",
+    "courses": [
+      "ABCT 1111"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 1130": {
+    "text": "ABCT 1120 , ABCT 1142",
+    "courses": [
+      "ABCT 1120",
+      "ABCT 1142"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 1214": {
+    "text": "ABCT 1120 , ABCT 1130 , ABCT 1142",
+    "courses": [
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 1216": {
+    "text": "ABCT 1130 , ABCT 1150 , ABCT 1142 , ABCT 1214",
+    "courses": [
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1214"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 1230": {
+    "text": "ABCT 1130 , ABCT 1142 , ABCT 1214 , ABCT 1216",
+    "courses": [
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1214",
+      "ABCT 1216"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2106": {
+    "text": "ABCT 1111 , ABCT 1120 , ABCT 1130 , ABCT 1142 , ABCT 1150 , ABCT 1212 , ABCT 1214 , ABCT 1216 , ABCT 1230",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1214",
+      "ABCT 1216",
+      "ABCT 1230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2103": {
+    "text": "ABCT 1111 , ABCT 1120 , ABCT 1130 , ABCT 1142 , ABCT 1150 , ABCT 1212 , ABCT 1214 , ABCT 1216 , ABCT 1230",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1214",
+      "ABCT 1216",
+      "ABCT 1230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2100": {
+    "text": "ABCT 1111 , ABCT 1120 , ABCT 1130 , ABCT 1142 , ABCT 1150 , ABCT 1212 , ABCT 1214 , ABCT 1216 , ABCT 1230",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1214",
+      "ABCT 1216",
+      "ABCT 1230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2212": {
+    "text": "ABCT 2108",
+    "courses": [
+      "ABCT 2108"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2108": {
+    "text": "ABCT 1111 , ABCT 1120 , ABCT 1130 , ABCT 1142 , ABCT 1150 , ABCT 1212 , ABCT 1214 , ABCT 1216 , ABCT 1230",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1214",
+      "ABCT 1216",
+      "ABCT 1230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2230": {
+    "text": "ABCT 1111 , ABCT 1120 , ABCT 1130 , ABCT 1142 , ABCT 1150 , ABCT 1212 , ABCT 1214 , ABCT 1216 , ABCT 1230",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1214",
+      "ABCT 1216",
+      "ABCT 1230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2970": {
+    "text": "ABCT 1142 , ABCT 1212 , ABCT 2108 , ABCT 1230 , ABCT 2230 , ABCT 2106 , ABCT 1130 , ABCT 1150 , ABCT 1120 , ABCT 2103 , ABCT 1111 , ABCT 1216",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1216",
+      "ABCT 1230",
+      "ABCT 2103",
+      "ABCT 2106",
+      "ABCT 2108",
+      "ABCT 2230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ABCT 2240": {
+    "text": "ABCT 1142 , ABCT 1212 , ABCT 2108 , ABCT 1230 , ABCT 2230 , ABCT 2106 , ABCT 1130 , ABCT 1150 , ABCT 1120 , ABCT 2103 , ABCT 1111 , ABCT 1216",
+    "courses": [
+      "ABCT 1111",
+      "ABCT 1120",
+      "ABCT 1130",
+      "ABCT 1142",
+      "ABCT 1150",
+      "ABCT 1212",
+      "ABCT 1216",
+      "ABCT 1230",
+      "ABCT 2103",
+      "ABCT 2106",
+      "ABCT 2108",
+      "ABCT 2230"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 1013": {
+    "text": "ACCT 1010",
+    "courses": [
+      "ACCT 1010"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 1206": {
+    "text": "ACCT 1010",
+    "courses": [
+      "ACCT 1010"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2000": {
+    "text": "ACCT 1013",
+    "courses": [
+      "ACCT 1013"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2003": {
+    "text": "ACCT 2000",
+    "courses": [
+      "ACCT 2000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2110": {
+    "text": "ACCT 1010",
+    "courses": [
+      "ACCT 1010"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2113": {
+    "text": "ACCT 2110",
+    "courses": [
+      "ACCT 2110"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2206": {
+    "text": "ACCT 1013",
+    "courses": [
+      "ACCT 1013"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2200": {
+    "text": "ACCT 1010",
+    "courses": [
+      "ACCT 1010"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 1208": {
+    "text": "ARCT 1108",
+    "courses": [
+      "ARCT 1108"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 1500": {
+    "text": "ARCT 1000",
+    "courses": [
+      "ARCT 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 1540": {
+    "text": "IDES 1020 or ARCT 1020",
+    "courses": [
+      "ARCT 1020",
+      "IDES 1020"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 2101": {
+    "text": "ARCT 1500",
+    "courses": [
+      "ARCT 1500"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 2970": {
+    "text": "ARCT 2101",
+    "courses": [
+      "ARCT 2101"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 2108": {
+    "text": "IDES 1108 or ARCT 1108",
+    "courses": [
+      "ARCT 1108",
+      "IDES 1108"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ARCT 2200": {
+    "text": "ARCT 2101",
+    "courses": [
+      "ARCT 2101"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 1105": {
+    "text": "ASEP 1101 , ASEP 1102",
+    "courses": [
+      "ASEP 1101",
+      "ASEP 1102"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 1104": {
+    "text": "ASEP 1101 , ASEP 1102 , ASEP 1103",
+    "courses": [
+      "ASEP 1101",
+      "ASEP 1102",
+      "ASEP 1103"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 1108": {
+    "text": "ASEP 1101",
+    "courses": [
+      "ASEP 1101"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 1103": {
+    "text": "ASEP 1101 , ASEP 1102",
+    "courses": [
+      "ASEP 1101",
+      "ASEP 1102"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 1212": {
+    "text": "ASEP 1101 , ASEP 1102 , ASEP 1103 , ASEP 1104",
+    "courses": [
+      "ASEP 1101",
+      "ASEP 1102",
+      "ASEP 1103",
+      "ASEP 1104"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 2110": {
+    "text": "ASEP 1101",
+    "courses": [
+      "ASEP 1101"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ASEP 2111": {
+    "text": "ASEP 1101 , ASEP 1102",
+    "courses": [
+      "ASEP 1101",
+      "ASEP 1102"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BIOL 2000": {
+    "text": "BIOL 1500 with a grade of C or better",
+    "courses": [
+      "BIOL 1500"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BIOL 2020": {
+    "text": "BIOL 1500 with a grade of C or better",
+    "courses": [
+      "BIOL 1500"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BMET 1530": {
+    "text": "BMET 1113",
+    "courses": [
+      "BMET 1113"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BMET 1300": {
+    "text": "BMET 1220",
+    "courses": [
+      "BMET 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BMET 2300": {
+    "text": "BMET 1300",
+    "courses": [
+      "BMET 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BMET 2970": {
+    "text": "ISTC 2006 , ISTC 2011 , BMET 1300 , BMET 2300 , BMET 1114",
+    "courses": [
+      "BMET 1114",
+      "BMET 1300",
+      "BMET 2300",
+      "ISTC 2006",
+      "ISTC 2011"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "BUSN 1310": {
+    "text": "BUSN 1300",
+    "courses": [
+      "BUSN 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 1222": {
+    "text": "CIVL 1151",
+    "courses": [
+      "CIVL 1151"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 1257": {
+    "text": "CIVL 1151",
+    "courses": [
+      "CIVL 1151"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 2132": {
+    "text": "CIVL 1222",
+    "courses": [
+      "CIVL 1222"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 2133": {
+    "text": "CIVL 1222",
+    "courses": [
+      "CIVL 1222"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 2155": {
+    "text": "CIVL 1222",
+    "courses": [
+      "CIVL 1222"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 2211": {
+    "text": "CIVL 2155",
+    "courses": [
+      "CIVL 2155"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 2221": {
+    "text": "CIVL 1251",
+    "courses": [
+      "CIVL 1251"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CIVL 2241": {
+    "text": "CIVL 2121",
+    "courses": [
+      "CIVL 2121"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2710": {
+    "text": "CMSV 2860",
+    "courses": [
+      "CMSV 2860"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2730": {
+    "text": "CMSV 2860",
+    "courses": [
+      "CMSV 2860"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2720": {
+    "text": "CMSV 2860",
+    "courses": [
+      "CMSV 2860"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2741": {
+    "text": "CMSV 2860",
+    "courses": [
+      "CMSV 2860"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2750": {
+    "text": "CMSV 2860",
+    "courses": [
+      "CMSV 2860"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2760": {
+    "text": "CMSV 2860",
+    "courses": [
+      "CMSV 2860"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2885": {
+    "text": "CMSV 2860 , CMSV 2870 , CMSV 2890",
+    "courses": [
+      "CMSV 2860",
+      "CMSV 2870",
+      "CMSV 2890"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "CMSV 2900": {
+    "text": "CMSV 2860 , CMSV 2870 , CMSV 2890",
+    "courses": [
+      "CMSV 2860",
+      "CMSV 2870",
+      "CMSV 2890"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 1320": {
+    "text": "ECYD 1215",
+    "courses": [
+      "ECYD 1215"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 1335": {
+    "text": "ECYD 1215",
+    "courses": [
+      "ECYD 1215"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 1360": {
+    "text": "ECYD 1215",
+    "courses": [
+      "ECYD 1215"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 1350": {
+    "text": "ECYD 1250 , ECYD 1215",
+    "courses": [
+      "ECYD 1215",
+      "ECYD 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 1520": {
+    "text": "ECYD 1250 , ECYD 1235 , ECYD 1215 , ECYD 1225 , ECYD 1110",
+    "courses": [
+      "ECYD 1110",
+      "ECYD 1215",
+      "ECYD 1225",
+      "ECYD 1235",
+      "ECYD 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 2340": {
+    "text": "ECYD 1215",
+    "courses": [
+      "ECYD 1215"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 2550": {
+    "text": "ECYD 1215",
+    "courses": [
+      "ECYD 1215"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 2520": {
+    "text": "ECYD 2340 , ECYD 1335 , ECYD 1520",
+    "courses": [
+      "ECYD 1335",
+      "ECYD 1520",
+      "ECYD 2340"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ECYD 2610": {
+    "text": "ECYD 1570 , ECYD 1225 , ECYD 1110 , ECYD 1235 , ECYD 1215",
+    "courses": [
+      "ECYD 1110",
+      "ECYD 1215",
+      "ECYD 1225",
+      "ECYD 1235",
+      "ECYD 1570"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 1210": {
+    "text": "ELEC 1110 , ELEC 1120 , MATS 1205",
+    "courses": [
+      "ELEC 1110",
+      "ELEC 1120",
+      "MATS 1205"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 1220": {
+    "text": "ELEC 1110 , ELEC 1120 , MATS 1205",
+    "courses": [
+      "ELEC 1110",
+      "ELEC 1120",
+      "MATS 1205"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 1230": {
+    "text": "ELEC 1130 , ELEC 1139",
+    "courses": [
+      "ELEC 1130",
+      "ELEC 1139"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 1240": {
+    "text": "ELEC 1130 , ELEC 1137 , ELEC 1139",
+    "courses": [
+      "ELEC 1130",
+      "ELEC 1137",
+      "ELEC 1139"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2120": {
+    "text": "ELEC 1120 , ELEC 1130 , ELEC 1240",
+    "courses": [
+      "ELEC 1120",
+      "ELEC 1130",
+      "ELEC 1240"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2110": {
+    "text": "ELEC 1120 , ELEC 1130 , ELEC 1240",
+    "courses": [
+      "ELEC 1120",
+      "ELEC 1130",
+      "ELEC 1240"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2131": {
+    "text": "ELEC 1220",
+    "courses": [
+      "ELEC 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2210": {
+    "text": "ELEC 1130",
+    "courses": [
+      "ELEC 1130"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2220": {
+    "text": "ELEC 2131 , ELEC 2141",
+    "courses": [
+      "ELEC 2131",
+      "ELEC 2141"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2141": {
+    "text": "ELEC 1220",
+    "courses": [
+      "ELEC 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2241": {
+    "text": "ELEC 1240",
+    "courses": [
+      "ELEC 1240"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2230": {
+    "text": "ELEC 1240",
+    "courses": [
+      "ELEC 1240"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2251": {
+    "text": "ELEC 1240",
+    "courses": [
+      "ELEC 1240"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1110": {
+    "text": "ELLW 0098",
+    "courses": [
+      "ELLW 0098"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELEC 2260": {
+    "text": "ELEC 1120 , ELEC 1110",
+    "courses": [
+      "ELEC 1110",
+      "ELEC 1120"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1120": {
+    "text": "ELLW 0098",
+    "courses": [
+      "ELLW 0098"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1140": {
+    "text": "ELLW 1110 , ELLW 1120",
+    "courses": [
+      "ELLW 1110",
+      "ELLW 1120"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1141": {
+    "text": "ELLW 1110 , ELLW 1120",
+    "courses": [
+      "ELLW 1110",
+      "ELLW 1120"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1150": {
+    "text": "ELLW 1110",
+    "courses": [
+      "ELLW 1110"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1160": {
+    "text": "ELLW 1130",
+    "courses": [
+      "ELLW 1130"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1162": {
+    "text": "ELLW 1160",
+    "courses": [
+      "ELLW 1160"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1170": {
+    "text": "ELLW 1172",
+    "courses": [
+      "ELLW 1172"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ELLW 1172": {
+    "text": "ELLW 1170",
+    "courses": [
+      "ELLW 1170"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ENGL 2000": {
+    "text": "ENGL 1150",
+    "courses": [
+      "ENGL 1150"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "GRDT 1096": {
+    "text": "GRDT 1030 , GRDT 1053",
+    "courses": [
+      "GRDT 1030",
+      "GRDT 1053"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "GRDT 2016": {
+    "text": "GRDT 1016 GRDT 1430",
+    "courses": [
+      "GRDT 1016",
+      "GRDT 1430"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "GRDT 2415": {
+    "text": "GRDT 1430",
+    "courses": [
+      "GRDT 1430"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "GRDT 2400": {
+    "text": "GRDT 1010",
+    "courses": [
+      "GRDT 1010"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "GRDT 2420": {
+    "text": "GRDT 1410",
+    "courses": [
+      "GRDT 1410"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HCEM 1140": {
+    "text": "HCEM 1102",
+    "courses": [
+      "HCEM 1102"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HCEM 1234": {
+    "text": "HCEM 1132",
+    "courses": [
+      "HCEM 1132"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HCEM 1246": {
+    "text": "HCEM 1102 , HCEM 1140",
+    "courses": [
+      "HCEM 1102",
+      "HCEM 1140"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HCEM 1250": {
+    "text": "HCEM 1102",
+    "courses": [
+      "HCEM 1102"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HCEM 2145": {
+    "text": "HCEM 2135 , HCEM 2177",
+    "courses": [
+      "HCEM 2135",
+      "HCEM 2177"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HCEM 2280": {
+    "text": "HCEM 2135",
+    "courses": [
+      "HCEM 2135"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HVAC 1200": {
+    "text": "HVAC 1140 or HVAC 1320 and HVAC 1170",
+    "courses": [
+      "HVAC 1140",
+      "HVAC 1170",
+      "HVAC 1320"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HVAC 1231": {
+    "text": "HVAC 1140 or HVAC 1320 and HVAC 1170",
+    "courses": [
+      "HVAC 1140",
+      "HVAC 1170",
+      "HVAC 1320"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HVAC 1232": {
+    "text": "HVAC 1130 , HVAC 1140 , HVAC 1150 , HVAC 1170",
+    "courses": [
+      "HVAC 1130",
+      "HVAC 1140",
+      "HVAC 1150",
+      "HVAC 1170"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HVAC 1210": {
+    "text": "HVAC 1170 , HVAC 1140",
+    "courses": [
+      "HVAC 1140",
+      "HVAC 1170"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HVAC 1240": {
+    "text": "HVAC 1140 or HVAC 1320 , and HVAC 1170 , HVAC 1150",
+    "courses": [
+      "HVAC 1140",
+      "HVAC 1150",
+      "HVAC 1170",
+      "HVAC 1320"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "HVAC 1250": {
+    "text": "HVAC 1120 , HVAC 1140 , HVAC 1150 , HVAC 1170",
+    "courses": [
+      "HVAC 1120",
+      "HVAC 1140",
+      "HVAC 1150",
+      "HVAC 1170"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 1020": {
+    "text": "Accepted into NCIDQ Certificate",
+    "courses": [],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 1208": {
+    "text": "IDES 1108 , or ARCT 1108",
+    "courses": [
+      "ARCT 1108",
+      "IDES 1108"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 1241": {
+    "text": "IDES 1137",
+    "courses": [
+      "IDES 1137"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2108": {
+    "text": "Accepted into NCIDQ Certificate",
+    "courses": [],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2138": {
+    "text": "Accepted into NCIDQ Certificate and IDES 1218",
+    "courses": [
+      "IDES 1218"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2188": {
+    "text": "Accepted into NCIDQ Certificate and IDES 1108 , or ARCT 1108",
+    "courses": [
+      "ARCT 1108",
+      "IDES 1108"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2202": {
+    "text": "IDES 1218 , IDES 2147",
+    "courses": [
+      "IDES 1218",
+      "IDES 2147"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2972": {
+    "text": "IDES 1218 , IDES 2147",
+    "courses": [
+      "IDES 1218",
+      "IDES 2147"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2973": {
+    "text": "Accepted into NCIDQ Certificate and ARCT 1520 , ARCT 2108 , IDES 1020 , IDES 1520 , IDES 2188 , ARCT 1020",
+    "courses": [
+      "ARCT 1020",
+      "ARCT 1520",
+      "ARCT 2108",
+      "IDES 1020",
+      "IDES 1520",
+      "IDES 2188"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IDES 2975": {
+    "text": "IDES 1207 , IDES 1241 , IDES 2111 and IDES 1208",
+    "courses": [
+      "IDES 1207",
+      "IDES 1208",
+      "IDES 1241",
+      "IDES 2111"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IETA 1800": {
+    "text": "IETA 1300",
+    "courses": [
+      "IETA 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IETA 2000": {
+    "text": "IETA 1300",
+    "courses": [
+      "IETA 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "IETA 2300": {
+    "text": "IETA 1300 and IETA 1800",
+    "courses": [
+      "IETA 1300",
+      "IETA 1800"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 1033": {
+    "text": "ISTC 1030",
+    "courses": [
+      "ISTC 1030"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 1050": {
+    "text": "ISTC 1015",
+    "courses": [
+      "ISTC 1015"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 1100": {
+    "text": "ISTC 1015",
+    "courses": [
+      "ISTC 1015"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 1061": {
+    "text": "ISTC 1045",
+    "courses": [
+      "ISTC 1045"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 1230": {
+    "text": "ISTC 1300",
+    "courses": [
+      "ISTC 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 1510": {
+    "text": "ISTC 1300",
+    "courses": [
+      "ISTC 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2006": {
+    "text": "ISTC 1045",
+    "courses": [
+      "ISTC 1045"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2011": {
+    "text": "ISTC 2006",
+    "courses": [
+      "ISTC 2006"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2035": {
+    "text": "ISTC 1033",
+    "courses": [
+      "ISTC 1033"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2037": {
+    "text": "ISTC 2035",
+    "courses": [
+      "ISTC 2035"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2040": {
+    "text": "ISTC 1050",
+    "courses": [
+      "ISTC 1050"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2066": {
+    "text": "ISTC 1061",
+    "courses": [
+      "ISTC 1061"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2050": {
+    "text": "ISTC 1300",
+    "courses": [
+      "ISTC 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2071": {
+    "text": "ISTC 1015 , ISTC 1033",
+    "courses": [
+      "ISTC 1015",
+      "ISTC 1033"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2100": {
+    "text": "ISTC 1015",
+    "courses": [
+      "ISTC 1015"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2110": {
+    "text": "ISTC 1510",
+    "courses": [
+      "ISTC 1510"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2080": {
+    "text": "ISTC 2011 , ISTC 2066",
+    "courses": [
+      "ISTC 2011",
+      "ISTC 2066"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2315": {
+    "text": "ISTC 1300",
+    "courses": [
+      "ISTC 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2320": {
+    "text": "ISTC 1300",
+    "courses": [
+      "ISTC 1300"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2150": {
+    "text": "ISTC 1061 , ISTC 2035",
+    "courses": [
+      "ISTC 1061",
+      "ISTC 2035"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2325": {
+    "text": "ISTC 2320",
+    "courses": [
+      "ISTC 2320"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2610": {
+    "text": "ISTC 2110",
+    "courses": [
+      "ISTC 2110"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ISTC 2330": {
+    "text": "ISTC 1510",
+    "courses": [
+      "ISTC 1510"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1101": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1103": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1102": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1201": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1202": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1301": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1401": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1203": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1303": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1302": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1402": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCAP 1403": {
+    "text": "MCAP 1000",
+    "courses": [
+      "MCAP 1000"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCOD 1380": {
+    "text": "MCOD 1361",
+    "courses": [
+      "MCOD 1361"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MCOD 1440": {
+    "text": "MCOD 1045 , MCOD 1410",
+    "courses": [
+      "MCOD 1045",
+      "MCOD 1410"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 1211": {
+    "text": "HEAL 1101",
+    "courses": [
+      "HEAL 1101"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 1223": {
+    "text": "MDAS 1125",
+    "courses": [
+      "MDAS 1125"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 1232": {
+    "text": "MDAS 1132",
+    "courses": [
+      "MDAS 1132"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 1271": {
+    "text": "MDAS 1151",
+    "courses": [
+      "MDAS 1151"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 2970": {
+    "text": "MDAS 1232 , MDAS 1151 , MDAS 1125 , MDAS 1132 , MDAS 1271 , MDAS 1702 , MDAS 1223",
+    "courses": [
+      "MDAS 1125",
+      "MDAS 1132",
+      "MDAS 1151",
+      "MDAS 1223",
+      "MDAS 1232",
+      "MDAS 1271",
+      "MDAS 1702"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 2960": {
+    "text": "HEAL 1101 , MDAS 1702 , MDAS 1271 , MDAS 1150, MDAS 1211 , MDAS 1132 , MDAS 1125 , MDAS 1232 , HEAL 1502 , MDAS 1223",
+    "courses": [
+      "HEAL 1101",
+      "HEAL 1502",
+      "MDAS 1125",
+      "MDAS 1132",
+      "MDAS 1150",
+      "MDAS 1211",
+      "MDAS 1223",
+      "MDAS 1232",
+      "MDAS 1271",
+      "MDAS 1702"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "MDAS 2990": {
+    "text": "MDAS 1232 , MDAS 1125 , MDAS 1223 , MDAS 1271 , MDAS 1151 , MDAS 1702 , MDAS 1132",
+    "courses": [
+      "MDAS 1125",
+      "MDAS 1132",
+      "MDAS 1151",
+      "MDAS 1223",
+      "MDAS 1232",
+      "MDAS 1271",
+      "MDAS 1702"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1120": {
+    "text": "PHOT 1050 or PHOT 1100 and PHOT 1110",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1100",
+      "PHOT 1110"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1420": {
+    "text": "PHOT 1050 , PHOT 1110",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1110"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1510": {
+    "text": "PHOT 1310 , PHOT 1320",
+    "courses": [
+      "PHOT 1310",
+      "PHOT 1320"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1550": {
+    "text": "PHOT 1310 , PHOT 1050",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1310"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1610": {
+    "text": "PHOT 1310 , PHOT 1050 , PHOT 1320",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1310",
+      "PHOT 1320"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1740": {
+    "text": "PHOT 1050 , PHOT 1100",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1100"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1651": {
+    "text": "PHOT 1420 , PHOT 1320 , PHOT 1110 , PHOT 1050 , PHOT 1310",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1110",
+      "PHOT 1310",
+      "PHOT 1320",
+      "PHOT 1420"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 1830": {
+    "text": "PHOT 1420 , PHOT 1050 , PHOT 1110",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1110",
+      "PHOT 1420"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 2525": {
+    "text": "PHOT 1100",
+    "courses": [
+      "PHOT 1100"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 2610": {
+    "text": "PHOT 1100 or PHOT 1050",
+    "courses": [
+      "PHOT 1050",
+      "PHOT 1100"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 2560": {
+    "text": "PHOT 1310 , PHOT 1320 , PHOT 1510",
+    "courses": [
+      "PHOT 1310",
+      "PHOT 1320",
+      "PHOT 1510"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHOT 2651": {
+    "text": "PHOT 1310 , PHOT 1320 , PHOT 1510 , PHOT 1610",
+    "courses": [
+      "PHOT 1310",
+      "PHOT 1320",
+      "PHOT 1510",
+      "PHOT 1610"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PHYS 1100": {
+    "text": "MATS 1300 or MATS 1340",
+    "courses": [
+      "MATS 1300",
+      "MATS 1340"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1355": {
+    "text": "Acceptance into the PN program",
+    "courses": [],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1010": {
+    "text": "Acceptance into the PN program",
+    "courses": [],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1400": {
+    "text": "Acceptance into the PN Program",
+    "courses": [],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1410": {
+    "text": "PNSG 1010 , PNSG 1355 , PNSG 1400 , PNSG 1600",
+    "courses": [
+      "PNSG 1010",
+      "PNSG 1355",
+      "PNSG 1400",
+      "PNSG 1600"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1600": {
+    "text": "HEAL 1101 , HEAL 1150 , HEAL 1502 , HEAL 1061 , HEAL 1501 , HEAL 1060, PSYC 1350",
+    "courses": [
+      "HEAL 1060",
+      "HEAL 1061",
+      "HEAL 1101",
+      "HEAL 1150",
+      "HEAL 1501",
+      "HEAL 1502",
+      "PSYC 1350"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1620": {
+    "text": "PNSG 1010 , PNSG 1355 , PNSG 1400 , PNSG 1600",
+    "courses": [
+      "PNSG 1010",
+      "PNSG 1355",
+      "PNSG 1400",
+      "PNSG 1600"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1755": {
+    "text": "PNSG 1010 , PNSG 1355 , PNSG 1400 , PNSG 1600",
+    "courses": [
+      "PNSG 1010",
+      "PNSG 1355",
+      "PNSG 1400",
+      "PNSG 1600"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 2001": {
+    "text": "PNSG 1010 , PNSG 1355 , PNSG 1400 , PNSG 1600",
+    "courses": [
+      "PNSG 1010",
+      "PNSG 1355",
+      "PNSG 1400",
+      "PNSG 1600"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PNSG 1805": {
+    "text": "PNSG 1010 , PNSG 1355 , PNSG 1400 , PNSG 1600",
+    "courses": [
+      "PNSG 1010",
+      "PNSG 1355",
+      "PNSG 1400",
+      "PNSG 1600"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1130": {
+    "text": "PTEC 1100 and PTEC 1120",
+    "courses": [
+      "PTEC 1100",
+      "PTEC 1120"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1200": {
+    "text": "PTEC 1130",
+    "courses": [
+      "PTEC 1130"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1220": {
+    "text": "PTEC 1130",
+    "courses": [
+      "PTEC 1130"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1230": {
+    "text": "PTEC 1200 and PTEC 1220",
+    "courses": [
+      "PTEC 1200",
+      "PTEC 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1240": {
+    "text": "PTEC 1200 and PTEC 1220",
+    "courses": [
+      "PTEC 1200",
+      "PTEC 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1250": {
+    "text": "PTEC 1200 and PTEC 1220",
+    "courses": [
+      "PTEC 1200",
+      "PTEC 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "PTEC 1260": {
+    "text": "PTEC 1200 and PTEC 1220",
+    "courses": [
+      "PTEC 1200",
+      "PTEC 1220"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1001": {
+    "text": "HEAL 1502 , BIOL 1450 , ENGL 1150 , COMS 1020",
+    "courses": [
+      "BIOL 1450",
+      "COMS 1020",
+      "ENGL 1150",
+      "HEAL 1502"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1100": {
+    "text": "BIOL 1450 , HEAL 1502 , COMS 1020 , ENGL 1150",
+    "courses": [
+      "BIOL 1450",
+      "COMS 1020",
+      "ENGL 1150",
+      "HEAL 1502"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1110": {
+    "text": "BIOL 1450 , SPEE 1020, COMS 1020 , ENGL 1150 , HEAL 1502",
+    "courses": [
+      "BIOL 1450",
+      "COMS 1020",
+      "ENGL 1150",
+      "HEAL 1502",
+      "SPEE 1020"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1003": {
+    "text": "VTEC 1230 , VTEC 1240 , VTEC 1002 , VTEC 1250 , VTEC 1220",
+    "courses": [
+      "VTEC 1002",
+      "VTEC 1220",
+      "VTEC 1230",
+      "VTEC 1240",
+      "VTEC 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1002": {
+    "text": "VTEC 1001 , VTEC 1100 , VTEC 1110 , VTEC 1120 , VTEC 1210 , VTEC 1200",
+    "courses": [
+      "VTEC 1001",
+      "VTEC 1100",
+      "VTEC 1110",
+      "VTEC 1120",
+      "VTEC 1200",
+      "VTEC 1210"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1120": {
+    "text": "COMS 1020 , ENGL 1150 , BIOL 1450 , HEAL 1502",
+    "courses": [
+      "BIOL 1450",
+      "COMS 1020",
+      "ENGL 1150",
+      "HEAL 1502"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1200": {
+    "text": "COMS 1020 , BIOL 1450 , HEAL 1502 , ENGL 1150",
+    "courses": [
+      "BIOL 1450",
+      "COMS 1020",
+      "ENGL 1150",
+      "HEAL 1502"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1210": {
+    "text": "SPEE 1020, ENGL 1150 , BIOL 1450 , COMS 1020 , HEAL 1502",
+    "courses": [
+      "BIOL 1450",
+      "COMS 1020",
+      "ENGL 1150",
+      "HEAL 1502",
+      "SPEE 1020"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1220": {
+    "text": "VTEC 1200 , VTEC 1120 , VTEC 1110 , VTEC 1210 , VTEC 1001 , VTEC 1100",
+    "courses": [
+      "VTEC 1001",
+      "VTEC 1100",
+      "VTEC 1110",
+      "VTEC 1120",
+      "VTEC 1200",
+      "VTEC 1210"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1230": {
+    "text": "VTEC 1210 , VTEC 1200 , VTEC 1120 , VTEC 1110 , VTEC 1100 , VTEC 1001",
+    "courses": [
+      "VTEC 1001",
+      "VTEC 1100",
+      "VTEC 1110",
+      "VTEC 1120",
+      "VTEC 1200",
+      "VTEC 1210"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1240": {
+    "text": "VTEC 1210 , VTEC 1110 , VTEC 1120 , VTEC 1001 , VTEC 1100 , VTEC 1200",
+    "courses": [
+      "VTEC 1001",
+      "VTEC 1100",
+      "VTEC 1110",
+      "VTEC 1120",
+      "VTEC 1200",
+      "VTEC 1210"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 1250": {
+    "text": "VTEC 1200 , VTEC 1100 , VTEC 1210 , VTEC 1001 , VTEC 1110 , VTEC 1120",
+    "courses": [
+      "VTEC 1001",
+      "VTEC 1100",
+      "VTEC 1110",
+      "VTEC 1120",
+      "VTEC 1200",
+      "VTEC 1210"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 2100": {
+    "text": "VTEC 1002 , VTEC 1240 , VTEC 1230 , VTEC 1250 , VTEC 1220",
+    "courses": [
+      "VTEC 1002",
+      "VTEC 1220",
+      "VTEC 1230",
+      "VTEC 1240",
+      "VTEC 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 2120": {
+    "text": "VTEC 1002 , VTEC 1220 , VTEC 1240 , VTEC 1230 , VTEC 1250",
+    "courses": [
+      "VTEC 1002",
+      "VTEC 1220",
+      "VTEC 1230",
+      "VTEC 1240",
+      "VTEC 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 2131": {
+    "text": "VTEC 1240 , VTEC 1220 , VTEC 1250 , VTEC 1230 , VTEC 1002",
+    "courses": [
+      "VTEC 1002",
+      "VTEC 1220",
+      "VTEC 1230",
+      "VTEC 1240",
+      "VTEC 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "VTEC 2110": {
+    "text": "VTEC 1220 , VTEC 1230 , VTEC 1002 , VTEC 1250 , VTEC 1240",
+    "courses": [
+      "VTEC 1002",
+      "VTEC 1220",
+      "VTEC 1230",
+      "VTEC 1240",
+      "VTEC 1250"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WEBD 1750": {
+    "text": "WEBD 1650",
+    "courses": [
+      "WEBD 1650"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WEBD 2690": {
+    "text": "WEBD 2685",
+    "courses": [
+      "WEBD 2685"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WEBD 2695": {
+    "text": "GRDT 1016",
+    "courses": [
+      "GRDT 1016"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WELD 1200": {
+    "text": "WELD 1150",
+    "courses": [
+      "WELD 1150"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WELD 1230": {
+    "text": "WELD 1111 , WELD 1101",
+    "courses": [
+      "WELD 1101",
+      "WELD 1111"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WELD 1240": {
+    "text": "WELD 1101 , WELD 1120",
+    "courses": [
+      "WELD 1101",
+      "WELD 1120"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "WELD 1250": {
+    "text": "WELD 1101 , WELD 1130",
+    "courses": [
+      "WELD 1101",
+      "WELD 1130"
+    ],
+    "source": "dakota-county-technical-college"
+  },
+  "ACCT 2101": {
+    "text": "MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ACCT 2241": {
+    "text": "ACCT 2101 or ACCT 2101",
+    "courses": [
+      "ACCT 2101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ACCT 2102": {
+    "text": "ACCT 2101 , or ACCT 2101",
+    "courses": [
+      "ACCT 2101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ACCT 2230": {
+    "text": "ACCT 2101",
+    "courses": [
+      "ACCT 2101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ANTH 2130": {
+    "text": "ANTH 1110 or ANTH 1130 recommended, but not required",
+    "courses": [
+      "ANTH 1110",
+      "ANTH 1130"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ANTH 2120": {
+    "text": "ANTH 2110 , ANTH 1160 , ANTH 1130 , ANTH 1131 , ANTH 1100 , ANTH 1150 , ANTH 1101 , ANTH 1120 , ANTH 1110",
+    "courses": [
+      "ANTH 1100",
+      "ANTH 1101",
+      "ANTH 1110",
+      "ANTH 1120",
+      "ANTH 1130",
+      "ANTH 1131",
+      "ANTH 1150",
+      "ANTH 1160",
+      "ANTH 2110"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ART 1115": {
+    "text": "ART 1114",
+    "courses": [
+      "ART 1114"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ART 2101": {
+    "text": "ART 2100",
+    "courses": [
+      "ART 2100"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ART 2201": {
+    "text": "ART 2200",
+    "courses": [
+      "ART 2200"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ART 2217": {
+    "text": "ART 2207",
+    "courses": [
+      "ART 2207"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ART 2251": {
+    "text": "ART 1114",
+    "courses": [
+      "ART 1114"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ART 2252": {
+    "text": "ART 2251",
+    "courses": [
+      "ART 2251"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 1114": {
+    "text": "ENG 0099 or ENG 1108",
+    "courses": [
+      "ENG 0099",
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 1120": {
+    "text": "ENG 0099 or ENG 1108",
+    "courses": [
+      "ENG 0099",
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 1154": {
+    "text": "ENG 0099 or ENG 1108",
+    "courses": [
+      "ENG 0099",
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 1123": {
+    "text": "ENG 0099 or ENG 1108",
+    "courses": [
+      "ENG 0099",
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 1155": {
+    "text": "BIOL 1154",
+    "courses": [
+      "BIOL 1154"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 2201": {
+    "text": "BIOL 1154 or BIOL 1120",
+    "courses": [
+      "BIOL 1120",
+      "BIOL 1154"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 2303": {
+    "text": "BIOL 1154",
+    "courses": [
+      "BIOL 1154"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 2205": {
+    "text": "BIOL 1120 or BIOL 1154",
+    "courses": [
+      "BIOL 1120",
+      "BIOL 1154"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 2306": {
+    "text": "BIOL 1154",
+    "courses": [
+      "BIOL 1154"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BIOL 2301": {
+    "text": "BIOL 1154 , BIOL 1154",
+    "courses": [
+      "BIOL 1154"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BUS 1189": {
+    "text": "Permission of instructor",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "BUS 2250": {
+    "text": "BUS 1121",
+    "courses": [
+      "BUS 1121"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BUS 2400": {
+    "text": "BUS 1100",
+    "courses": [
+      "BUS 1100"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "BUS 2450": {
+    "text": "BUS 2400",
+    "courses": [
+      "BUS 2400"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CHEM 1010": {
+    "text": "MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 1150": {
+    "text": "ENG 1108",
+    "courses": [
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 1152": {
+    "text": "CJS 1150",
+    "courses": [
+      "CJS 1150"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 1154": {
+    "text": "CJS 1150",
+    "courses": [
+      "CJS 1150"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 2114": {
+    "text": "CJS 1156",
+    "courses": [
+      "CJS 1156"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 2112": {
+    "text": "CJS 1156",
+    "courses": [
+      "CJS 1156"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 2116": {
+    "text": "CJS 1156 , ENG 1108 with a grade of C or higher in both courses",
+    "courses": [
+      "CJS 1156",
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 2160": {
+    "text": "CJS 1150 or instructor approval",
+    "courses": [
+      "CJS 1150"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CJS 2289": {
+    "text": "Permission of the internship coordinator",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "CS 1110": {
+    "text": "MATH 1118",
+    "courses": [
+      "MATH 1118"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CS 1101": {
+    "text": "MATH 1118",
+    "courses": [
+      "MATH 1118"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CS 1119": {
+    "text": "MATH 1118",
+    "courses": [
+      "MATH 1118"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CS 1117": {
+    "text": "MATH 1118",
+    "courses": [
+      "MATH 1118"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CS 2200": {
+    "text": "CS 1119",
+    "courses": [
+      "CS 1119"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CS 2300": {
+    "text": "CS 2200",
+    "courses": [
+      "CS 2200"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "CS 2350": {
+    "text": "CS 1110 , CS 1119 , CS 2300 , MATH 1118 , MATH 1119 , MATH 1127",
+    "courses": [
+      "CS 1110",
+      "CS 1119",
+      "CS 2300",
+      "MATH 1118",
+      "MATH 1119",
+      "MATH 1127"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EAP 0098": {
+    "text": "EAP 0090 , READ 0090",
+    "courses": [
+      "EAP 0090",
+      "READ 0090"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ECON 1105": {
+    "text": "Recommended Math MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ECON 1106": {
+    "text": "Recommended MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EDU 1138": {
+    "text": "EDU 1109",
+    "courses": [
+      "EDU 1109"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EDU 1141": {
+    "text": "Recommended concurrent or previous enrollment in EDU 1109",
+    "courses": [
+      "EDU 1109"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1101": {
+    "text": "One of these two: EAP 0099 or ENG 0099 (Minimum grade: 1.67 GPA Equivalent)",
+    "courses": [
+      "EAP 0099",
+      "ENG 0099"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1110": {
+    "text": "EMS 1101 and Current CPR certification and valid driver’s license",
+    "courses": [
+      "EMS 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1102": {
+    "text": "One of these two: EAP 0099 or ENG 0099 (Minimum grade: 1.67 GPA Equivalent)",
+    "courses": [
+      "EAP 0099",
+      "ENG 0099"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1115": {
+    "text": "EMS 1110",
+    "courses": [
+      "EMS 1110"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1122": {
+    "text": "EMS 1101",
+    "courses": [
+      "EMS 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1150": {
+    "text": "EMS 1101",
+    "courses": [
+      "EMS 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 1188": {
+    "text": "EMS 1110 , EMS 1150 , EMS 1131",
+    "courses": [
+      "EMS 1110",
+      "EMS 1131",
+      "EMS 1150"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2464": {
+    "text": "EMS 2420 grade of C or better",
+    "courses": [
+      "EMS 2420"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2470": {
+    "text": "EMS 1131 and current EMT certification",
+    "courses": [
+      "EMS 1131"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2488": {
+    "text": "EMS 2440 , EMS 2470 , EMS 2460",
+    "courses": [
+      "EMS 2440",
+      "EMS 2460",
+      "EMS 2470"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2530": {
+    "text": "EMS 2460",
+    "courses": [
+      "EMS 2460"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2560": {
+    "text": "EMS 2460",
+    "courses": [
+      "EMS 2460"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2570": {
+    "text": "EMS 2470",
+    "courses": [
+      "EMS 2470"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2588": {
+    "text": "EMS 2560 , EMS 2570 , EMS 2488",
+    "courses": [
+      "EMS 2488",
+      "EMS 2560",
+      "EMS 2570"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2589": {
+    "text": "EMS 2588",
+    "courses": [
+      "EMS 2588"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "EMS 2580": {
+    "text": "EMS 2460 , EMS 2464 , EMS 2466 , EMS 2530 , EMS 2560",
+    "courses": [
+      "EMS 2460",
+      "EMS 2464",
+      "EMS 2466",
+      "EMS 2530",
+      "EMS 2560"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 0108": {
+    "text": "READ 0090 or ENG 0099",
+    "courses": [
+      "ENG 0099",
+      "READ 0090"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1108": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1114": {
+    "text": "ENG 1108 with grade of C or better",
+    "courses": [
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1111": {
+    "text": "ENG 1108 with grade of C or better",
+    "courses": [
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1116": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1130": {
+    "text": "ENG 1108 with grade of C or better",
+    "courses": [
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1118": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1140": {
+    "text": "Both of these groups: 1.One of these two: EAP 0099,ENG 0099 (Minimum grade: 1.67 GPA Equivalent)",
+    "courses": [
+      "EAP 0099",
+      "ENG 0099"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1145": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1601": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1180": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2214": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 1605": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2235": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2215": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2222": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2223": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2239": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2237": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2238": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2241": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2250": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2240": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2251": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2252": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2253": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENG 2255": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 1110": {
+    "text": "Grade of C or higher in MATH 0940 or",
+    "courses": [
+      "MATH 0940"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2020": {
+    "text": "Grade of C or higher in MATH 1133 . PHYS 1081 strongly recommended",
+    "courses": [
+      "MATH 1133",
+      "PHYS 1081"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2000": {
+    "text": "Grade of C or higher in both MATH 1133 CHEM 1061 . PHYS 1081 strongly recommended",
+    "courses": [
+      "CHEM 1061",
+      "MATH 1133",
+      "PHYS 1081"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2024": {
+    "text": "ENGR 2020",
+    "courses": [
+      "ENGR 2020"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2025": {
+    "text": "PHYS 1081 , ENGR 2020 , MATH 1134",
+    "courses": [
+      "ENGR 2020",
+      "MATH 1134",
+      "PHYS 1081"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2041": {
+    "text": "Grade of C or higher in both MATH 1134 and PHYS 1082",
+    "courses": [
+      "MATH 1134",
+      "PHYS 1082"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2042": {
+    "text": "Grade of C or higher in ENGR 2041",
+    "courses": [
+      "ENGR 2041"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ENGR 2043": {
+    "text": "Grade of C or higher in ENGR 2041",
+    "courses": [
+      "ENGR 2041"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "FREN 1102": {
+    "text": "FREN 1101",
+    "courses": [
+      "FREN 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "FREN 2201": {
+    "text": "FREN 1102",
+    "courses": [
+      "FREN 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "FREN 2202": {
+    "text": "FREN 2201",
+    "courses": [
+      "FREN 2201"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "HSER 1107": {
+    "text": "HSER 1100 , HSER 1106",
+    "courses": [
+      "HSER 1100",
+      "HSER 1106"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "HSER 1112": {
+    "text": "HSER 1106",
+    "courses": [
+      "HSER 1106"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "HSER 1179": {
+    "text": "Permission from instructor is required",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "HSER 1189": {
+    "text": "Permission from instructor is required",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "INTS 1010": {
+    "text": "ENG 1108 or ENG 0099",
+    "courses": [
+      "ENG 0099",
+      "ENG 1108"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2000": {
+    "text": "ENG 0099 and READ 0093 or READ 0094 with a grade of C or higher",
+    "courses": [
+      "ENG 0099",
+      "READ 0093",
+      "READ 0094"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2310": {
+    "text": "ITC 2530 , with a grade of C or better and ITC 2536",
+    "courses": [
+      "ITC 2530",
+      "ITC 2536"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2320": {
+    "text": "ITC 2000",
+    "courses": [
+      "ITC 2000"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2350": {
+    "text": "ITC 2430",
+    "courses": [
+      "ITC 2430"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2420": {
+    "text": "ITC 2430",
+    "courses": [
+      "ITC 2430"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2430": {
+    "text": "ITC 1400",
+    "courses": [
+      "ITC 1400"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2410": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2440": {
+    "text": "ITC 2430 , ITC 2420 , ITC 2410",
+    "courses": [
+      "ITC 2410",
+      "ITC 2420",
+      "ITC 2430"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2480": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2510": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2516": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2520": {
+    "text": "ITC 2510",
+    "courses": [
+      "ITC 2510"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2530": {
+    "text": "ITC 2520 , ITC 2510 , ITC 2516",
+    "courses": [
+      "ITC 2510",
+      "ITC 2516",
+      "ITC 2520"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2536": {
+    "text": "ITC 2510 , ITC 2516 , ITC 2520",
+    "courses": [
+      "ITC 2510",
+      "ITC 2516",
+      "ITC 2520"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2611": {
+    "text": "ITC 2530 , ITC 2536",
+    "courses": [
+      "ITC 2530",
+      "ITC 2536"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2621": {
+    "text": "ITC 2611 , ITC 2536",
+    "courses": [
+      "ITC 2536",
+      "ITC 2611"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2800": {
+    "text": "ITC 2520 , ITC 2516",
+    "courses": [
+      "ITC 2516",
+      "ITC 2520"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2810": {
+    "text": "ITC 2000",
+    "courses": [
+      "ITC 2000"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2830": {
+    "text": "ITC 2520 , ITC 2530",
+    "courses": [
+      "ITC 2520",
+      "ITC 2530"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2820": {
+    "text": "ITC 2430 , ITC 2536 , ITC 2480 , ITC 2530",
+    "courses": [
+      "ITC 2430",
+      "ITC 2480",
+      "ITC 2530",
+      "ITC 2536"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2840": {
+    "text": "ITC 2536 , ITC 2830",
+    "courses": [
+      "ITC 2536",
+      "ITC 2830"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2850": {
+    "text": "ITC 2530 , ITC 2536 , ITC 2800",
+    "courses": [
+      "ITC 2530",
+      "ITC 2536",
+      "ITC 2800"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 9320": {
+    "text": "ITC 2000",
+    "courses": [
+      "ITC 2000"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ITC 2900": {
+    "text": "ITC 2516 , ITC 2480 , ITC 2430",
+    "courses": [
+      "ITC 2430",
+      "ITC 2480",
+      "ITC 2516"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 0103": {
+    "text": "MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 0118": {
+    "text": "MATH 0094",
+    "courses": [
+      "MATH 0094"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1101": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1103": {
+    "text": "MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1107": {
+    "text": "MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1120": {
+    "text": "A grade of C or higher in MATH 1118 , or MATH 1127",
+    "courses": [
+      "MATH 1118",
+      "MATH 1127"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1118": {
+    "text": "MATH 0940",
+    "courses": [
+      "MATH 0940"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1119": {
+    "text": "MATH 1118",
+    "courses": [
+      "MATH 1118"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1127": {
+    "text": "MATH 0940",
+    "courses": [
+      "MATH 0940"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1134": {
+    "text": "MATH 1133",
+    "courses": [
+      "MATH 1133"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 1133": {
+    "text": "MATH 1127 , MATH 1119",
+    "courses": [
+      "MATH 1119",
+      "MATH 1127"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 2221": {
+    "text": "MATH 1134",
+    "courses": [
+      "MATH 1134"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 2219": {
+    "text": "MATH 1134",
+    "courses": [
+      "MATH 1134"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 2222": {
+    "text": "MATH 1134",
+    "courses": [
+      "MATH 1134"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MATH 2223": {
+    "text": "MATH 2219",
+    "courses": [
+      "MATH 2219"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 1106": {
+    "text": "MUSC 1104",
+    "courses": [
+      "MUSC 1104"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 1112": {
+    "text": "MUSC 1111",
+    "courses": [
+      "MUSC 1111"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 1114": {
+    "text": "MUSC 1113",
+    "courses": [
+      "MUSC 1113"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 1120": {
+    "text": "MUSC 1133 , MUSC 1119",
+    "courses": [
+      "MUSC 1119",
+      "MUSC 1133"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 1134": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 1135": {
+    "text": "Instructor and departmental approval",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "MUSC 2189": {
+    "text": "MUSC 1111 , MUSC 1113 , and MUSC 2128",
+    "courses": [
+      "MUSC 1111",
+      "MUSC 1113",
+      "MUSC 2128"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURA 1001": {
+    "text": "READ 0090",
+    "courses": [
+      "READ 0090"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2702": {
+    "text": "BIOL 2201 ,BIOL 2205 ,ENG 1108 and PSYC 1101 or PSYC 1210",
+    "courses": [
+      "BIOL 2201",
+      "BIOL 2205",
+      "ENG 1108",
+      "PSYC 1101",
+      "PSYC 1210"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2712": {
+    "text": "BIOL 2201 , BIOL 2205 , ENG 1108 and PSYC 1101 or PSYC 1210",
+    "courses": [
+      "BIOL 2201",
+      "BIOL 2205",
+      "ENG 1108",
+      "PSYC 1101",
+      "PSYC 1210"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2792": {
+    "text": "BIOL 2201 ,BIOL 2205 ,ENG 1108 and PSYC 1101 or PSYC 1210",
+    "courses": [
+      "BIOL 2201",
+      "BIOL 2205",
+      "ENG 1108",
+      "PSYC 1101",
+      "PSYC 1210"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2801": {
+    "text": "NURS 2721 , NURS 2791 , NURS 2731 , NURS 2701 , NURS 2741",
+    "courses": [
+      "NURS 2701",
+      "NURS 2721",
+      "NURS 2731",
+      "NURS 2741",
+      "NURS 2791"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2812": {
+    "text": "NURS 2702 , NURS 2712 , NURS 2731 and NURS 2741 or NURS 2792",
+    "courses": [
+      "NURS 2702",
+      "NURS 2712",
+      "NURS 2731",
+      "NURS 2741",
+      "NURS 2792"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2902": {
+    "text": "NURS 2801 NURS 2812 NURS 2852",
+    "courses": [
+      "NURS 2801",
+      "NURS 2812",
+      "NURS 2852"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2852": {
+    "text": "NURS 2702 , NURS 2712 , NURS 2731 and NURS 2741 or NURS 2792",
+    "courses": [
+      "NURS 2702",
+      "NURS 2712",
+      "NURS 2731",
+      "NURS 2741",
+      "NURS 2792"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2912": {
+    "text": "NURS 2801 ,NURS 2812 , NURS 2852",
+    "courses": [
+      "NURS 2801",
+      "NURS 2812",
+      "NURS 2852"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "NURS 2922": {
+    "text": "NURS 2801 NURS 2812 NURS 2852",
+    "courses": [
+      "NURS 2801",
+      "NURS 2812",
+      "NURS 2852"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 1103": {
+    "text": "PA 1102",
+    "courses": [
+      "PA 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 1102": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "PA 1105": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2201": {
+    "text": "Grade of C or higher in PA 1102",
+    "courses": [
+      "PA 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2202": {
+    "text": "Grade of C or higher in PA 1102",
+    "courses": [
+      "PA 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2204": {
+    "text": "Grade of C or higher in PA 1102",
+    "courses": [
+      "PA 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2205": {
+    "text": "Grade of C or higher in PA 1102",
+    "courses": [
+      "PA 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2208": {
+    "text": "Grade of C or higher in PA 1102",
+    "courses": [
+      "PA 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2289": {
+    "text": "PA 2222",
+    "courses": [
+      "PA 2222"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2222": {
+    "text": "PA 2220 , ENG 1108",
+    "courses": [
+      "ENG 1108",
+      "PA 2220"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PA 2220": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "PHED 2000": {
+    "text": "PHED 1109",
+    "courses": [
+      "PHED 1109"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PHYS 1023": {
+    "text": "PHYS 1022 , MATH 0840",
+    "courses": [
+      "MATH 0840",
+      "PHYS 1022"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PHYS 1030": {
+    "text": "MATH 0840",
+    "courses": [
+      "MATH 0840"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PSYC 1101": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "PSYC 2000": {
+    "text": "PSYC 1101 , MATH 1103 or higher level math course",
+    "courses": [
+      "MATH 1103",
+      "PSYC 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PSYC 2100": {
+    "text": "PSYC 1101",
+    "courses": [
+      "PSYC 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "PSYC 2251": {
+    "text": "PSYC 1101",
+    "courses": [
+      "PSYC 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "READ 0099": {
+    "text": "READ 0090 , or EAP 0090",
+    "courses": [
+      "EAP 0090",
+      "READ 0090"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "READ 0090": {
+    "text": "READ 0090",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "READ 1000": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "READ 1100": {
+    "text": "READ 0093, or READ 0094",
+    "courses": [
+      "READ 0093",
+      "READ 0094"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "SJS 1200": {
+    "text": "SJS 1100",
+    "courses": [
+      "SJS 1100"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "SPAN 1102": {
+    "text": "SPAN 1101",
+    "courses": [
+      "SPAN 1101"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "SPAN 2101": {
+    "text": "SPAN 1102",
+    "courses": [
+      "SPAN 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "SPAN 2201": {
+    "text": "SPAN 1102",
+    "courses": [
+      "SPAN 1102"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "SPAN 2202": {
+    "text": "SPAN 2201",
+    "courses": [
+      "SPAN 2201"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "INFS 1000": {
+    "text": "Both of these groups:",
+    "courses": [],
+    "source": "inver-hills-community-college"
+  },
+  "THTR 2153": {
+    "text": "THTR 1152",
+    "courses": [
+      "THTR 1152"
+    ],
+    "source": "inver-hills-community-college"
+  },
+  "ACCT 2411": {
+    "text": "ACCT 2420 or ACCT 1515",
+    "courses": [
+      "ACCT 1515",
+      "ACCT 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ACCT 2420": {
+    "text": "ACCT 2410",
+    "courses": [
+      "ACCT 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ACCT 2540": {
+    "text": "ACCT 1410 or ACCT 2410",
+    "courses": [
+      "ACCT 1410",
+      "ACCT 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ACCT 2591": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ANTH 1710": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ANTH 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ANTH 1730": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ACCT 1512": {
+    "text": "ACCT 1511",
+    "courses": [
+      "ACCT 1511"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ANTH 1790": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARAB 1310": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARAB 1320": {
+    "text": "ARAB 1310 Beginning Arabic 1 with grade of “C” or better",
+    "courses": [
+      "ARAB 1310"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1713": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1714": {
+    "text": "ARTS 1713 Photography 1 with a grade of “C” or better",
+    "courses": [
+      "ARTS 1713"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1717": {
+    "text": "ARTS 1714 Photography 2 with a grade of “C” or better",
+    "courses": [
+      "ARTS 1714"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1726": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1746": {
+    "text": "Appropriate assessment scores",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ACCT 1511": {
+    "text": "ACCT 1410 or ACCT 2410",
+    "courses": [
+      "ACCT 1410",
+      "ACCT 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1757": {
+    "text": "ARTS 1756 with a grade of “C” or better",
+    "courses": [
+      "ARTS 1756"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ARTS 1790": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1412": {
+    "text": "ASLS 1411 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1411"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1413": {
+    "text": "ASLS 1412 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1412"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1414": {
+    "text": "ASLS 1413 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1413"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1415": {
+    "text": "ASLS 1414 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1414"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1420": {
+    "text": "ASLS 1414 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1414"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1430": {
+    "text": "ASLS 1420 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1443": {
+    "text": "ASLS 1414 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1414"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1450": {
+    "text": "ASLS 1414 with grade of “C” or better",
+    "courses": [
+      "ASLS 1414"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1446": {
+    "text": "ASLS 1420 with grade of “C” or better",
+    "courses": [
+      "ASLS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ASLS 1469": {
+    "text": "ASLS 1420 with a grade of “C” or better or instructor approval",
+    "courses": [
+      "ASLS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1415": {
+    "text": "Admission to the Automotive Service Program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1430": {
+    "text": "AUTO 1415",
+    "courses": [
+      "AUTO 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1510": {
+    "text": "AUTO 1415",
+    "courses": [
+      "AUTO 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1441": {
+    "text": "AUTO 1415 & AUTO 1530",
+    "courses": [
+      "AUTO 1415",
+      "AUTO 1530"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1530": {
+    "text": "AUTO 1415",
+    "courses": [
+      "AUTO 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1523": {
+    "text": "AUTO 1415 & AUTO 1530",
+    "courses": [
+      "AUTO 1415",
+      "AUTO 1530"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1540": {
+    "text": "AUTO 1415 & AUTO 1530",
+    "courses": [
+      "AUTO 1415",
+      "AUTO 1530"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 1550": {
+    "text": "AUTO 1415 & AUTO 1530",
+    "courses": [
+      "AUTO 1415",
+      "AUTO 1530"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2110": {
+    "text": "Grade of “C” or better in AUTO 2450 or instructor permission",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2100": {
+    "text": "Grade of “C” or better in AUTO 2450 or instructor permission",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2120": {
+    "text": "Grade of “C” or better in AUTO 2450 or instructor permission",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2130": {
+    "text": "Grade of “C” or better in AUTO 2450 or instructor permission",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2140": {
+    "text": "Grade of “C” or better in AUTO 2450 or instructor permission",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2150": {
+    "text": "Grade of “C” or better in AUTO 2450 or instructor permission",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2410": {
+    "text": "AUTO 1550",
+    "courses": [
+      "AUTO 1550"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2310": {
+    "text": "AUTO 2410 , AUTO 2420 , AUTO 2430 , AUTO 2440 , and AUTO 2450 with a grade of “C” or better",
+    "courses": [
+      "AUTO 2410",
+      "AUTO 2420",
+      "AUTO 2430",
+      "AUTO 2440",
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2430": {
+    "text": "AUTO 1550",
+    "courses": [
+      "AUTO 1550"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2513": {
+    "text": "AUTO 2450",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2514": {
+    "text": "AUTO 2450",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2530": {
+    "text": "AUTO 2450",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "AUTO 2560": {
+    "text": "AUTO 2450",
+    "courses": [
+      "AUTO 2450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOC 2700": {
+    "text": "CHEM 2720 and BIOL 1740 with a grade of “C” or better or instructor permission",
+    "courses": [
+      "BIOL 1740",
+      "CHEM 2720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOC 2790": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1471": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1725": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1730": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1735": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1740": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1745": {
+    "text": "BIOL 1740 General Biology 1: The Living Cell with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1755": {
+    "text": "BIOL 1740 or CHEM 1711 with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740",
+      "CHEM 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1760": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1782": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 1785": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2721": {
+    "text": "BIOL 1740 General Biology 1: The Living Cell with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2722": {
+    "text": "BIOL 2721 Human Anatomy and Physiology 1 with a grade of “C” or better",
+    "courses": [
+      "BIOL 2721"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2750": {
+    "text": "BIOL 1740 General Biology 1: The Living Cell with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2755": {
+    "text": "BIOL 1740 General Biology 1: The Living Cell with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2770": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2760": {
+    "text": "BIOL 2750 General Microbiology with a grade of “C” or better",
+    "courses": [
+      "BIOL 2750"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BIOL 2790": {
+    "text": "BIOL 1755 Research Fundamentals or CHEM 1755 Research Fundamentals; Instructor approval",
+    "courses": [
+      "BIOL 1755",
+      "CHEM 1755"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BSLM 2491": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "BSLM 2497": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "BTEC 1423": {
+    "text": "BTEC 1421 or CSCI 2410",
+    "courses": [
+      "BTEC 1421",
+      "CSCI 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BTEC 2590": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "BTEC 2506": {
+    "text": "BTEC 1423",
+    "courses": [
+      "BTEC 1423"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BUSN 1782": {
+    "text": "BUSN 1760 Principles of Finance",
+    "courses": [
+      "BUSN 1760"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BUSN 1784": {
+    "text": "BUSN 1760 Principles of Finance",
+    "courses": [
+      "BUSN 1760"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BUSN 2474": {
+    "text": "BTEC 1421 with a grade of “C” or better or instructor permission",
+    "courses": [
+      "BTEC 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BUSN 2475": {
+    "text": "BUSN 1475 Project Management 1",
+    "courses": [
+      "BUSN 1475"
+    ],
+    "source": "saint-paul-college"
+  },
+  "BUSN 2480": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CARP 2410": {
+    "text": "CARP 1510 , CARP 1521 , CARP 1522",
+    "courses": [
+      "CARP 1510",
+      "CARP 1521",
+      "CARP 1522"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CDEV 1610": {
+    "text": "Completion of all certificate level coursework or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 1640": {
+    "text": "Completion of all certificate level coursework or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 1910": {
+    "text": "Completion of all other Diploma level courses and instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 2300": {
+    "text": "Completion of all certificate level coursework or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 2340": {
+    "text": "Completion of all certificate level coursework or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 2620": {
+    "text": "Successful completion of all other required AAS coursework and Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 2630": {
+    "text": "Completion of all other Diploma level courses and instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CDEV 2650": {
+    "text": "Completion of all certificate level coursework or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CHEM 1700": {
+    "text": "MATH 0910 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 1711": {
+    "text": "MATH 0920 or CHEM 1700 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "CHEM 1700",
+      "MATH 0920"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 1712": {
+    "text": "CHEM 1711 with a grade of “C” or better",
+    "courses": [
+      "CHEM 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 1730": {
+    "text": "CHEM 1711 or BIOL 1740 with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740",
+      "CHEM 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 1755": {
+    "text": "BIOL 1740 or CHEM 1711 with a grade of “C” or better",
+    "courses": [
+      "BIOL 1740",
+      "CHEM 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 2720": {
+    "text": "CHEM 1712 with a grade of “C” or better",
+    "courses": [
+      "CHEM 1712"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 2721": {
+    "text": "CHEM 2720 with a grade of “C” or better",
+    "courses": [
+      "CHEM 2720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 2730": {
+    "text": "CHEM 1711 with a grade of “C” or better or instructor permission",
+    "courses": [
+      "CHEM 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHEM 2790": {
+    "text": "BIOL 1755 Research Fundamentals or CHEM 1755 Research Fundamentals; Instructor approval",
+    "courses": [
+      "BIOL 1755",
+      "CHEM 1755"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHIN 1710": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHIN 1720": {
+    "text": "CHIN 1710 with a grade of “C” or better or instructor approval",
+    "courses": [
+      "CHIN 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHSN 1551": {
+    "text": "Completion or concurrent enrollment in CHSN 1443",
+    "courses": [
+      "CHSN 1443"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CHSN 1698": {
+    "text": "Enrollment in Cosmetology, Nail Technician or Esthetician Program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CHSN 1699": {
+    "text": "High School Diploma or a GED",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CNCT 1710": {
+    "text": "CNCT 1431 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 1720": {
+    "text": "CNCT 1431 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 1730": {
+    "text": "CNCT 1431",
+    "courses": [
+      "CNCT 1431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 1731": {
+    "text": "CNCT 1730",
+    "courses": [
+      "CNCT 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2412": {
+    "text": "CNCT 1420 and CNCT 1731 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1420",
+      "CNCT 1731"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2421": {
+    "text": "CNCT 1744 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1744"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2441": {
+    "text": "CNCT 1730 and CNCT 1731 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1730",
+      "CNCT 1731"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2431": {
+    "text": "CNCT 1731 , CNCT 1744 and CNCT 2520 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1731",
+      "CNCT 1744",
+      "CNCT 2520"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2530": {
+    "text": "CNCT 1430 and CNCT 1431 with a grade of “C” or better",
+    "courses": [
+      "CNCT 1430",
+      "CNCT 1431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2560": {
+    "text": "A grade of “C” or better in all program courses",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CNCT 2551": {
+    "text": "A grade of “C” or better in CNCT 1410 , CNCT 1420 , CNCT 1430 , and CNCT 1431",
+    "courses": [
+      "CNCT 1410",
+      "CNCT 1420",
+      "CNCT 1430",
+      "CNCT 1431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COMM 1740": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1601": {
+    "text": "Completion of or concurrent with CHSN 1698 and CHSN 1699",
+    "courses": [
+      "CHSN 1698",
+      "CHSN 1699"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1602": {
+    "text": "Completion of or concurrent enrollment in COSM 1601",
+    "courses": [
+      "COSM 1601"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1603": {
+    "text": "Completion of or concurrent enrollment in CHSN 1698 and CHSN 1699",
+    "courses": [
+      "CHSN 1698",
+      "CHSN 1699"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1604": {
+    "text": "COSM 1601",
+    "courses": [
+      "COSM 1601"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1606": {
+    "text": "Completion of or concurrent enrollment in COSM 1601 and COSM 1602",
+    "courses": [
+      "COSM 1601",
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1620": {
+    "text": "Completion of or concurrent enrollment in COSM 1605",
+    "courses": [
+      "COSM 1605"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1605": {
+    "text": "Completion of or concurrent enrollment in COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1901": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1902": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1905": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1903": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1904": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1907": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1906": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1908": {
+    "text": "COSM 1603",
+    "courses": [
+      "COSM 1603"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1909": {
+    "text": "COSM 1603",
+    "courses": [
+      "COSM 1603"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1911": {
+    "text": "COSM 1602 and COSM 1910",
+    "courses": [
+      "COSM 1602",
+      "COSM 1910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1910": {
+    "text": "COSM 1602",
+    "courses": [
+      "COSM 1602"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1951": {
+    "text": "Completion or concurrent enrollment in COSM 1901 or COSM 1905 or COSM 1908",
+    "courses": [
+      "COSM 1901",
+      "COSM 1905",
+      "COSM 1908"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1952": {
+    "text": "Completion or concurrent enrollment in COSM 1901 or COSM 1905 or COSM 1908",
+    "courses": [
+      "COSM 1901",
+      "COSM 1905",
+      "COSM 1908"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1953": {
+    "text": "Completion or concurrent enrollment in COSM 1901 or COSM 1905 or COSM 1908",
+    "courses": [
+      "COSM 1901",
+      "COSM 1905",
+      "COSM 1908"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1954": {
+    "text": "Completion or concurrent enrollment in COSM 1901 or COSM 1905 or COSM 1908",
+    "courses": [
+      "COSM 1901",
+      "COSM 1905",
+      "COSM 1908"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1956": {
+    "text": "Completion or concurrent enrollment in COSM 1901 or COSM 1905 or COSM 1908",
+    "courses": [
+      "COSM 1901",
+      "COSM 1905",
+      "COSM 1908"
+    ],
+    "source": "saint-paul-college"
+  },
+  "COSM 1955": {
+    "text": "Completion or concurrent enrollment in COSM 1901 or COSM 1905 or COSM 1908",
+    "courses": [
+      "COSM 1901",
+      "COSM 1905",
+      "COSM 1908"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1410": {
+    "text": "Grade of “C” or better in MATH 0910 or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1113": {
+    "text": "Grade of “C” or better in MATH 1750 , MATH 1762 , or appropriate assessment score",
+    "courses": [
+      "MATH 1750",
+      "MATH 1762"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1423": {
+    "text": "Grade of “C” or better in MATH 0910 or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1440": {
+    "text": "Grade of “C” or better in MATH 0910 or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1450": {
+    "text": "Grade of “C” or better in MATH 0910 or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1470": {
+    "text": "CSCI 1450",
+    "courses": [
+      "CSCI 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1524": {
+    "text": "CSCI 1523 , CSCI 1541 , and MATH 1730 or instructor approval",
+    "courses": [
+      "CSCI 1523",
+      "CSCI 1541",
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1523": {
+    "text": "CSCI 1410 and MATH 0920",
+    "courses": [
+      "CSCI 1410",
+      "MATH 0920"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1533": {
+    "text": "CSCI 1523",
+    "courses": [
+      "CSCI 1523"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1541": {
+    "text": "CSCI 1410 or CSCI 1523",
+    "courses": [
+      "CSCI 1410",
+      "CSCI 1523"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1550": {
+    "text": "CSCI 1410",
+    "courses": [
+      "CSCI 1410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2410": {
+    "text": "CSCI 1550",
+    "courses": [
+      "CSCI 1550"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1542": {
+    "text": "CSCI 1541",
+    "courses": [
+      "CSCI 1541"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 1714": {
+    "text": "MATH 1740",
+    "courses": [
+      "MATH 1740"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2420": {
+    "text": "CSCI 1475 or CSCI 1423 , and CSCI 1440",
+    "courses": [
+      "CSCI 1423",
+      "CSCI 1440",
+      "CSCI 1475"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2440": {
+    "text": "CSCI 1450",
+    "courses": [
+      "CSCI 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2451": {
+    "text": "CSCI 2420",
+    "courses": [
+      "CSCI 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2442": {
+    "text": "CSCI 1450",
+    "courses": [
+      "CSCI 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2453": {
+    "text": "CSCI 2420 or CSCI 2461",
+    "courses": [
+      "CSCI 2420",
+      "CSCI 2461"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2460": {
+    "text": "CSCI 1410 and MATH 1730 or higher",
+    "courses": [
+      "CSCI 1410",
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2461": {
+    "text": "CSCI 1423 or CSCI 1475",
+    "courses": [
+      "CSCI 1423",
+      "CSCI 1475"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2465": {
+    "text": "CSCI 1440",
+    "courses": [
+      "CSCI 1440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2469": {
+    "text": "CSCI 1524",
+    "courses": [
+      "CSCI 1524"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2466": {
+    "text": "CSCI 1450 and CSCI 1541",
+    "courses": [
+      "CSCI 1450",
+      "CSCI 1541"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2482": {
+    "text": "Grade of “C” or better in CSCI 1523 and CSCI 2420 or instructor approval",
+    "courses": [
+      "CSCI 1523",
+      "CSCI 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2480": {
+    "text": "Grade of “C” or better in CSCI 2420 and CSCI 2461 or instructor approval",
+    "courses": [
+      "CSCI 2420",
+      "CSCI 2461"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2484": {
+    "text": "Grade of “C” or better in CSCI 1523 and CSCI 2420 or instructor approval",
+    "courses": [
+      "CSCI 1523",
+      "CSCI 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2485": {
+    "text": "CSCI 2465 with a grade of “C” or better or instructor permission",
+    "courses": [
+      "CSCI 2465"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2622": {
+    "text": "CSCI 2440",
+    "courses": [
+      "CSCI 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2597": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2570": {
+    "text": "CSCI 1523 and MATH 1730",
+    "courses": [
+      "CSCI 1523",
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2690": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "CSCI 2950": {
+    "text": "CSCI 1714 and MATH 2100",
+    "courses": [
+      "CSCI 1714",
+      "MATH 2100"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1425": {
+    "text": "CULA 1405 or instructor approval",
+    "courses": [
+      "CULA 1405"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1426": {
+    "text": "CULA 1402",
+    "courses": [
+      "CULA 1402"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1431": {
+    "text": "CULA 1426",
+    "courses": [
+      "CULA 1426"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1435": {
+    "text": "CULA 1431",
+    "courses": [
+      "CULA 1431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1441": {
+    "text": "CULA 1435",
+    "courses": [
+      "CULA 1435"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1445": {
+    "text": "CULA 1405 and CULA 1415",
+    "courses": [
+      "CULA 1405",
+      "CULA 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1500": {
+    "text": "CULA 1441",
+    "courses": [
+      "CULA 1441"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1505": {
+    "text": "CULA 1445 , CULA 1455 , CULA 1465",
+    "courses": [
+      "CULA 1445",
+      "CULA 1455",
+      "CULA 1465"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1504": {
+    "text": "CULA 1441",
+    "courses": [
+      "CULA 1441"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1508": {
+    "text": "CULA 1441",
+    "courses": [
+      "CULA 1441"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1515": {
+    "text": "CULA 1445 , CULA 1455 , CULA 1465",
+    "courses": [
+      "CULA 1445",
+      "CULA 1455",
+      "CULA 1465"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1511": {
+    "text": "CULA 1441",
+    "courses": [
+      "CULA 1441"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1545": {
+    "text": "CULA 1445 , CULA 1455 , CULA 1465",
+    "courses": [
+      "CULA 1445",
+      "CULA 1455",
+      "CULA 1465"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1525": {
+    "text": "CULA 1445 , CULA 1455 , CULA 1465",
+    "courses": [
+      "CULA 1445",
+      "CULA 1455",
+      "CULA 1465"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1541": {
+    "text": "CULA 1441",
+    "courses": [
+      "CULA 1441"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1580": {
+    "text": "CULA 1511",
+    "courses": [
+      "CULA 1511"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1575": {
+    "text": "CULA 1511",
+    "courses": [
+      "CULA 1511"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1585": {
+    "text": "CULA 1405 and CULA 1415",
+    "courses": [
+      "CULA 1405",
+      "CULA 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1590": {
+    "text": "CULA 1505 , CULA 1515 , CULA 1525 , CULA 1545",
+    "courses": [
+      "CULA 1505",
+      "CULA 1515",
+      "CULA 1525",
+      "CULA 1545"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1612": {
+    "text": "CULA 1611",
+    "courses": [
+      "CULA 1611"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1614": {
+    "text": "CULA 1613",
+    "courses": [
+      "CULA 1613"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1613": {
+    "text": "CULA 1612",
+    "courses": [
+      "CULA 1612"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1671": {
+    "text": "CULA 1616",
+    "courses": [
+      "CULA 1616"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1676": {
+    "text": "CULA 1614",
+    "courses": [
+      "CULA 1614"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1677": {
+    "text": "CULA 1614",
+    "courses": [
+      "CULA 1614"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1710": {
+    "text": "CULA 1441 or CULA 1445 and instructor permission",
+    "courses": [
+      "CULA 1441",
+      "CULA 1445"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1700": {
+    "text": "CULA 1441 or CULA 1445 or instructor approval",
+    "courses": [
+      "CULA 1441",
+      "CULA 1445"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2100": {
+    "text": "CULA 1545",
+    "courses": [
+      "CULA 1545"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 1705": {
+    "text": "CULA 1441 or CULA 1445 or instructor permission",
+    "courses": [
+      "CULA 1441",
+      "CULA 1445"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2105": {
+    "text": "CULA 1545",
+    "courses": [
+      "CULA 1545"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2115": {
+    "text": "CULA 1590",
+    "courses": [
+      "CULA 1590"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2110": {
+    "text": "CULA 1545",
+    "courses": [
+      "CULA 1545"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2230": {
+    "text": "CULA 1490 or Instructor approval",
+    "courses": [
+      "CULA 1490"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2225": {
+    "text": "CULA 2220",
+    "courses": [
+      "CULA 2220"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2220": {
+    "text": "CULA 1545 and completion of General Education requirements",
+    "courses": [
+      "CULA 1545"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2235": {
+    "text": "CULA 2225",
+    "courses": [
+      "CULA 2225"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2500": {
+    "text": "CULA 1580 or instructor permission",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2515": {
+    "text": "CULA 1580",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2505": {
+    "text": "CULA 1580",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2520": {
+    "text": "CULA 1580",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2510": {
+    "text": "CULA 1580",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2525": {
+    "text": "CULA 1580",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2530": {
+    "text": "CULA 1580 or instructor permission",
+    "courses": [
+      "CULA 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2700": {
+    "text": "BUSN 2455 or instructor permission",
+    "courses": [
+      "BUSN 2455"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2535": {
+    "text": "CULA 2515",
+    "courses": [
+      "CULA 2515"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2705": {
+    "text": "BUSN 2455 or instructor permission",
+    "courses": [
+      "BUSN 2455"
+    ],
+    "source": "saint-paul-college"
+  },
+  "CULA 2710": {
+    "text": "CULA 2700 , CULA 2705",
+    "courses": [
+      "CULA 2700",
+      "CULA 2705"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 1444": {
+    "text": "It is recommended that student taking this course have taken DGIM 1443 or its equivalent",
+    "courses": [
+      "DGIM 1443"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 1484": {
+    "text": "DGIM 1483 Photoshop 1 or equivalent knowledge",
+    "courses": [
+      "DGIM 1483"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2520": {
+    "text": "DGIM 1490 3D Animation Fundamentals",
+    "courses": [
+      "DGIM 1490"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2530": {
+    "text": "Completion or concurrent enrollment DGIM 2521 2D Web Animation or instructor permission",
+    "courses": [
+      "DGIM 2521"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2569": {
+    "text": "DGIM 1400 Introduction to Computer Graphics or instructor approval",
+    "courses": [
+      "DGIM 1400"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2588": {
+    "text": "DGIM 2587 Digital Video 1",
+    "courses": [
+      "DGIM 2587"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2589": {
+    "text": "DGIM 2587 Digital Video 1 or concurrent",
+    "courses": [
+      "DGIM 2587"
+    ],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2597": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2591": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "DGIM 2704": {
+    "text": "DGIM 1490 3D Animation Fundamentals",
+    "courses": [
+      "DGIM 1490"
+    ],
+    "source": "saint-paul-college"
+  },
+  "EAPP 0760": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EAPP 0770": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EAPP 0780": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EAPP 1420": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EAPP 1410": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EAPP 1460": {
+    "text": "Appropriate assessment score or completion of EAPP 0760 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0760"
+    ],
+    "source": "saint-paul-college"
+  },
+  "EAPP 1470": {
+    "text": "Appropriate assessment score or completion of EAPP 0770 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0770"
+    ],
+    "source": "saint-paul-college"
+  },
+  "EAPP 1480": {
+    "text": "Appropriate assessment score or completion of EAPP 0780 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0780"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ECON 1710": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "EAPP 1590": {
+    "text": "Appropriate assessment score or completion of EAPP 1460 , EAPP 1470 , and EAPP 1480 with a “C” or better",
+    "courses": [
+      "EAPP 1460",
+      "EAPP 1470",
+      "EAPP 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ECON 1730": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ECON 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1410": {
+    "text": "Appropriate assessment scores",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1422": {
+    "text": "Appropriate assessment scores",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1432": {
+    "text": "ELTN 1422 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1422"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1442": {
+    "text": "ELTN 1432 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1432"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1512": {
+    "text": "ELTN 1442 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1442"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1470": {
+    "text": "ELTN 1422 or instructor approval",
+    "courses": [
+      "ELTN 1422"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 1522": {
+    "text": "ELTN 1512 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2410": {
+    "text": "ELTN 1512 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2420": {
+    "text": "ELTN 1512 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2430": {
+    "text": "ELTN 1512 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2440": {
+    "text": "ELTN 1512 with a grade of “D” or better",
+    "courses": [
+      "ELTN 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2510": {
+    "text": "ELTN 2440 with a grade of “D” or better",
+    "courses": [
+      "ELTN 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2532": {
+    "text": "ELTN 2440 with a grade of “D” or better",
+    "courses": [
+      "ELTN 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2522": {
+    "text": "ELTN 2440 with a grade of “D” or better",
+    "courses": [
+      "ELTN 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2540": {
+    "text": "ELTN 2440 with a grade of “D” or better",
+    "courses": [
+      "ELTN 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ELTN 2550": {
+    "text": "ELTN 2440 with a grade of “C” or better",
+    "courses": [
+      "ELTN 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "EMEC 2620": {
+    "text": "Journeyman electrician or ELTN/CNEL diploma/AAS or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EMEC 2625": {
+    "text": "Journeyman electrician or ELTN/CNEL diploma/AAS or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EMEC 2751": {
+    "text": "Journeyman electrician or ELTN/CNEL diploma/AAS or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EMEC 2741": {
+    "text": "Journeyman electrician or ELTN/CNEL diploma/AAS or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EMEC 2760": {
+    "text": "Journeyman electrician or ELTN/CNEL diploma/AAS or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "EMEC 2770": {
+    "text": "Journeyman electrician or ELTN/CNEL diploma/AAS or instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ENGL 0921": {
+    "text": "Placement into this course will be according to college assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1712": {
+    "text": "Grade of “C” or better in ENGL 1711",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1711": {
+    "text": "Grade of “C” or better in READ 0722 or READ 0724 and ENGL 0922 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "ENGL 0922",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 0922": {
+    "text": "ENGL 0921 or EAPP 0870 and READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "EAPP 0870",
+      "ENGL 0921",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1725": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1720": {
+    "text": "Grade of “C” or better in ENGL 1711",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1730": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1735": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1745": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1740": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1755": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1760": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1750": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1770": {
+    "text": "ENGL 1711 Composition 1 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1780": {
+    "text": "ENGL 1711 Composition 1 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1795": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 1790": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2722": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2721": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2726": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2727": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2728": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2730": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2740": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2755": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2760": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2775": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2776": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2778": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGL 2750": {
+    "text": "ENGL 1711 with a grade of “C” or better",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGR 1717": {
+    "text": "PHYS 2710 and MATH 2760 or instructor approval",
+    "courses": [
+      "MATH 2760",
+      "PHYS 2710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGR 2705": {
+    "text": "PHYS 2700 or instructor approval",
+    "courses": [
+      "PHYS 2700"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGR 2710": {
+    "text": "Grade of “C” or better in ENGR 2705",
+    "courses": [
+      "ENGR 2705"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGR 2712": {
+    "text": "ENGR 2705",
+    "courses": [
+      "ENGR 2705"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ENGR 2715": {
+    "text": "Grade of “C” or better in CHEM 1711 and PHYS 2700",
+    "courses": [
+      "CHEM 1711",
+      "PHYS 2700"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ESTH 1645": {
+    "text": "CHSN 1698 , CHSN 1699 , concurrent enrollment or within the same semester",
+    "courses": [
+      "CHSN 1698",
+      "CHSN 1699"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ESTH 1652": {
+    "text": "Students must have 480 clock hours and have completed all preceding courses in the Esthetics program, ESTH 1651",
+    "courses": [
+      "ESTH 1651"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ESTH 1650": {
+    "text": "CHSN 1698 , CHSN 1699 , and ESTH 1645 , concurrent enrollment or within the same semester",
+    "courses": [
+      "CHSN 1698",
+      "CHSN 1699",
+      "ESTH 1645"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ESTH 1651": {
+    "text": "CHSN 1698 , CHSN 1699 , ESTH 1645 and ESTH 1650 or concurrent enrollment",
+    "courses": [
+      "CHSN 1698",
+      "CHSN 1699",
+      "ESTH 1645",
+      "ESTH 1650"
+    ],
+    "source": "saint-paul-college"
+  },
+  "ESTH 1671": {
+    "text": "High School Diploma/GED",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "ESTH 1672": {
+    "text": "ESTH 1671",
+    "courses": [
+      "ESTH 1671"
+    ],
+    "source": "saint-paul-college"
+  },
+  "GEOG 1700": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "GEOG 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "GEOG 1740": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "GEOG 1790": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "GEOG 1750": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "GLOS 1710": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1745": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or concurrent enrollment or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1750": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or concurrent enrollment or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1760": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or concurrent enrollment or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1746": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or concurrent enrollment or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1761": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or concurrent enrollment or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1770": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or concurrent enrollment or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1773": {
+    "text": "Grade of “C” or better in READ 0721 or READ 0724 or EAPP 0860 or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HIST 1780": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1422": {
+    "text": "Declared major in Massage Therapy or Personal Trainer program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1410": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1421": {
+    "text": "Declared major in Massage Therapy, Personal Trainer, or Yoga program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1418": {
+    "text": "Declared major in Massage Therapy or Personal Trainer major",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1425": {
+    "text": "HLTH 1421 recommended OR instructor approval. Physical ability to palpate the human body and willingness to view selected Human Cadaver videos are recommended",
+    "courses": [
+      "HLTH 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1485": {
+    "text": "HLTH 1425 recommended",
+    "courses": [
+      "HLTH 1425"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1580": {
+    "text": "HLTH 1410",
+    "courses": [
+      "HLTH 1410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1610": {
+    "text": "Must be accepted into Program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1620": {
+    "text": "PTRN 1410 or HLTH 1610 with a grade of “C” or better",
+    "courses": [
+      "HLTH 1610",
+      "PTRN 1410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1630": {
+    "text": "PTRN 1410 or HLTH 1610 with a grade of “C” or better",
+    "courses": [
+      "HLTH 1610",
+      "PTRN 1410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1690": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HLTH 1900": {
+    "text": "Recommendation(s): HLTH 1421",
+    "courses": [
+      "HLTH 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHSC 1445": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHSC 1455": {
+    "text": "EAPP 0900 , READ 0722 , or READ 0724 with a grade of “C” or better and MATH 0745 with a grade of “P” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "MATH 0745",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HLUC 2491": {
+    "text": "Successful completion of all HLUC courses: HLUC 1410; HLUC 1420; HLUC 1510; HLUC 1511 with a grade of “C” or better to be eligible for participation in internship",
+    "courses": [
+      "HLUC 1410",
+      "HLUC 1420",
+      "HLUC 1510",
+      "HLUC 1511"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHSC 1450": {
+    "text": "READ 0722 or READ 0724 and ENGL 0922 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "ENGL 0922",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HMRS 2550": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HMRS 2591": {
+    "text": "Advisor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HSPM 2591": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1720": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1730": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1775": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1740": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1780": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1790": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "HUMA 1795": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTL 2491": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "INTL 2497": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "INTP 1440": {
+    "text": "INTP 1500 Interpreting Process with a grade of “C” or better",
+    "courses": [
+      "INTP 1500"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 1442": {
+    "text": "Completion of ASLS 1413 American Sign Language 3 with a grade of “C” or better",
+    "courses": [
+      "ASLS 1413"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 1500": {
+    "text": "Acceptance into the Sign Language Interpreter/Transliterator Program and ASLS 1420 and/or INTP 1442 with a grade of “C” or better or taken concurrently with ASLS 1420 and INTP 1442 . It is necessary for students in the Sign Language Interpreter/Transliterator Program to be able to process auditory and visual information",
+    "courses": [
+      "ASLS 1420",
+      "INTP 1442"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 1512": {
+    "text": "Grade of “C” or better in ASLS 1420 and INTP 1500",
+    "courses": [
+      "ASLS 1420",
+      "INTP 1500"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2410": {
+    "text": "INTP 2592 Interpreter Internship with a grade of “C” or better",
+    "courses": [
+      "INTP 2592"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 1513": {
+    "text": "Grade of “C” or better in ASLS 1430 and INTP 1512",
+    "courses": [
+      "ASLS 1430",
+      "INTP 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2411": {
+    "text": "INTP 1513 with a grade of “C” or better",
+    "courses": [
+      "INTP 1513"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2412": {
+    "text": "INTP 2411 with a grade of “C” or better",
+    "courses": [
+      "INTP 2411"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2421": {
+    "text": "Grade of “C” or better in INTP 1513",
+    "courses": [
+      "INTP 1513"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2422": {
+    "text": "Completion of INTP 2421 with a grade of “C” or better",
+    "courses": [
+      "INTP 2421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2431": {
+    "text": "Grade of “C” or better in INTP 1513",
+    "courses": [
+      "INTP 1513"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2432": {
+    "text": "Grade of “C” or better in INTP 2431",
+    "courses": [
+      "INTP 2431"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2585": {
+    "text": "Grade of “C” or better in INTP 1513",
+    "courses": [
+      "INTP 1513"
+    ],
+    "source": "saint-paul-college"
+  },
+  "INTP 2450": {
+    "text": "ASLS 1430 , INTP 1512",
+    "courses": [
+      "ASLS 1430",
+      "INTP 1512"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1400": {
+    "text": "Declared Massage Therapy Major",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "INTP 2592": {
+    "text": "Internship Eligibility: Grade of “C” or better in INTP 2411 , INTP 2421 , and INTP 2431 . Internship Placement: Grade of “C” or better in Interactive Performance Skills Evaluations in INTP 2412 Sign to Voice 2, INTP 2422 Voice to Sign 2 and INTP 2432 Transliterating 2",
+    "courses": [
+      "INTP 2411",
+      "INTP 2412",
+      "INTP 2421",
+      "INTP 2422",
+      "INTP 2431",
+      "INTP 2432"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1422": {
+    "text": "MASS 1400 with a grade of “C” or better",
+    "courses": [
+      "MASS 1400"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1421": {
+    "text": "MASS 1400 with a grade of “C” or better",
+    "courses": [
+      "MASS 1400"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1423": {
+    "text": "Certificate in Massage Therapy or equivalent as evaluated by faculty",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MASS 1480": {
+    "text": "MASS 1400 and MASS 1422 with a grade of “C” or better",
+    "courses": [
+      "MASS 1400",
+      "MASS 1422"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1482": {
+    "text": "MASS 1481 with a grade of “C” or better or instructor permission",
+    "courses": [
+      "MASS 1481"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1490": {
+    "text": "MASS 1423 with a grade of “C” or better, instructor approval or completion of entire clinical massage curriculum and professional membership with ABMP including liability insurance. Students must have current CPR certificate and liability insurance on file at Saint Paul College before starting internship",
+    "courses": [
+      "MASS 1423"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MASS 1900": {
+    "text": "HLTH 1421",
+    "courses": [
+      "HLTH 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 0731": {
+    "text": "MATH 0910 with a “C” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 0740": {
+    "text": "MATH 0745 with a “P” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 0745"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 0920": {
+    "text": "Grade of “C” or better in MATH 0910 or appropriate assessment score",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 1411": {
+    "text": "Placement into this course will be according to the college assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MATH 1720": {
+    "text": "MATH 0745 with a grade of “P” or better or appropriate assessment score",
+    "courses": [
+      "MATH 0745"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 1420": {
+    "text": "Placement into this course will be according to college assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MATH 1730": {
+    "text": "MATH 0920 with a “C” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 0920"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 1740": {
+    "text": "MATH 0740 or MATH 0910 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "MATH 0740",
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 1750": {
+    "text": "MATH 1730 with a grade of “C” or better",
+    "courses": [
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 1762": {
+    "text": "MATH 0920 with a grade of “C” or better, or MATH 1730 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 0920",
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 2240": {
+    "text": "PSYC 1710 and MATH 1740 with a grade of “C” or better, or MATH 1730 with a grade of “C” or better, or a higher MATH course with a grade of “C” or better",
+    "courses": [
+      "MATH 1730",
+      "MATH 1740",
+      "PSYC 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 2460": {
+    "text": "MATH 1730 or higher",
+    "courses": [
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 2749": {
+    "text": "MATH 1750 or MATH 1762 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 1750",
+      "MATH 1762"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 2753": {
+    "text": "MATH 2750 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "MATH 2750"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 2760": {
+    "text": "MATH 2750 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "MATH 2750"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MATH 2750": {
+    "text": "MATH 2749 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "MATH 2749"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1400": {
+    "text": "MDLT 1600 and CHEM 1711 ”C” or better; BIOL 1730 ”C” or better or concurrent enrollment",
+    "courses": [
+      "BIOL 1730",
+      "CHEM 1711",
+      "MDLT 1600"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1421": {
+    "text": "Enrollment in MDLT Major courses",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1410": {
+    "text": "MDLT 1600 and CHEM 1711 ”C” or better; BIOL 1730 ”C” or better or concurrent enrollment",
+    "courses": [
+      "BIOL 1730",
+      "CHEM 1711",
+      "MDLT 1600"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1430": {
+    "text": "Enrollment in MDLT Major courses",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1422": {
+    "text": "BIOL 1740 or concurrent enrollment & a grade of “C” or better in MDLT 1421 & HLTH 1410 & BIOL 1730",
+    "courses": [
+      "BIOL 1730",
+      "BIOL 1740",
+      "HLTH 1410",
+      "MDLT 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1441": {
+    "text": "Enrollment in MDLT Major courses",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1446": {
+    "text": "Enrollment in MDLT major courses",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1442": {
+    "text": "BIOL 1740 ;or concurrent enrollment and a grade of “C” or better in MDLT 1421 , HLTH 1410 , and BIOL 1730",
+    "courses": [
+      "BIOL 1730",
+      "BIOL 1740",
+      "HLTH 1410",
+      "MDLT 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1510": {
+    "text": "BIOL 1740 &nbsp;or concurrent enrollment & a grade of “C” or better in MDLT 1421 &nbsp;& HLTH 1410 &nbsp;& BIOL 1730",
+    "courses": [
+      "BIOL 1730",
+      "BIOL 1740",
+      "HLTH 1410",
+      "MDLT 1421"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 1600": {
+    "text": "Appropriate assessment scores or MATH 0910 with a grade of “C” or better",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 2410": {
+    "text": "Grade of “C” or better in MDLT 1510",
+    "courses": [
+      "MDLT 1510"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 2420": {
+    "text": "Grade of “C” or better in MDLT 1510",
+    "courses": [
+      "MDLT 1510"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 2591": {
+    "text": "Grade of “C” or better in all MDLT program requirements except MDLT 2593",
+    "courses": [
+      "MDLT 2593"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MDLT 2593": {
+    "text": "Grade of “C” or better in all required courses in the Medical Laboratory AAS degree including successful completion of MDLT 2591 Clinical Practice",
+    "courses": [
+      "MDLT 2591"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 1551": {
+    "text": "MEDS 1480 or concurrent enrollment",
+    "courses": [
+      "MEDS 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 1552": {
+    "text": "MEDS 1551",
+    "courses": [
+      "MEDS 1551"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 1553": {
+    "text": "MEDS 1552",
+    "courses": [
+      "MEDS 1552"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 1560": {
+    "text": "MEDS 1420",
+    "courses": [
+      "MEDS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 1562": {
+    "text": "MEDS 1420",
+    "courses": [
+      "MEDS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 1570": {
+    "text": "MEDS 1480 or MEDS 1470 or instructor permission",
+    "courses": [
+      "MEDS 1470",
+      "MEDS 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2430": {
+    "text": "MEDS 1480",
+    "courses": [
+      "MEDS 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2432": {
+    "text": "MEDS 1420",
+    "courses": [
+      "MEDS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2434": {
+    "text": "MEDS 1420",
+    "courses": [
+      "MEDS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2440": {
+    "text": "MEDS 1420",
+    "courses": [
+      "MEDS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2461": {
+    "text": "A grade of “C” or better in MEDS 1470 and MEDS 1480",
+    "courses": [
+      "MEDS 1470",
+      "MEDS 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2462": {
+    "text": "A grade of “C” or better in MEDS 1470 and MEDS 1480",
+    "courses": [
+      "MEDS 1470",
+      "MEDS 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2470": {
+    "text": "A grade of “C” or better in MEDS 1470 and MEDS 1480",
+    "courses": [
+      "MEDS 1470",
+      "MEDS 1480"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2480": {
+    "text": "A grade of “C” or better in MEDS 2461 , MEDS 2462 and MEDS 2470",
+    "courses": [
+      "MEDS 2461",
+      "MEDS 2462",
+      "MEDS 2470"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2510": {
+    "text": "MEDS 1420 with a grade of “C” or better",
+    "courses": [
+      "MEDS 1420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2590": {
+    "text": "All Required Coursework for the Health Information Technology AAS Degree with a grade of “C” or better in all MEDS-prefix courses and instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1100": {
+    "text": "(Prerequisite(s): Placement into this course will be according to college assessment score)",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MEDS 2594": {
+    "text": "MEDS 1480 , MEDS 1470 , MEDS 2461 , MEDS 2462 , and MEDS 2470 with a grade of “C” or better",
+    "courses": [
+      "MEDS 1470",
+      "MEDS 1480",
+      "MEDS 2461",
+      "MEDS 2462",
+      "MEDS 2470"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1110": {
+    "text": "MHTT 1100 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1100"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1120": {
+    "text": "MHTT 1110 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1130": {
+    "text": "MHTT 1110 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1140": {
+    "text": "Placement into this course will be according to college assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1210": {
+    "text": "MHTT 1110 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1220": {
+    "text": "MHTT 1110 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1230": {
+    "text": "MHTT 1110 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 1240": {
+    "text": "MHTT 1110 and MHTT 1120 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110",
+      "MHTT 1120"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2110": {
+    "text": "MHTT 1120 and MHTT 1130 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1120",
+      "MHTT 1130"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2120": {
+    "text": "MHTT 1110 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1110"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2130": {
+    "text": "MHTT 2120 with a grade of “C” or better",
+    "courses": [
+      "MHTT 2120"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2225": {
+    "text": "MHTT 2120 with a grade of “C” or better",
+    "courses": [
+      "MHTT 2120"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2227": {
+    "text": "MHTT 2225 with a grade of “C” or better",
+    "courses": [
+      "MHTT 2225"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2240": {
+    "text": "MHTT 1120 , MHTT 1240 , MHTT 2110 , and MHTT 2227 with a grade of “C” or better",
+    "courses": [
+      "MHTT 1120",
+      "MHTT 1240",
+      "MHTT 2110",
+      "MHTT 2227"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2250": {
+    "text": "All MHTT 11XX, MHTT 12XX, and MHTT 21XX level classes with a grade of “C” or better",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2260": {
+    "text": "(Prerequisite(s): All MHTT classes lower than MHTT 2240 with a grade of “C” or better)",
+    "courses": [
+      "MHTT 2240"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MHTT 2290": {
+    "text": "All other MHTT classes lower than MHTT 2290 with a grade of “C” or better",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1701": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1702": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1703": {
+    "text": "MUSC 1701 Music Theory 1 with a grade of “C” or better",
+    "courses": [
+      "MUSC 1701"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1704": {
+    "text": "MUSC 1701 Music Theory 1 and MUSC 1702 Aural Skills 1 with a grade of “C” or better",
+    "courses": [
+      "MUSC 1701",
+      "MUSC 1702"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1720": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1736": {
+    "text": "MUSC 1735 with a grade of “C” or better or instructor approval",
+    "courses": [
+      "MUSC 1735"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1740": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1750": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1745": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1770": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 1800": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2700": {
+    "text": "MUSC 1703 Music Theory 2 with a grade of “C” or better",
+    "courses": [
+      "MUSC 1703"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2705": {
+    "text": "MUSC 1703 Music Theory 2 and MUSC 1704 Aural Skills 2 with a grade of “C” or better",
+    "courses": [
+      "MUSC 1703",
+      "MUSC 1704"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2710": {
+    "text": "MUSC 2700 Music Theory 3 with a grade of “C” or better",
+    "courses": [
+      "MUSC 2700"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2720": {
+    "text": "ENGL 1711",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2715": {
+    "text": "MUSC 2700 Music Theory III and MUSC 2705 Aural Skills III with a grade of “C” or better",
+    "courses": [
+      "MUSC 2700",
+      "MUSC 2705"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2721": {
+    "text": "ENGL 1711",
+    "courses": [
+      "ENGL 1711"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2800": {
+    "text": "MUSC 1800 Music Production 1 with a grade of “C” or better",
+    "courses": [
+      "MUSC 1800"
+    ],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2900": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "MUSC 2950": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "NAST 1112": {
+    "text": "NAST 1111",
+    "courses": [
+      "NAST 1111"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NAST 1111": {
+    "text": "Appropriate assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1710": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1730": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1740": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1721": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1750": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1770": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1780": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 1782": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "NSCI 2770": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "OJIB 1310": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "OJIB 1320": {
+    "text": "OJIB 1310",
+    "courses": [
+      "OJIB 1310"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 1720": {
+    "text": "MATH 0910 with a grade of “C” or better",
+    "courses": [
+      "MATH 0910"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 1735": {
+    "text": "PHAR 1715 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1715"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 1730": {
+    "text": "PHAR 1720 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 1740": {
+    "text": "PHAR 1710 , PHAR 1715 , PHAR 1720 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1710",
+      "PHAR 1715",
+      "PHAR 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 1750": {
+    "text": "PHAR 1710 , PHAR 1715 , and PHAR 1720 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1710",
+      "PHAR 1715",
+      "PHAR 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 2700": {
+    "text": "PHAR 1730 , PHAR 1735 , PHAR 2710 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1730",
+      "PHAR 1735",
+      "PHAR 2710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 2710": {
+    "text": "PHAR 1715 Fundamentals of Pharmacy Technology 1 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1715"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 2720": {
+    "text": "PHAR 2710 with a grade of “C” or better",
+    "courses": [
+      "PHAR 2710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 2750": {
+    "text": "PHAR 1750 and PHAR 2710 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1750",
+      "PHAR 2710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHAR 2740": {
+    "text": "PHAR 1715 with a grade of “C” or better",
+    "courses": [
+      "PHAR 1715"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1700": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1710": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1715": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1720": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1724": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1722": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1742": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1750": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1760": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1780": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHYS 1720": {
+    "text": "MATH 1730 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "MATH 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHIL 1790": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHYS 1760": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHYS 1722": {
+    "text": "PHYS 1720 Principles of Physics 1 (Minimum grade: 1.66 GPA Equivalent)",
+    "courses": [
+      "PHYS 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHYS 2700": {
+    "text": "MATH 2749 Calculus 1 with a grade of “C” or better",
+    "courses": [
+      "MATH 2749"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHYS 2710": {
+    "text": "PHYS 2700 General Physics 1 (Minimum grade: 1.66 GPA Equivalent)",
+    "courses": [
+      "PHYS 2700"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PHYS 2760": {
+    "text": "MATH 0745 with a “P” or better or appropriate assessment score",
+    "courses": [
+      "MATH 0745"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1451": {
+    "text": "Must be enrolled in Pipefitting pre-apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1410": {
+    "text": "Must be enrolled in Pipefitting pre-apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1452": {
+    "text": "PIPE 1451 and must be enrolled in Pipefitting pre-apprenticeship program",
+    "courses": [
+      "PIPE 1451"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1540": {
+    "text": "PIPE 1451 , PIPE 1555 and must be enrolled in Pipefitting pre-apprenticeship program",
+    "courses": [
+      "PIPE 1451",
+      "PIPE 1555"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1550": {
+    "text": "PIPE 1451 and must be enrolled in Pipefitting pre-apprenticeship program",
+    "courses": [
+      "PIPE 1451"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1555": {
+    "text": "Must be enrolled in the Pipefitting apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 1585": {
+    "text": "Must be enrolled in the Pipefitting apprenticeship program and PIPE 1580",
+    "courses": [
+      "PIPE 1580"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2605": {
+    "text": "Must be enrolled in the Pipefitters apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2606": {
+    "text": "Must be enrolled in the Pipefitters apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2615": {
+    "text": "Must be enrolled in the Pipefitter apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2616": {
+    "text": "Must be enrolled in the Pipefitter apprenticeship program and PIPE 2615",
+    "courses": [
+      "PIPE 2615"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2628": {
+    "text": "Must be enrolled in the Pipefitters apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2631": {
+    "text": "Must be enrolled in the Pipefitters apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2632": {
+    "text": "Must be enrolled in the Pipefitting pre- apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2641": {
+    "text": "Must be enrolled in the Pipefitter apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2652": {
+    "text": "Graduate of Pipefitting day school program or pipefitting work experience",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2653": {
+    "text": "Graduate of Pipefitting day school program or pipefitting work experience",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2651": {
+    "text": "Must be enrolled in the Pipefitting pre-apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2654": {
+    "text": "Graduate of Pipefitting day school program or pipefitting work experience",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2658": {
+    "text": "Must be enrolled in the Pipefitter apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2659": {
+    "text": "Must be enrolled in the Pipefitters apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PIPE 2660": {
+    "text": "Must be enrolled in the Pipefitters apprenticeship program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2610": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2612": {
+    "text": "Must be accepted into the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2614": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2616": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2618": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2621": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2622": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2623": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2624": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2631": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2633": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2632": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2634": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "PLMB 2640": {
+    "text": "Must be enrolled in the Plumbing apprentice program",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "POLS 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "POLS 1740": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "POLS 1760": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "POLS 1750": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1425": {
+    "text": "HLTH 1310 , HLTH 1410 , BIOL 1730 , ENGL 1711 , and PSYC 1720 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "BIOL 1730",
+      "ENGL 1711",
+      "HLTH 1310",
+      "HLTH 1410",
+      "PSYC 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1436": {
+    "text": "HLTH 1310 , HLTH 1410 , BIOL 1730 , ENGL 1711 , and PSYC 1720 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "BIOL 1730",
+      "ENGL 1711",
+      "HLTH 1310",
+      "HLTH 1410",
+      "PSYC 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1481": {
+    "text": "HLTH 1310 , HLTH 1410 , BIOL 1730 , ENGL 1711 , and PSYC 1720 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "BIOL 1730",
+      "ENGL 1711",
+      "HLTH 1310",
+      "HLTH 1410",
+      "PSYC 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1483": {
+    "text": "PRNS 1484 and PRNS 1531 with a grade of “C” or better",
+    "courses": [
+      "PRNS 1484",
+      "PRNS 1531"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1484": {
+    "text": "PRNS 1425 , PRNS 1436 , PRNS 1481 , PRNS 1521 , and PRNS 2410 with a grade of “C” or better",
+    "courses": [
+      "PRNS 1425",
+      "PRNS 1436",
+      "PRNS 1481",
+      "PRNS 1521",
+      "PRNS 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1521": {
+    "text": "HLTH 1310 , HLTH 1410 , BIOL 1730 , ENGL 1711 , and PSYC 1720 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "BIOL 1730",
+      "ENGL 1711",
+      "HLTH 1310",
+      "HLTH 1410",
+      "PSYC 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1524": {
+    "text": "PRNS 1425 , PRNS 1436 , PRNS 1481 , PRNS 1521 , and PRNS 2410 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "PRNS 1425",
+      "PRNS 1436",
+      "PRNS 1481",
+      "PRNS 1521",
+      "PRNS 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 1531": {
+    "text": "PRNS 1425 , PRNS 1436 , PRNS 1481 , PRNS 1521 , and PRNS 2410 with a grade of “C” or better",
+    "courses": [
+      "PRNS 1425",
+      "PRNS 1436",
+      "PRNS 1481",
+      "PRNS 1521",
+      "PRNS 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 2411": {
+    "text": "HLTH 1310 , HLTH 1410 , BIOL 1730 , ENGL 1711 , PSYC 1720 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "BIOL 1730",
+      "ENGL 1711",
+      "HLTH 1310",
+      "HLTH 1410",
+      "PSYC 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 2410": {
+    "text": "HLTH 1410 , BIOL 1730 , ENGL 1711 , and PSYC 1720 with a grade of “C” or better. Must be accepted as a Practical Nursing major",
+    "courses": [
+      "BIOL 1730",
+      "ENGL 1711",
+      "HLTH 1410",
+      "PSYC 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PRNS 2492": {
+    "text": "PRNS 1425 , PRNS 1436 , PRNS 1481 , PRNS 1484 , PRNS 1483 , PRNS 1521 , PRNS 1524 , PRNS 1531 , and PRNS 2410 with a grade of “C” or better",
+    "courses": [
+      "PRNS 1425",
+      "PRNS 1436",
+      "PRNS 1481",
+      "PRNS 1483",
+      "PRNS 1484",
+      "PRNS 1521",
+      "PRNS 1524",
+      "PRNS 1531",
+      "PRNS 2410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 1710": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or concurrent enrollment, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 1740": {
+    "text": "PSYC 1710 General Psychology",
+    "courses": [
+      "PSYC 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 1750": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 1780": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 2240": {
+    "text": "PSYC 1710 and MATH 1740 with a grade of “C” or better, or MATH 1730 with a grade of “C” or better, or a higher MATH course with a grade of “C” or better",
+    "courses": [
+      "MATH 1730",
+      "MATH 1740",
+      "PSYC 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PSYC 2720": {
+    "text": "PSYC 1710 or SOCI 1710",
+    "courses": [
+      "PSYC 1710",
+      "SOCI 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PUBH 2750": {
+    "text": "PUBH 2710",
+    "courses": [
+      "PUBH 2710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "PUBH 2770": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "READ 0721": {
+    "text": "Placement into this course will be according to college assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "READ 0722": {
+    "text": "Placement into this course will be according to assessment score or successful completion of READ 0721 or EAPP 0860 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721"
+    ],
+    "source": "saint-paul-college"
+  },
+  "READ 0724": {
+    "text": "Placement into this course will be according to college assessment score",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "READ 0925": {
+    "text": "Placement into this course will be according to assessment score or successful completion of READ 0721 or EAPP 0860 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721"
+    ],
+    "source": "saint-paul-college"
+  },
+  "READ 1350": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "READ 1450": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1411": {
+    "text": "Acceptance into the program major",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "RESP 1510": {
+    "text": "CHEM 1711 , HLTH 1410 , and either BIOL 1730 or both BIOL 2721 and BIOL 2722",
+    "courses": [
+      "BIOL 1730",
+      "BIOL 2721",
+      "BIOL 2722",
+      "CHEM 1711",
+      "HLTH 1410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1523": {
+    "text": "RESP 1412",
+    "courses": [
+      "RESP 1412"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1524": {
+    "text": "RESP 1412",
+    "courses": [
+      "RESP 1412"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1521": {
+    "text": "CHEM 1711 , RESP 1411 and RESP 1412 , BIOL 1730 or BIOL 2721 & BIOL 2722",
+    "courses": [
+      "BIOL 1730",
+      "BIOL 2721",
+      "BIOL 2722",
+      "CHEM 1711",
+      "RESP 1411",
+      "RESP 1412"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1540": {
+    "text": "CHEM 1711 , HLTH 1410 and BIOL 1730",
+    "courses": [
+      "BIOL 1730",
+      "CHEM 1711",
+      "HLTH 1410"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1582": {
+    "text": "RESP 1581",
+    "courses": [
+      "RESP 1581"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1581": {
+    "text": "RESP 1411 and RESP 1412",
+    "courses": [
+      "RESP 1411",
+      "RESP 1412"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1583": {
+    "text": "RESP 1582",
+    "courses": [
+      "RESP 1582"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1584": {
+    "text": "RESP 1583",
+    "courses": [
+      "RESP 1583"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1592": {
+    "text": "RESP 1510 , RESP 1520, RESP 1540 , RESP 1591",
+    "courses": [
+      "RESP 1510",
+      "RESP 1520",
+      "RESP 1540",
+      "RESP 1591"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1597": {
+    "text": "RESP 1583",
+    "courses": [
+      "RESP 1583"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 1599": {
+    "text": "RESP 1597",
+    "courses": [
+      "RESP 1597"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2411": {
+    "text": "RESP 1510 , RESP 1521 , RESP 1522, RESP 1540 , RESP 1591",
+    "courses": [
+      "RESP 1510",
+      "RESP 1521",
+      "RESP 1522",
+      "RESP 1540",
+      "RESP 1591"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2413": {
+    "text": "RESP 1500 and RESP 1524",
+    "courses": [
+      "RESP 1500",
+      "RESP 1524"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2420": {
+    "text": "RESP 1510",
+    "courses": [
+      "RESP 1510"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2450": {
+    "text": "RESP 2420",
+    "courses": [
+      "RESP 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2440": {
+    "text": "RESP 2411 , RESP 2412 , and RESP 2420",
+    "courses": [
+      "RESP 2411",
+      "RESP 2412",
+      "RESP 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2452": {
+    "text": "RESP 2440 and BLS Card through AHA",
+    "courses": [
+      "RESP 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2453": {
+    "text": "RESP 2413",
+    "courses": [
+      "RESP 2413"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2458": {
+    "text": "RESP 2440",
+    "courses": [
+      "RESP 2440"
+    ],
+    "source": "saint-paul-college"
+  },
+  "RESP 2470": {
+    "text": "RESP 24XX and RESP 2412",
+    "courses": [
+      "RESP 2412"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SMET 1510": {
+    "text": "SMET 1410 , SMET 1415 , SMET 1420 , SMET 1430 , SMET 1440 , SMET 1450",
+    "courses": [
+      "SMET 1410",
+      "SMET 1415",
+      "SMET 1420",
+      "SMET 1430",
+      "SMET 1440",
+      "SMET 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SMET 1520": {
+    "text": "SMET 1410 , SMET 1415 , SMET 1420 , SMET 1430 , SMET 1440 , SMET 1450",
+    "courses": [
+      "SMET 1410",
+      "SMET 1415",
+      "SMET 1420",
+      "SMET 1430",
+      "SMET 1440",
+      "SMET 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SMET 1530": {
+    "text": "SMET 1410 , SMET 1415 , SMET 1420 , SMET 1430 , SMET 1440 , SMET 1450",
+    "courses": [
+      "SMET 1410",
+      "SMET 1415",
+      "SMET 1420",
+      "SMET 1430",
+      "SMET 1440",
+      "SMET 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SMET 1540": {
+    "text": "SMET 1410 , SMET 1415 , SMET 1420 , SMET 1430 , SMET 1440 , SMET 1450",
+    "courses": [
+      "SMET 1410",
+      "SMET 1415",
+      "SMET 1420",
+      "SMET 1430",
+      "SMET 1440",
+      "SMET 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SMLI 1510": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SMET 1550": {
+    "text": "SMET 1410 , SMET 1415 , SMET 1420 , SMET 1430 , SMET 1440 , SMET 1450",
+    "courses": [
+      "SMET 1410",
+      "SMET 1415",
+      "SMET 1420",
+      "SMET 1430",
+      "SMET 1440",
+      "SMET 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1710": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1730": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1720": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1740": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1760": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1765": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1766": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1772": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1774": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1776": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1790": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 1791": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SOCI 2720": {
+    "text": "PSYC 1710 or SOCI 1710",
+    "courses": [
+      "PSYC 1710",
+      "SOCI 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SPAN 1710": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SPAN 1720": {
+    "text": "SPAN 1710 with grade of “C” or better or Placement Exam or instructor approval",
+    "courses": [
+      "SPAN 1710"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SPAN 1730": {
+    "text": "SPAN 1720 with a grade of “C” or better or Placement Exam or instructor approval",
+    "courses": [
+      "SPAN 1720"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SPAN 1740": {
+    "text": "SPAN 1730 with a grade of “C” or better or Placement Exam or permission of Instructor",
+    "courses": [
+      "SPAN 1730"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 1410": {
+    "text": "BIOL 1471 , BIOL 1740 , BIOL 2721 , and BIOL 2722",
+    "courses": [
+      "BIOL 1471",
+      "BIOL 1740",
+      "BIOL 2721",
+      "BIOL 2722"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 1415": {
+    "text": "BIOL 1471 , BIOL 1740 , BIOL 2721 , and BIOL 2722",
+    "courses": [
+      "BIOL 1471",
+      "BIOL 1740",
+      "BIOL 2721",
+      "BIOL 2722"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2400": {
+    "text": "SURG 1405 , SURG 1410 , and SURG 1415",
+    "courses": [
+      "SURG 1405",
+      "SURG 1410",
+      "SURG 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2405": {
+    "text": "SURG 1405 , SURG 1410 , and SURG 1415",
+    "courses": [
+      "SURG 1405",
+      "SURG 1410",
+      "SURG 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2411": {
+    "text": "BIOL 2722 , SURG 1405 , SURG 1410 , and SURG 1415",
+    "courses": [
+      "BIOL 2722",
+      "SURG 1405",
+      "SURG 1410",
+      "SURG 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2415": {
+    "text": "SURG 1405 , SURG 1410 , and SURG 1415",
+    "courses": [
+      "SURG 1405",
+      "SURG 1410",
+      "SURG 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2430": {
+    "text": "SURG 2405 , SURG 2411 , SURG 2415 , and SURG 2420",
+    "courses": [
+      "SURG 2405",
+      "SURG 2411",
+      "SURG 2415",
+      "SURG 2420"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2420": {
+    "text": "SURG 1405 , SURG 1410 , and SURG 1415",
+    "courses": [
+      "SURG 1405",
+      "SURG 1410",
+      "SURG 1415"
+    ],
+    "source": "saint-paul-college"
+  },
+  "SURG 2435": {
+    "text": "SURG 2405 , SURG 2411 , SURG 2415 , SURG 2420 , and SURG 2430",
+    "courses": [
+      "SURG 2405",
+      "SURG 2411",
+      "SURG 2415",
+      "SURG 2420",
+      "SURG 2430"
+    ],
+    "source": "saint-paul-college"
+  },
+  "THTR 1725": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better. or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "THTR 1731": {
+    "text": "Instructor permission",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "THTR 1732": {
+    "text": "Instructor permission",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "THTR 1740": {
+    "text": "READ 0722 or READ 0724 or EAPP 0900 with a grade of “C” or better, or appropriate assessment score",
+    "courses": [
+      "EAPP 0900",
+      "READ 0722",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "THTR 2725": {
+    "text": "THTR 1725 or instructor approval",
+    "courses": [
+      "THTR 1725"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WGST 1785": {
+    "text": "READ 0721 or READ 0724 or EAPP 0860 with a grade of “C” or better or appropriate assessment score",
+    "courses": [
+      "EAPP 0860",
+      "READ 0721",
+      "READ 0724"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WINE 1600": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 1610": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 1620": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 1630": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 2710": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 2700": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 1640": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 2720": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 2730": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WINE 2740": {
+    "text": "Must be 21 years or older",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WLDG 1502": {
+    "text": "Must complete 1st semester courses WLDG 1402 -WLDG 1450",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 1510": {
+    "text": "Must complete 1st semester courses WLDG 1402 -WLDG 1450",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 1520": {
+    "text": "Must complete 1st semester courses WLDG 1402 -WLDG 1450",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 1530": {
+    "text": "Must complete 1st semester courses WLDG 1402 -WLDG 1450",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1450"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 1540": {
+    "text": "Must complete 1st semester courses WLDG 1502 -1540",
+    "courses": [
+      "WLDG 1502"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 2402": {
+    "text": "Must complete 1st and 2nd semester courses WLDG 1402 -WLDG 1540",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1540"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 2420": {
+    "text": "1st & 2nd semester courses WLDG 1402 -WLDG 1540",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1540"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 2430": {
+    "text": "Must complete 1st & 2nd semester courses WLDG 1402 -WLDG 1540",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1540"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 2590": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "saint-paul-college"
+  },
+  "WLDG 2411": {
+    "text": "Must complete 1st & 2nd semester courses WLDG 1402 -WLDG 1540",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1540"
+    ],
+    "source": "saint-paul-college"
+  },
+  "WLDG 2442": {
+    "text": "Must complete 1st & 2nd semester courses WLDG 1402 -WLDG 1540",
+    "courses": [
+      "WLDG 1402",
+      "WLDG 1540"
+    ],
+    "source": "saint-paul-college"
+  },
   "ABCT 1020": {
     "text": "Recommended: ABCT 1145, ABCT 2040, and ABCT 2051",
     "courses": [
@@ -48,16 +17898,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ABCT 2055": {
-    "text": "Recommended: ABCT 1160, ABCT 2000, ABCT 2006, and ABCT 2051",
-    "courses": [
-      "ABCT 1160",
-      "ABCT 2000",
-      "ABCT 2006",
-      "ABCT 2051"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ABCT 2051": {
     "text": "Recommended: ABCT 1155, ABCT 1160, ABCT 2150, and ABCT 2190",
     "courses": [
@@ -68,6 +17908,16 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ABCT 2055": {
+    "text": "Recommended: ABCT 1160, ABCT 2000, ABCT 2006, and ABCT 2051",
+    "courses": [
+      "ABCT 1160",
+      "ABCT 2000",
+      "ABCT 2006",
+      "ABCT 2051"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ABCT 2060": {
     "text": "ABCT 2051",
     "courses": [
@@ -75,7 +17925,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ABCT 2085": {
+  "ABCT 2075": {
     "text": "Recommended: ABCT 2051 or concurrent enrollment",
     "courses": [
       "ABCT 2051"
@@ -89,7 +17939,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ABCT 2075": {
+  "ABCT 2085": {
     "text": "Recommended: ABCT 2051 or concurrent enrollment",
     "courses": [
       "ABCT 2051"
@@ -101,16 +17951,6 @@
     "courses": [
       "ENGL 0901"
     ],
-    "source": "hennepin-technical-college"
-  },
-  "ABCT 2505": {
-    "text": "Successful completion of all ABCT courses or instructor approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "ABCT 2501": {
-    "text": "Successful completion of all ABCT courses or instructor approval",
-    "courses": [],
     "source": "hennepin-technical-college"
   },
   "ABCT 2190": {
@@ -125,11 +17965,20 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "ACCT 1111": {
-    "text": "ACCT 1000 or ACCT 1102 or concurrent",
+  "ABCT 2501": {
+    "text": "Successful completion of all ABCT courses or instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "ABCT 2505": {
+    "text": "Successful completion of all ABCT courses or instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "ACCT 1102": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
-      "ACCT 1000",
-      "ACCT 1102"
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -140,21 +17989,22 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ACCT 1102": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+  "ACCT 1111": {
+    "text": "ACCT 1000 or ACCT 1102 or concurrent",
     "courses": [
-      "ENGL 0921"
+      "ACCT 1000",
+      "ACCT 1102"
     ],
     "source": "hennepin-technical-college"
   },
-  "ACCT 1135": {
+  "ACCT 1130": {
     "text": "ACCT 1102",
     "courses": [
       "ACCT 1102"
     ],
     "source": "hennepin-technical-college"
   },
-  "ACCT 1130": {
+  "ACCT 1135": {
     "text": "ACCT 1102",
     "courses": [
       "ACCT 1102"
@@ -178,32 +18028,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ACCT 2200": {
-    "text": "ACCT 1107",
-    "courses": [
-      "ACCT 1107"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ACCT 2206": {
-    "text": "Recommended: ACCT 1107",
-    "courses": [
-      "ACCT 1107"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ACCT 2221": {
     "text": "ACCT 2155 AND qualifying score on math assessment test OR MATH 0940",
     "courses": [
       "ACCT 2155",
       "MATH 0940"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ACCT 2700": {
-    "text": "ACCT 1107",
-    "courses": [
-      "ACCT 1107"
     ],
     "source": "hennepin-technical-college"
   },
@@ -222,6 +18051,13 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ACCT 2700": {
+    "text": "ACCT 1107",
+    "courses": [
+      "ACCT 1107"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ACCT 2800": {
     "text": "Instructor approval",
     "courses": [],
@@ -235,16 +18071,16 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ACCT 2950": {
+    "text": "75% of required courses are recommended to have been completed",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "ARCH 1008": {
     "text": "Qualifying score on reading assessment test or ENGL 0901",
     "courses": [
       "ENGL 0901"
     ],
-    "source": "hennepin-technical-college"
-  },
-  "ACCT 2950": {
-    "text": "75% of required courses are recommended to have been completed",
-    "courses": [],
     "source": "hennepin-technical-college"
   },
   "ARCH 1011": {
@@ -289,10 +18125,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARCH 2121": {
-    "text": "ARCH 2370",
+  "ARCH 2301": {
+    "text": "Qualifying score on reading assessment test or ENGL 0901",
     "courses": [
-      "ARCH 2370"
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -303,10 +18139,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARCH 2370": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901",
+  "ARCH 2121": {
+    "text": "ARCH 2370",
     "courses": [
-      "ENGL 0901"
+      "ARCH 2370"
     ],
     "source": "hennepin-technical-college"
   },
@@ -315,8 +18151,8 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "ARCH 2301": {
-    "text": "Qualifying score on reading assessment test or ENGL 0901",
+  "ARCH 2370": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
     ],
@@ -336,6 +18172,11 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ARCH 2640": {
+    "text": "Basic computer skills are required",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "ARCH 2800": {
     "text": "ARCH 1101 or ARCH 2370",
     "courses": [
@@ -344,21 +18185,16 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARCH 2640": {
-    "text": "Basic computer skills are required",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "ARCH 2900": {
-    "text": "Instructor approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "ARCH 2850": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "ARCH 2900": {
+    "text": "Instructor approval",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "ARCH 2920": {
@@ -371,17 +18207,17 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "ARCH 2936": {
-    "text": "ARCH 2370 OR Previous Revit experience",
-    "courses": [
-      "ARCH 2370"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ARCH 2955": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ARCH 2936": {
+    "text": "ARCH 2370 OR Previous Revit experience",
+    "courses": [
+      "ARCH 2370"
     ],
     "source": "hennepin-technical-college"
   },
@@ -401,17 +18237,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARET 1190": {
-    "text": "Recommended: ARET 1126 or ARET 1175 or relevant experience",
+  "ARET 1180": {
+    "text": "ARET 1175",
     "courses": [
-      "ARET 1126",
       "ARET 1175"
     ],
     "source": "hennepin-technical-college"
   },
-  "ARET 1180": {
-    "text": "ARET 1175",
+  "ARET 1190": {
+    "text": "Recommended: ARET 1126 or ARET 1175 or relevant experience",
     "courses": [
+      "ARET 1126",
       "ARET 1175"
     ],
     "source": "hennepin-technical-college"
@@ -428,11 +18264,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARET 2181": {
-    "text": "Completion of at least 50% of your degree or diploma and instructor approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "ARET 2111": {
     "text": "ARET 1190",
     "courses": [
@@ -440,31 +18271,20 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ARET 2181": {
+    "text": "Completion of at least 50% of your degree or diploma and instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "ARET 2185": {
     "text": "Instructor permission and verified employment at the company",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "ARET 2330": {
-    "text": "ARET 1180 and ARET 2320 or Instructor approval",
+  "ARET 2200": {
+    "text": "Recommended: ARET 1200",
     "courses": [
-      "ARET 1180",
-      "ARET 2320"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARET 2320": {
-    "text": "ARET 1175 or Instructor approval",
-    "courses": [
-      "ARET 1175"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARET 2300": {
-    "text": "ARET 1126 and ARET 1130 or instructor approval",
-    "courses": [
-      "ARET 1126",
-      "ARET 1130"
+      "ARET 1200"
     ],
     "source": "hennepin-technical-college"
   },
@@ -476,10 +18296,26 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARET 2200": {
-    "text": "Recommended: ARET 1200",
+  "ARET 2300": {
+    "text": "ARET 1126 and ARET 1130 or instructor approval",
     "courses": [
-      "ARET 1200"
+      "ARET 1126",
+      "ARET 1130"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ARET 2320": {
+    "text": "ARET 1175 or Instructor approval",
+    "courses": [
+      "ARET 1175"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ARET 2330": {
+    "text": "ARET 1180 and ARET 2320 or Instructor approval",
+    "courses": [
+      "ARET 1180",
+      "ARET 2320"
     ],
     "source": "hennepin-technical-college"
   },
@@ -491,17 +18327,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARET 2580": {
-    "text": "ARET 2560",
+  "ARET 2360": {
+    "text": "ARET 2105 or Instructor approval",
     "courses": [
-      "ARET 2560"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARET 2560": {
-    "text": "ARET 1190",
-    "courses": [
-      "ARET 1190"
+      "ARET 2105"
     ],
     "source": "hennepin-technical-college"
   },
@@ -523,10 +18352,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARET 2360": {
-    "text": "ARET 2105 or Instructor approval",
+  "ARET 2560": {
+    "text": "ARET 1190",
     "courses": [
-      "ARET 2105"
+      "ARET 1190"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ARET 2580": {
+    "text": "ARET 2560",
+    "courses": [
+      "ARET 2560"
     ],
     "source": "hennepin-technical-college"
   },
@@ -534,6 +18370,15 @@
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and concurrent enrollment in ARSP 1110 and ARSP 1130",
     "courses": [
       "ARSP 1110",
+      "ARSP 1130",
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ARSP 1110": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921 and concurrent enrollment in ARSP 1100 and ARSP 1130",
+    "courses": [
+      "ARSP 1100",
       "ARSP 1130",
       "ENGL 0921"
     ],
@@ -548,12 +18393,16 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 1110": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921 and concurrent enrollment in ARSP 1100 and ARSP 1130",
+  "ARSP 1300": {
+    "text": "Recommended: ARSP 1100, ARSP 1110, ARSP 1130 or instructor approval. This course should be taken concurrently with ARSP 1310, ARSP 1320, ARSP 1331, and ARSP 2120",
     "courses": [
       "ARSP 1100",
+      "ARSP 1110",
       "ARSP 1130",
-      "ENGL 0921"
+      "ARSP 1310",
+      "ARSP 1320",
+      "ARSP 1331",
+      "ARSP 2120"
     ],
     "source": "hennepin-technical-college"
   },
@@ -563,19 +18412,6 @@
       "ARSP 1100",
       "ARSP 1110",
       "ARSP 1300",
-      "ARSP 1320",
-      "ARSP 1331",
-      "ARSP 2120"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARSP 1300": {
-    "text": "Recommended: ARSP 1100, ARSP 1110, ARSP 1130 or instructor approval. This course should be taken concurrently with ARSP 1310, ARSP 1320, ARSP 1331, and ARSP 2120",
-    "courses": [
-      "ARSP 1100",
-      "ARSP 1110",
-      "ARSP 1130",
-      "ARSP 1310",
       "ARSP 1320",
       "ARSP 1331",
       "ARSP 2120"
@@ -617,6 +18453,13 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "ARSP 1510": {
+    "text": "Recommended: ARSP 1500 or instructor approval",
+    "courses": [
+      "ARSP 1500"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ARSP 1500": {
     "text": "Recommended: ARSP 1300 and ARSP 1310. Prereq. or concurrent ARSP 1320, ARSP 1331, ARSP 1510 and ARSP 2120 or instructor approval",
     "courses": [
@@ -636,10 +18479,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 1510": {
-    "text": "Recommended: ARSP 1500 or instructor approval",
+  "ARSP 1541": {
+    "text": "ARSP 1100",
     "courses": [
-      "ARSP 1500"
+      "ARSP 1100"
     ],
     "source": "hennepin-technical-college"
   },
@@ -652,15 +18495,16 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 1541": {
-    "text": "ARSP 1100",
+  "ARSP 2111": {
+    "text": "Recommended: ARSP 1500 and ARSP 1510",
     "courses": [
-      "ARSP 1100"
+      "ARSP 1500",
+      "ARSP 1510"
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 2111": {
-    "text": "Recommended: ARSP 1500 and ARSP 1510",
+  "ARSP 2115": {
+    "text": "Recommended: ARSP 1500 and ARSP 1510 or instructor approval",
     "courses": [
       "ARSP 1500",
       "ARSP 1510"
@@ -677,11 +18521,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 2115": {
-    "text": "Recommended: ARSP 1500 and ARSP 1510 or instructor approval",
+  "ARSP 2150": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
-      "ARSP 1500",
-      "ARSP 1510"
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -693,36 +18536,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 2150": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ARSP 2171": {
     "text": "Recommended: ARSP 1100, ARSP 1110, ARSP 1130, ARSP 1300, ARSP 1310, and ARSP 1320, or instructor approval",
-    "courses": [
-      "ARSP 1100",
-      "ARSP 1110",
-      "ARSP 1130",
-      "ARSP 1300",
-      "ARSP 1310",
-      "ARSP 1320"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARSP 2247": {
-    "text": "Recommended: ARSP 1100, ARSP 1110, and ARSP 1130",
-    "courses": [
-      "ARSP 1100",
-      "ARSP 1110",
-      "ARSP 1130"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARSP 2185": {
-    "text": "Recommended: ARSP 1100, ARSP 1110, ARSP 1130, ARSP 1300, ARSP 1310, and ARSP 1320",
     "courses": [
       "ARSP 1100",
       "ARSP 1110",
@@ -749,17 +18564,31 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ARSP 2185": {
+    "text": "Recommended: ARSP 1100, ARSP 1110, ARSP 1130, ARSP 1300, ARSP 1310, and ARSP 1320",
+    "courses": [
+      "ARSP 1100",
+      "ARSP 1110",
+      "ARSP 1130",
+      "ARSP 1300",
+      "ARSP 1310",
+      "ARSP 1320"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ARSP 2247": {
+    "text": "Recommended: ARSP 1100, ARSP 1110, and ARSP 1130",
+    "courses": [
+      "ARSP 1100",
+      "ARSP 1110",
+      "ARSP 1130"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ARSP 2270": {
     "text": "Recommended: ARSP 2171 or instructor approval",
     "courses": [
       "ARSP 2171"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARSP 2325": {
-    "text": "Recommended: ARSP 2120",
-    "courses": [
-      "ARSP 2120"
     ],
     "source": "hennepin-technical-college"
   },
@@ -775,6 +18604,13 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ARSP 2325": {
+    "text": "Recommended: ARSP 2120",
+    "courses": [
+      "ARSP 2120"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ARSP 2380": {
     "text": "Instructor approval",
     "courses": [],
@@ -782,6 +18618,11 @@
   },
   "ARSP 2390": {
     "text": "Instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "ARSP 2585": {
+    "text": "Completion of 48 credits or instructor approval",
     "courses": [],
     "source": "hennepin-technical-college"
   },
@@ -797,9 +18638,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 2585": {
-    "text": "Completion of 48 credits or instructor approval",
-    "courses": [],
+  "ARSP 2595": {
+    "text": "Recommended: ARSP 2585 and instructor approval",
+    "courses": [
+      "ARSP 2585"
+    ],
     "source": "hennepin-technical-college"
   },
   "ARSP 2600": {
@@ -820,10 +18663,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ARSP 2595": {
-    "text": "Recommended: ARSP 2585 and instructor approval",
+  "ARTS 1000": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0960",
     "courses": [
-      "ARSP 2585"
+      "ENGL 0921",
+      "ENGL 0960"
     ],
     "source": "hennepin-technical-college"
   },
@@ -831,14 +18675,6 @@
     "text": "Recommended: ARSP 1541",
     "courses": [
       "ARSP 1541"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ARTS 1000": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0960",
-    "courses": [
-      "ENGL 0921",
-      "ENGL 0960"
     ],
     "source": "hennepin-technical-college"
   },
@@ -858,10 +18694,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1210": {
-    "text": "ATEC 1625",
+  "ATEC 1105": {
+    "text": "ATEC 1615",
     "courses": [
-      "ATEC 1625"
+      "ATEC 1615"
     ],
     "source": "hennepin-technical-college"
   },
@@ -872,13 +18708,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1305": {
-    "text": "ATEC 1615",
-    "courses": [
-      "ATEC 1615"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ATEC 1205": {
     "text": "ATEC 1615",
     "courses": [
@@ -886,14 +18715,28 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1105": {
+  "ATEC 1210": {
+    "text": "ATEC 1625",
+    "courses": [
+      "ATEC 1625"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ATEC 1405": {
     "text": "ATEC 1615",
     "courses": [
       "ATEC 1615"
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1405": {
+  "ATEC 1305": {
+    "text": "ATEC 1615",
+    "courses": [
+      "ATEC 1615"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ATEC 1505": {
     "text": "ATEC 1615",
     "courses": [
       "ATEC 1615"
@@ -907,7 +18750,22 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1505": {
+  "ATEC 1620": {
+    "text": "ATEC 1615",
+    "courses": [
+      "ATEC 1615"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ATEC 1625": {
+    "text": "Qualifying score on math assessment test OR MATH 0800 and Recommended: ATEC 1615",
+    "courses": [
+      "ATEC 1615",
+      "MATH 0800"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ATEC 1705": {
     "text": "ATEC 1615",
     "courses": [
       "ATEC 1615"
@@ -921,22 +18779,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1625": {
-    "text": "Qualifying score on math assessment test OR MATH 0800 and Recommended: ATEC 1615",
-    "courses": [
-      "ATEC 1615",
-      "MATH 0800"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ATEC 1620": {
-    "text": "ATEC 1615",
-    "courses": [
-      "ATEC 1615"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ATEC 1705": {
+  "ATEC 1820": {
     "text": "ATEC 1615",
     "courses": [
       "ATEC 1615"
@@ -950,10 +18793,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1820": {
-    "text": "ATEC 1615",
+  "ATEC 1855": {
+    "text": "ATEC 1110",
     "courses": [
-      "ATEC 1615"
+      "ATEC 1110"
     ],
     "source": "hennepin-technical-college"
   },
@@ -971,16 +18814,24 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 1855": {
-    "text": "ATEC 1110",
-    "courses": [
-      "ATEC 1110"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ATEC 1900": {
     "text": "ATEC 1615 and Instructor approval",
     "courses": [
+      "ATEC 1615"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ATEC 2100": {
+    "text": "ATEC 1850 or Instructor approval",
+    "courses": [
+      "ATEC 1850"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ATEC 2685": {
+    "text": "ATEC 1505 and ATEC 1615 or Instructor approval",
+    "courses": [
+      "ATEC 1505",
       "ATEC 1615"
     ],
     "source": "hennepin-technical-college"
@@ -998,18 +18849,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ATEC 2685": {
-    "text": "ATEC 1505 and ATEC 1615 or Instructor approval",
+  "ATEC 2700": {
+    "text": "ATEC 2685",
     "courses": [
-      "ATEC 1505",
-      "ATEC 1615"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ATEC 2100": {
-    "text": "ATEC 1850 or Instructor approval",
-    "courses": [
-      "ATEC 1850"
+      "ATEC 2685"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1017,13 +18860,6 @@
     "text": "ATEC 1625 or instructor approval",
     "courses": [
       "ATEC 1625"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ATEC 2700": {
-    "text": "ATEC 2685",
-    "courses": [
-      "ATEC 2685"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1039,6 +18875,21 @@
     "courses": [
       "ATEC 2800",
       "ATEC 2805"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "BIOL 1100": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "BIOL 1000": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Qualifying score on math assessment test OR MATH 0800",
+    "courses": [
+      "ENGL 0921",
+      "MATH 0800"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1059,21 +18910,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BIOL 1000": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Qualifying score on math assessment test OR MATH 0800",
-    "courses": [
-      "ENGL 0921",
-      "MATH 0800"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "BIOL 1100": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "BIOL 2005": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Qualifying score on math assessment test OR MATH 0940 or MATH 0960",
     "courses": [
@@ -1083,18 +18919,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BUSN 1020": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0930",
+  "BIOL 2125": {
+    "text": "BIOL 2005 with a grade equivalent of \"C\" or better OR BIOL 1400 with a grade equivalent of \"C\" or better",
     "courses": [
-      "ENGL 0930"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "BIOL 2235": {
-    "text": "BIOL 2005 with a grade of \"C\" or better and BIOL 2125 with a grade of \"C\" or better",
-    "courses": [
-      "BIOL 2005",
-      "BIOL 2125"
+      "BIOL 1400",
+      "BIOL 2005"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1107,11 +18936,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BIOL 2125": {
-    "text": "BIOL 2005 with a grade equivalent of \"C\" or better OR BIOL 1400 with a grade equivalent of \"C\" or better",
+  "BIOL 2235": {
+    "text": "BIOL 2005 with a grade of \"C\" or better and BIOL 2125 with a grade of \"C\" or better",
     "courses": [
-      "BIOL 1400",
-      "BIOL 2005"
+      "BIOL 2005",
+      "BIOL 2125"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1119,6 +18948,13 @@
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0930",
     "courses": [
       "ENGL 0921",
+      "ENGL 0930"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "BUSN 1020": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0930",
+    "courses": [
       "ENGL 0930"
     ],
     "source": "hennepin-technical-college"
@@ -1132,13 +18968,6 @@
     "source": "hennepin-technical-college"
   },
   "BUSN 1030": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0930",
-    "courses": [
-      "ENGL 0930"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "BUSN 1060": {
     "text": "Qualifying score on writing assessment test OR ENGL 0930",
     "courses": [
       "ENGL 0930"
@@ -1160,18 +18989,17 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "BUSN 1060": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0930",
+    "courses": [
+      "ENGL 0930"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "BUSN 1075": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
       "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "BUSN 1091": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0930",
-    "courses": [
-      "ENGL 0921",
-      "ENGL 0930"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1182,10 +19010,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BUSN 1225": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+  "BUSN 1091": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0930",
     "courses": [
-      "ENGL 0921"
+      "ENGL 0921",
+      "ENGL 0930"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1204,6 +19033,13 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "BUSN 1225": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "BUSN 1510": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0930",
     "courses": [
@@ -1219,17 +19055,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BUSN 2010": {
-    "text": "BUSN 2000",
-    "courses": [
-      "BUSN 2000"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "BUSN 2005": {
     "text": "Qualifying score on writing assessment test OR ENGL 0930",
     "courses": [
       "ENGL 0930"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "BUSN 2010": {
+    "text": "BUSN 2000",
+    "courses": [
+      "BUSN 2000"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1257,10 +19093,24 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "BUSN 2060": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "BUSN 2055": {
     "text": "Qualifying score on writing assessment test OR ENGL 0930",
     "courses": [
       "ENGL 0930"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "BUSN 2070": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1269,20 +19119,6 @@
     "courses": [
       "ENGL 0921",
       "ENGL 0930"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "BUSN 2060": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "BUSN 2070": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1302,6 +19138,16 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "BUSN 2101": {
+    "text": "BUSN 1000, BUSN 1020, BUSN 2060, and BUSN 1510",
+    "courses": [
+      "BUSN 1000",
+      "BUSN 1020",
+      "BUSN 1510",
+      "BUSN 2060"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "BUSN 2090": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: ACCT 2155, BUSN 1000, BUSN 1225, BUSN 2055, BUSN 2060, BUSN 2080, ITEC 1032, and ITEC 2055",
     "courses": [
@@ -1317,16 +19163,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BUSN 2101": {
-    "text": "BUSN 1000, BUSN 1020, BUSN 2060, and BUSN 1510",
-    "courses": [
-      "BUSN 1000",
-      "BUSN 1020",
-      "BUSN 1510",
-      "BUSN 2060"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "BUSN 2170": {
     "text": "Completion of at least 16 Business credits with a grade of \"C\" or better in each course or an arrangement with instructor",
     "courses": [],
@@ -1339,14 +19175,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BUSN 2205": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: BUSN 2200",
-    "courses": [
-      "BUSN 2200",
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "BUSN 2210": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: BUSN 2200",
     "courses": [
@@ -1355,7 +19183,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "BUSN 2215": {
+  "BUSN 2205": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: BUSN 2200",
     "courses": [
       "BUSN 2200",
@@ -1371,10 +19199,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CARP 1102": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901",
+  "BUSN 2215": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: BUSN 2200",
     "courses": [
-      "ENGL 0901"
+      "BUSN 2200",
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1390,14 +19219,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CARP 1111": {
+  "CARP 1102": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
-  "CARP 1141": {
+  "CARP 1111": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
@@ -1408,6 +19237,13 @@
     "text": "CARP 1141",
     "courses": [
       "CARP 1141"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CARP 1141": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901",
+    "courses": [
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1437,13 +19273,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CARP 1711": {
-    "text": "CARP 1180",
-    "courses": [
-      "CARP 1180"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CARP 1511": {
     "text": "CARP 1102",
     "courses": [
@@ -1451,10 +19280,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CARP 1810": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901",
+  "CARP 1711": {
+    "text": "CARP 1180",
     "courses": [
-      "ENGL 0901"
+      "CARP 1180"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CARP 1720": {
+    "text": "CARP 1102",
+    "courses": [
+      "CARP 1102"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1466,17 +19302,17 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "CARP 1810": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901",
+    "courses": [
+      "ENGL 0901"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CARP 1830": {
     "text": "CARP 1810",
     "courses": [
       "CARP 1810"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CARP 1720": {
-    "text": "CARP 1102",
-    "courses": [
-      "CARP 1102"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1515,10 +19351,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CBTG 1141": {
-    "text": "CBTG 1121",
+  "CBTG 1111": {
+    "text": "Qualifying score on math assessment test OR MATH 0800",
     "courses": [
-      "CBTG 1121"
+      "MATH 0800"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1537,10 +19373,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CBTG 1111": {
-    "text": "Qualifying score on math assessment test OR MATH 0800",
+  "CBTG 1141": {
+    "text": "CBTG 1121",
     "courses": [
-      "MATH 0800"
+      "CBTG 1121"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1591,21 +19427,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CBTG 2432": {
-    "text": "CBTG 2423",
-    "courses": [
-      "CBTG 2423"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CBTG 2423": {
-    "text": "Recommended: CBTG 1121 and CBTG 1170 or instructor approval",
-    "courses": [
-      "CBTG 1121",
-      "CBTG 1170"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CBTG 2240": {
     "text": "Recommended: CBTG 1242 or instructor approval",
     "courses": [
@@ -1628,17 +19449,25 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "CBTG 2423": {
+    "text": "Recommended: CBTG 1121 and CBTG 1170 or instructor approval",
+    "courses": [
+      "CBTG 1121",
+      "CBTG 1170"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CBTG 2432": {
+    "text": "CBTG 2423",
+    "courses": [
+      "CBTG 2423"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CBTG 2450": {
     "text": "CBTG 1121",
     "courses": [
       "CBTG 1121"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CBTG 2553": {
-    "text": "CBTG 2523. Basic computer skills and understanding of Internet strongly recommended for successful course completion",
-    "courses": [
-      "CBTG 2523"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1647,6 +19476,13 @@
     "courses": [
       "CBTG 1121",
       "CBTG 1170"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CBTG 2553": {
+    "text": "CBTG 2523. Basic computer skills and understanding of Internet strongly recommended for successful course completion",
+    "courses": [
+      "CBTG 2523"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1671,15 +19507,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CCDS 1020": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0930, qualifying score on reading assessment test OR ENGL 0921, and successful completion of CCDS 1040 strongly recommended",
-    "courses": [
-      "CCDS 1040",
-      "ENGL 0921",
-      "ENGL 0930"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CBTG 2800": {
     "text": "Taken concurrently with CBTG 2700",
     "courses": [
@@ -1687,10 +19514,12 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CDEV 1020": {
-    "text": "Recommended - ENGL 1100",
+  "CCDS 1020": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0930, qualifying score on reading assessment test OR ENGL 0921, and successful completion of CCDS 1040 strongly recommended",
     "courses": [
-      "ENGL 1100"
+      "CCDS 1040",
+      "ENGL 0921",
+      "ENGL 0930"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1701,7 +19530,21 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "CDEV 1020": {
+    "text": "Recommended - ENGL 1100",
+    "courses": [
+      "ENGL 1100"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CDEV 1030": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0960",
+    "courses": [
+      "ENGL 0960"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CDEV 1530": {
     "text": "Qualifying score on writing assessment test OR ENGL 0960",
     "courses": [
       "ENGL 0960"
@@ -1711,13 +19554,6 @@
   "CDEV 1725": {
     "text": "Instructor approval",
     "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "CDEV 1530": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0960",
-    "courses": [
-      "ENGL 0960"
-    ],
     "source": "hennepin-technical-college"
   },
   "CDEV 1750": {
@@ -1732,13 +19568,6 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "CDEV 2200": {
-    "text": "CDEV 1725 to be taken concurrently",
-    "courses": [
-      "CDEV 1725"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CDEV 2016": {
     "text": "Required - ENGL 1100",
     "courses": [
@@ -1746,7 +19575,21 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "CDEV 2200": {
+    "text": "CDEV 1725 to be taken concurrently",
+    "courses": [
+      "CDEV 1725"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CELE 1070": {
+    "text": "CELE 1030",
+    "courses": [
+      "CELE 1030"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CELE 1090": {
     "text": "CELE 1030",
     "courses": [
       "CELE 1030"
@@ -1760,17 +19603,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CELE 1090": {
+  "CELE 1130": {
     "text": "CELE 1030",
     "courses": [
       "CELE 1030"
     ],
     "source": "hennepin-technical-college"
   },
-  "CELE 1130": {
-    "text": "CELE 1030",
+  "CELE 2010": {
+    "text": "CELE 1090",
     "courses": [
-      "CELE 1030"
+      "CELE 1090"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1795,22 +19638,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CELE 2010": {
-    "text": "CELE 1090",
-    "courses": [
-      "CELE 1090"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CELE 2050": {
-    "text": "CELE 1030 and CELE 1070",
-    "courses": [
-      "CELE 1030",
-      "CELE 1070"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CELE 2060": {
     "text": "CELE 1030 and CELE 1070",
     "courses": [
       "CELE 1030",
@@ -1827,10 +19655,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CELE 2140": {
-    "text": "CELE 2040",
+  "CELE 2060": {
+    "text": "CELE 1030 and CELE 1070",
     "courses": [
-      "CELE 2040"
+      "CELE 1030",
+      "CELE 1070"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1850,11 +19679,25 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "CELE 2140": {
+    "text": "CELE 2040",
+    "courses": [
+      "CELE 2040"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CELE 2150": {
     "text": "CELE 1030 and CELE 1070",
     "courses": [
       "CELE 1030",
       "CELE 1070"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CELE 2200": {
+    "text": "CELE 2040",
+    "courses": [
+      "CELE 2040"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1865,10 +19708,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CELE 2200": {
-    "text": "CELE 2040",
+  "CELE 2300": {
+    "text": "CELE 2200",
     "courses": [
-      "CELE 2040"
+      "CELE 2200"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1883,13 +19726,6 @@
     "text": "Qualifying score on math assessment test OR MATH 0940",
     "courses": [
       "MATH 0940"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CELE 2300": {
-    "text": "CELE 2200",
-    "courses": [
-      "CELE 2200"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1929,17 +19765,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CMAE 1554": {
-    "text": "Qualifying score on the reading assessment test OR ENGL 0901",
-    "courses": [
-      "ENGL 0901"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CMAE 1552": {
     "text": "CMAE 1550 or equivalent course",
     "courses": [
       "CMAE 1550"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CMAE 1554": {
+    "text": "Qualifying score on the reading assessment test OR ENGL 0901",
+    "courses": [
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -1955,6 +19791,13 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "COMM 1260": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921. Basic computer literacy skills required",
+    "courses": [
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "COMM 1250": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921. Basic computer literacy skills required",
     "courses": [
@@ -1962,7 +19805,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "COMM 1260": {
+  "COMM 1280": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921. Basic computer literacy skills required",
     "courses": [
       "ENGL 0921"
@@ -1973,13 +19816,6 @@
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "COMM 1280": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921. Basic computer literacy skills required",
-    "courses": [
-      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2010,18 +19846,18 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CULA 1000": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901 and qualifying score on math assessment test",
-    "courses": [
-      "ENGL 0901"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "CPLT 1200": {
     "text": "Qualifying score on computer literacy assessment test OR CPLT 0900 or CPLT 1000",
     "courses": [
       "CPLT 0900",
       "CPLT 1000"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "CULA 1000": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901 and qualifying score on math assessment test",
+    "courses": [
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2032,8 +19868,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CULA 1126": {
-    "text": "Recommended: CULA 1000, CULA 1106, and CULA 1117 or instructor approval",
+  "CULA 1136": {
+    "text": "CULA 1000, CULA 1106, and CULA 1117 or instructor approval",
     "courses": [
       "CULA 1000",
       "CULA 1106",
@@ -2041,8 +19877,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "CULA 1136": {
-    "text": "CULA 1000, CULA 1106, and CULA 1117 or instructor approval",
+  "CULA 1126": {
+    "text": "Recommended: CULA 1000, CULA 1106, and CULA 1117 or instructor approval",
     "courses": [
       "CULA 1000",
       "CULA 1106",
@@ -2091,6 +19927,13 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "CULA 1335": {
+    "text": "Recommended: CULA 1000",
+    "courses": [
+      "CULA 1000"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CULA 1325": {
     "text": "Recommended: CULA 1000",
     "courses": [
@@ -2102,13 +19945,6 @@
     "text": "CULA 1117 or instructor approval",
     "courses": [
       "CULA 1117"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CULA 1335": {
-    "text": "Recommended: CULA 1000",
-    "courses": [
-      "CULA 1000"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2125,24 +19961,6 @@
     "courses": [
       "CULA 1117",
       "CULA 1156"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CULA 1700": {
-    "text": "Recommended: CULA 1000, CULA 1106, and CULA 1117 or instructor approval",
-    "courses": [
-      "CULA 1000",
-      "CULA 1106",
-      "CULA 1117"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "CULA 1710": {
-    "text": "CULA 1000, CULA 1106, and CULA 1117 or instructor approval",
-    "courses": [
-      "CULA 1000",
-      "CULA 1106",
-      "CULA 1117"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2172,6 +19990,18 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "DNTL 1000": {
+    "text": "Successful completion of 1st semester courses",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "DNTL 1121": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "CULA 2185": {
     "text": "CULA 1117, CULA 1126, CULA 1270, CULA 1275, CULA 1280, CULA 1290, and CULA 1295 or Instructor Approval",
     "courses": [
@@ -2185,8 +20015,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "DNTL 1000": {
-    "text": "Successful completion of 1st semester courses",
+  "DNTL 1140": {
+    "text": "Admission into the Dental Assistant Program",
     "courses": [],
     "source": "hennepin-technical-college"
   },
@@ -2195,24 +20025,7 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "DNTL 1140": {
-    "text": "Admission into the Dental Assistant Program",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "DNTL 1121": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "DNTL 1180": {
-    "text": "Admission into the Dental Assistant Program",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "DNTL 1200": {
     "text": "Admission into the Dental Assistant Program",
     "courses": [],
     "source": "hennepin-technical-college"
@@ -2227,6 +20040,16 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "DNTL 1200": {
+    "text": "Admission into the Dental Assistant Program",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "DNTL 1261": {
+    "text": "Successful completion of 1st semester courses",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "DNTL 1305": {
     "text": "Successful completion of 1st and 2nd semester courses. DNTL 1321 and DNTL 1325 must be taken concurrently with this course",
     "courses": [
@@ -2235,23 +20058,18 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "DNTL 1261": {
-    "text": "Successful completion of 1st semester courses",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "DNTL 1321": {
-    "text": "Successful completion of 1st and 2nd semester courses",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "DNTL 1325": {
     "text": "Successful completion of 1st and 2nd semester courses",
     "courses": [],
     "source": "hennepin-technical-college"
   },
   "DNTL 1900": {
     "text": "Instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "DNTL 1325": {
+    "text": "Successful completion of 1st and 2nd semester courses",
     "courses": [],
     "source": "hennepin-technical-college"
   },
@@ -2262,17 +20080,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 1050": {
-    "text": "ELEC 1000 or equivalent",
-    "courses": [
-      "ELEC 1000"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ECON 1300": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
       "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ELEC 1050": {
+    "text": "ELEC 1000 or equivalent",
+    "courses": [
+      "ELEC 1000"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2290,13 +20108,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 1250": {
-    "text": "ELEC 1150 or equivalent",
-    "courses": [
-      "ELEC 1150"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ELEC 1285": {
     "text": "ELEC 1000 and ELEC 1050",
     "courses": [
@@ -2305,17 +20116,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 1450": {
+  "ELEC 1300": {
     "text": "ELEC 1250 or equivalent",
     "courses": [
       "ELEC 1250"
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 1400": {
-    "text": "ELEC 1250 or equivalent",
+  "ELEC 1250": {
+    "text": "ELEC 1150 or equivalent",
     "courses": [
-      "ELEC 1250"
+      "ELEC 1150"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2327,7 +20138,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 1300": {
+  "ELEC 1400": {
+    "text": "ELEC 1250 or equivalent",
+    "courses": [
+      "ELEC 1250"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ELEC 1450": {
     "text": "ELEC 1250 or equivalent",
     "courses": [
       "ELEC 1250"
@@ -2371,10 +20189,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 2220": {
-    "text": "Recommended: ELEC 2200",
+  "ELEC 2420": {
+    "text": "ELEC 2400",
     "courses": [
-      "ELEC 2200"
+      "ELEC 2400"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2395,11 +20213,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 2475": {
-    "text": "Instructor approval and completion of at least 50% of your degree or diploma",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "ELEC 2450": {
     "text": "ELEC 1300 or equivalent",
     "courses": [
@@ -2407,24 +20220,22 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ELEC 2420": {
-    "text": "ELEC 2400",
+  "EMSV 1050": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
-      "ELEC 2400"
+      "ENGL 0921"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "ELEC 2475": {
+    "text": "Instructor approval and completion of at least 50% of your degree or diploma",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "EMSV 1100": {
     "text": "EMSV 1050 and required vaccinations",
     "courses": [
       "EMSV 1050"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "EMSV 1050": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2441,16 +20252,16 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "EMSV 1130": {
-    "text": "18 years old, and valid driver`s license with good driving record",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "EMSV 1120": {
     "text": "EMSV 1100 and current State Certified EMT-B",
     "courses": [
       "EMSV 1100"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "EMSV 1130": {
+    "text": "18 years old, and valid driver`s license with good driving record",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "EMSV 1140": {
@@ -2465,6 +20276,11 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "EMSV 1170": {
+    "text": "Instructor approval. Students must be at least 18 years old",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "EMSV 1180": {
     "text": "EMSV 1020 OR Current CPR certification OR taken currently with EMSV 1100",
     "courses": [
@@ -2473,16 +20289,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "EMSV 1170": {
-    "text": "Instructor approval. Students must be at least 18 years old",
+  "EMSV 1225": {
+    "text": "Healthcare Provider Basic Life Support",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "EMSV 2012": {
-    "text": "Instructor approval and EMSV 2001",
-    "courses": [
-      "EMSV 2001"
-    ],
+  "EMSV 1260": {
+    "text": "Minnesota First Responder who is current in their certification",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "EMSV 2001": {
@@ -2493,20 +20307,24 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "EMSV 1260": {
-    "text": "Minnesota First Responder who is current in their certification",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "EMSV 1225": {
-    "text": "Healthcare Provider Basic Life Support",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "EMSV 2026": {
     "text": "Instructor approval and EMSV 2012",
     "courses": [
       "EMSV 2012"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "EMSV 2012": {
+    "text": "Instructor approval and EMSV 2001",
+    "courses": [
+      "EMSV 2001"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "EMSV 2045": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2517,15 +20335,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "EMSV 2060": {
+  "EMSV 2050": {
     "text": "Qualifying score on reading assessment test or ENGL 0921",
-    "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "EMSV 2045": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
       "ENGL 0921"
     ],
@@ -2538,7 +20349,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "EMSV 2050": {
+  "EMSV 2060": {
     "text": "Qualifying score on reading assessment test or ENGL 0921",
     "courses": [
       "ENGL 0921"
@@ -2559,17 +20370,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "EMSV 2080": {
-    "text": "EMSV 2075",
-    "courses": [
-      "EMSV 2075"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "EMSV 2075": {
     "text": "EMSV 2036",
     "courses": [
       "EMSV 2036"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "EMSV 2080": {
+    "text": "EMSV 2075",
+    "courses": [
+      "EMSV 2075"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2607,10 +20418,9 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ENGC 1070": {
-    "text": "Instructor approval or ENGC 1050 and one of the following: ENGC 1160, ENGC 1250, ENGC 2100, MMVP 1545",
+  "ENGC 1060": {
+    "text": "Choose one of the following: ENGC 1160, ENGC 1250, ENGC 2100, MMVP 1545",
     "courses": [
-      "ENGC 1050",
       "ENGC 1160",
       "ENGC 1250",
       "ENGC 2100",
@@ -2618,9 +20428,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ENGC 1060": {
-    "text": "Choose one of the following: ENGC 1160, ENGC 1250, ENGC 2100, MMVP 1545",
+  "ENGC 1070": {
+    "text": "Instructor approval or ENGC 1050 and one of the following: ENGC 1160, ENGC 1250, ENGC 2100, MMVP 1545",
     "courses": [
+      "ENGC 1050",
       "ENGC 1160",
       "ENGC 1250",
       "ENGC 2100",
@@ -2639,17 +20450,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ENGC 1255": {
-    "text": "ENGC 1250",
-    "courses": [
-      "ENGC 1250"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ENGC 1260": {
     "text": "Concurrent enrollment in or completion of ENGC 1255 or instructor approval",
     "courses": [
       "ENGC 1255"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ENGC 1255": {
+    "text": "ENGC 1250",
+    "courses": [
+      "ENGC 1250"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2660,6 +20471,11 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ENGC 1900": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "ENGC 2001": {
     "text": "Recommended: ENGC 1021 and one or more of the following: ENGC 1250 or ENGC 2100",
     "courses": [
@@ -2667,11 +20483,6 @@
       "ENGC 1250",
       "ENGC 2100"
     ],
-    "source": "hennepin-technical-college"
-  },
-  "ENGC 1900": {
-    "text": "Instructor approval",
-    "courses": [],
     "source": "hennepin-technical-college"
   },
   "ENGC 2011": {
@@ -2717,13 +20528,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ENGL 0921": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901 with a grade of \"C\" or better. Basic computer literacy skills required",
-    "courses": [
-      "ENGL 0901"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ENGL 0930": {
     "text": "Qualifying score on writing assessment test OR ESOL 0831 with a grade of \"C\" or better and the ability to word process simple documents. Basic computer literacy skills required",
     "courses": [
@@ -2731,17 +20535,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ENGL 0960": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0930 or Instructor approval",
-    "courses": [
-      "ENGL 0930"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ENGL 0965": {
     "text": "Qualifying score on reading assessment test or ENGL 0901 and ENGL 0930 and the ability to word process simple documents. Basic computer literacy skills required",
     "courses": [
       "ENGL 0901",
+      "ENGL 0930"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ENGL 0960": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0930 or Instructor approval",
+    "courses": [
       "ENGL 0930"
     ],
     "source": "hennepin-technical-college"
@@ -2799,18 +20603,18 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "FACM 1000": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0930",
-    "courses": [
-      "ENGL 0930"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ENGL 1300": {
     "text": "Qualifying score on writing assessment test OR ENGL 0960 with a grade of \"C\" or better and Qualifying score on reading assessment test OR ENGL 0921. Basic computer literacy skills required",
     "courses": [
       "ENGL 0921",
       "ENGL 0960"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "FACM 1000": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0930",
+    "courses": [
+      "ENGL 0930"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2835,6 +20639,15 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "FDAS 2040": {
+    "text": "Successful completion of FDAS 1260, FDAS 2230, and FDAS 2240 or equivalent",
+    "courses": [
+      "FDAS 1260",
+      "FDAS 2230",
+      "FDAS 2240"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "FDAS 2030": {
     "text": "Successful completion of FDAS 1250, FDAS 1400, FDAS 1410, and FDAS 1701 or equivalent",
     "courses": [
@@ -2845,12 +20658,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "FDAS 2040": {
-    "text": "Successful completion of FDAS 1260, FDAS 2230, and FDAS 2240 or equivalent",
+  "FLPW 1101": {
+    "text": "Qualifying score on math assessment test OR MATH 0800 and Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
-      "FDAS 1260",
-      "FDAS 2230",
-      "FDAS 2240"
+      "ENGL 0901",
+      "MATH 0800"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2858,14 +20670,6 @@
     "text": "FLPW 1101 or concurrent",
     "courses": [
       "FLPW 1101"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "FLPW 1101": {
-    "text": "Qualifying score on math assessment test OR MATH 0800 and Qualifying score on reading assessment test OR ENGL 0901",
-    "courses": [
-      "ENGL 0901",
-      "MATH 0800"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2883,17 +20687,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "FLPW 1320": {
-    "text": "FLPW 1101",
-    "courses": [
-      "FLPW 1101"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "FLPW 1236": {
     "text": "FLPW 1231",
     "courses": [
       "FLPW 1231"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "FLPW 1320": {
+    "text": "FLPW 1101",
+    "courses": [
+      "FLPW 1101"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2915,6 +20719,13 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "FLPW 2180": {
+    "text": "FLPW 1106",
+    "courses": [
+      "FLPW 1106"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "FLPW 2020": {
     "text": "FLPW 2000 or instructor approval",
     "courses": [
@@ -2926,13 +20737,6 @@
     "text": "FLPW 1231 should be taken prior to or concurrent with this course",
     "courses": [
       "FLPW 1231"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "FLPW 2180": {
-    "text": "FLPW 1106",
-    "courses": [
-      "FLPW 1106"
     ],
     "source": "hennepin-technical-college"
   },
@@ -2985,17 +20789,17 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "FMLR 1301": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "FMLR 1100": {
     "text": "Instructor approval",
     "courses": [],
     "source": "hennepin-technical-college"
   },
   "FMLR 1200": {
-    "text": "Instructor approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "FMLR 1301": {
     "text": "Instructor approval",
     "courses": [],
     "source": "hennepin-technical-college"
@@ -3040,17 +20844,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "FRPT 1166": {
-    "text": "Completed or taking concurrently with FRPT 1285 or instructor approval",
-    "courses": [
-      "FRPT 1285"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "FRPT 1176": {
     "text": "FRPT 1101",
     "courses": [
       "FRPT 1101"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "FRPT 1166": {
+    "text": "Completed or taking concurrently with FRPT 1285 or instructor approval",
+    "courses": [
+      "FRPT 1285"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3105,18 +20909,18 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "FRPT 2105": {
+    "text": "FRPT 1110",
+    "courses": [
+      "FRPT 1110"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "FRPT 1290": {
     "text": "EMSV 1100 Emergency Medical Technician or FRPT 1101 or instructor approval",
     "courses": [
       "EMSV 1100",
       "FRPT 1101"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "FRPT 2105": {
-    "text": "FRPT 1110",
-    "courses": [
-      "FRPT 1110"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3192,6 +20996,15 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "FRPT 2280": {
+    "text": "FRPT 1105 or FRPT 1137 or FRPT 1255 or instructor approval",
+    "courses": [
+      "FRPT 1105",
+      "FRPT 1137",
+      "FRPT 1255"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "FRPT 2270": {
     "text": "FRPT 1270 or instructor approval",
     "courses": [
@@ -3207,16 +21020,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "FRPT 2280": {
-    "text": "FRPT 1105 or FRPT 1137 or FRPT 1255 or instructor approval",
+  "HCCC 1030": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
-      "FRPT 1105",
-      "FRPT 1137",
-      "FRPT 1255"
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
-  "HCCC 1030": {
+  "HCCC 1050": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
@@ -3230,13 +21041,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HCCC 1070": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901",
-    "courses": [
-      "ENGL 0901"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "HCCC 1060": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
@@ -3244,7 +21048,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HCCC 1050": {
+  "HCCC 1070": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
@@ -3316,13 +21120,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HLTH 1020": {
-    "text": "HLTH 1010 or BIOL 1400 and HLUC 1020 or MAST 1010",
+  "HLTH 2001": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
-      "BIOL 1400",
-      "HLTH 1010",
-      "HLUC 1020",
-      "MAST 1010"
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3333,10 +21134,13 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HLTH 2001": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+  "HLTH 1020": {
+    "text": "HLTH 1010 or BIOL 1400 and HLUC 1020 or MAST 1010",
     "courses": [
-      "ENGL 0921"
+      "BIOL 1400",
+      "HLTH 1010",
+      "HLUC 1020",
+      "MAST 1010"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3354,18 +21158,17 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "HVAC 1025": {
+    "text": "HVAC 1040 or Industry Experience",
+    "courses": [
+      "HVAC 1040"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "HVAC 1020": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "HVAC 1030": {
-    "text": "HVAC 1000 and HVAC 1020",
-    "courses": [
-      "HVAC 1000",
-      "HVAC 1020"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3375,6 +21178,14 @@
       "HVAC 1000",
       "HVAC 1010",
       "HVAC 1110"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "HVAC 1030": {
+    "text": "HVAC 1000 and HVAC 1020",
+    "courses": [
+      "HVAC 1000",
+      "HVAC 1020"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3393,22 +21204,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 1055": {
-    "text": "HVAC 1050 or knowledge of HVAC systems operations",
-    "courses": [
-      "HVAC 1050"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "HVAC 1050": {
     "text": "An understanding of a Refrigeration System operation",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "HVAC 1060": {
-    "text": "HVAC 1040 and HVAC 1050",
+  "HVAC 1055": {
+    "text": "HVAC 1050 or knowledge of HVAC systems operations",
     "courses": [
-      "HVAC 1040",
       "HVAC 1050"
     ],
     "source": "hennepin-technical-college"
@@ -3420,17 +21223,18 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "HVAC 1060": {
+    "text": "HVAC 1040 and HVAC 1050",
+    "courses": [
+      "HVAC 1040",
+      "HVAC 1050"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "HVAC 1071": {
     "text": "HVAC 1110",
     "courses": [
       "HVAC 1110"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "HVAC 1025": {
-    "text": "HVAC 1040 or Industry Experience",
-    "courses": [
-      "HVAC 1040"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3484,8 +21288,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 1140": {
-    "text": "HVAC 1000, HVAC 1040 and HVAC 1110",
+  "HVAC 1146": {
+    "text": "HVAC 1000, HVAC 1040, and HVAC 1110",
     "courses": [
       "HVAC 1000",
       "HVAC 1040",
@@ -3493,8 +21297,8 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 1146": {
-    "text": "HVAC 1000, HVAC 1040, and HVAC 1110",
+  "HVAC 1140": {
+    "text": "HVAC 1000, HVAC 1040 and HVAC 1110",
     "courses": [
       "HVAC 1000",
       "HVAC 1040",
@@ -3538,11 +21342,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 2010": {
-    "text": "Residential HVAC Diploma or equivalent industry experience",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "HVAC 2005": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901 and HVAC 1000, HVAC 1010, HVAC 1040, HVAC 1050, HVAC 1071 & HVAC 1110",
     "courses": [
@@ -3556,11 +21355,9 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 2020": {
-    "text": "HVAC 1040",
-    "courses": [
-      "HVAC 1040"
-    ],
+  "HVAC 2010": {
+    "text": "Residential HVAC Diploma or equivalent industry experience",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "HVAC 2025": {
@@ -3581,7 +21378,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 2055": {
+  "HVAC 2045": {
     "text": "HVAC 1040 and HVAC 1050",
     "courses": [
       "HVAC 1040",
@@ -3589,7 +21386,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 2045": {
+  "HVAC 2055": {
     "text": "HVAC 1040 and HVAC 1050",
     "courses": [
       "HVAC 1040",
@@ -3626,17 +21423,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "HVAC 2165": {
-    "text": "Residential HVAC Diploma or equivalent industry experience",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "HVAC 2130": {
     "text": "HVAC 1040 and HVAC 1110",
     "courses": [
       "HVAC 1040",
       "HVAC 1110"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "HVAC 2165": {
+    "text": "Residential HVAC Diploma or equivalent industry experience",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "ITEC 1000": {
@@ -3661,14 +21458,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ITEC 1042": {
-    "text": "Qualifying score on keyboarding assessment test OR CPLT 1100 or CPLT 1200 or instructor approval",
-    "courses": [
-      "CPLT 1100",
-      "CPLT 1200"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ITEC 1035": {
     "text": "Qualifying score on keyboarding assessment test OR CPLT 1100 or CPLT 1200 or instructor approval",
     "courses": [
@@ -3677,10 +21466,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ITEC 1090": {
-    "text": "ITEC 1080 or instructor approval",
+  "ITEC 1042": {
+    "text": "Qualifying score on keyboarding assessment test OR CPLT 1100 or CPLT 1200 or instructor approval",
     "courses": [
-      "ITEC 1080"
+      "CPLT 1100",
+      "CPLT 1200"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3688,6 +21478,13 @@
     "text": "Qualifying score on reading assessment test OR ENGL 0901 or instructor approval",
     "courses": [
       "ENGL 0901"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ITEC 1090": {
+    "text": "ITEC 1080 or instructor approval",
+    "courses": [
+      "ITEC 1080"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3713,18 +21510,18 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ITEC 1421": {
+    "text": "ITEC 1105",
+    "courses": [
+      "ITEC 1105"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ITEC 1310": {
     "text": "Qualifying score on computer literacy assessment test OR CPLT 1100 or CPLT 1200 or instructor approval",
     "courses": [
       "CPLT 1100",
       "CPLT 1200"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ITEC 1421": {
-    "text": "ITEC 1105",
-    "courses": [
-      "ITEC 1105"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3767,18 +21564,18 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "ITEC 2065": {
+    "text": "ITEC 1000 or instructor approval",
+    "courses": [
+      "ITEC 1000"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ITEC 2055": {
     "text": "Qualifying score on math assessment test OR MATH 0910 or MATH 0920 or instructor approval",
     "courses": [
       "MATH 0910",
       "MATH 0920"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ITEC 2065": {
-    "text": "ITEC 1000 or instructor approval",
-    "courses": [
-      "ITEC 1000"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3830,18 +21627,18 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "ITEC 2270": {
+    "text": "ITEC 1110",
+    "courses": [
+      "ITEC 1110"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "ITEC 2162": {
     "text": "ITEC 1505 and ITEC 2122",
     "courses": [
       "ITEC 1505",
       "ITEC 2122"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ITEC 2270": {
-    "text": "ITEC 1110",
-    "courses": [
-      "ITEC 1110"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3879,10 +21676,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ITEC 2520": {
-    "text": "ITEC 1505",
+  "ITEC 2536": {
+    "text": "ITEC 2122 and ITEC 2415",
     "courses": [
-      "ITEC 1505"
+      "ITEC 2122",
+      "ITEC 2415"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3893,18 +21691,18 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ITEC 2536": {
-    "text": "ITEC 2122 and ITEC 2415",
-    "courses": [
-      "ITEC 2122",
-      "ITEC 2415"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ITEC 2580": {
     "text": "ITEC 1505",
     "courses": [
       "ITEC 1505"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ITEC 2585": {
+    "text": "Recommended: ITEC 2575 and ITEC 2701",
+    "courses": [
+      "ITEC 2575",
+      "ITEC 2701"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3914,14 +21712,6 @@
       "ITEC 1301",
       "ITEC 1505",
       "ITEC 1515"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "ITEC 2585": {
-    "text": "Recommended: ITEC 2575 and ITEC 2701",
-    "courses": [
-      "ITEC 2575",
-      "ITEC 2701"
     ],
     "source": "hennepin-technical-college"
   },
@@ -3947,17 +21737,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "ITEC 2786": {
-    "text": "Recommended: ITEC 1032",
-    "courses": [
-      "ITEC 1032"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "ITEC 2781": {
     "text": "Recommended: ITEC 2701",
     "courses": [
       "ITEC 2701"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "ITEC 2786": {
+    "text": "Recommended: ITEC 1032",
+    "courses": [
+      "ITEC 1032"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4023,17 +21813,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "LNDC 2290": {
-    "text": "Previous windows-based computer knowledge required",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "LNDC 2280": {
     "text": "LNDC 2160 and LNDC 2271",
     "courses": [
       "LNDC 2160",
       "LNDC 2271"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "LNDC 2290": {
+    "text": "Previous windows-based computer knowledge required",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "LNDC 2350": {
@@ -4055,10 +21845,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 1120": {
-    "text": "MACH 1110 or instructor approval",
+  "MACH 1110": {
+    "text": "Qualifying score on math assessment test OR MATH 0800",
     "courses": [
-      "MACH 1110"
+      "MATH 0800"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4069,17 +21859,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 1110": {
-    "text": "Qualifying score on math assessment test OR MATH 0800",
-    "courses": [
-      "MATH 0800"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MACH 1130": {
     "text": "MACH 1125 or instructor approval",
     "courses": [
       "MACH 1125"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MACH 1120": {
+    "text": "MACH 1110 or instructor approval",
+    "courses": [
+      "MACH 1110"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4107,22 +21897,15 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "MACH 2410": {
-    "text": "METS 1000 or basic computer skills",
-    "courses": [
-      "METS 1000"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MACH 2406": {
     "text": "CNC Operators Certificate, or instructor approval",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "MACH 2425": {
-    "text": "Recommended: MATH 0940 or equivalent",
+  "MACH 2410": {
+    "text": "METS 1000 or basic computer skills",
     "courses": [
-      "MATH 0940"
+      "METS 1000"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4133,13 +21916,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2420": {
-    "text": "MACH 1056 or instructor approval",
-    "courses": [
-      "MACH 1056"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MACH 2430": {
     "text": "MACH 2415",
     "courses": [
@@ -4147,14 +21923,11 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2435": {
-    "text": "CNC Operators Certificate, or equivalent industry experience with instructor's approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "MACH 2450": {
-    "text": "CNC Operators Certificate, or equivalent industry experience with instructor's approval",
-    "courses": [],
+  "MACH 2425": {
+    "text": "Recommended: MATH 0940 or equivalent",
+    "courses": [
+      "MATH 0940"
+    ],
     "source": "hennepin-technical-college"
   },
   "MACH 2445": {
@@ -4164,16 +21937,21 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2455": {
-    "text": "CNC Operators Certificate, or equivalent industry experience with instructor's approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "MACH 2460": {
     "text": "MACH 2455",
     "courses": [
       "MACH 2455"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "MACH 2455": {
+    "text": "CNC Operators Certificate, or equivalent industry experience with instructor's approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "MACH 2450": {
+    "text": "CNC Operators Certificate, or equivalent industry experience with instructor's approval",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "MACH 2465": {
@@ -4197,17 +21975,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2495": {
-    "text": "Instructor approval and completion of at least 50% of your degree or diploma",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "MACH 2480": {
     "text": "Prerequisite: MACH 1140. Recommended: MACH 2406",
     "courses": [
       "MACH 1140",
       "MACH 2406"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "MACH 2495": {
+    "text": "Instructor approval and completion of at least 50% of your degree or diploma",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "MACH 2500": {
@@ -4229,14 +22007,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2525": {
+  "MACH 2520": {
     "text": "MACH 1140",
     "courses": [
       "MACH 1140"
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2520": {
+  "MACH 2525": {
     "text": "MACH 1140",
     "courses": [
       "MACH 1140"
@@ -4266,13 +22044,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MACH 2620": {
-    "text": "MACH 2615 or instructor approval",
-    "courses": [
-      "MACH 2615"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MACH 2625": {
     "text": "Recommended: MACH 2440 or Instructor Approval",
     "courses": [
@@ -4280,24 +22051,18 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MATH 0910": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901 with a grade of \"C\" or better and Qualifying score on math assessment test MATH 0800",
-    "courses": [
-      "ENGL 0901",
-      "MATH 0800"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MATH 0920": {
-    "text": "Qualifying score on math assessment test and Qualifying score on reading assessment test",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "MATH 0940": {
     "text": "Qualifying score on math assessment test OR MATH 0910 or MATH 0920 with a grade of \"C\" or better",
     "courses": [
       "MATH 0910",
       "MATH 0920"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MACH 2620": {
+    "text": "MACH 2615 or instructor approval",
+    "courses": [
+      "MACH 2615"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4328,11 +22093,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MATH 1070": {
-    "text": "Recommended: Students should be able to perform basic math skills involving measurement, fractions, decimals, proportions and percentages",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "MATH 1150": {
     "text": "Qualifying score on math assessment test OR MATH 0960 OR MATH 0980 with a grade of \"C\" or better",
     "courses": [
@@ -4353,13 +22113,6 @@
     "text": "Qualifying score on math assessment test OR MATH 1400 with a grade of \"C\" or better",
     "courses": [
       "MATH 1400"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MATH 1400": {
-    "text": "Qualifying score on math assessment test OR MATH 0980 with a grade of \"C\" or better",
-    "courses": [
-      "MATH 0980"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4406,18 +22159,18 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MGDP 1230": {
-    "text": "MGDP 1205 or instructor approval",
-    "courses": [
-      "MGDP 1205"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MGDP 1220": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901 and Qualifying score on computer literacy assessment test OR CPLT 1200",
     "courses": [
       "CPLT 1200",
       "ENGL 0901"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MGDP 1230": {
+    "text": "MGDP 1205 or instructor approval",
+    "courses": [
+      "MGDP 1205"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4427,14 +22180,6 @@
       "CPLT 1200",
       "ENGL 0901",
       "MGDP 1205"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MGDP 1265": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901 and Qualifying score on computer literacy assessment test OR CPLT 1200",
-    "courses": [
-      "CPLT 1200",
-      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4449,6 +22194,14 @@
     "text": "MGDP 1205 or instructor approval",
     "courses": [
       "MGDP 1205"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MGDP 1265": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901 and Qualifying score on computer literacy assessment test OR CPLT 1200",
+    "courses": [
+      "CPLT 1200",
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4514,17 +22267,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MGDP 2080": {
-    "text": "MGDP 1205",
-    "courses": [
-      "MGDP 1205"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MGDP 2050": {
     "text": "MGDP 1250",
     "courses": [
       "MGDP 1250"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MGDP 2080": {
+    "text": "MGDP 1205",
+    "courses": [
+      "MGDP 1205"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4552,6 +22305,11 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "MGDP 2215": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "MHTT 1002": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901 and Qualifying score on computer literacy assessment test OR CPLT 0900",
     "courses": [
@@ -4566,11 +22324,6 @@
       "CPLT 0900",
       "ENGL 0901"
     ],
-    "source": "hennepin-technical-college"
-  },
-  "MGDP 2215": {
-    "text": "Instructor approval",
-    "courses": [],
     "source": "hennepin-technical-college"
   },
   "MHTT 1015": {
@@ -4596,20 +22349,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MHTT 1131": {
-    "text": "MHTT 1002",
-    "courses": [
-      "MHTT 1002"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MHTT 1100": {
-    "text": "MHTT 1002",
-    "courses": [
-      "MHTT 1002"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MHTT 1115": {
     "text": "MHTT 1002",
     "courses": [
@@ -4617,14 +22356,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MHTT 1200": {
+  "MHTT 1131": {
     "text": "MHTT 1002",
     "courses": [
       "MHTT 1002"
     ],
     "source": "hennepin-technical-college"
   },
-  "MHTT 1210": {
+  "MHTT 1200": {
     "text": "MHTT 1002",
     "courses": [
       "MHTT 1002"
@@ -4645,19 +22384,19 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "MHTT 1401": {
+    "text": "MHTT 1300",
+    "courses": [
+      "MHTT 1300"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "MHTT 1332": {
     "text": "MHTT 1100, MHTT 1115, and MHTT 1200",
     "courses": [
       "MHTT 1100",
       "MHTT 1115",
       "MHTT 1200"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MHTT 1401": {
-    "text": "MHTT 1300",
-    "courses": [
-      "MHTT 1300"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4749,16 +22488,16 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MMST 1900": {
-    "text": "Instructor approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "MMST 1130": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "MMST 1900": {
+    "text": "Instructor approval",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "MMST 1145": {
@@ -4775,13 +22514,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MMST 2110": {
-    "text": "MMST 1130",
-    "courses": [
-      "MMST 1130"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MMST 2126": {
     "text": "MMST 1130",
     "courses": [
@@ -4789,7 +22521,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MMST 2175": {
+  "MMST 2110": {
     "text": "MMST 1130",
     "courses": [
       "MMST 1130"
@@ -4799,6 +22531,13 @@
   "MMST 2140": {
     "text": "Successful completion of the Marine, Motorsport and Outdoor Power Equipment - Maintenance Technician Diploma, or instructor approval",
     "courses": [],
+    "source": "hennepin-technical-college"
+  },
+  "MMST 2175": {
+    "text": "MMST 1130",
+    "courses": [
+      "MMST 1130"
+    ],
     "source": "hennepin-technical-college"
   },
   "MMST 2180": {
@@ -4829,11 +22568,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MMST 2315": {
-    "text": "Successful completion of all first year courses",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "MMST 2320": {
     "text": "Second year student",
     "courses": [],
@@ -4844,6 +22578,11 @@
     "courses": [
       "MMST 1105"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "MMST 2315": {
+    "text": "Successful completion of all first year courses",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "MMST 2355": {
@@ -4875,18 +22614,18 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "MMVP 1565": {
+    "text": "MMVP 1500 with a grade of \"C\" or better or instructor approval",
+    "courses": [
+      "MMVP 1500"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "MMVP 1562": {
     "text": "Recommended: Qualifying score on computer literacy assessment test OR CPLT 1100 or CPLT 1200",
     "courses": [
       "CPLT 1100",
       "CPLT 1200"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MMVP 1565": {
-    "text": "MMVP 1500 with a grade of \"C\" or better or instructor approval",
-    "courses": [
-      "MMVP 1500"
     ],
     "source": "hennepin-technical-college"
   },
@@ -4969,19 +22708,19 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MMVP 2530": {
-    "text": "Basic computer skills and understanding of Internet strongly recommended for successful course completion. MGDP 1250 and MGDP 2050 or equivalent",
-    "courses": [
-      "MGDP 1250",
-      "MGDP 2050"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MMVP 2550": {
     "text": "MMVP 1511 with a grade of C or better and MMVP 1600 with a grade of \"C\" or better or instructor approval",
     "courses": [
       "MMVP 1511",
       "MMVP 1600"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MMVP 2530": {
+    "text": "Basic computer skills and understanding of Internet strongly recommended for successful course completion. MGDP 1250 and MGDP 2050 or equivalent",
+    "courses": [
+      "MGDP 1250",
+      "MGDP 2050"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5022,17 +22761,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "MMVP 2615": {
-    "text": "Basic computer skills and understanding of Internet strongly recommended for successful course completion. MMVP 1600 or equivalent",
-    "courses": [
-      "MMVP 1600"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "MMVP 2605": {
     "text": "MMVP 1511 with a grade of \"C\" or better and MMVP 1600 with a grade of \"C\" or better or instructor approval",
     "courses": [
       "MMVP 1511",
+      "MMVP 1600"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "MMVP 2615": {
+    "text": "Basic computer skills and understanding of Internet strongly recommended for successful course completion. MMVP 1600 or equivalent",
+    "courses": [
       "MMVP 1600"
     ],
     "source": "hennepin-technical-college"
@@ -5066,6 +22805,13 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "MUSC 1010": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+    "courses": [
+      "ENGL 0921"
+    ],
+    "source": "hennepin-technical-college"
+  },
   "MUBE 2020": {
     "text": "Recommended: MUBE 2010 or instructor approval",
     "courses": [
@@ -5075,13 +22821,6 @@
   },
   "MUSC 1015": {
     "text": "Recommended: Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "MUSC 1010": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
       "ENGL 0921"
     ],
@@ -5122,17 +22861,12 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "NURS 1381": {
-    "text": "Acceptance into the nursing program",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "NURS 1376": {
     "text": "Acceptance into the nursing program",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "NURS 1425": {
+  "NURS 1381": {
     "text": "Acceptance into the nursing program",
     "courses": [],
     "source": "hennepin-technical-college"
@@ -5142,12 +22876,12 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "NURS 1435": {
+  "NURS 1425": {
     "text": "Acceptance into the nursing program",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "NURS 1440": {
+  "NURS 1435": {
     "text": "Acceptance into the nursing program",
     "courses": [],
     "source": "hennepin-technical-college"
@@ -5157,6 +22891,11 @@
     "courses": [
       "NURS 1440"
     ],
+    "source": "hennepin-technical-college"
+  },
+  "NURS 1440": {
+    "text": "Acceptance into the nursing program",
+    "courses": [],
     "source": "hennepin-technical-college"
   },
   "NURS 2325": {
@@ -5173,16 +22912,6 @@
       "NURS 1381",
       "NURS 1430",
       "NURS 1435"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "NURS 2350": {
-    "text": "NURS 1430, NURS 1435, NURS 1440, and NURS 1445",
-    "courses": [
-      "NURS 1430",
-      "NURS 1435",
-      "NURS 1440",
-      "NURS 1445"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5238,10 +22967,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "PHIL 1600": {
-    "text": "Qualifying score on writing assessment test OR ENGL 0960",
+  "PHIL 1401": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0921",
     "courses": [
-      "ENGL 0960"
+      "ENGL 0921"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5252,17 +22981,10 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "PHIL 1401": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
+  "PHIL 1600": {
+    "text": "Qualifying score on writing assessment test OR ENGL 0960",
     "courses": [
-      "ENGL 0921"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "PHIL 1700": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0921",
-    "courses": [
-      "ENGL 0921"
+      "ENGL 0960"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5277,13 +22999,6 @@
     "text": "PHYS 1005",
     "courses": [
       "PHYS 1005"
-    ],
-    "source": "hennepin-technical-college"
-  },
-  "PLBG 1000": {
-    "text": "Qualifying score on reading assessment test OR ENGL 0901",
-    "courses": [
-      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5302,14 +23017,14 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "PLBG 1005": {
+  "PLBG 1011": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
-  "PLBG 1011": {
+  "PLBG 1005": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
@@ -5323,13 +23038,6 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "PLBG 1031": {
-    "text": "Qualifying score on math assessment test OR MATH 0800",
-    "courses": [
-      "MATH 0800"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "PLBG 1020": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
@@ -5337,10 +23045,17 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "PLBG 1025": {
+  "PLBG 1000": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901",
     "courses": [
       "ENGL 0901"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "PLBG 1031": {
+    "text": "Qualifying score on math assessment test OR MATH 0800",
+    "courses": [
+      "MATH 0800"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5362,6 +23077,13 @@
     "text": "PLBG 1036",
     "courses": [
       "PLBG 1036"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "PLBG 1025": {
+    "text": "Qualifying score on reading assessment test OR ENGL 0901",
+    "courses": [
+      "ENGL 0901"
     ],
     "source": "hennepin-technical-college"
   },
@@ -5447,16 +23169,16 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "PLST 2240": {
+    "text": "Injection Molding certificate or equivalent experience with instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "PLST 2245": {
     "text": "PLST 2240 and Injection Molding certificate or equivalent with instructor's approval",
     "courses": [
       "PLST 2240"
     ],
-    "source": "hennepin-technical-college"
-  },
-  "PLST 2240": {
-    "text": "Injection Molding certificate or equivalent experience with instructor approval",
-    "courses": [],
     "source": "hennepin-technical-college"
   },
   "PLST 2250": {
@@ -5484,12 +23206,12 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "POLC 2230": {
+  "POLC 2225": {
     "text": "Admission into the Peace Officer Program",
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "POLC 2225": {
+  "POLC 2230": {
     "text": "Admission into the Peace Officer Program",
     "courses": [],
     "source": "hennepin-technical-college"
@@ -5519,17 +23241,17 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
+  "POLC 2281": {
+    "text": "Admission into the Peace Officer Program",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "POLC 2265": {
     "text": "Admission into the Peace Officer Program",
     "courses": [],
     "source": "hennepin-technical-college"
   },
   "POLC 2285": {
-    "text": "Admission into the Peace Officer Program",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "POLC 2281": {
     "text": "Admission into the Peace Officer Program",
     "courses": [],
     "source": "hennepin-technical-college"
@@ -5601,7 +23323,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "SOCI 1500": {
+  "SOCI 1400": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0960. Basic computer skills recommended",
     "courses": [
       "ENGL 0921",
@@ -5609,7 +23331,7 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "SOCI 1400": {
+  "SOCI 1500": {
     "text": "Qualifying score on reading assessment test OR ENGL 0921 and Recommended: Qualifying score on writing assessment test OR ENGL 0960. Basic computer skills recommended",
     "courses": [
       "ENGL 0921",
@@ -5641,19 +23363,19 @@
     ],
     "source": "hennepin-technical-college"
   },
-  "WLDG 1165": {
-    "text": "WLDG 1140",
-    "courses": [
-      "WLDG 1140"
-    ],
-    "source": "hennepin-technical-college"
-  },
   "WLDG 1175": {
     "text": "Qualifying score on reading assessment test OR ENGL 0901, Qualifying score on math assessment test OR MATH 0800, WLDG 1135, and WLDG 1140",
     "courses": [
       "ENGL 0901",
       "MATH 0800",
       "WLDG 1135",
+      "WLDG 1140"
+    ],
+    "source": "hennepin-technical-college"
+  },
+  "WLDG 1165": {
+    "text": "WLDG 1140",
+    "courses": [
       "WLDG 1140"
     ],
     "source": "hennepin-technical-college"
@@ -5715,6 +23437,11 @@
     ],
     "source": "hennepin-technical-college"
   },
+  "WLDG 1500": {
+    "text": "Instructor approval",
+    "courses": [],
+    "source": "hennepin-technical-college"
+  },
   "WLDG 1360": {
     "text": "WLDG 1182 and WLDG 1350",
     "courses": [
@@ -5728,11 +23455,6 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "WLDG 1500": {
-    "text": "Instructor approval",
-    "courses": [],
-    "source": "hennepin-technical-college"
-  },
   "WLDG 2035": {
     "text": "Instructor Approval or GMAW Certificate or Welding Diploma",
     "courses": [],
@@ -5741,13 +23463,6 @@
   "WLDG 2045": {
     "text": "Instructor Approval or GTAW Certificate or Welding Diploma",
     "courses": [],
-    "source": "hennepin-technical-college"
-  },
-  "WLDG 2055": {
-    "text": "WLDG 2050",
-    "courses": [
-      "WLDG 2050"
-    ],
     "source": "hennepin-technical-college"
   },
   "WLDG 2050": {
@@ -5763,473 +23478,12 @@
     "courses": [],
     "source": "hennepin-technical-college"
   },
-  "ADSC 1010": {
-    "text": "ADSC 1003",
+  "WLDG 2055": {
+    "text": "WLDG 2050",
     "courses": [
-      "ADSC 1003"
+      "WLDG 2050"
     ],
-    "source": "anoka-technical-college"
-  },
-  "ADSC 1206": {
-    "text": "ADSC 1031 and ENGL 0900",
-    "courses": [
-      "ADSC 1031",
-      "ENGL 0900"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 1031": {
-    "text": "ARCH 1000",
-    "courses": [
-      "ARCH 1000"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 1040": {
-    "text": "ARCH 1043",
-    "courses": [
-      "ARCH 1043"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 1045": {
-    "text": "ARCH 1040",
-    "courses": [
-      "ARCH 1040"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 1058": {
-    "text": "CEST 1055",
-    "courses": [
-      "CEST 1055"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 1052": {
-    "text": "ARCH 1040 and ARCH 1043",
-    "courses": [
-      "ARCH 1040",
-      "ARCH 1043"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2025": {
-    "text": "ARCH 1043",
-    "courses": [
-      "ARCH 1043"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2005": {
-    "text": "ARCH 1000 and ARCH 1052",
-    "courses": [
-      "ARCH 1000",
-      "ARCH 1052"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2029": {
-    "text": "ARCH 2027",
-    "courses": [
-      "ARCH 2027"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2027": {
-    "text": "ARCH 2025",
-    "courses": [
-      "ARCH 2025"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2055": {
-    "text": "ARCH 1002 and ARCH 1052",
-    "courses": [
-      "ARCH 1002",
-      "ARCH 1052"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2030": {
-    "text": "ARCH 1015",
-    "courses": [
-      "ARCH 1015"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2070": {
-    "text": "ARCH 1015 and ARCH 2025",
-    "courses": [
-      "ARCH 1015",
-      "ARCH 2025"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2085": {
-    "text": "ARCH 1000 and ARCH 1043",
-    "courses": [
-      "ARCH 1000",
-      "ARCH 1043"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "ARCH 2095": {
-    "text": "ARCH 2090",
-    "courses": [
-      "ARCH 2090"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "DIAG 2700": {
-    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
-    "courses": [
-      "DIAG 2600",
-      "DIAG 2620",
-      "DIAG 2640",
-      "DIAG 2660",
-      "DIAG 2680"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "DIAG 2720": {
-    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
-    "courses": [
-      "DIAG 2600",
-      "DIAG 2620",
-      "DIAG 2640",
-      "DIAG 2660",
-      "DIAG 2680"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "DIAG 2760": {
-    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
-    "courses": [
-      "DIAG 2600",
-      "DIAG 2620",
-      "DIAG 2640",
-      "DIAG 2660",
-      "DIAG 2680"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "DIAG 2780": {
-    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
-    "courses": [
-      "DIAG 2600",
-      "DIAG 2620",
-      "DIAG 2640",
-      "DIAG 2660",
-      "DIAG 2680"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "DIAG 2740": {
-    "text": "DIAG 2600 , DIAG 2620 , DIAG 2640 , DIAG 2660 , and DIAG 2680",
-    "courses": [
-      "DIAG 2600",
-      "DIAG 2620",
-      "DIAG 2640",
-      "DIAG 2660",
-      "DIAG 2680"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2129": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2135": {
-    "text": "AUTO 1010 and AUTO 1167",
-    "courses": [
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2005": {
-    "text": "AUTO 2145 and AUTO 2159",
-    "courses": [
-      "AUTO 2145",
-      "AUTO 2159"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2119": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2166": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2175": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2164": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2183": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2187": {
-    "text": "AUTO 1010 and AUTO 1167",
-    "courses": [
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2480": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 2183",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 2183"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "AUTO 2460": {
-    "text": "AUTO 1000 , AUTO 1010 , and AUTO 1167 or instructor permission",
-    "courses": [
-      "AUTO 1000",
-      "AUTO 1010",
-      "AUTO 1167"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BHHS 1550": {
-    "text": "BHHS 1010 and BHHS 1570",
-    "courses": [
-      "BHHS 1010",
-      "BHHS 1570"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BHHS 1570": {
-    "text": "BHHS 1010",
-    "courses": [
-      "BHHS 1010"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BHHS 2020": {
-    "text": "BHHS 1020",
-    "courses": [
-      "BHHS 1020"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BHHS 2050": {
-    "text": "BHHS 1010 , BHHS 1020 , BHHS 1031 , and BHHS 1040",
-    "courses": [
-      "BHHS 1010",
-      "BHHS 1020",
-      "BHHS 1031",
-      "BHHS 1040"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BHHS 2105": {
-    "text": "Instructor permission",
-    "courses": [],
-    "source": "anoka-technical-college"
-  },
-  "BHHS 2101": {
-    "text": "Instructor permission",
-    "courses": [],
-    "source": "anoka-technical-college"
-  },
-  "BIOL 1106": {
-    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
-    "courses": [
-      "ENGL 0900"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BIOL 1130": {
-    "text": "ENGL 0900 with a grade of C or better or appropriate placement score",
-    "courses": [
-      "ENGL 0900"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BMET 1301": {
-    "text": "ETEC 1151 with a grade of C or better",
-    "courses": [
-      "ETEC 1151"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BIOL 2100": {
-    "text": "BIOL 1106",
-    "courses": [
-      "BIOL 1106"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BIOL 2200": {
-    "text": "BIOL 2100",
-    "courses": [
-      "BIOL 2100"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BMET 1200": {
-    "text": "ETEC 1202 , ETEC 1260 , ETEC 1281 and BMET 1301",
-    "courses": [
-      "BMET 1301",
-      "ETEC 1202",
-      "ETEC 1260",
-      "ETEC 1281"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BMET 2012": {
-    "text": "BMET 1200 , ETEC 2276 , and ETEC 2138",
-    "courses": [
-      "BMET 1200",
-      "ETEC 2138",
-      "ETEC 2276"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BDAT 1010": {
-    "text": "ITEC 1006",
-    "courses": [
-      "ITEC 1006"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BDAT 1040": {
-    "text": "BDAT 1005 and ITEC 1006",
-    "courses": [
-      "BDAT 1005",
-      "ITEC 1006"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "BDAT 2140": {
-    "text": "ITEC 1006",
-    "courses": [
-      "ITEC 1006"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 1200": {
-    "text": "ELEC 1002",
-    "courses": [
-      "ELEC 1002"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 1210": {
-    "text": "ELEC 1002",
-    "courses": [
-      "ELEC 1002"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2300": {
-    "text": "ELEC 2021 and MAIN 1200",
-    "courses": [
-      "ELEC 2021",
-      "MAIN 1200"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2310": {
-    "text": "ELEC 1002 , ELEC 2021 , and MAIN 1100",
-    "courses": [
-      "ELEC 1002",
-      "ELEC 2021",
-      "MAIN 1100"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2320": {
-    "text": "ETEC 1250 and ETEC 1113",
-    "courses": [
-      "ETEC 1113",
-      "ETEC 1250"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2330": {
-    "text": "MAIN 1100",
-    "courses": [
-      "MAIN 1100"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2400": {
-    "text": "MACH 1251 , MAIN 2310 , MAIN 2330 , and MAIN 2350",
-    "courses": [
-      "MACH 1251",
-      "MAIN 2310",
-      "MAIN 2330",
-      "MAIN 2350"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2350": {
-    "text": "MAIN 1200 and MAIN 1210",
-    "courses": [
-      "MAIN 1200",
-      "MAIN 1210"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2440": {
-    "text": "MACH 1251 , MAIN 2310 , MAIN 2330 , AND MAIN 2350",
-    "courses": [
-      "MACH 1251",
-      "MAIN 2310",
-      "MAIN 2330",
-      "MAIN 2350"
-    ],
-    "source": "anoka-technical-college"
-  },
-  "MAIN 2430": {
-    "text": "MAIN 2330",
-    "courses": [
-      "MAIN 2330"
-    ],
-    "source": "anoka-technical-college"
+    "source": "hennepin-technical-college"
   },
   "ACCT 2252": {
     "text": "ACCT 2251",
@@ -6246,16 +23500,16 @@
     ],
     "source": "normandale-community-college"
   },
+  "ACCT 1900": {
+    "text": "Topic-dependent",
+    "courses": [],
+    "source": "normandale-community-college"
+  },
   "ACCT 2096": {
     "text": "ACCT 2251 and consent of instructor",
     "courses": [
       "ACCT 2251"
     ],
-    "source": "normandale-community-college"
-  },
-  "ACCT 1900": {
-    "text": "Topic-dependent",
-    "courses": [],
     "source": "normandale-community-college"
   },
   "ANTH 1188": {
@@ -6268,17 +23522,17 @@
     ],
     "source": "normandale-community-college"
   },
+  "ANTH 1900": {
+    "text": "Topic-dependent",
+    "courses": [],
+    "source": "normandale-community-college"
+  },
   "ANTH 1236": {
     "text": "Eligible for ENGC 1101 and READ 1106",
     "courses": [
       "ENGC 1101",
       "READ 1106"
     ],
-    "source": "normandale-community-college"
-  },
-  "ANTH 1900": {
-    "text": "Topic-dependent",
-    "courses": [],
     "source": "normandale-community-college"
   },
   "ANTH 2096": {
@@ -6300,33 +23554,10 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "ART 2200": {
-    "text": "ART 1118 and ART 1121 and ART 1122",
-    "courses": [
-      "ART 1118",
-      "ART 1121",
-      "ART 1122"
-    ],
-    "source": "normandale-community-college"
-  },
-  "ART 2201": {
-    "text": "ART 1121",
-    "courses": [
-      "ART 1121"
-    ],
-    "source": "normandale-community-college"
-  },
   "ART 2204": {
     "text": "ART 1121",
     "courses": [
       "ART 1121"
-    ],
-    "source": "normandale-community-college"
-  },
-  "ART 2206": {
-    "text": "ART 1125",
-    "courses": [
-      "ART 1125"
     ],
     "source": "normandale-community-college"
   },
@@ -6335,6 +23566,13 @@
     "courses": [
       "ART 1110",
       "ART 1114"
+    ],
+    "source": "normandale-community-college"
+  },
+  "ART 2206": {
+    "text": "ART 1125",
+    "courses": [
+      "ART 1125"
     ],
     "source": "normandale-community-college"
   },
@@ -6358,7 +23596,7 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "BIOL 1101": {
+  "BIOL 1102": {
     "text": "ENGC 0960 (C/P or higher) or READ 0960 (C/P or higher) or placement into ENGC 1101",
     "courses": [
       "ENGC 0960",
@@ -6367,7 +23605,7 @@
     ],
     "source": "normandale-community-college"
   },
-  "BIOL 1102": {
+  "BIOL 1101": {
     "text": "ENGC 0960 (C/P or higher) or READ 0960 (C/P or higher) or placement into ENGC 1101",
     "courses": [
       "ENGC 0960",
@@ -6405,25 +23643,6 @@
     ],
     "source": "normandale-community-college"
   },
-  "BIOL 1120": {
-    "text": "ENGC 0960 (C/P or higher) or ENGC 0900 (C/P or higher) and READ 0960 (C/P or higher) or placement into ENGC 1101",
-    "courses": [
-      "ENGC 0900",
-      "ENGC 0960",
-      "ENGC 1101",
-      "READ 0960"
-    ],
-    "source": "normandale-community-college"
-  },
-  "BIOL 1125": {
-    "text": "ENGC 0960 (C/P or higher) or EAP 1100 (C or higher) or placement into College Level Reading and College Level Writing (ENGC 1101)",
-    "courses": [
-      "EAP 1100",
-      "ENGC 0960",
-      "ENGC 1101"
-    ],
-    "source": "normandale-community-college"
-  },
   "BIOL 1501": {
     "text": "MATH 1080 or MATH 1090 or MATH 0700 (C/P or higher, valid for 5 years) or placement into MATH 1500 or MATH 1150 or higher; and ENGC 0960 (C/P or higher) or ENGC 0900 (C/P or higher) and READ 0960 (C/P or higher) or placement into ENGC 1101",
     "courses": [
@@ -6436,6 +23655,15 @@
       "MATH 1150",
       "MATH 1500",
       "READ 0960"
+    ],
+    "source": "normandale-community-college"
+  },
+  "BIOL 1125": {
+    "text": "ENGC 0960 (C/P or higher) or EAP 1100 (C or higher) or placement into College Level Reading and College Level Writing (ENGC 1101)",
+    "courses": [
+      "EAP 1100",
+      "ENGC 0960",
+      "ENGC 1101"
     ],
     "source": "normandale-community-college"
   },
@@ -6495,32 +23723,10 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "BIOL 2202": {
-    "text": "BIOL 1106 or BIOL 1502 (C or higher)",
-    "courses": [
-      "BIOL 1106",
-      "BIOL 1502"
-    ],
-    "source": "normandale-community-college"
-  },
   "BIOL 2203": {
     "text": "BIOL 1501 (C or higher)",
     "courses": [
       "BIOL 1501"
-    ],
-    "source": "normandale-community-college"
-  },
-  "BIOL 2205": {
-    "text": "BIOL 1502 (C or higher)",
-    "courses": [
-      "BIOL 1502"
-    ],
-    "source": "normandale-community-college"
-  },
-  "BIOL 2206": {
-    "text": "BIOL 1502 (C or higher)",
-    "courses": [
-      "BIOL 1502"
     ],
     "source": "normandale-community-college"
   },
@@ -6621,50 +23827,9 @@
     ],
     "source": "normandale-community-college"
   },
-  "CHEM 1061": {
-    "text": "CHEM 1020 (C or higher) or CHEM self assessment eligibility and MATH 0700 (C or higher) or placement level in MATH 1020 / MATH 1055 / MATH 1080 / MATH 1100",
-    "courses": [
-      "CHEM 1020",
-      "MATH 0700",
-      "MATH 1020",
-      "MATH 1055",
-      "MATH 1080",
-      "MATH 1100"
-    ],
-    "source": "normandale-community-college"
-  },
-  "CHEM 1062": {
-    "text": "CHEM 1061 (C or higher)",
-    "courses": [
-      "CHEM 1061"
-    ],
-    "source": "normandale-community-college"
-  },
   "CHEM 1900": {
     "text": "Topic-dependent",
     "courses": [],
-    "source": "normandale-community-college"
-  },
-  "CHEM 2041": {
-    "text": "CHEM 1062",
-    "courses": [
-      "CHEM 1062"
-    ],
-    "source": "normandale-community-college"
-  },
-  "CHEM 2061": {
-    "text": "CHEM 1062",
-    "courses": [
-      "CHEM 1062"
-    ],
-    "source": "normandale-community-college"
-  },
-  "CHEM 2062": {
-    "text": "CHEM 2061 or CHEM 2058 with instructor's permission",
-    "courses": [
-      "CHEM 2058",
-      "CHEM 2061"
-    ],
     "source": "normandale-community-college"
   },
   "CHEM 2900": {
@@ -6685,17 +23850,17 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "COMM 2096": {
-    "text": "Previous coursework in Communication and consent of instructor",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
   "COMM 2111": {
     "text": "COMM 1100 or COMM 1111 (C or higher)",
     "courses": [
       "COMM 1100",
       "COMM 1111"
     ],
+    "source": "normandale-community-college"
+  },
+  "COMM 2096": {
+    "text": "Previous coursework in Communication and consent of instructor",
+    "courses": [],
     "source": "normandale-community-college"
   },
   "COMM 2900": {
@@ -6717,17 +23882,17 @@
     ],
     "source": "normandale-community-college"
   },
-  "COMT 1182": {
-    "text": "COMT 1181",
-    "courses": [
-      "COMT 1181"
-    ],
-    "source": "normandale-community-college"
-  },
   "COMT 1184": {
     "text": "COMT 1107",
     "courses": [
       "COMT 1107"
+    ],
+    "source": "normandale-community-college"
+  },
+  "COMT 1182": {
+    "text": "COMT 1181",
+    "courses": [
+      "COMT 1181"
     ],
     "source": "normandale-community-college"
   },
@@ -6756,25 +23921,16 @@
     ],
     "source": "normandale-community-college"
   },
-  "COMT 2250": {
-    "text": "Eligible for CSCI 1101 and COMT 2188",
-    "courses": [
-      "COMT 2188",
-      "CSCI 1101"
-    ],
-    "source": "normandale-community-college"
-  },
   "COMT 2900": {
     "text": "Topic-dependent",
     "courses": [],
     "source": "normandale-community-college"
   },
-  "CSCI 1101": {
-    "text": "MATH 0700 or MATH 0670 (C or higher) or eligible for MATH 1100",
+  "COMT 2250": {
+    "text": "Eligible for CSCI 1101 and COMT 2188",
     "courses": [
-      "MATH 0670",
-      "MATH 0700",
-      "MATH 1100"
+      "COMT 2188",
+      "CSCI 1101"
     ],
     "source": "normandale-community-college"
   },
@@ -6785,21 +23941,14 @@
     ],
     "source": "normandale-community-college"
   },
-  "CSCI 1113": {
-    "text": "MATH 1510",
-    "courses": [
-      "MATH 1510"
-    ],
-    "source": "normandale-community-college"
-  },
-  "CSCI 1202": {
+  "CSCI 1203": {
     "text": "CSCI 1111",
     "courses": [
       "CSCI 1111"
     ],
     "source": "normandale-community-college"
   },
-  "CSCI 1203": {
+  "CSCI 1202": {
     "text": "CSCI 1111",
     "courses": [
       "CSCI 1111"
@@ -6834,25 +23983,6 @@
     ],
     "source": "normandale-community-college"
   },
-  "CSCI 2021": {
-    "text": "CSCI 1101 and experience with C, C++, or Java",
-    "courses": [
-      "CSCI 1101"
-    ],
-    "source": "normandale-community-college"
-  },
-  "CSCI 2033": {
-    "text": "MATH 1510",
-    "courses": [
-      "MATH 1510"
-    ],
-    "source": "normandale-community-college"
-  },
-  "CSCI 2900": {
-    "text": "Topic-dependent",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
   "DSCI 2000": {
     "text": "MATH 1080 or MATH 1090 or MATH 2400 or BUSN 2220, and CSCI 1111 or CSCI 1113 or COMT 2250",
     "courses": [
@@ -6866,17 +23996,7 @@
     ],
     "source": "normandale-community-college"
   },
-  "DENH 1112": {
-    "text": "Acceptance into Dental Hygiene Program",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
   "DENH 1140": {
-    "text": "Acceptance into Dental Hygiene Program",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
-  "DENH 1141": {
     "text": "Acceptance into Dental Hygiene Program",
     "courses": [],
     "source": "normandale-community-college"
@@ -6890,26 +24010,17 @@
     ],
     "source": "normandale-community-college"
   },
-  "DENH 1142": {
-    "text": "Acceptance into Dental Hygiene Program, DENH 1112, DENH 1140, and DENH 1141",
+  "DENH 1151": {
+    "text": "Acceptance into Dental Hygiene Program, graduated from an accredited Dental Assisting program, Minnesota licensed dental assistant; petition out of DEN 1150 and DENH 1112",
     "courses": [
-      "DENH 1112",
-      "DENH 1140",
-      "DENH 1141"
+      "DEN 1150",
+      "DENH 1112"
     ],
     "source": "normandale-community-college"
   },
   "DENH 1150": {
     "text": "Acceptance into Dental Hygiene Program and DENH 1112",
     "courses": [
-      "DENH 1112"
-    ],
-    "source": "normandale-community-college"
-  },
-  "DENH 1151": {
-    "text": "Acceptance into Dental Hygiene Program, graduated from an accredited Dental Assisting program, Minnesota licensed dental assistant; petition out of DEN 1150 and DENH 1112",
-    "courses": [
-      "DEN 1150",
       "DENH 1112"
     ],
     "source": "normandale-community-college"
@@ -6967,20 +24078,20 @@
     ],
     "source": "normandale-community-college"
   },
-  "DENH 2244": {
-    "text": "Acceptance into the Dental Hygiene program, DENH 2241, DENH 2243, and instructor recommendation",
-    "courses": [
-      "DENH 2241",
-      "DENH 2243"
-    ],
-    "source": "normandale-community-college"
-  },
   "DENH 2243": {
     "text": "Acceptance into Dental Hygiene Program, DENH 2240, DENH 2241, and DENH 2264",
     "courses": [
       "DENH 2240",
       "DENH 2241",
       "DENH 2264"
+    ],
+    "source": "normandale-community-college"
+  },
+  "DENH 2244": {
+    "text": "Acceptance into the Dental Hygiene program, DENH 2241, DENH 2243, and instructor recommendation",
+    "courses": [
+      "DENH 2241",
+      "DENH 2243"
     ],
     "source": "normandale-community-college"
   },
@@ -7018,16 +24129,16 @@
     ],
     "source": "normandale-community-college"
   },
-  "DENH 2281": {
-    "text": "Acceptance into Dental Hygiene Program",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
   "DENH 2266": {
     "text": "Acceptance into Dental Hygiene Program and DENH 1112",
     "courses": [
       "DENH 1112"
     ],
+    "source": "normandale-community-college"
+  },
+  "DENH 2281": {
+    "text": "Acceptance into Dental Hygiene Program",
+    "courses": [],
     "source": "normandale-community-college"
   },
   "DENH 2900": {
@@ -7190,22 +24301,6 @@
     ],
     "source": "normandale-community-college"
   },
-  "ENGL 1021": {
-    "text": "Eligible for ENGC 0900 and READ 0960",
-    "courses": [
-      "ENGC 0900",
-      "READ 0960"
-    ],
-    "source": "normandale-community-college"
-  },
-  "ENGL 1120": {
-    "text": "Eligible for ENGC 1101 and READ 1106",
-    "courses": [
-      "ENGC 1101",
-      "READ 1106"
-    ],
-    "source": "normandale-community-college"
-  },
   "ENGL 1130": {
     "text": "ENGC 0960 (C/P or higher) or EAP 1100 (C or higher), or placement into College Level Reading and College Level Writing (ENGC 1101)",
     "courses": [
@@ -7269,14 +24364,6 @@
   "ENGL 1900": {
     "text": "Topic-dependent",
     "courses": [],
-    "source": "normandale-community-college"
-  },
-  "ENGL 2000": {
-    "text": "ENGC 1101 (C or higher) and eligible for READ 1106",
-    "courses": [
-      "ENGC 1101",
-      "READ 1106"
-    ],
     "source": "normandale-community-college"
   },
   "ENGL 2060": {
@@ -7375,14 +24462,6 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "ENGR 1020": {
-    "text": "MATH 1100 (C or higher) or placement into MATH 1500",
-    "courses": [
-      "MATH 1100",
-      "MATH 1500"
-    ],
-    "source": "normandale-community-college"
-  },
   "ENGR 2015": {
     "text": "PHYS 1121 (C or higher) and PHYS 1122 (C or higher) or concurrent regisration, and MATH 1520 (C or higher), MATH 2520 (C or higher) or concurrent registration, or consent of instructor",
     "courses": [
@@ -7393,11 +24472,6 @@
     ],
     "source": "normandale-community-college"
   },
-  "ENGR 2096": {
-    "text": "Previous coursework in Engineering and consent of instructor and the Center for Experiential Education",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
   "ENGR 2017": {
     "text": "PHYS 1122 (C or higher), MATH 1520 (C or higher)",
     "courses": [
@@ -7406,12 +24480,9 @@
     ],
     "source": "normandale-community-college"
   },
-  "ENGR 2231": {
-    "text": "CHEM 1061 (C or higher), MATH 1510 (C or higher)",
-    "courses": [
-      "CHEM 1061",
-      "MATH 1510"
-    ],
+  "ENGR 2096": {
+    "text": "Previous coursework in Engineering and consent of instructor and the Center for Experiential Education",
+    "courses": [],
     "source": "normandale-community-college"
   },
   "ENGR 2115": {
@@ -7421,6 +24492,14 @@
       "ENGR 2016",
       "MATH 2520",
       "PHYS 1122"
+    ],
+    "source": "normandale-community-college"
+  },
+  "ENGR 2231": {
+    "text": "CHEM 1061 (C or higher), MATH 1510 (C or higher)",
+    "courses": [
+      "CHEM 1061",
+      "MATH 1510"
     ],
     "source": "normandale-community-college"
   },
@@ -7697,11 +24776,6 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "HLTH 1900": {
-    "text": "Topic-dependent",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
   "HLTH 2096": {
     "text": "Complete at least one HLTH course and consent of instructor",
     "courses": [],
@@ -7792,6 +24866,16 @@
     ],
     "source": "normandale-community-college"
   },
+  "MATH 1055": {
+    "text": "MATH 0630 (C or higher) or MATH 0991 (C or higher) or MATH 0980 (C or higher) or MATH 0601, 0602, or 0603 with mastery of sufficient topics",
+    "courses": [
+      "MATH 0601",
+      "MATH 0630",
+      "MATH 0980",
+      "MATH 0991"
+    ],
+    "source": "normandale-community-college"
+  },
   "MATH 1065": {
     "text": "MATH 1055",
     "courses": [
@@ -7811,42 +24895,10 @@
     ],
     "source": "normandale-community-college"
   },
-  "MATH 1055": {
-    "text": "MATH 0630 (C or higher) or MATH 0991 (C or higher) or MATH 0980 (C or higher) or MATH 0601, 0602, or 0603 with mastery of sufficient topics",
-    "courses": [
-      "MATH 0601",
-      "MATH 0630",
-      "MATH 0980",
-      "MATH 0991"
-    ],
-    "source": "normandale-community-college"
-  },
-  "MATH 1090": {
-    "text": "MATH 0990",
-    "courses": [
-      "MATH 0990"
-    ],
-    "source": "normandale-community-college"
-  },
   "MATH 1095": {
     "text": "Eligible for MATH 0990",
     "courses": [
       "MATH 0990"
-    ],
-    "source": "normandale-community-college"
-  },
-  "MATH 1100": {
-    "text": "MATH 0700 (C or higher) or MATH 0991 (C or higher)",
-    "courses": [
-      "MATH 0700",
-      "MATH 0991"
-    ],
-    "source": "normandale-community-college"
-  },
-  "MATH 1500": {
-    "text": "MATH 1100 (C or higher) or placement in MATH 1500",
-    "courses": [
-      "MATH 1100"
     ],
     "source": "normandale-community-college"
   },
@@ -7936,19 +24988,31 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "MUSC 1132": {
-    "text": "MUSC 1131",
+  "DENH 1112": {
+    "text": "Acceptance into Dental Hygiene Program",
+    "courses": [],
+    "source": "normandale-community-college"
+  },
+  "DENH 1142": {
+    "text": "Acceptance into Dental Hygiene Program, DENH 1112, DENH 1140, and DENH 1141",
     "courses": [
-      "MUSC 1131"
+      "DENH 1112",
+      "DENH 1140",
+      "DENH 1141"
     ],
     "source": "normandale-community-college"
   },
-  "MUSC 1142": {
-    "text": "instructor's permission",
+  "DENH 1141": {
+    "text": "Acceptance into Dental Hygiene Program",
     "courses": [],
     "source": "normandale-community-college"
   },
   "MUSC 1141": {
+    "text": "instructor's permission",
+    "courses": [],
+    "source": "normandale-community-college"
+  },
+  "MUSC 1142": {
     "text": "instructor's permission",
     "courses": [],
     "source": "normandale-community-college"
@@ -7961,6 +25025,13 @@
   "MUSC 1144": {
     "text": "instructor's permission",
     "courses": [],
+    "source": "normandale-community-college"
+  },
+  "MUSC 1132": {
+    "text": "MUSC 1131",
+    "courses": [
+      "MUSC 1131"
+    ],
     "source": "normandale-community-college"
   },
   "MUSC 1151": {
@@ -7980,6 +25051,16 @@
     "courses": [],
     "source": "normandale-community-college"
   },
+  "MUSC 1176": {
+    "text": "MUSC 1100 or MUSC 1120 or MUSC 1131 or MUSC 1151",
+    "courses": [
+      "MUSC 1100",
+      "MUSC 1120",
+      "MUSC 1131",
+      "MUSC 1151"
+    ],
+    "source": "normandale-community-college"
+  },
   "MUSC 1182": {
     "text": "MUSC 1181",
     "courses": [
@@ -7997,16 +25078,6 @@
   "MUSC 1900": {
     "text": "Topic-dependent",
     "courses": [],
-    "source": "normandale-community-college"
-  },
-  "MUSC 1176": {
-    "text": "MUSC 1100 or MUSC 1120 or MUSC 1131 or MUSC 1151",
-    "courses": [
-      "MUSC 1100",
-      "MUSC 1120",
-      "MUSC 1131",
-      "MUSC 1151"
-    ],
     "source": "normandale-community-college"
   },
   "MUSC 2231": {
@@ -8030,18 +25101,18 @@
     ],
     "source": "normandale-community-college"
   },
+  "MUSC 2270": {
+    "text": "MUSC 1170",
+    "courses": [
+      "MUSC 1170"
+    ],
+    "source": "normandale-community-college"
+  },
   "MUSC 2252": {
     "text": "8 credits of MUSC 1151 4 semesters of MUSC 1152 and audition and consent of Applied Music Coordinator",
     "courses": [
       "MUSC 1151",
       "MUSC 1152"
-    ],
-    "source": "normandale-community-college"
-  },
-  "MUSC 2270": {
-    "text": "MUSC 1170",
-    "courses": [
-      "MUSC 1170"
     ],
     "source": "normandale-community-college"
   },
@@ -8057,11 +25128,6 @@
     "courses": [
       "MUSC 2281"
     ],
-    "source": "normandale-community-college"
-  },
-  "MUSC 2900": {
-    "text": "Topic-dependent",
-    "courses": [],
     "source": "normandale-community-college"
   },
   "NCC 1000": {
@@ -8155,66 +25221,7 @@
     ],
     "source": "normandale-community-college"
   },
-  "NURS 2700": {
-    "text": "Acceptance into Nursing Program",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
-  "NURS 2720": {
-    "text": "Acceptance into Nursing Program",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
-  "NURS 2750": {
-    "text": "Acceptance into Nursing Program",
-    "courses": [],
-    "source": "normandale-community-college"
-  },
-  "NURS 2800": {
-    "text": "NURS 2700 or NURS 2720 (C or higher) and NURS 2750 (C or higher)",
-    "courses": [
-      "NURS 2700",
-      "NURS 2720",
-      "NURS 2750"
-    ],
-    "source": "normandale-community-college"
-  },
-  "NURS 2820": {
-    "text": "NURS 2700 or NURS 2720 (C or higher) and NURS 2750 (C or higher)",
-    "courses": [
-      "NURS 2700",
-      "NURS 2720",
-      "NURS 2750"
-    ],
-    "source": "normandale-community-college"
-  },
-  "NURS 2850": {
-    "text": "NURS 2700 or NURS 2720 (C or higher) and NURS 2750 (C or higher)",
-    "courses": [
-      "NURS 2700",
-      "NURS 2720",
-      "NURS 2750"
-    ],
-    "source": "normandale-community-college"
-  },
   "NURS 2910": {
-    "text": "NURS 2800, NURS 2820 and NURS 2850 (C or higher)",
-    "courses": [
-      "NURS 2800",
-      "NURS 2820",
-      "NURS 2850"
-    ],
-    "source": "normandale-community-college"
-  },
-  "NURS 2920": {
-    "text": "NURS 2800 and NURS 2850 (C or higher)",
-    "courses": [
-      "NURS 2800",
-      "NURS 2850"
-    ],
-    "source": "normandale-community-college"
-  },
-  "NURS 2950": {
     "text": "NURS 2800, NURS 2820 and NURS 2850 (C or higher)",
     "courses": [
       "NURS 2800",
@@ -8352,17 +25359,6 @@
     "courses": [],
     "source": "normandale-community-college"
   },
-  "PSYC 2100": {
-    "text": "PSYC 1110 and completion of one of the following: MATH 1080, MATH 1090, MATH 1095, MATH 1100 or math placement higher than MATH 1100",
-    "courses": [
-      "MATH 1080",
-      "MATH 1090",
-      "MATH 1095",
-      "MATH 1100",
-      "PSYC 1110"
-    ],
-    "source": "normandale-community-college"
-  },
   "PSYC 2200": {
     "text": "PSYC 1110",
     "courses": [
@@ -8377,14 +25373,14 @@
     ],
     "source": "normandale-community-college"
   },
-  "PSYC 2300": {
+  "PSYC 2400": {
     "text": "PSYC 1110",
     "courses": [
       "PSYC 1110"
     ],
     "source": "normandale-community-college"
   },
-  "PSYC 2400": {
+  "PSYC 2300": {
     "text": "PSYC 1110",
     "courses": [
       "PSYC 1110"
@@ -8669,6 +25665,11 @@
     "courses": [
       "VACT 2301"
     ],
+    "source": "normandale-community-college"
+  },
+  "CSCI 2900": {
+    "text": "Topic-dependent",
+    "courses": [],
     "source": "normandale-community-college"
   }
 }

--- a/data/mn/programs/dakota-county-technical-college.json
+++ b/data/mn/programs/dakota-county-technical-college.json
@@ -1,0 +1,4251 @@
+{
+  "college_slug": "dakota-county-technical-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.dctc.edu",
+  "scraped_at": "2026-05-30T01:14:50.045Z",
+  "programs": [
+    {
+      "title": "Minnesota Transfer Curriculum (MnTC)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=202",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accountant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=110",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accountant, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=111",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Clerk, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=112",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 6 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Administrative Assistant, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=115",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Drafting, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=137",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=136",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1301",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Auto Body Collision Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=186",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Auto Body Collision Technology, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=187",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Service (GM-ASEP), A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=189",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Service Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=188",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - First Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Second Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - First Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Second Semester: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Biomedical Equipment Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=175",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Year - Spring Semester: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biomedical Equipment Technology, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=176",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Spring Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Fall Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=117",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Graduation Project/Internship registration is in the last semester of attendance. Credits are variable. You must have advisor approval to ensure you have enough credits to graduate.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (Goal 2, 6, 8, 9, or 10) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (from BUSN) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=118",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Technical Paths: 28-30 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Graduation Project or Internship: 1-4* Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Graduation Project/Internship registration is in the last semester of attendance. Credits vary based on your certificate and diploma choices. You must have advisor approval to ensure you have enough credits to graduate.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Child & Family Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=158",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (any ECYD) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 9 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Civil Engineering & Land Survey Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=138",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INDS",
+              "number": "1020",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering & Land Survey Technology, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=139",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Commercial HVAC/R, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=140",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Codes & Inspection, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=143",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Codes & Permitting Specialist, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=144",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=142",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Management, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=141",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Dental Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=155",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assistant, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=156",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Desktop Programming, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=184",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Illustration, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=197",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Marketing Specialist, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=126",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Early Childhood & Youth Development, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=159",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (any ECYD or BUSN) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (any ECYD or BUSN) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (any ECYD or BUSN) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood & Youth Development, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=161",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood & Youth Development, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=160",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (any ECYD) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Summer Session: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=157",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 9 Credits **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 9 Credits **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical Construction & Maintenance, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=145",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Summer Session 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Construction & Maintenance, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=146",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Lineworker, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=147",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "July Start*: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Fall Semester: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional Requirements: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Lineworker, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=148",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "July Start*: 6 Credit",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Fall Semester: 20 Credit",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credit",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Executive Administrative Specialist, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=114",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives 4 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Exercise & Sport Science, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=163",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (EXER) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (EXER) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Exercise Science Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=162",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (EXER or PHED) 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 6 or 8) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 5 or 10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 6) 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=198",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Summer Session: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Heavy Construction Equip. Maintenance, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=192",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Construction Equip. Mechanic, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=191",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 21 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Construction Equip. Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=190",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 21 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Duty Truck Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=193",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall or Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Fall or Spring Semester: 22 Credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall or Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall or Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Duty Truck Technology, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=194",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resource Management, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=122",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "HVAC & Refrigeration, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=149",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC & Refrigeration, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=150",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Individualized Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=203",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Credits",
+              "credits": 18,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Minnesota Transfer Curriculum 34 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Engineering Technician, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=151",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 14 Credit",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credit",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 7 Credit",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 13 Credit",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 11 Credit",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATS",
+              "number": "1340",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Information Systems Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=177",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (any ISTC) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Interior Design, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=152",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "1310",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interior Design: NCIDQ Pathway, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=153",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Administrative Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=128",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Summer Session 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Administrative Assistant, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=129",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=130",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Administrative Specialist, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=131",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Administrative Specialist, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=132",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=165",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=166",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Summer Session: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding Specialist, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=167",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding Specialist, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=169",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding Specialist, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=168",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Microsoft Office Applications Management, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=116",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mopar CAP, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=196",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Summer Session: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multicultural Human Resources Management, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=119",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Multicultural Leadership, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=120",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 28 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multicultural Quality Management, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=121",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Multicultural Supervision, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=123",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking Administration, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=179",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Assisting, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=170",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "PC Technician, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=181",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (any ISTC) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Personal Training, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=164",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Photography, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=200",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=171",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Third Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Process Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=172",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMS",
+              "number": "1020",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course in Goal 4 in the Minnesota Transfer Curriculum 4 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Credits (Any MnTC Goal Area) 5 credits *AAS degrees require 3 different goal areas within the 15 credits.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Photography, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=199",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (PHOT, ENTR, BUSN, MKTC) 2 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective (PHOT, ENTR, BUSN, MKTC) 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Administration, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=133",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Spring Semester: 12",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This course offers variable credit; students must register for three credits and have advisor approval to ensure they have enough credits for graduation.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Quality Improvement, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=124",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sales Specialist, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=127",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Small Business Accounting, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=113",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives 4 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Small Business Entrepreneur, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=134",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Software Development, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=182",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (Certificate Dependent) 3 Credits **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (Certificate Dependent) 6 Credits **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=183",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (Certificate Dependent) 3 Credits **",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (Certificate Dependent) 6 Credits **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (any MnTC Goal 1-10) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sport Management, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=173",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "1500",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Fall Semester: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUMA",
+              "number": "1100",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*generally offered in the fall semester",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "2000",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (MnTC Goal 6) 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Supervisory Leadership, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=125",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=135",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Curriculum: 45 Credits",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Graduation Project/Internship registration is in the last semester of attendance. Credits vary based on your certificate and diploma choices. You must have advisor approval to ensure you have enough credits to graduate.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives 30 Credits * or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Electives (any BUSN) 14 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives (any MnTC Goal 1-10) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Truck Fleet Maintenance, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=195",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technician, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=174",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INDS",
+              "number": "1020",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year - Spring Semester: 14 Credits *",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Summer Session: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Design, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=201",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Spring Semester: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Programming, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=185",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Fall Semester: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Year - Spring Semester: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.dctc.edu/preview_program.php?catoid=2&poid=154",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year - Fall Semester: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Year - Spring Semester: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/mn/programs/inver-hills-community-college.json
+++ b/data/mn/programs/inver-hills-community-college.json
@@ -1,0 +1,6459 @@
+{
+  "college_slug": "inver-hills-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.inverhills.edu",
+  "scraped_at": "2026-05-30T01:18:25.469Z",
+  "programs": [
+    {
+      "title": "Minnesota Transfer Curriculum (MnTC)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=84",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Health & Physical Education Requirement 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "a. Health (1 Credit)",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "b. Physical Education (1 Credit)",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=85",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Transfer Pathway Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 (with lab) course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC Goal 6 recommended) 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 course (with lab) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC courses only) 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 course (with lab) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 5-6 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 7-8 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC courses only) 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Anthropology, A.A. with Emphasis",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=86",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Anthropology Emphasis Curriculum: 13-14 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Anthropology Core Requirements: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Anthropology Electives (choose two): 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 17-18 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements: 27 Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 4 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE Course 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course (non-ANTH) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives 5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art Transfer Pathway, A.F.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=87",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Art Pathway Curriculum: 37 Credits",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Art Electives (choose four): 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Free Art Electives (choose two): 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 23 Credits",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted ART elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted ART electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted ART elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a or 3b with lab course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 12-14 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Free ART electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective 0-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted ART electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 11-12 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted ART elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a or 3b with lab course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 10-11 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Free ART electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 7-9 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of Arts, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=83",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education/Minnesota Transfer Curriculum (MnTC): 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health and Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Elective Courses: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTS",
+              "number": "1000",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE course 1 credit",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INTS",
+              "number": "1000",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE course 1 credit",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 8-11 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 8-11 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 4-5 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=88",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Biology Transfer Pathway Curriculum: 28 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 32 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 4 courses to fulfill at least 8 Credits Option 1: MATH 1103 - Introduction to Statistics and MATH 1118 - College Algebra I or higher-level course (e g Calculus) Option 2: Two courses from Math; must be MATH 1118 or higher-level courses (e g Calculus)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 8-9 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC course only) 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC course only) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC course only) 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business Analytics, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=91",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Business Analytics Curriculum: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=89",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Transfer Pathway Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Electives 9 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC courses only) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC courses only) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemistry Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=98",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Chemistry Transfer Pathway Curriculum: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 4-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (recommend Goals 5-10) 4-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Climate Change Studies, A.A. with Emphasis",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=99",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Climate Change Curriculum: 16-17 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Introduction to Climate Change: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Climate Science Curriculum: 4-8 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Climate & Society Curriculum: Social Concerns: 3-7 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Climate & Society Curriculum: Solutions: 3-6 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 23-24 Credits",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Climate Science Curriculum course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 8-9 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9-11 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Climate and Society Curriculum: Social Concerns course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 6-7 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 6-8 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Climate Change, Certifcate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=100",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Climate Change Curriculum: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Climate Science Curriculum: 4-8 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Climate & Society Curriculum: Social Concerns: 3-7 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Climate & Society Curriculum: Solutions: 3-6 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Studies Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=101",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Communication Pathway Curriculum: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements: 28 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 4 course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 9 course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a or 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 10 course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives 7-8 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Community Paramedic, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=114",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Community Paramedic Core Curriculum: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Programmer, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=103",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Computer Programmer Core: 29 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Electives: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Computer Science course(s)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Liberal Arts Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts elective (MnTC courses only) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 7 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts elective (MnTC courses only) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=102",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Computer Science Pathway Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Liberal Arts: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHYS",
+              "number": "1081",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts electives (MnTC courses only) 4-7 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any additional Computer Science course(s)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional Liberal Arts electives (MnTC courses only)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Choose one of the following Elective (Computer Science or Liberal Arts):",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective (Computer Science or Liberal Arts) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective (Computer Science or Liberal Arts) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 course 3-5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts elective (MnTC courses only) 4-7 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Contemporary Business Practice A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=90",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Business Curriculum: 44 Credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business electives 12 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective (MnTC courses only) 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Corrections, Certifcate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=105",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Corrections Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=104",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Criminal Justice Curriculum: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Program Core: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Electives (choose from the following): 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements: 42 Credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a/8 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1123",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b/10 course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a or 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program elective 3 , 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "1123",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a/8 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program elective 3 , 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culturally Responsive Professional Peace Officer, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=106",
+      "total_credits": 68,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Professional Peace Officer Curriculum: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Professional Licensing Core: 26 Credits",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "First Semester: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Second Semester: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culturally Responsive Professional Peace Officer, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=107",
+      "total_credits": 28,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Professional Peace Officer Curriculum: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Professional Licensing Core (Semester 1): 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Economics Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=108",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Economics Pathway Curriculum: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1. Introduction to Economics: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2. Mathematical Foundation: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 26 Credits",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course (non-ECON) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 9 course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health and PE 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 10-11 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health and PE 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course (non-ECON) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 11-12 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Elementary Education Foundations Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=109",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Elementary Education Foundations Curriculum: 42 Credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Electives: 0-5 Credits",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 13-18 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 9 course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective (any EDU or MnTC course) 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 8-9 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 5-6 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, A.S. (Accelerated Track)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=111",
+      "total_credits": 70,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Department Curriculum: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Liberal Arts: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, A.S. (Traditional Track)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=110",
+      "total_credits": 70,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Paramedic Curriculum: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=113",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "EMT Certifcate Curriculum: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Fundamentals, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=115",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Engineering Core Curriculum: Choose 13-14 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 46-47 Credits",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5, 6, 8, 9 or 10 course 3 or 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=116",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required English Pathway Curriculum: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Introduction to Literary Studies (choose one): 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Literature Survey Course (choose one): 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Diverse Literature Course (choose one): 3 or 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Writing for a Specifc Purpose (choose one): 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements: 29-40 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Electives: 3-15 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health and Physical Education 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-17 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 2-5 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Enterprise Networking and Security, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=129",
+      "total_credits": 18,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Enterprise Networking and Security Certifcate: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=118",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Environmental Science Curriculum: 31 Credits",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 29 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 12 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1111",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Higher level math courses, such as Pre-calculus or Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Organic Chemistry I and II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GIS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Geography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Exercise Science Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=119",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pathway Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15-17 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PHED elective 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 4-6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Gender and Women’s Studies, A.A. with Emphasis",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=120",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Gender and Women’s Studies Curriculum: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Program Electives (choose two): 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education: 28 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 4 course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 8-10 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 4 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences Broad Field, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=121",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Health Sciences Curriculum: 53-54 Credits",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Electives: 6-7 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Courses that fulfll additional MnTC requirements (Goal 1b, 6, 8, & 10)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=122",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required History Pathway Curriculum: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1. Introduction to US History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2. Introduction to World History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements: 28 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Survey (frst in a sequence of US or World) 4 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course (non-HIST) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Survey (frst in a sequence of US or World) 4 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 8-10 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 6-7 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "history"
+    },
+    {
+      "title": "Human Resource Management, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=93",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Human Resource Management Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Individualized Professional Studies, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=124",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Individualized Professional Studies: 44 Credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Planning courses - highly recommended: 0-4 Credits",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and/or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 (with lab) course or MnTC Goal 4 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Individualized Professional Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=123",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Individualized Professional Studies: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Planning courses - highly recommended: 0-4 Credits",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and/or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 (with lab) or MnTC Goal 4 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 7-10 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts electives (MnTC courses only) 11 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Support, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=125",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Information Technology Support Curriculum: 44 Credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 (with lab) course or MnTC Goal 4 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1 (Fall): 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (Communications) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring): 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3 (Fall): 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (MnTC Goal 5) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring): 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (MnTC Goal 6) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "IT HelpDesk & Cybersecurity Operations, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=130",
+      "total_credits": 18,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "IP Help Desk and Cybersecurity Certifcate: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "IT System Administrator, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=131",
+      "total_credits": 18,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "IT System Administration Certifcate: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing & Sales, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=94",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Marketing & Sales Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mathematics Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=133",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Mathematics Transfer Pathway Requirements: 15 Credit",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics Electives: 3-6 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 35 Credits",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 2-5 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health and PE 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a with lab course 4 MnTC Goal 5 course 3 credits 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and/or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a or 6b course 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective 0-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 10-11 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 8-9 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and/or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health and PE 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective 0-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 8: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Music, A.F.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=134",
+      "total_credits": 68,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Music Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Music Electives Curriculum: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Choose 6 credits from the following:",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Choose 2 credits from the following:",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Choose 2 credits from the following:",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Business and Economics Curriculum: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Choose at least 8 credits from the following:",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 14 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Applied Lessons 2 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives 6-7 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 5 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Applied Lessons 2 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Applied Lessons 2 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MUSC Applied Lessons 2 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Electives 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Technology and Security, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=126",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Network Technology & Security Curriculum: 44 Credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 (with lab) course or MnTC Goal 4 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1 (Fall): 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2 (Spring): 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (Communications) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall): 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (MnTC Goal 5) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (MnTC Goal 3 or 4) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring): 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Liberal Arts Course (MnTC Goal 6) 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking & Cybersecurity Operations, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=132",
+      "total_credits": 18,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Networking and Cybersecurity Operations Certifcate: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Nursing Assistant, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=137",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Nursing Core Curriculum: 5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing Mobility-License Practical Nurse (LPN), A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=136",
+      "total_credits": 64,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Mobility Track Nursing Curriculum: 34 Credits",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Assessment of LPN knowledge and Skills 4 -13 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=135",
+      "total_credits": 64,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Nursing Curriculum: 34 Credits",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paralegal, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=138",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Paralegal Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Liberal Arts: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3 course (with lab) or MnTC Goal 4 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives (MnTC courses only) 8-9 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=139",
+      "total_credits": 30,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Paralegal Curriculum: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic, Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=112",
+      "total_credits": 40,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Paramedic Curriculum: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=140",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Political Science Pathway Curriculum: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 31 Credits",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 4 course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE Course 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 4-5 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Social Work Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=141",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Pathway Curriculum: 38 Credits",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 22 Credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HSER elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HSER Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Goal 3b/10 elective without lab or MnTC Goal 3b/10 course with lab 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HSER elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HSER Elective 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Goal 3b/10 elective without lab or MnTC Goal 3b/10 course with lab 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Project Management, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=95",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Project Management Curriculum: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Psychology Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=142",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Psychology Pathway Curriculum: 21-22 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Elective Psychology Choose one course from:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any additional core psychology course, above",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematical Foundation Choose one course from:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any higher level MATH course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Health/Physical Education 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 0-15 Credits",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & PE Course 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Core Psychology course 3 Credits * 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course (non-PSYC) 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a with lab course (BIOL recommended) 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any elective PSYC course 3 Credits * 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course (non-PSYC) 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6b course 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 8-9 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Small Business Development, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=96",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Small Business Development Curriculum: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Social Justice, A.A. with Emphasis",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=143",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Social Justice Curriculum: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements: 24-25 Credits",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Justice breadth course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Justice breadth course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-16 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 8-9 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Justice breadth course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a/8 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Justice breadth course or general elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 4-6 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Justice, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=144",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Social Justice Curriculum: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Social Justice Theory and Action: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=145",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Sociology Pathway Curriculum: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Electives: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 6a course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "1103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General electives 6-7",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a course 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective (SOC course) 3 Credits *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 4-6 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish Transfer Pathway, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=146",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 40 Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Health/Physical Education: 2 Credits",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & Physical Education 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 4 course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3b/10 course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective 0-1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5/7 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health & Physical Education 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 3a course 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 7: 6-7 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=147",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Curriculum: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Special Education Foundations Transfer Pathway, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=148",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Pathway Curriculum: 42 Credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Electives: 0-5 Credits",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional MnTC Requirements: 13-18 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General elective 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1: 7 Credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 3: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 10 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 8-9 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MnTC Goal 5 course 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 7: 5-6 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Supervision, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=97",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Supervision Curriculum: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Transfer Pathway, A.F.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=149",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Theatre Pathway Curriculum: 20 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Required Courses: 8 Credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Restricted Theatre Electives: 3-6 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Theatre Electives: 6-9 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Electives: 6-12 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Requirements: 28-34 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 14-15 Credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted THTR elective or THTR elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "1103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 15-16 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4: 13-15 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 1: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "First Year Experience Course 1-2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1101",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3: 11 Credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Restricted THTR elective or THTR elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "1103",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 5: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 6: 10-12 Credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Workplace Writing, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.inverhills.edu/preview_program.php?catoid=2&poid=117",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Workplace Writing Certifcate Curriculum: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/scripts/mn/scrape-catalog-prereqs.ts
+++ b/scripts/mn/scrape-catalog-prereqs.ts
@@ -32,6 +32,7 @@
  */
 import * as fs from "fs";
 import * as path from "path";
+import { chromium, type BrowserContext } from "playwright";
 
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -76,30 +77,72 @@ const COLLEGES: CollegeCatalog[] = [
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+// ---------------------------------------------------------------------------
+// AWS WAF cookie acquisition via headless Chromium
+// ---------------------------------------------------------------------------
+
+const wafCookies = new Map<string, string>();
+
+async function acquireWafCookies(baseUrl: string): Promise<string> {
+  const cached = wafCookies.get(baseUrl);
+  if (cached) return cached;
+
+  console.log(`  Acquiring WAF cookies via headless browser: ${baseUrl}`);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const ctx = await browser.newContext({ userAgent: UA });
+    const page = await ctx.newPage();
+    await page.goto(baseUrl, { waitUntil: "networkidle", timeout: 30_000 });
+    const html = await page.content();
+    if (html.length < 5_000 && html.includes("awswaf")) {
+      await page.waitForNavigation({ timeout: 15_000 }).catch(() => {});
+    }
+    const cookies = await ctx.cookies();
+    const cookieStr = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    wafCookies.set(baseUrl, cookieStr);
+    console.log(`  WAF cookies acquired (${cookies.length} cookies)`);
+    return cookieStr;
+  } finally {
+    await browser.close();
+  }
+}
+
+function isWafChallenge(html: string): boolean {
+  return html.length < 5_000 && html.includes("awswaf");
+}
+
+async function retryFetch(url: string, label: string, attempts = 3, baseUrl?: string): Promise<string> {
   let lastErr: unknown;
-  // Acalog catalogs sit behind AWS WAF Bot Control — needs full Chrome-like
-  // header set + Referer matching the catalog origin or it returns an
-  // empty JS-challenge page.
   for (let i = 0; i < attempts; i++) {
     try {
       const u = new URL(url);
       const referer = `${u.protocol}//${u.host}/`;
-      const res = await fetch(url, {
-        headers: {
-          "User-Agent": UA,
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-          "Accept-Language": "en-US,en;q=0.9",
-          "Accept-Encoding": "gzip, deflate, br",
-          Referer: referer,
-          "Sec-Fetch-Dest": "document",
-          "Sec-Fetch-Mode": "navigate",
-          "Sec-Fetch-Site": "same-origin",
-          "Sec-Fetch-User": "?1",
-          "Upgrade-Insecure-Requests": "1",
-        },
-      });
-      if (res.ok) return await res.text();
+      const headers: Record<string, string> = {
+        "User-Agent": UA,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        Referer: referer,
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-User": "?1",
+        "Upgrade-Insecure-Requests": "1",
+      };
+      if (baseUrl) {
+        const cookies = wafCookies.get(baseUrl);
+        if (cookies) headers["Cookie"] = cookies;
+      }
+      const res = await fetch(url, { headers });
+      if (res.ok) {
+        const text = await res.text();
+        if (isWafChallenge(text) && baseUrl && i === 0) {
+          console.log(`  WAF challenge on ${label}, acquiring cookies via browser...`);
+          await acquireWafCookies(baseUrl);
+          continue;
+        }
+        return text;
+      }
       if (res.status >= 500) lastErr = new Error(`HTTP ${res.status}`);
       else return "";
     } catch (e) {
@@ -183,13 +226,15 @@ function extractCourseCodes(text: string, excludeOwn?: string): string[] {
 }
 
 function parseAcalogDetail(html: string): { prefix: string; number: string; text: string; courses: string[] } | null {
-  const titleMatch = html.match(/<title>\s*([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\s*-/);
+  // Title may use &nbsp; as separator (Anoka-Ramsey) or plain space.
+  const titleMatch = html.match(/<title>\s*([A-Z]{2,5})\s*(?:&nbsp;)?\s*(\d{3,4}[A-Z]?)\s*(?:&nbsp;)?\s*-/);
   if (!titleMatch) return null;
   const prefix = titleMatch[1].toUpperCase();
   const number = titleMatch[2];
-  // Match optional leading "Course " (anokatech) and trailing punctuation.
+  // Anoka-Ramsey adds "(must have a grade of C or better) or Corequisite(s):"
+  // after "Prerequisite(s)" — allow arbitrary text between the keyword and </strong>.
   const m = html.match(
-    /<strong>\s*(?:Course\s+)?Pre[-\s]?[Rr]equisite(?:s|\(s\))?\s*:?\s*<\/strong>\s*([\s\S]*?)(?:<br\s*\/?>\s*<br|<\/p>|<strong>)/i,
+    /<strong>\s*(?:Course\s+)?Pre[-\s]?[Rr]equisite(?:s|\(s\))?[^<]*<\/strong>\s*([\s\S]*?)(?:<br\s*\/?>\s*<br|<\/p>|<strong>)/i,
   );
   if (!m) return null;
   const text = decodeText(m[1]).replace(/[.;,]\s*$/, "").trim();
@@ -199,22 +244,22 @@ function parseAcalogDetail(html: string): { prefix: string; number: string; text
 
 async function scrapeAcalog(c: CollegeCatalog, maxPages: number): Promise<Record<string, PrereqEntry>> {
   console.log(`  [${c.slug}] Acalog catoid=${c.catoid} navoid=${c.navoid}`);
+  const base = c.baseUrl!;
+
+  // Pre-acquire WAF cookies: probe the catalog index; if challenged, solve via browser.
+  try {
+    const probe = await fetch(base, { headers: { "User-Agent": UA } });
+    const probeText = await probe.text();
+    if (isWafChallenge(probeText)) await acquireWafCookies(base);
+  } catch {
+    await acquireWafCookies(base);
+  }
+
   const allCoids = new Set<string>();
   let consecutiveEmpty = 0;
   for (let cpage = 1; cpage <= maxPages; cpage++) {
-    let html = await retryFetch(acalogListUrl(c, cpage), `${c.slug} list(${cpage})`);
-    let coids = extractAcalogCoids(html);
-    // AWS WAF Bot Control returns a 1991-byte challenge page on the first
-    // request after a cold start or rate-limit cooldown. If we get an
-    // empty list page, warm up again and retry once.
-    if (coids.length === 0 && cpage === 1) {
-      console.log(`    page 1 empty — re-warming session and retrying`);
-      await sleep(3000);
-      await warmupSession(c.baseUrl!);
-      await sleep(1000);
-      html = await retryFetch(acalogListUrl(c, cpage), `${c.slug} list(${cpage}) retry`);
-      coids = extractAcalogCoids(html);
-    }
+    const html = await retryFetch(acalogListUrl(c, cpage), `${c.slug} list(${cpage})`, 3, base);
+    const coids = extractAcalogCoids(html);
     if (coids.length === 0) {
       consecutiveEmpty++;
       if (consecutiveEmpty >= 2) break;
@@ -230,7 +275,7 @@ async function scrapeAcalog(c: CollegeCatalog, maxPages: number): Promise<Record
   const out: Record<string, PrereqEntry> = {};
   let done = 0;
   await pmap(coidList, CONCURRENCY, async (coid) => {
-    const html = await retryFetch(acalogDetailUrl(c, coid), `${c.slug} coid=${coid}`);
+    const html = await retryFetch(acalogDetailUrl(c, coid), `${c.slug} coid=${coid}`, 3, base);
     const parsed = parseAcalogDetail(html);
     if (parsed) {
       const key = `${parsed.prefix} ${parsed.number}`;
@@ -361,19 +406,6 @@ async function scrapeSmartCatalogIq(c: CollegeCatalog): Promise<Record<string, P
 // Main
 // ----------------------------------------------------------------------
 
-/**
- * Warm up the WAF session by hitting the catalog index page once. AWS
- * WAF Bot Control returns a 1991-byte challenge HTML on the first
- * content request unless the client has issued an index.php request
- * recently from the same origin.
- */
-async function warmupSession(baseUrl: string): Promise<void> {
-  try {
-    await retryFetch(`${baseUrl}/index.php`, `${baseUrl} warmup`);
-  } catch {
-    /* non-fatal */
-  }
-}
 
 async function main() {
   const args = process.argv.slice(2);
@@ -406,8 +438,6 @@ async function main() {
 
   for (const c of targets) {
     try {
-      // Warm up WAF session for Acalog instances before each college.
-      if (c.platform === "acalog" && c.baseUrl) await warmupSession(c.baseUrl);
       const partial = c.platform === "acalog" ? await scrapeAcalog(c, maxPages) : await scrapeSmartCatalogIq(c);
       for (const [k, v] of Object.entries(partial)) {
         // First writer wins (MnSCU common course codes mean values should match)

--- a/scripts/mn/scrape-programs-acalog.ts
+++ b/scripts/mn/scrape-programs-acalog.ts
@@ -20,11 +20,11 @@ import type { AcalogProgramConfig } from "../lib/scrape-acalog-programs.js";
 
 const COLLEGES: AcalogProgramConfig[] = [
   { collegeSlug: "anoka-technical-college", baseUrl: "https://catalog.anokatech.edu", catoidFallback: 6, programNavoids: [292], autoDiscoverCatoid: true },
-  { collegeSlug: "anoka-ramsey-community-college", baseUrl: "https://catalog.anokaramsey.edu", catoidFallback: 3, programNavoids: [141], autoDiscoverCatoid: true },
-  { collegeSlug: "century-college", baseUrl: "https://catalog.century.edu", catoidFallback: 23, programNavoids: [1602], autoDiscoverCatoid: true },
-  { collegeSlug: "dakota-county-technical-college", baseUrl: "https://catalog.dctc.edu", catoidFallback: 2, programNavoids: [43], autoDiscoverCatoid: true },
-  { collegeSlug: "inver-hills-community-college", baseUrl: "https://catalog.inverhills.edu", catoidFallback: 2, programNavoids: [40], autoDiscoverCatoid: true },
-  { collegeSlug: "saint-paul-college", baseUrl: "https://catalog.saintpaul.edu", catoidFallback: 5, programNavoids: [224], autoDiscoverCatoid: true },
+  { collegeSlug: "anoka-ramsey-community-college", baseUrl: "https://catalog.anokaramsey.edu", catoidFallback: 3, programNavoids: [141], autoDiscoverCatoid: true, usePlaywright: true },
+  { collegeSlug: "century-college", baseUrl: "https://catalog.century.edu", catoidFallback: 23, programNavoids: [1602], autoDiscoverCatoid: true, usePlaywright: true },
+  { collegeSlug: "dakota-county-technical-college", baseUrl: "https://catalog.dctc.edu", catoidFallback: 2, programNavoids: [43], autoDiscoverCatoid: true, usePlaywright: true },
+  { collegeSlug: "inver-hills-community-college", baseUrl: "https://catalog.inverhills.edu", catoidFallback: 2, programNavoids: [40], autoDiscoverCatoid: false, usePlaywright: true },
+  { collegeSlug: "saint-paul-college", baseUrl: "https://catalog.saintpaul.edu", catoidFallback: 5, programNavoids: [224], autoDiscoverCatoid: true, usePlaywright: true },
 ];
 
 async function main() {


### PR DESCRIPTION
## What changes for site users

Minnesota's prereq coverage nearly triples — from 1,197 to 3,313 mappings. Five colleges that were previously returning empty data (Anoka-Ramsey, Century, DCTC, Inver Hills, Saint Paul) now contribute prereqs. Two colleges also gain program catalogs: DCTC (92 programs) and Inver Hills (64 programs). Students searching MN courses will see prerequisite chains they couldn't see before.

## What changed technically

The 5 Acalog catalogs sit behind AWS WAF Bot Control, which returns a small JS-challenge page on the first request. The existing scraper used plain `fetch()` with Chrome-like headers and a warmup request, but cookies weren't persisted between calls — so after the first college succeeded, all subsequent colleges hit the WAF and got empty responses.

Fix: added Playwright-based cookie acquisition (same proven pattern as the TX and MS scrapers). Each Acalog college gets probed before scraping; if the response is a WAF challenge (< 5 KB + contains "awswaf"), headless Chromium solves the challenge and the session cookies are attached to all subsequent fetch requests.

Also fixed a prereq-parsing regex that missed Anoka-Ramsey's format (`Prerequisite(s) (must have a grade of C or better) or Corequisite(s):`) and `&nbsp;` separators in title tags.

| College | Before | After |
|---|---|---|
| anoka-ramsey-community-college | 0 prereqs | 225 |
| century-college | 0 | 700 |
| dakota-county-technical-college | 0 | 218 |
| inver-hills-community-college | 0 | 191 |
| saint-paul-college | 0 | 641 |
| **Total (all 8 colleges)** | **1,197** | **3,313** |

Programs added: DCTC (92) + Inver Hills (64) = 156 new programs.

## Test plan

- [x] Smoke-tested DCTC and Inver Hills prereqs with `--limit-pages 2`
- [x] Full 8-college scrape completed successfully (3,313 prereqs)
- [x] DCTC programs scrape: 92 programs
- [x] Inver Hills programs scrape: 64 programs (with `autoDiscoverCatoid: false` to use correct catoid=2)
- [x] Verified WAF cookie acquisition triggers and logs correctly for challenged colleges

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)