### PR TITLE
feat(planner): suggested term-by-term sequence — Phase 2 of degree-path planner

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
+++ b/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import type { MajorPlan, PlanCourse, TransferStatus } from "@/lib/programs/planner";
+import type { MajorPlan, PlanCourse, PlanTerm, TransferStatus } from "@/lib/programs/planner";
 
 interface Props {
   plan: MajorPlan;
@@ -31,6 +31,7 @@ const PILL_MUTED =
 
 export default function PlanClient({ plan, transferHref }: Props) {
   const [uni, setUni] = useState<string>(plan.universities[0]?.slug ?? "__all__");
+  const [view, setView] = useState<"requirements" | "sequence">("requirements");
 
   const allCourses = useMemo(
     () => plan.groups.flatMap((g) => g.courses),
@@ -140,43 +141,123 @@ export default function PlanClient({ plan, transferHref }: Props) {
         </Link>
       </p>
 
-      {/* Requirement groups */}
-      <div className="space-y-6">
-        {plan.groups.map((g, i) => (
-          <section
-            key={`${g.name}-${i}`}
-            className="rounded-lg border border-gray-200 dark:border-slate-700"
-          >
-            <header className="flex items-baseline justify-between border-b border-gray-100 dark:border-slate-800 bg-gray-50 dark:bg-slate-800 px-4 py-2">
-              <h3 className="font-semibold text-gray-900 dark:text-slate-100">{g.name}</h3>
-              {g.creditsRequired != null && (
-                <span className="text-xs text-gray-500 dark:text-slate-400">
-                  {g.creditsRequired} credits
-                </span>
+      {/* View toggle — only when a meaningful sequence is available */}
+      {plan.sequence && (
+        <div className="flex items-center gap-1 rounded-lg bg-gray-100 dark:bg-slate-800 p-1 w-fit">
+          <ToggleButton active={view === "requirements"} onClick={() => setView("requirements")}>
+            By requirement
+          </ToggleButton>
+          <ToggleButton active={view === "sequence"} onClick={() => setView("sequence")}>
+            Suggested sequence
+          </ToggleButton>
+        </div>
+      )}
+
+      {view === "sequence" && plan.sequence ? (
+        <SequenceView terms={plan.sequence.terms} uni={uni} coverage={plan.sequence.prereqCoverage} />
+      ) : (
+        /* Requirement groups */
+        <div className="space-y-6">
+          {plan.groups.map((g, i) => (
+            <section
+              key={`${g.name}-${i}`}
+              className="rounded-lg border border-gray-200 dark:border-slate-700"
+            >
+              <header className="flex items-baseline justify-between border-b border-gray-100 dark:border-slate-800 bg-gray-50 dark:bg-slate-800 px-4 py-2">
+                <h3 className="font-semibold text-gray-900 dark:text-slate-100">{g.name}</h3>
+                {g.creditsRequired != null && (
+                  <span className="text-xs text-gray-500 dark:text-slate-400">
+                    {g.creditsRequired} credits
+                  </span>
+                )}
+              </header>
+              {g.unenumerated ? (
+                <p className="px-4 py-3 text-sm text-gray-500 dark:text-slate-400">
+                  This requirement is satisfied by a choice of courses the catalog
+                  doesn&apos;t list individually
+                  {g.chooseN ? ` (choose ${g.chooseN})` : ""}.
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+                  {g.courses.map((c) => (
+                    <CourseRow key={c.code} course={c} uni={uni} />
+                  ))}
+                </ul>
               )}
-            </header>
-            {g.unenumerated ? (
-              <p className="px-4 py-3 text-sm text-gray-500 dark:text-slate-400">
-                This requirement is satisfied by a choice of courses the catalog
-                doesn&apos;t list individually
-                {g.chooseN ? ` (choose ${g.chooseN})` : ""}.
-              </p>
-            ) : (
-              <ul className="divide-y divide-gray-100 dark:divide-slate-800">
-                {g.courses.map((c) => (
-                  <CourseRow key={c.code} course={c} uni={uni} />
-                ))}
-              </ul>
-            )}
-          </section>
-        ))}
-      </div>
+            </section>
+          ))}
+        </div>
+      )}
 
       <p className="text-xs text-gray-400 dark:text-slate-500">
         Transfer outcomes reflect recorded course-to-course equivalencies and may
         not capture every agreement. Confirm with your advisor and the receiving
         university before enrolling.
       </p>
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
+        active
+          ? "bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 shadow-sm"
+          : "text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-300"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SequenceView({
+  terms,
+  uni,
+  coverage,
+}: {
+  terms: PlanTerm[];
+  uni: string;
+  coverage: number;
+}) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 dark:text-slate-300">
+        A suggested order to take these courses, based on recorded prerequisites
+        ({Math.round(coverage * 100)}% of courses have prerequisite data). This is
+        a starting point — your advisor sets the official sequence.
+      </p>
+      {terms.map((t) => (
+        <section
+          key={t.index}
+          className="rounded-lg border border-gray-200 dark:border-slate-700"
+        >
+          <header className="flex items-baseline justify-between border-b border-gray-100 dark:border-slate-800 bg-gray-50 dark:bg-slate-800 px-4 py-2">
+            <h3 className="font-semibold text-gray-900 dark:text-slate-100">
+              Term {t.index}
+            </h3>
+            <span className="text-xs text-gray-500 dark:text-slate-400">
+              {t.credits} credits
+            </span>
+          </header>
+          <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+            {t.courses.map((c) => (
+              <CourseRow key={c.code} course={c} uni={uni} />
+            ))}
+          </ul>
+        </section>
+      ))}
     </div>
   );
 }

--- a/lib/programs/__tests__/sequence.test.ts
+++ b/lib/programs/__tests__/sequence.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildSequence } from "../planner";
+import type { PlanCourse, PlanGroup } from "../planner";
+
+// Minimal PlanCourse factory — only the fields buildSequence reads matter.
+function course(prefix: string, number: string, credits = 3): PlanCourse {
+  return {
+    prefix,
+    number,
+    code: `${prefix} ${number}`,
+    title: `${prefix} ${number}`,
+    credits,
+    alternatives: [],
+    transfers: {},
+    acceptingCount: 0,
+    sectionsThisTerm: 0,
+  };
+}
+
+function group(courses: PlanCourse[], chooseN: number | null = null): PlanGroup {
+  return { name: "G", creditsRequired: null, chooseN, courses, unenumerated: false };
+}
+
+function prereqMap(entries: Record<string, string[]>): Map<string, { text: string; courses: string[] }> {
+  return new Map(Object.entries(entries).map(([k, v]) => [k, { text: "", courses: v }]));
+}
+
+const termOf = (seq: NonNullable<ReturnType<typeof buildSequence>>, code: string) =>
+  seq.terms.find((t) => t.courses.some((c) => c.code === code))!.index;
+
+describe("buildSequence", () => {
+  it("orders a prereq chain across terms (A → B → C)", () => {
+    const groups = [group([course("ENG", "101"), course("ENG", "102"), course("ENG", "201")])];
+    const seq = buildSequence(groups, prereqMap({ "ENG 102": ["ENG 101"], "ENG 201": ["ENG 102"] }));
+    expect(seq).not.toBeNull();
+    expect(termOf(seq!, "ENG 102")).toBeGreaterThan(termOf(seq!, "ENG 101"));
+    expect(termOf(seq!, "ENG 201")).toBeGreaterThan(termOf(seq!, "ENG 102"));
+  });
+
+  it("ignores prereqs outside the program (no false ordering edge)", () => {
+    // BUS 101→100 and BUS 102→101 are intra edges (pass the gate). BUS 200's
+    // only prereq (MAT 150) is OUTSIDE the program → it must stay in term 1.
+    const seq = buildSequence(
+      [group([course("BUS", "100"), course("BUS", "101"), course("BUS", "102"), course("BUS", "200")])],
+      prereqMap({ "BUS 101": ["BUS 100"], "BUS 102": ["BUS 101"], "BUS 200": ["MAT 150"] }),
+    );
+    expect(seq).not.toBeNull();
+    expect(termOf(seq!, "BUS 200")).toBe(1);
+  });
+
+  it("caps credits per term (6 × 3cr courses split across terms at cap 16)", () => {
+    const six = Array.from({ length: 6 }, (_, i) => course("ART", `10${i}`));
+    // Give them a light chain so coverage/edges pass the gate.
+    const seq = buildSequence([group(six)], prereqMap({ "ART 101": ["ART 100"], "ART 102": ["ART 100"] }));
+    expect(seq).not.toBeNull();
+    // 18 credits total, cap 16 → at least 2 terms.
+    expect(seq!.terms.length).toBeGreaterThanOrEqual(2);
+    for (const t of seq!.terms) expect(t.credits).toBeLessThanOrEqual(16);
+  });
+
+  it("returns null when prereq coverage is too thin to order", () => {
+    const groups = [group([course("X", "1"), course("X", "2"), course("X", "3"), course("X", "4")])];
+    expect(buildSequence(groups, prereqMap({}))).toBeNull();
+  });
+
+  it("sequences only N representatives of a choose-N group", () => {
+    const seq = buildSequence(
+      [
+        group([course("CORE", "1"), course("CORE", "2"), course("CORE", "3")]),
+        group([course("OPT", "1"), course("OPT", "2")], 1), // choose 1 of 2
+      ],
+      prereqMap({ "CORE 2": ["CORE 1"], "CORE 3": ["CORE 2"] }),
+    );
+    expect(seq).not.toBeNull();
+    const codes = seq!.terms.flatMap((t) => t.courses.map((c) => c.code));
+    expect(codes).toContain("OPT 1");
+    expect(codes).not.toContain("OPT 2"); // only the first of the choose-1 group
+  });
+});

--- a/lib/programs/planner.ts
+++ b/lib/programs/planner.ts
@@ -23,6 +23,7 @@ import * as path from "path";
 import { loadCollegePrograms } from "@/lib/programs/requirements";
 import { loadTransferMappings } from "@/lib/transfer";
 import { loadInstitutions } from "@/lib/institutions";
+import { loadPrereqs } from "@/lib/prereqs";
 import { getCurrentTerm } from "@/lib/terms";
 import {
   isRealCourse,
@@ -98,6 +99,28 @@ export interface MajorPlan {
     listedCourses: number;
     offeredThisTerm: number;
   };
+  /**
+   * Suggested term-by-term ordering (Phase 2). Null when prereq coverage is
+   * too thin for the ordering to mean anything — the UI then shows only the
+   * requirement checklist. This is a *suggestion* from recorded prerequisites,
+   * not an official advising sequence.
+   */
+  sequence: PlanSequence | null;
+}
+
+export interface PlanTerm {
+  /** 1-based term position. */
+  index: number;
+  courses: PlanCourse[];
+  credits: number;
+}
+
+export interface PlanSequence {
+  terms: PlanTerm[];
+  /** Fraction of sequenced courses that had any recorded prerequisite data. */
+  prereqCoverage: number;
+  /** Credit ceiling used when packing courses into a term. */
+  creditsPerTerm: number;
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────
@@ -281,6 +304,8 @@ export async function buildMajorPlan(
     .map(([slugU, v]) => ({ slug: slugU, name: v.name, accepts: v.accepts }))
     .sort((a, b) => b.accepts - a.accepts || a.name.localeCompare(b.name));
 
+  const sequence = buildSequence(groups, loadPrereqs(state));
+
   return {
     state,
     collegeId,
@@ -298,10 +323,111 @@ export async function buildMajorPlan(
     groups,
     universities,
     totals: { listedCourses, offeredThisTerm },
+    sequence,
   };
 }
 
 /** direct beats elective beats no-credit when a course maps multiple ways. */
 function rank(s: TransferStatus): number {
   return s === "direct" ? 0 : s === "elective" ? 1 : 2;
+}
+
+// ── Phase 2: suggested term-by-term sequence ────────────────────────────────
+
+/** Credits packed into one term before opening the next. */
+const TERM_CREDIT_CAP = 16;
+/** Below this prereq coverage the ordering is noise — show only the checklist. */
+const SEQUENCE_MIN_COVERAGE = 0.25;
+
+/**
+ * Order a program's courses into credit-capped terms using recorded
+ * prerequisites *among the program's own courses*. Returns null when there's
+ * too little prereq signal for the ordering to be meaningful. Cycle-safe.
+ *
+ * Honesty: this is a suggestion derived from `prereqs.json`, not an official
+ * advising sequence. External prereqs (placement tests, gen-eds outside the
+ * program) don't create ordering edges here — only intra-program dependencies.
+ */
+export function buildSequence(
+  groups: PlanGroup[],
+  prereqs: Map<string, { text: string; courses: string[] }>,
+): PlanSequence | null {
+  // For "choose N" groups, sequence only N representatives (a student takes N).
+  const seen = new Set<string>();
+  const courses: PlanCourse[] = [];
+  for (const g of groups) {
+    if (g.unenumerated) continue;
+    const take =
+      g.chooseN && g.chooseN < g.courses.length ? g.chooseN : g.courses.length;
+    for (const c of g.courses.slice(0, take)) {
+      if (!seen.has(c.code)) {
+        seen.add(c.code);
+        courses.push(c);
+      }
+    }
+  }
+  if (courses.length === 0) return null;
+
+  const S = new Set(courses.map((c) => c.code));
+  const coverage = courses.filter((c) => prereqs.has(c.code)).length / courses.length;
+
+  // Intra-program edges only.
+  const intra = new Map<string, string[]>();
+  let edgeCount = 0;
+  for (const c of courses) {
+    const deps = (prereqs.get(c.code)?.courses ?? []).filter(
+      (d) => S.has(d) && d !== c.code,
+    );
+    intra.set(c.code, deps);
+    edgeCount += deps.length;
+  }
+  if (coverage < SEQUENCE_MIN_COVERAGE || edgeCount < 2) return null;
+
+  // Longest dependency depth per course (cycle-safe memoized DFS).
+  const depth = new Map<string, number>();
+  const visiting = new Set<string>();
+  const computeDepth = (code: string): number => {
+    const cached = depth.get(code);
+    if (cached !== undefined) return cached;
+    if (visiting.has(code)) return 0; // defensive: break any cycle
+    visiting.add(code);
+    const deps = intra.get(code) ?? [];
+    const d = deps.length === 0 ? 0 : Math.max(...deps.map(computeDepth)) + 1;
+    visiting.delete(code);
+    depth.set(code, d);
+    return d;
+  };
+  for (const c of courses) computeDepth(c.code);
+
+  const ordered = [...courses].sort(
+    (a, b) =>
+      computeDepth(a.code) - computeDepth(b.code) || a.code.localeCompare(b.code),
+  );
+
+  // Greedy credit-capped packing that never puts a course before its prereq.
+  const termOf = new Map<string, number>();
+  const terms: { courses: PlanCourse[]; credits: number }[] = [];
+  for (const c of ordered) {
+    const deps = intra.get(c.code) ?? [];
+    const minTerm =
+      deps.length === 0 ? 0 : Math.max(...deps.map((d) => termOf.get(d) ?? 0)) + 1;
+    const cr = c.credits ?? 3;
+    let t = minTerm;
+    for (;;) {
+      if (t >= terms.length) terms.push({ courses: [], credits: 0 });
+      if (terms[t].courses.length === 0 || terms[t].credits + cr <= TERM_CREDIT_CAP) {
+        terms[t].courses.push(c);
+        terms[t].credits += cr;
+        termOf.set(c.code, t);
+        break;
+      }
+      t += 1;
+    }
+  }
+
+  return {
+    terms: terms.map((t, i) => ({ index: i + 1, courses: t.courses, credits: t.credits })),
+    prereqCoverage: coverage,
+    creditsPerTerm: TERM_CREDIT_CAP,
+  };
 }


### PR DESCRIPTION
## What changes for someone using the site

The transfer-plan page (shipped in #809) gets a second view. On a program's plan — e.g. `/ga/college/atlanta-tech/program/business-management-aas-as` — there's now a **"By requirement / Suggested sequence"** toggle. Switch to **Suggested sequence** and the same required courses are reorganized into **Term 1, Term 2, …**, each capped at ~16 credits, ordered so you never take a course before its prerequisite. Every course keeps its transfer badge and "N sections this term" from Phase 1.

So instead of just *"here are the 26 courses this degree needs,"* a student sees *"here's a sensible order to take them in"* — e.g. for GA Atlanta Tech's Business Management AAS: foundational courses (`ACCT 1100`, `COMP 1000`) in Term 1, and dependent ones (`BUSN 1430`, which requires nine earlier courses; `MGMT 2210`) in the final term.

There's an honest disclaimer in the view: *"This is a starting point — your advisor sets the official sequence."*

## What changes technically

All in `lib/programs/planner.ts` (`buildSequence`) + the client view in `PlanClient.tsx`:

- Builds a prerequisite graph **among the program's own courses only** (external prereqs like placement tests or gen-eds outside the program don't create ordering edges), computes each course's longest dependency depth (cycle-safe memoized DFS), then **greedily packs courses into ~16-credit terms**, never placing a course before a prerequisite already assigned to a later term.
- For **"choose N" groups** it sequences only N representatives (a student takes N, not all alternatives).
- **Gated honestly:** returns `null` — and the UI shows only the Phase 1 checklist, no toggle — when prereq coverage is under 25% or there are fewer than 2 intra-program edges. Thin-prereq states never display a misleading order.

### Why GA, and what's still gated
This pilots in **GA**, where programs + prereqs + transfer + sections all align on the same courses (92% prereq coverage on the test program). National rollout of sequencing is still gated on the **P0 inline-prereq sweep** — 42% of colleges nationally have 0% inline prereqs (see project memory). Where prereqs are thin, this PR degrades gracefully to the checklist.

## Test plan
- ✅ `tsc --noEmit` — zero errors in changed files.
- ✅ `eslint` — clean.
- ✅ **5 new unit tests** (`sequence.test.ts`): prereq-chain ordering, external-prereq isolation, credit capping, the coverage gate (null), and choose-N representative selection. All 13 planner tests pass.
- ✅ Verified end-to-end in local dev: toggle switches views, 5 balanced terms render in dark mode, ordering respects prerequisites, no console errors.
- ✅ `next build` — **`✓ Compiled successfully`**. (Full static export can't finish in the sandbox — Supabase unreachable, pre-existing `/sitemap/transfer.xml` route times out — unrelated to this change; Vercel builds it fine.)

Builds on #809 (Phase 1), now merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)