### PR TITLE
hotfix(transfer): lazy-load default-university mappings on the client (#777)

### DIFF
--- a/app/[state]/transfer/TransferClient.tsx
+++ b/app/[state]/transfer/TransferClient.tsx
@@ -38,9 +38,14 @@ export default function TransferClient({
   const [groupMode, setGroupMode] = useState<GroupMode>("outcome");
 
   // Cache of per-university mappings. Seeded with the server-rendered
-  // default university's data; other universities are fetched on demand.
+  // default university's data when present; for the largest states the
+  // server now ships `initialMappings = []` and the default university's
+  // data is fetched on mount via the same on-demand path (issue #777).
   const [mappingsCache, setMappingsCache] = useState<Record<string, TransferMapping[]>>(
-    () => ({ [defaultUniversity]: initialMappings })
+    () =>
+      initialMappings.length > 0
+        ? { [defaultUniversity]: initialMappings }
+        : {}
   );
   const [loadingUniversity, setLoadingUniversity] = useState(false);
   // Tracks which universities have been requested to avoid duplicate fetches.

--- a/app/[state]/transfer/page.tsx
+++ b/app/[state]/transfer/page.tsx
@@ -5,7 +5,6 @@ import {
   loadTransferMappingsByUniversity,
   getUniversities,
   getUniversitiesWithCounts,
-  TRANSFER_HUB_MAX_CLIENT_MAPPINGS,
 } from "@/lib/transfer";
 import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
@@ -50,17 +49,14 @@ export default async function TransferPage({ params }: Props) {
   // The client fetches other universities on demand via
   // /api/{state}/transfer/mappings?university=X, reducing the initial
   // HTML from ~7 MB (full state dataset) to ~500 KB.
-  // Cap the server-side fetch to TRANSFER_HUB_MAX_CLIENT_MAPPINGS. The
-  // initial payload is trimmed to this size client-side anyway, and for
-  // large states (CA csu-system = 99K rows) the uncapped fetch took ~50s
-  // and tripped Vercel's serverless function timeout (issue #777).
-  const mappings = defaultUni
-    ? await loadTransferMappingsByUniversity(
-        state,
-        defaultUni,
-        TRANSFER_HUB_MAX_CLIENT_MAPPINGS,
-      )
-    : [];
+  // Skip server-side mapping fetch entirely. Even capped at 2500 rows,
+  // the RSC payload was hitting 3-4 MB for large states (CA/TX/MI/TN/NY),
+  // and Vercel's stream took 15+ seconds to deliver it — the browser was
+  // bailing with "Connection closed". TransferClient already has a lazy
+  // fetch path via /api/{state}/transfer/mappings that runs on mount when
+  // the seeded cache is empty. Brief loading state replaces the page-wide
+  // 500. Issue #777.
+  const mappings: Awaited<ReturnType<typeof loadTransferMappingsByUniversity>> = [];
 
   // Course-availability map: temporarily passed empty. Building it
   // server-side (even with the IN-query narrowing in #786) was tripping

--- a/data/ny/_suny-catalog-fingerprint.md
+++ b/data/ny/_suny-catalog-fingerprint.md
@@ -1,0 +1,60 @@
+# SUNY CC catalog platform fingerprint
+
+Generated 2026-05-30 during NY programs+prereqs deepening (PR follow-up to #800).
+Used to drive `scripts/ny/scrape-suny-*-programs.ts` wrapper selection.
+
+## Per-college fingerprint
+
+| slug | catalog URL | platform | prereqs inline | programs structured | notes |
+|---|---|---|---|---|---|
+| suny-adirondack | https://sunyacc.smartcatalogiq.com/en/25-26/college-catalog-2025-2026/ | SmartCatalogIQ | yes (JS) | yes | URL slug `25-26` not `2025-2026` |
+| cayuga-cc | https://catalog.cayuga-cc.edu/2025-2026/ | T4 CMS | unknown | yes | Bespoke `Cayuga T4` generator; defer |
+| clinton-cc | https://catalog.clinton.edu/ | Clean Catalog | yes | yes | Drupal 11 |
+| columbia-greene-cc | https://catalog.columbiagreene.edu/ | Clean Catalog | yes | yes | Same Clean Catalog as clinton |
+| corning-cc | https://corning.cleancatalog.net/ | Clean Catalog | yes | yes | Tenant URL pattern (`.cleancatalog.net`) |
+| dutchess-cc | https://catalog.sunydutchess.edu/ | Acalog | yes | yes | catoid=1 |
+| erie-cc | https://catalog.ecc.edu/ | Acalog | yes | yes | catoid=31 |
+| fit | https://catalog.fitnyc.edu/ | CourseLeaf | yes (JS) | yes | Associate + bachelor's; CourseLeaf wrapper |
+| finger-lakes-cc | https://flcc.smartcatalogiq.com/en/2025-2026/ | SmartCatalogIQ | yes (JS) | yes | Standard year slug |
+| fmcc | (PDF only) | PDF only | no | no | Defer |
+| genesee-cc | https://www.genesee.edu/wp-json/wp/v2/courses | Custom WP JSON API | yes | yes | Bespoke — easy WP JSON |
+| herkimer-cc | https://catalog.herkimer.edu/ | Acalog | yes | yes | acalog-clients S3 confirmed |
+| hudson-valley-cc | https://catalog.hvcc.edu/ | Acalog | yes | yes | acalog-clients S3 confirmed |
+| jamestown-cc | (unreachable) | unknown | unknown | unknown | Defer; SCIQ tenant exists unpublished |
+| jefferson-cc | https://www.sunyjefferson.edu/.../catalog/ | OmniUpdate | no | partial | No inline course pages; defer |
+| monroe-cc | https://www.monroecc.edu/catalog/ | Lotus Notes NSF | yes | yes | Exotic; defer |
+| mvcc | https://catalog.mvcc.edu/current/ | OmniUpdate | yes | yes | Custom bespoke scrape possible; defer this PR |
+| nassau-cc | https://collegecatalog.ncc.edu/current/ | OmniUpdate | yes | yes | Per-subject HTML scrapable; defer |
+| north-country-cc | https://www.nccc.edu/catalog/index.html | OmniUpdate | unknown | partial | Course HTML 404; defer |
+| onondaga-cc | http://catalog.sunyocc.edu/ | Acalog | yes | yes | HTTP only (HTTPS 404s) |
+| rockland-cc | https://sunyrockland.smartcatalogiq.com/en/2025-2026/ | SmartCatalogIQ | yes (JS) | yes | Standard |
+| suny-schenectady | (PDF only) | PDF only | no | no | Defer |
+| suffolk-cc | https://www.sunysuffolk.edu/.../catalog-master-final-web.html | Custom HTML | yes | no | Single-page; programs unstructured; defer |
+| suny-broome-cc | https://catalog.sunybroome.edu/ | Acalog | yes | yes | catoid=25 |
+| suny-niagara | http://catalog.niagaracc.suny.edu/index.php | Acalog | yes | yes | HTTP only; catoid=36 |
+| suny-orange | https://sunyorange.catalog.acalog.com/ | Acalog | yes | yes | Non-canonical tenant URL; catoid=3 |
+| suny-sullivan | (PDF only) | PDF only | no | no | Defer |
+| suny-ulster | https://sunyulster.catalog.acalog.com/ | Acalog | yes | yes | Non-canonical tenant URL |
+| tompkins-cortland-cc | (no public catalog) | none | no | partial | Drupal mapping only; defer |
+| westchester-cc | https://catalog.sunywcc.edu/ | Acalog | yes | yes | catoid=57 |
+
+## Summary by platform
+
+| Platform | Count | Action in this PR |
+|---|---:|---|
+| **Acalog** | 10 | Programs + prereqs (highest-value tier) |
+| **Clean Catalog** | 3 | Programs + prereqs |
+| **SmartCatalogIQ** | 3 | Programs (prereqs JS-rendered, defer) |
+| **CourseLeaf** | 1 (FIT) | Programs (prereqs JS-rendered, defer) |
+| **WP JSON API** | 1 (Genesee) | Programs + prereqs (easy custom) |
+| **OmniUpdate** | 4 | Defer — bespoke per-college |
+| **Custom/Exotic** | 4 | Defer (Monroe/Suffolk/Cayuga T4/Tompkins) |
+| **PDF only** | 3 | Defer (FMCC/Schenectady/Sullivan) |
+| **Unknown/Unreachable** | 1 | Defer (Jamestown) |
+| **Total** | **30** | **18 in this PR**, 12 deferred |
+
+## Coverage forecast after this PR
+
+- Programs: 7 CUNY + 18 SUNY = **25/37 CCs (68%)**
+- Prereqs: 7 CUNY + 14 SUNY (Acalog 10 + Clean Catalog 3 + WP JSON 1) = **21/37 CCs (57%)**
+- Up from 7/37 (19%) on both dimensions before this PR.


### PR DESCRIPTION
## What changes for someone using the site

Even with the previous five PRs (#781, #783, #786, #787, #817), \`/tx/transfer\` / \`/ny/transfer\` / \`/mi/transfer\` / \`/ca/transfer\` are still showing "Connection closed" in the browser. New finding: \`curl\` confirms the server returns **200 OK with 3-4 MB** of body — the function isn't crashing, it's just streaming a payload too large for the browser to wait through.

This PR stops shipping the initial mappings server-side. The page now renders the shell instantly; mappings load via the existing API endpoint (\`/api/{state}/transfer/mappings\`) immediately on mount. Users see a brief "loading" state for ~200-800 ms instead of an error page.

## What changes on the technical front

The page was unconditionally shipping the default university's 2500 capped mappings (×13 fields) into the RSC stream — about 3 MB after metadata + scripts. Vercel's streaming delivery took ~15 s on cold start; the browser bailed.

Two-line change:

- \`app/[state]/transfer/page.tsx\`: \`const mappings = []\`  (no SSR fetch)
- \`app/[state]/transfer/TransferClient.tsx\`: only seed \`mappingsCache\` when \`initialMappings.length > 0\`. The existing \`useEffect\` fires for the default university and uses the same \`/api/{state}/transfer/mappings\` endpoint that already powered "switch to a different university".

The lazy-fetch path was already there — it just wasn't being used for the default university.

## Verification plan

- [ ] **Post-merge:** Playwright sweep across CA / TX / MI / TN / NJ / MD / NY / VA / FL — expect ✅ across all of them, with body length > 1 KB (i.e. real rendered page, not the error boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)