### PR TITLE
hotfix(transfer): bump function maxDuration to 60s (#777)

### DIFF
--- a/app/[state]/transfer/page.tsx
+++ b/app/[state]/transfer/page.tsx
@@ -13,6 +13,10 @@ import TransferClient from "./TransferClient";
 
 // Render on demand — some states' transfer data exceeds Vercel's ISR size limit
 export const dynamic = "force-dynamic";
+// Bump function timeout above the default 15s. Even after the perf fixes in
+// #781 / #786 / #787, cold-start variance on Vercel was tipping TX/NY/MI
+// over the default cap. 60s is the Pro tier ceiling for serverless. Issue #777.
+export const maxDuration = 60;
 
 type Props = {
   params: Promise<{ state: string }>;


### PR DESCRIPTION
## What changes for someone using the site

Even after #781 + #786 + #787 brought the transfer page's SSR to under 400ms locally, /tx/transfer and /ny/transfer (and intermittently /mi/transfer, /ca/transfer) are still showing "Connection closed" in production. Vercel function logs confirm the cause:

\`\`\`
λ GET /tx/transfer   Vercel Runtime Timeout Error
\`\`\`

Vercel's default function timeout (~15s for streamed RSC responses) is killing the function before render finishes, even though the actual work is fast — cold-start variance is the difference.

This PR sets \`maxDuration = 60\` (the Pro tier ceiling) explicitly on the transfer page route. The page should now render reliably for all states.

## What changes on the technical front

Four lines added to \`app/[state]/transfer/page.tsx\`:

\`\`\`ts
export const maxDuration = 60;
\`\`\`

That's the only change. The perf work in the previous PRs stands; this just gives Vercel permission to wait for it.

## Test plan

- [ ] **Post-merge:** Playwright sweep of /[ca,tx,mi,tn,nj,md,ny,va]/transfer — expect ✅ across the board

🤖 Generated with [Claude Code](https://claude.com/claude-code)