### PR TITLE
feat(planner): transfer-validated major plan — Phase 1 of degree-path planner

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
+++ b/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { MajorPlan, PlanCourse, TransferStatus } from "@/lib/programs/planner";
+
+interface Props {
+  plan: MajorPlan;
+  transferHref: string;
+}
+
+const STATUS_PILL: Record<TransferStatus, { label: string; cls: string }> = {
+  direct: {
+    label: "Transfers",
+    cls: "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-800",
+  },
+  elective: {
+    label: "Elective credit",
+    cls: "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 ring-amber-200 dark:ring-amber-800",
+  },
+  "no-credit": {
+    label: "No credit",
+    cls: "bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400 ring-rose-200 dark:ring-rose-800",
+  },
+};
+
+const PILL_BASE =
+  "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ring-inset";
+const PILL_MUTED =
+  "bg-gray-50 dark:bg-slate-800 text-gray-400 dark:text-slate-500 ring-gray-200 dark:ring-slate-700";
+
+export default function PlanClient({ plan, transferHref }: Props) {
+  const [uni, setUni] = useState<string>(plan.universities[0]?.slug ?? "__all__");
+
+  const allCourses = useMemo(
+    () => plan.groups.flatMap((g) => g.courses),
+    [plan.groups],
+  );
+
+  const summary = useMemo(() => {
+    let direct = 0,
+      elective = 0,
+      noCredit = 0,
+      unknown = 0;
+    for (const c of allCourses) {
+      if (uni === "__all__") {
+        if (c.acceptingCount > 0) direct += 1;
+        else unknown += 1;
+        continue;
+      }
+      const t = c.transfers[uni];
+      if (!t) unknown += 1;
+      else if (t.status === "direct") direct += 1;
+      else if (t.status === "elective") elective += 1;
+      else noCredit += 1;
+    }
+    return { direct, elective, noCredit, unknown };
+  }, [allCourses, uni]);
+
+  const selectedUniName =
+    uni === "__all__"
+      ? "any university"
+      : (plan.universities.find((u) => u.slug === uni)?.name ?? uni);
+
+  return (
+    <div className="space-y-6">
+      {/* University picker */}
+      <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 p-4">
+        <label
+          htmlFor="uni"
+          className="block text-sm font-medium text-gray-700 dark:text-slate-200"
+        >
+          Show how these courses transfer to:
+        </label>
+        <select
+          id="uni"
+          value={uni}
+          onChange={(e) => setUni(e.target.value)}
+          className="mt-2 w-full max-w-md rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="__all__">Any university (show coverage)</option>
+          {plan.universities.map((u) => (
+            <option key={u.slug} value={u.slug}>
+              {u.name} — accepts {u.accepts} of {plan.totals.listedCourses}
+            </option>
+          ))}
+        </select>
+        {plan.universities.length === 0 && (
+          <p className="mt-2 text-sm text-gray-500 dark:text-slate-400">
+            No transfer equivalencies are recorded for this program yet.
+          </p>
+        )}
+      </div>
+
+      {/* Summary line */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+        <SummaryStat
+          n={summary.direct}
+          label={uni === "__all__" ? "transfer somewhere" : "transfer directly"}
+          cls="text-emerald-700 dark:text-emerald-400"
+        />
+        {uni !== "__all__" && summary.elective > 0 && (
+          <SummaryStat
+            n={summary.elective}
+            label="as elective credit"
+            cls="text-amber-700 dark:text-amber-400"
+          />
+        )}
+        {uni !== "__all__" && summary.noCredit > 0 && (
+          <SummaryStat
+            n={summary.noCredit}
+            label="don't transfer"
+            cls="text-rose-700 dark:text-rose-400"
+          />
+        )}
+        {summary.unknown > 0 && (
+          <SummaryStat
+            n={summary.unknown}
+            label="no transfer data"
+            cls="text-gray-500 dark:text-slate-400"
+          />
+        )}
+        <SummaryStat
+          n={plan.totals.offeredThisTerm}
+          label={`offered this term (${plan.term})`}
+          cls="text-teal-700 dark:text-teal-400"
+        />
+      </div>
+
+      <p className="text-sm text-gray-600 dark:text-slate-300">
+        Showing transfer outcomes to{" "}
+        <strong className="text-gray-900 dark:text-slate-100">{selectedUniName}</strong>{" "}
+        for <strong className="text-gray-900 dark:text-slate-100">{plan.totals.listedCourses}</strong>{" "}
+        required courses at {plan.collegeName}.{" "}
+        <Link
+          href={transferHref}
+          className="text-blue-600 dark:text-blue-400 underline"
+        >
+          Browse all transfer pathways &rarr;
+        </Link>
+      </p>
+
+      {/* Requirement groups */}
+      <div className="space-y-6">
+        {plan.groups.map((g, i) => (
+          <section
+            key={`${g.name}-${i}`}
+            className="rounded-lg border border-gray-200 dark:border-slate-700"
+          >
+            <header className="flex items-baseline justify-between border-b border-gray-100 dark:border-slate-800 bg-gray-50 dark:bg-slate-800 px-4 py-2">
+              <h3 className="font-semibold text-gray-900 dark:text-slate-100">{g.name}</h3>
+              {g.creditsRequired != null && (
+                <span className="text-xs text-gray-500 dark:text-slate-400">
+                  {g.creditsRequired} credits
+                </span>
+              )}
+            </header>
+            {g.unenumerated ? (
+              <p className="px-4 py-3 text-sm text-gray-500 dark:text-slate-400">
+                This requirement is satisfied by a choice of courses the catalog
+                doesn&apos;t list individually
+                {g.chooseN ? ` (choose ${g.chooseN})` : ""}.
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+                {g.courses.map((c) => (
+                  <CourseRow key={c.code} course={c} uni={uni} />
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
+      </div>
+
+      <p className="text-xs text-gray-400 dark:text-slate-500">
+        Transfer outcomes reflect recorded course-to-course equivalencies and may
+        not capture every agreement. Confirm with your advisor and the receiving
+        university before enrolling.
+      </p>
+    </div>
+  );
+}
+
+function SummaryStat({ n, label, cls }: { n: number; label: string; cls: string }) {
+  return (
+    <span className={`font-semibold ${cls}`}>
+      {n} <span className="font-normal text-gray-500 dark:text-slate-400">{label}</span>
+    </span>
+  );
+}
+
+function CourseRow({ course, uni }: { course: PlanCourse; uni: string }) {
+  const t = uni === "__all__" ? null : course.transfers[uni];
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5">
+      <span className="font-mono text-sm font-semibold text-gray-900 dark:text-slate-100">
+        {course.code}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-gray-600 dark:text-slate-300">
+        {course.title}
+      </span>
+
+      {/* Transfer pill */}
+      {uni === "__all__" ? (
+        course.acceptingCount > 0 ? (
+          <span
+            className={`${PILL_BASE} bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-800`}
+          >
+            ✓ {course.acceptingCount} school{course.acceptingCount === 1 ? "" : "s"}
+          </span>
+        ) : (
+          <span className={`${PILL_BASE} ${PILL_MUTED}`}>no transfer data</span>
+        )
+      ) : t ? (
+        <span
+          className={`${PILL_BASE} ${STATUS_PILL[t.status].cls}`}
+          title={t.univCourse ? `→ ${t.univCourse}` : undefined}
+        >
+          {STATUS_PILL[t.status].label}
+          {t.status !== "no-credit" && t.univCourse ? ` → ${t.univCourse}` : ""}
+        </span>
+      ) : (
+        <span className={`${PILL_BASE} ${PILL_MUTED}`}>no transfer data</span>
+      )}
+
+      {/* Section availability */}
+      {course.sectionsThisTerm > 0 ? (
+        <span className="text-xs text-teal-700 dark:text-teal-400">
+          {course.sectionsThisTerm} section{course.sectionsThisTerm === 1 ? "" : "s"}
+        </span>
+      ) : (
+        <span className="text-xs text-gray-400 dark:text-slate-500">
+          not offered this term
+        </span>
+      )}
+    </li>
+  );
+}

--- a/app/[state]/college/[id]/program/[slug]/page.tsx
+++ b/app/[state]/college/[id]/program/[slug]/page.tsx
@@ -1,0 +1,108 @@
+/**
+ * Transfer-Validated Major Plan — Phase 1 of the Degree-Path Planner.
+ *
+ * e.g. `/ga/college/atlanta-tech/program/business-management-aas`
+ *
+ * For one college program, shows every required course with a per-university
+ * transfer verdict (direct / elective / no-credit) and live section counts —
+ * the cross-dataset join that the separate search / transfer / schedule tools
+ * make the student assemble by hand. See lib/programs/planner.ts.
+ *
+ * ISR (1 day), same cadence as the college page. University selection happens
+ * client-side from a tiny server-built payload, so the route stays static and
+ * never opts into dynamic rendering (cf. the college page's searchParams note).
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
+import { loadInstitutions } from "@/lib/institutions";
+import { buildMajorPlan } from "@/lib/programs/planner";
+import { termLabel } from "@/lib/terms";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import PlanClient from "./PlanClient";
+
+export const revalidate = 86400; // 1 day
+export const dynamicParams = true;
+
+interface PageProps {
+  params: Promise<{ state: string; id: string; slug: string }>;
+}
+
+function siteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { state, id, slug } = await props.params;
+  if (!isValidState(state)) return {};
+  const plan = await buildMajorPlan(state, id, slug).catch(() => null);
+  if (!plan) return {};
+  const title = `${plan.program.title} (${plan.program.credential}) at ${plan.collegeName} — Transfer Plan`;
+  const description = `Every required course for the ${plan.program.title} ${plan.program.credential} at ${plan.collegeName}, with which transfer to your target university and which are offered this term.`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `${siteUrl()}/${state}/college/${id}/program/${slug}` },
+  };
+}
+
+export default async function MajorPlanPage(props: PageProps) {
+  const { state, id, slug } = await props.params;
+  if (!isValidState(state)) notFound();
+  const config = requireStateConfig(state);
+
+  const institution = loadInstitutions(state).find((i) => i.id === id);
+  if (!institution) notFound();
+
+  const plan = await buildMajorPlan(state, id, slug);
+  if (!plan) notFound();
+
+  const collegeHref = `/${state}/college/${id}`;
+  const transferHref = `/${state}/transfer`;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8">
+      <Breadcrumbs
+        siteUrl={siteUrl()}
+        items={[
+          { name: "Home", href: "/" },
+          { name: config.name, href: `/${state}` },
+          { name: plan.collegeName, href: collegeHref },
+          {
+            name: `${plan.program.title} plan`,
+            href: `/${state}/college/${id}/program/${slug}`,
+          },
+        ]}
+      />
+
+      <header className="mb-6 mt-4">
+        <p className="text-sm font-medium uppercase tracking-wide text-blue-600 dark:text-blue-400">
+          Transfer plan
+        </p>
+        <h1 className="mt-1 text-2xl font-bold text-gray-900 dark:text-slate-100 sm:text-3xl">
+          {plan.program.title}{" "}
+          <span className="text-gray-400 dark:text-slate-500">({plan.program.credential})</span>
+        </h1>
+        <p className="mt-1 text-gray-600 dark:text-slate-300">
+          at{" "}
+          <a href={collegeHref} className="text-blue-600 dark:text-blue-400 underline">
+            {plan.collegeName}
+          </a>
+          {plan.program.totalCredits ? ` · ${plan.program.totalCredits} credits` : ""}
+          {plan.term ? ` · sections shown for ${termLabel(plan.term)}` : ""}
+        </p>
+        {plan.program.catalogUrl && (
+          <p className="mt-1 text-xs text-gray-400 dark:text-slate-500">
+            <a href={plan.program.catalogUrl} className="underline" rel="nofollow">
+              Official catalog →
+            </a>
+          </p>
+        )}
+      </header>
+
+      <PlanClient plan={plan} transferHref={transferHref} />
+    </main>
+  );
+}

--- a/app/[state]/college/[id]/programs/page.tsx
+++ b/app/[state]/college/[id]/programs/page.tsx
@@ -156,7 +156,12 @@ export default async function CollegeProgramsPage(props: PageProps) {
       </header>
 
       {programs.length > 0 && (
-        <ProgramList state={state} programs={programs} availability={availability} />
+        <ProgramList
+          state={state}
+          collegeId={id}
+          programs={programs}
+          availability={availability}
+        />
       )}
 
       <div className="mt-10 pt-6 border-t border-gray-200 dark:border-slate-700">

--- a/components/ProgramRequirements.tsx
+++ b/components/ProgramRequirements.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { countRealCourses, programSlug, PLAN_MIN_COURSES } from "@/lib/programs/plan-shared";
 import type { ProgramRequirement } from "@/lib/types";
 import type { Institution } from "@/lib/types";
 
@@ -18,11 +19,14 @@ export type AvailabilityRecord = Record<string, number>;
 function ProgramCard({
   program,
   state,
+  collegeId,
   defaultOpen,
   availability,
 }: {
   program: ProgramRequirement;
   state: string;
+  /** When set, render a link to this program's transfer-validated plan. */
+  collegeId?: string;
   defaultOpen?: boolean;
   availability?: AvailabilityRecord;
 }) {
@@ -32,6 +36,11 @@ function ProgramCard({
     program.credential === "other"
       ? ""
       : ` (${program.credential.toUpperCase()})`;
+
+  const planHref =
+    collegeId && countRealCourses(program) >= PLAN_MIN_COURSES
+      ? `/${state}/college/${collegeId}/program/${programSlug(program)}`
+      : null;
 
   return (
     <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900">
@@ -81,6 +90,17 @@ function ProgramCard({
           />
         </svg>
       </button>
+
+      {planHref && (
+        <div className="border-t border-gray-100 dark:border-slate-800 px-4 py-2">
+          <Link
+            href={planHref}
+            className="inline-flex items-center text-xs font-medium text-teal-700 dark:text-teal-400 hover:underline"
+          >
+            See transfer plan — which courses transfer &amp; what&apos;s offered &rarr;
+          </Link>
+        </div>
+      )}
 
       {open && (
         <div className="border-t border-gray-200 dark:border-slate-700 px-4 py-3 space-y-4">
@@ -297,10 +317,12 @@ export default function ProgramRequirements({
 
 export function ProgramList({
   state,
+  collegeId,
   programs,
   availability,
 }: {
   state: string;
+  collegeId?: string;
   programs: ProgramRequirement[];
   availability?: AvailabilityRecord;
 }) {
@@ -339,7 +361,13 @@ export function ProgramList({
             {progs
               .sort((a, b) => a.title.localeCompare(b.title))
               .map((prog, pi) => (
-                <ProgramCard key={pi} program={prog} state={state} availability={availability} />
+                <ProgramCard
+                  key={pi}
+                  program={prog}
+                  state={state}
+                  collegeId={collegeId}
+                  availability={availability}
+                />
               ))}
           </div>
         </section>

--- a/lib/programs/__tests__/plan-shared.test.ts
+++ b/lib/programs/__tests__/plan-shared.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRealCourse,
+  countRealCourses,
+  programSlug,
+  PLAN_MIN_COURSES,
+} from "../plan-shared";
+import type { RequirementGroup } from "@/lib/types";
+
+describe("isRealCourse", () => {
+  it("accepts a normal course code", () => {
+    expect(isRealCourse({ prefix: "MGMT", number: "1100" })).toBe(true);
+    expect(isRealCourse({ prefix: "BIO", number: "101LAB" })).toBe(true);
+  });
+
+  it("rejects XXX placeholders in either field", () => {
+    expect(isRealCourse({ prefix: "ELEC", number: "XXX" })).toBe(false);
+    expect(isRealCourse({ prefix: "XXX", number: "100" })).toBe(false);
+    expect(isRealCourse({ prefix: "MGNT", number: "0XXX" })).toBe(false);
+  });
+
+  it("rejects a number with no digit (label, not a course)", () => {
+    expect(isRealCourse({ prefix: "ELEC", number: "Elective" })).toBe(false);
+    expect(isRealCourse({ prefix: "HUM", number: "" })).toBe(false);
+  });
+});
+
+describe("countRealCourses", () => {
+  const groups = (courses: Array<{ prefix: string; number: string }>): RequirementGroup[] => [
+    {
+      name: "G",
+      credits_required: null,
+      choose_n: null,
+      courses: courses.map((c) => ({ ...c, title: "", credits: null, or_alternatives: [] })),
+    },
+  ];
+
+  it("counts only real courses across groups", () => {
+    const p = {
+      requirement_groups: [
+        ...groups([
+          { prefix: "MGMT", number: "1100" },
+          { prefix: "ELEC", number: "XXX" },
+        ]),
+        ...groups([{ prefix: "ACCT", number: "2101" }]),
+      ],
+    };
+    expect(countRealCourses(p)).toBe(2);
+  });
+
+  it("returns 0 for an all-placeholder program (the NJ failure mode)", () => {
+    const p = { requirement_groups: groups([{ prefix: "ELEC", number: "XXX" }]) };
+    expect(countRealCourses(p)).toBe(0);
+  });
+});
+
+describe("programSlug", () => {
+  it("produces a stable, URL-safe slug from title + credential", () => {
+    expect(programSlug({ title: "Business Management AAS", credential: "AS" })).toBe(
+      "business-management-aas-as",
+    );
+    expect(programSlug({ title: "Nursing", credential: "AAS" })).toBe("nursing-aas");
+  });
+
+  it("collapses punctuation and trims separators", () => {
+    expect(
+      programSlug({ title: "Accounting for Forensic Accounting", credential: "AS" }),
+    ).toBe("accounting-for-forensic-accounting-as");
+    expect(programSlug({ title: "  A/B & C!  ", credential: "other" })).toBe("a-b-c-other");
+  });
+});
+
+describe("PLAN_MIN_COURSES", () => {
+  it("is a sane gate", () => {
+    expect(PLAN_MIN_COURSES).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/lib/programs/plan-shared.ts
+++ b/lib/programs/plan-shared.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helpers shared between the server-side planner (lib/programs/planner.ts)
+ * and client components (e.g. the program list). NO server-only imports (fs,
+ * supabase) — safe to pull into a client bundle.
+ */
+
+import type { RequirementGroup } from "@/lib/types";
+
+/** A program needs this many real courses before a plan is worth rendering. */
+export const PLAN_MIN_COURSES = 5;
+
+/** A "real" course has a digit in its number and is not an XXX placeholder. */
+export function isRealCourse(c: { prefix: string; number: string }): boolean {
+  const num = String(c.number ?? "");
+  const pre = String(c.prefix ?? "");
+  if (pre.toUpperCase().includes("XXX") || num.toUpperCase().includes("XXX")) {
+    return false;
+  }
+  return /\d/.test(num);
+}
+
+/** Count the real (non-placeholder) courses listed in a program's groups. */
+export function countRealCourses(p: { requirement_groups: RequirementGroup[] }): number {
+  return p.requirement_groups.flatMap((g) => g.courses).filter(isRealCourse).length;
+}
+
+/** Stable, unique-within-college slug for a program: title + credential. */
+export function programSlug(p: { title: string; credential: string }): string {
+  return `${p.title} ${p.credential}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/lib/programs/planner.ts
+++ b/lib/programs/planner.ts
@@ -1,0 +1,307 @@
+/**
+ * Transfer-Validated Major Plan — Phase 1 of the Degree-Path Planner.
+ *
+ * Joins three datasets we already hold, for ONE college program:
+ *   1. programs   (data/{state}/programs/{college}.json) — what's required
+ *   2. transfer   (data/{state}/transfer-equiv.json)     — will it transfer
+ *   3. sections   (data/{state}/courses/{college}/*.json) — offered this term
+ *
+ * The result is a per-course checklist: each required course shows whether it
+ * transfers to the student's target university (direct / elective / no-credit /
+ * unknown) and how many live sections exist. Prereq-based term *sequencing* is
+ * deliberately NOT attempted here — see project memory: national inline-prereq
+ * coverage is too thin (42% of colleges at 0%) to sequence reliably. Phase 2
+ * layers that in, piloting in GA where all four datasets line up.
+ *
+ * Data-honesty rule (CLAUDE.md invariant #4): never fabricate a course or a
+ * transfer match. Un-enumerated requirement groups (e.g. "choose from Gen-Ed")
+ * are surfaced honestly as having no listed courses rather than invented.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { loadCollegePrograms } from "@/lib/programs/requirements";
+import { loadTransferMappings } from "@/lib/transfer";
+import { loadInstitutions } from "@/lib/institutions";
+import { getCurrentTerm } from "@/lib/terms";
+import {
+  isRealCourse,
+  countRealCourses,
+  programSlug,
+  PLAN_MIN_COURSES,
+} from "@/lib/programs/plan-shared";
+import type { RequiredCourse } from "@/lib/types";
+
+// Re-export the pure helpers so existing `@/lib/programs/planner` imports work.
+export { isRealCourse, countRealCourses, programSlug, PLAN_MIN_COURSES };
+
+export type TransferStatus = "direct" | "elective" | "no-credit";
+
+/** One university's verdict on a single required course. */
+export interface CourseTransfer {
+  universitySlug: string;
+  universityName: string;
+  status: TransferStatus;
+  /** The receiving course code, e.g. "ACCT 2101" or "BUS 1XXX". */
+  univCourse: string;
+}
+
+export interface PlanCourse {
+  prefix: string;
+  number: string;
+  code: string; // "PREFIX NUMBER"
+  title: string;
+  credits: number | null;
+  alternatives: Array<{ prefix: string; number: string; title: string }>;
+  /** Per-university transfer verdicts, keyed by university slug. Tiny payload. */
+  transfers: Record<string, CourseTransfer>;
+  /** Distinct universities that grant *some* credit (direct or elective). */
+  acceptingCount: number;
+  /** Live sections at this college in the active term. */
+  sectionsThisTerm: number;
+}
+
+export interface PlanGroup {
+  name: string;
+  creditsRequired: number | null;
+  chooseN: number | null;
+  courses: PlanCourse[];
+  /** True when the catalog group lists no concrete courses (e.g. gen-ed pick). */
+  unenumerated: boolean;
+}
+
+export interface PlanUniversity {
+  slug: string;
+  name: string;
+  /** How many of this program's required courses transfer to this university. */
+  accepts: number;
+}
+
+export interface MajorPlan {
+  state: string;
+  collegeId: string;
+  collegeName: string;
+  collegeSlug: string;
+  term: string;
+  program: {
+    title: string;
+    credential: string;
+    slug: string;
+    catalogUrl: string;
+    totalCredits: number | null;
+    gpaMinimum: number | null;
+  };
+  groups: PlanGroup[];
+  /** Universities that accept ≥1 required course, ranked by coverage. */
+  universities: PlanUniversity[];
+  totals: {
+    listedCourses: number;
+    offeredThisTerm: number;
+  };
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+/** Join key: uppercase, whitespace-stripped. "MGMT 1100" → "MGMT1100". */
+function joinKey(prefix: string, number: string): string {
+  return `${prefix}${number}`.toUpperCase().replace(/\s+/g, "");
+}
+
+/** Count sections per course code for a college+term, read from local JSON. */
+function sectionCountsFromFiles(
+  state: string,
+  collegeSlug: string,
+  term: string,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  const file = path.join(
+    process.cwd(),
+    "data",
+    state,
+    "courses",
+    collegeSlug,
+    `${term}.json`,
+  );
+  if (!fs.existsSync(file)) return counts;
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, "utf-8")) as
+      | Array<Record<string, unknown>>
+      | { sections?: Array<Record<string, unknown>> };
+    const sections = Array.isArray(raw) ? raw : (raw.sections ?? []);
+    for (const s of sections) {
+      const key = joinKey(String(s.course_prefix ?? ""), String(s.course_number ?? ""));
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  } catch {
+    // unreadable term file — treat as no availability data
+  }
+  return counts;
+}
+
+/** Pick the most relevant term that actually has a JSON file for this college. */
+function resolveTerm(
+  state: string,
+  collegeSlug: string,
+  preferred: string,
+): string | null {
+  const dir = path.join(process.cwd(), "data", state, "courses", collegeSlug);
+  if (!fs.existsSync(dir)) return null;
+  const terms = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => f.replace(/\.json$/, ""));
+  if (terms.length === 0) return null;
+  if (terms.includes(preferred)) return preferred;
+  // Otherwise the lexicographically-largest term code (e.g. 2026SU > 2026SP).
+  return terms.sort()[terms.length - 1];
+}
+
+// ── program discovery ───────────────────────────────────────────────────────
+
+/** Programs at a college that have enough real courses to build a plan. */
+export async function listPlannableProgramsForCollege(
+  state: string,
+  collegeSlug: string,
+): Promise<Array<{ slug: string; title: string; credential: string; courseCount: number }>> {
+  const programs = await loadCollegePrograms(state, collegeSlug);
+  const out: Array<{ slug: string; title: string; credential: string; courseCount: number }> = [];
+  for (const p of programs) {
+    const courseCount = countRealCourses(p);
+    if (courseCount >= PLAN_MIN_COURSES) {
+      out.push({ slug: programSlug(p), title: p.title, credential: p.credential, courseCount });
+    }
+  }
+  return out.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+// ── the join ────────────────────────────────────────────────────────────────
+
+/**
+ * Build the transfer-validated plan for one college program. Returns null when
+ * the college, program, or program's real-course list can't be resolved
+ * (callers should `notFound()`).
+ */
+export async function buildMajorPlan(
+  state: string,
+  collegeId: string,
+  slug: string,
+): Promise<MajorPlan | null> {
+  const institution = loadInstitutions(state).find((i) => i.id === collegeId);
+  if (!institution) return null;
+  const collegeSlug = institution.college_slug;
+
+  const programs = await loadCollegePrograms(state, collegeSlug);
+  const program = programs.find((p) => programSlug(p) === slug);
+  if (!program) return null;
+
+  // Gate on real courses — never render a plan from placeholders.
+  if (countRealCourses(program) < PLAN_MIN_COURSES) return null;
+
+  // Sections for the active term (local JSON; bundled in prod).
+  const preferredTerm = await getCurrentTerm(state).catch(() => "");
+  const term = resolveTerm(state, collegeSlug, preferredTerm) ?? preferredTerm;
+  const sectionCounts = term ? sectionCountsFromFiles(state, collegeSlug, term) : new Map();
+
+  // Index transfer mappings by join key for fast per-course lookup.
+  const mappings = await loadTransferMappings(state);
+  const transferIndex = new Map<string, CourseTransfer[]>();
+  for (const m of mappings) {
+    const key = joinKey(m.cc_prefix, m.cc_number);
+    const status: TransferStatus = m.no_credit
+      ? "no-credit"
+      : m.is_elective
+        ? "elective"
+        : "direct";
+    const arr = transferIndex.get(key) ?? [];
+    arr.push({
+      universitySlug: m.university,
+      universityName: m.university_name,
+      status,
+      univCourse: m.univ_course,
+    });
+    transferIndex.set(key, arr);
+  }
+
+  const uniCoverage = new Map<string, { name: string; accepts: number }>();
+  let offeredThisTerm = 0;
+  let listedCourses = 0;
+
+  const groups: PlanGroup[] = program.requirement_groups.map((g) => {
+    const real = g.courses.filter(isRealCourse);
+    const courses: PlanCourse[] = real.map((c: RequiredCourse) => {
+      const key = joinKey(c.prefix, c.number);
+      const rawMappings = transferIndex.get(key) ?? [];
+
+      // Collapse to one verdict per university (prefer direct > elective > no-credit).
+      const byUni: Record<string, CourseTransfer> = {};
+      for (const t of rawMappings) {
+        const existing = byUni[t.universitySlug];
+        if (!existing || rank(t.status) < rank(existing.status)) {
+          byUni[t.universitySlug] = t;
+        }
+      }
+
+      let acceptingCount = 0;
+      for (const t of Object.values(byUni)) {
+        if (t.status !== "no-credit") {
+          acceptingCount += 1;
+          const cov = uniCoverage.get(t.universitySlug) ?? { name: t.universityName, accepts: 0 };
+          cov.accepts += 1;
+          uniCoverage.set(t.universitySlug, cov);
+        }
+      }
+
+      const sections = sectionCounts.get(key) ?? 0;
+      if (sections > 0) offeredThisTerm += 1;
+      listedCourses += 1;
+
+      return {
+        prefix: c.prefix,
+        number: c.number,
+        code: `${c.prefix} ${c.number}`,
+        title: c.title,
+        credits: c.credits,
+        alternatives: c.or_alternatives ?? [],
+        transfers: byUni,
+        acceptingCount,
+        sectionsThisTerm: sections,
+      };
+    });
+
+    return {
+      name: g.name,
+      creditsRequired: g.credits_required,
+      chooseN: g.choose_n,
+      courses,
+      unenumerated: real.length === 0,
+    };
+  });
+
+  const universities: PlanUniversity[] = [...uniCoverage.entries()]
+    .map(([slugU, v]) => ({ slug: slugU, name: v.name, accepts: v.accepts }))
+    .sort((a, b) => b.accepts - a.accepts || a.name.localeCompare(b.name));
+
+  return {
+    state,
+    collegeId,
+    collegeName: institution.name,
+    collegeSlug,
+    term,
+    program: {
+      title: program.title,
+      credential: program.credential,
+      slug,
+      catalogUrl: program.catalog_url,
+      totalCredits: program.total_credits,
+      gpaMinimum: program.gpa_minimum,
+    },
+    groups,
+    universities,
+    totals: { listedCourses, offeredThisTerm },
+  };
+}
+
+/** direct beats elective beats no-credit when a course maps multiple ways. */
+function rank(s: TransferStatus): number {
+  return s === "direct" ? 0 : s === "elective" ? 1 : 2;
+}


### PR DESCRIPTION
## What changes for someone using the site

There's a new page that answers the question a student actually has — *"if I do this program, which courses will transfer to my target university, and which can I take this term?"* — instead of making them assemble it by hand across the search, transfer, and schedule tools.

Open any college's **Programs** page and each program now has a **"See transfer plan →"** link. The plan page (e.g. `/ga/college/atlanta-tech/program/business-management-aas-as`) lists every required course, and a university dropdown lets the student pick their transfer target. For the chosen university each course gets a badge — **Transfers** (direct, with the receiving course code), **Elective credit**, or **No credit** — plus how many sections are offered this term. The university list is ranked by how much of the degree each school accepts (e.g. *"University of West Georgia — accepts 24 of 26"*).

Two real examples it renders today:
- **GA · Atlanta Technical College · Business Management AAS** → mostly *elective* credit to UWG (technical-college courses map to lower-division electives), `ACCT 1100 → ACCT 2101` direct, `FYES 1001` no-credit.
- **NY · LaGuardia · Nursing AAS** → CUNY schools accept **19 of 20**, 8 transfer directly, all 20 offered this term.

## What changes technically

This is the **data join** behind the "Degree-Path Planner" idea — composing three datasets we already hold rather than scraping anything new:

- `lib/programs/planner.ts` — `buildMajorPlan(state, collegeId, slug)` flattens a program's required courses and joins each to (a) its transfer mappings across all universities (`transfer-equiv.json`) and (b) live section counts (read from local `data/{state}/courses/{college}/{term}.json`, bundled in prod). Returns a tiny per-course payload so university switching happens **client-side** — the route stays static, no dynamic rendering.
- `lib/programs/plan-shared.ts` — pure helpers (`programSlug`, `countRealCourses`, `isRealCourse`) split out so the client `ProgramList` can import them without pulling `fs`/supabase into the bundle.
- New route `app/[state]/college/[id]/program/[slug]/` (server page + `PlanClient`).
- `components/ProgramRequirements.tsx` — optional `collegeId` prop renders the per-program plan link (backward-compatible; the program-hub page passes nothing and is unchanged).

### Deliberate scope / known gaps
- **No prereq sequencing.** This is a checklist, not a term-by-term schedule. National inline-prereq coverage is too thin (42% of colleges at 0%) to sequence reliably — that's Phase 2, piloting in GA where all four datasets align on the same courses.
- **Data-honesty gates** (CLAUDE.md invariant #4): a program needs ≥5 real courses or no plan renders — so the NJ `ELEC XXX` scrape failure mode can't produce a fake plan. Un-enumerated gen-ed groups ("choose from Common Core") are surfaced as such, not invented.
- Only states with program data (20 today) expose plans; others simply show no link.

## Test plan
- ✅ `tsc --noEmit` — zero errors in new/changed files.
- ✅ `eslint` — clean (one pre-existing unused-import warning, not introduced here).
- ✅ 8 unit tests on the pure join helpers (`plan-shared.test.ts`) pass.
- ✅ Verified end-to-end in local dev (dark mode, university selector recomputes, no console errors) on GA + NY.
- ✅ `next build` — **compiles successfully** (`✓ Compiled successfully`). The full static export can't complete *in the sandbox* because Supabase is unreachable here and the pre-existing `/sitemap/transfer.xml` route times out — unrelated to this change; Vercel builds it fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)