### PR TITLE
feat(planner): cost & outcomes context on the major plan — Phase 3

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/page.tsx
+++ b/app/[state]/college/[id]/program/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { loadInstitutions } from "@/lib/institutions";
 import { buildMajorPlan } from "@/lib/programs/planner";
+import { getScorecard, formatDollar, formatPercent } from "@/lib/scorecard";
 import { termLabel } from "@/lib/terms";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import PlanClient from "./PlanClient";
@@ -62,6 +63,21 @@ export default async function MajorPlanPage(props: PageProps) {
   const collegeHref = `/${state}/college/${id}`;
   const transferHref = `/${state}/transfer`;
 
+  // College-wide outcomes (federal Scorecard) — context, NOT program-specific.
+  const sc = getScorecard(state, id);
+  const outcomeTiles: { label: string; value: string }[] = [];
+  if (sc) {
+    if (sc.cost.tuitionInState != null)
+      outcomeTiles.push({ label: "In-state tuition / yr", value: formatDollar(sc.cost.tuitionInState) });
+    if (sc.completion.completionRate150nt != null)
+      outcomeTiles.push({ label: "Graduate on time", value: formatPercent(sc.completion.completionRate150nt) });
+    const earn = sc.earnings.median1YrAfterCompletion ?? sc.earnings.median10YrsAfterEntry;
+    if (earn != null)
+      outcomeTiles.push({ label: "Median earnings after", value: formatDollar(earn) });
+    if (sc.earnings.shareEarningAboveHsGrad != null)
+      outcomeTiles.push({ label: "Earn above HS-grad wage", value: formatPercent(sc.earnings.shareEarningAboveHsGrad) });
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-4 py-8">
       <Breadcrumbs
@@ -101,6 +117,23 @@ export default async function MajorPlanPage(props: PageProps) {
           </p>
         )}
       </header>
+
+      {outcomeTiles.length > 0 && (
+        <section className="mb-6 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50 p-4">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {outcomeTiles.map((t) => (
+              <div key={t.label}>
+                <div className="text-lg font-bold text-gray-900 dark:text-slate-100">{t.value}</div>
+                <div className="text-xs text-gray-500 dark:text-slate-400">{t.label}</div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-gray-400 dark:text-slate-500">
+            College-wide figures for {plan.collegeName} from the federal College
+            Scorecard — not specific to this program.
+          </p>
+        </section>
+      )}
 
       <PlanClient plan={plan} transferHref={transferHref} />
     </main>


### PR DESCRIPTION
## What changes for someone using the site

Each major-plan page (e.g. `/ga/college/atlanta-tech/program/business-management-aas-as`) now opens with a **cost & outcomes strip** — four figures that answer *"is this worth it?"*:

- **In-state tuition / yr** (e.g. $3,382)
- **Graduate on time** — on-time completion rate (e.g. 49%)
- **Median earnings after** (e.g. $31,118)
- **Earn above HS-grad wage** — share of former students out-earning a typical high-school grad (e.g. 37%)

With Phases 1–2 already on the page (what to take, in what order, whether it transfers), the planner now answers the *whole* student question in one view: requirements → sequence → transfer → **cost & payoff**.

The strip is explicitly labeled **college-wide** — these are institution-level federal figures, not specific to the program — so it informs without overclaiming.

## What changes technically

One file: `app/[state]/college/[id]/program/[slug]/page.tsx`. It calls `getScorecard(state, id)` (federal College Scorecard data we already ingest into `data/{state}/scorecard/{college}.json`) and renders up to four tiles, **each gated on a non-null value**. If a college has no Scorecard record, the whole card is omitted — clean degradation, no empty shell. Server-rendered, no client code, no new dependencies.

## Test plan
- ✅ `tsc --noEmit` — zero errors in the changed file.
- ✅ `eslint` — clean.
- ✅ Verified in dev: GA Atlanta Tech renders all four tiles ($3,382 / 49% / $31,118 / 37%); NY LaGuardia (different state/college) also renders; no console errors.
- ✅ Confirmed the loader resolves real data for both colleges and the gate hides the card where fields are null.
- ✅ `next build` — **`✓ Compiled successfully`**. (Full static export can't finish in the sandbox — Supabase unreachable + pre-existing `/sitemap/transfer.xml` timeout — unrelated to this change.)

Builds on #809 (Phase 1) and #815 (Phase 2), both merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)