### PR TITLE
feat(planner): plain-language the major plan — Phase A (easy/intuitive)

### DIFF
--- a/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
+++ b/app/[state]/college/[id]/program/[slug]/PlanClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { termLabel } from "@/lib/term-label";
 import type { MajorPlan, PlanCourse, PlanTerm, TransferStatus } from "@/lib/programs/planner";
 
 interface Props {
@@ -9,17 +10,20 @@ interface Props {
   transferHref: string;
 }
 
+// Plain-language transfer verdicts. The precise receiving-course code (e.g.
+// "MGNT 0XXX") is kept on hover, not in the always-visible label — a first-gen
+// student reads "Counts as an elective", an advisor can hover for the code.
 const STATUS_PILL: Record<TransferStatus, { label: string; cls: string }> = {
   direct: {
     label: "Transfers",
     cls: "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-800",
   },
   elective: {
-    label: "Elective credit",
+    label: "Counts as an elective",
     cls: "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 ring-amber-200 dark:ring-amber-800",
   },
   "no-credit": {
-    label: "No credit",
+    label: "Won't transfer",
     cls: "bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400 ring-rose-200 dark:ring-rose-800",
   },
 };
@@ -97,33 +101,33 @@ export default function PlanClient({ plan, transferHref }: Props) {
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
         <SummaryStat
           n={summary.direct}
-          label={uni === "__all__" ? "transfer somewhere" : "transfer directly"}
+          label={uni === "__all__" ? "transfer to a school" : "transfer directly"}
           cls="text-emerald-700 dark:text-emerald-400"
         />
         {uni !== "__all__" && summary.elective > 0 && (
           <SummaryStat
             n={summary.elective}
-            label="as elective credit"
+            label="count as electives"
             cls="text-amber-700 dark:text-amber-400"
           />
         )}
         {uni !== "__all__" && summary.noCredit > 0 && (
           <SummaryStat
             n={summary.noCredit}
-            label="don't transfer"
+            label="won't transfer"
             cls="text-rose-700 dark:text-rose-400"
           />
         )}
         {summary.unknown > 0 && (
           <SummaryStat
             n={summary.unknown}
-            label="no transfer data"
+            label="not listed yet"
             cls="text-gray-500 dark:text-slate-400"
           />
         )}
         <SummaryStat
           n={plan.totals.offeredThisTerm}
-          label={`offered this term (${plan.term})`}
+          label={`open this term (${termLabel(plan.term)})`}
           cls="text-teal-700 dark:text-teal-400"
         />
       </div>
@@ -272,48 +276,55 @@ function SummaryStat({ n, label, cls }: { n: number; label: string; cls: string 
 
 function CourseRow({ course, uni }: { course: PlanCourse; uni: string }) {
   const t = uni === "__all__" ? null : course.transfers[uni];
+  const creditLabel = course.credits != null ? ` · ${course.credits} credit${course.credits === 1 ? "" : "s"}` : "";
   return (
-    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5">
-      <span className="font-mono text-sm font-semibold text-gray-900 dark:text-slate-100">
-        {course.code}
-      </span>
-      <span className="min-w-0 flex-1 truncate text-sm text-gray-600 dark:text-slate-300">
-        {course.title}
-      </span>
-
-      {/* Transfer pill */}
-      {uni === "__all__" ? (
-        course.acceptingCount > 0 ? (
-          <span
-            className={`${PILL_BASE} bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-800`}
-          >
-            ✓ {course.acceptingCount} school{course.acceptingCount === 1 ? "" : "s"}
+    <li className="px-4 py-3">
+      {/* Lead with the human name; code + credits are secondary. */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-gray-900 dark:text-slate-100">
+            {course.title || course.code}
+          </div>
+          <div className="font-mono text-xs text-gray-400 dark:text-slate-500">
+            {course.code}
+            {creditLabel}
+          </div>
+        </div>
+        {/* The two things that matter, on the right. */}
+        {course.sectionsThisTerm > 0 ? (
+          <span className="shrink-0 text-xs font-medium text-teal-700 dark:text-teal-400">
+            Open this term
           </span>
         ) : (
-          <span className={`${PILL_BASE} ${PILL_MUTED}`}>no transfer data</span>
-        )
-      ) : t ? (
-        <span
-          className={`${PILL_BASE} ${STATUS_PILL[t.status].cls}`}
-          title={t.univCourse ? `→ ${t.univCourse}` : undefined}
-        >
-          {STATUS_PILL[t.status].label}
-          {t.status !== "no-credit" && t.univCourse ? ` → ${t.univCourse}` : ""}
-        </span>
-      ) : (
-        <span className={`${PILL_BASE} ${PILL_MUTED}`}>no transfer data</span>
-      )}
+          <span className="shrink-0 text-xs text-gray-400 dark:text-slate-500">
+            Not offered this term
+          </span>
+        )}
+      </div>
 
-      {/* Section availability */}
-      {course.sectionsThisTerm > 0 ? (
-        <span className="text-xs text-teal-700 dark:text-teal-400">
-          {course.sectionsThisTerm} section{course.sectionsThisTerm === 1 ? "" : "s"}
-        </span>
-      ) : (
-        <span className="text-xs text-gray-400 dark:text-slate-500">
-          not offered this term
-        </span>
-      )}
+      {/* Transfer verdict — plain language, precise code on hover. */}
+      <div className="mt-1.5">
+        {uni === "__all__" ? (
+          course.acceptingCount > 0 ? (
+            <span
+              className={`${PILL_BASE} bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-800`}
+            >
+              Transfers to {course.acceptingCount} school{course.acceptingCount === 1 ? "" : "s"}
+            </span>
+          ) : (
+            <span className={`${PILL_BASE} ${PILL_MUTED}`}>Transfer not listed</span>
+          )
+        ) : t ? (
+          <span
+            className={`${PILL_BASE} ${STATUS_PILL[t.status].cls}`}
+            title={t.univCourse ? `Receiving course: ${t.univCourse}` : undefined}
+          >
+            {STATUS_PILL[t.status].label}
+          </span>
+        ) : (
+          <span className={`${PILL_BASE} ${PILL_MUTED}`}>Transfer not listed</span>
+        )}
+      </div>
     </li>
   );
 }

--- a/app/[state]/college/[id]/program/[slug]/page.tsx
+++ b/app/[state]/college/[id]/program/[slug]/page.tsx
@@ -25,6 +25,29 @@ import Breadcrumbs from "@/components/Breadcrumbs";
 import PlanClient from "./PlanClient";
 
 export const revalidate = 86400; // 1 day
+
+// Plain-English, jargon-free description of what each credential is. Coarse on
+// purpose (robust to AA/AS/AAS catalog quirks) — the goal is a first-gen
+// student understanding "what am I looking at", not a precise taxonomy.
+const CREDENTIAL_BLURB: Record<string, string> = {
+  AS: "An associate degree — designed to transfer to a 4-year school. About 2 years full-time.",
+  AA: "An associate degree — designed to transfer to a 4-year school. About 2 years full-time.",
+  AAS: "An applied associate degree — built to start a career. About 2 years full-time.",
+  certificate: "A certificate — a shorter, focused credential (less than a full degree).",
+  diploma: "A diploma — a focused, career-oriented credential.",
+};
+
+/** Prefer the credential token embedded in the catalog title; fall back to the
+ *  structured field. AAS is checked before AS so "...AAS" isn't read as "AS". */
+function resolveCredential(title: string, credential: string): string {
+  const t = title.toUpperCase();
+  if (/\bAAS\b/.test(t)) return "AAS";
+  if (/\bAS\b/.test(t)) return "AS";
+  if (/\bAA\b/.test(t)) return "AA";
+  if (/certificate/i.test(title)) return "certificate";
+  if (/diploma/i.test(title)) return "diploma";
+  return credential;
+}
 export const dynamicParams = true;
 
 interface PageProps {
@@ -63,6 +86,11 @@ export default async function MajorPlanPage(props: PageProps) {
   const collegeHref = `/${state}/college/${id}`;
   const transferHref = `/${state}/transfer`;
 
+  // Plain-language credential help. The catalog title is the more reliable
+  // signal (e.g. GA titles embed "...AAS" while the credential field may say
+  // "AS"), so read the token from the title first, then fall back to the field.
+  const credentialBlurb = CREDENTIAL_BLURB[resolveCredential(plan.program.title, plan.program.credential)] ?? "";
+
   // College-wide outcomes (federal Scorecard) — context, NOT program-specific.
   const sc = getScorecard(state, id);
   const outcomeTiles: { label: string; value: string }[] = [];
@@ -93,13 +121,12 @@ export default async function MajorPlanPage(props: PageProps) {
         ]}
       />
 
-      <header className="mb-6 mt-4">
+      <header className="mb-5 mt-4">
         <p className="text-sm font-medium uppercase tracking-wide text-blue-600 dark:text-blue-400">
-          Transfer plan
+          Your plan for this degree
         </p>
         <h1 className="mt-1 text-2xl font-bold text-gray-900 dark:text-slate-100 sm:text-3xl">
-          {plan.program.title}{" "}
-          <span className="text-gray-400 dark:text-slate-500">({plan.program.credential})</span>
+          {plan.program.title}
         </h1>
         <p className="mt-1 text-gray-600 dark:text-slate-300">
           at{" "}
@@ -107,12 +134,19 @@ export default async function MajorPlanPage(props: PageProps) {
             {plan.collegeName}
           </a>
           {plan.program.totalCredits ? ` · ${plan.program.totalCredits} credits` : ""}
-          {plan.term ? ` · sections shown for ${termLabel(plan.term)}` : ""}
+        </p>
+        {credentialBlurb && (
+          <p className="mt-2 text-sm text-gray-500 dark:text-slate-400">{credentialBlurb}</p>
+        )}
+        <p className="mt-3 rounded-md bg-blue-50 dark:bg-blue-950/30 px-3 py-2 text-sm text-gray-700 dark:text-slate-300">
+          Every course this degree needs — pick the school you want to transfer to and
+          see which ones count there, plus what&apos;s open to register for now
+          {plan.term ? ` (${termLabel(plan.term)})` : ""}.
         </p>
         {plan.program.catalogUrl && (
-          <p className="mt-1 text-xs text-gray-400 dark:text-slate-500">
+          <p className="mt-2 text-xs text-gray-400 dark:text-slate-500">
             <a href={plan.program.catalogUrl} className="underline" rel="nofollow">
-              Official catalog →
+              See the official catalog →
             </a>
           </p>
         )}


### PR DESCRIPTION
## What changes for someone using the site

The major-plan page is now readable by a first-generation student with no college background, on a phone, without hitting jargon. **No data or logic changed — this is wording and layout.**

Before, each course row led with a code (`MGMT 1100`) and a truncated title, and badges said things like `Elective credit → MGNT 0XXX` — which reads like an error message. Now:

- **Rows lead with the plain course name** — "Principles of Management" — with the code and credits demoted to small grey subtext.
- **Transfer verdicts are plain English:** *Transfers* / *Counts as an elective* / *Won't transfer* / *Transfer not listed*. The precise receiving-course code moves to a hover tooltip (useful for an advisor, invisible clutter for a student).
- **Availability reads "Open this term" / "Not offered this term"** instead of a bare section count.
- **The header** drops the confusing "(AS)" (the title already says "AAS", and the credential field disagreed), adds a plain blurb — *"An applied associate degree — built to start a career. About 2 years full-time."* — and a one-sentence explainer of what the page does. Terms show as "Summer 2026", not "2026SU".

## What changes technically

Two files, `PlanClient.tsx` + the plan `page.tsx`. The reworked `CourseRow` is shared by both the **checklist** and **suggested-sequence** views, so the plain language applies to both for free. The header adds a small `CREDENTIAL_BLURB` map and a `resolveCredential()` helper that reads the credential token from the catalog title first (more reliable than the structured field given GA's AAS/AS quirk).

## Test plan
- ✅ `tsc` clean · `eslint` clean · `next build` **`✓ Compiled successfully`**.
- ✅ Verified in dev on **desktop and a 375px mobile viewport** (audience is phone-first) — titles wrap fully and lead, no truncation or overflow, pills/availability stack readably.
- ✅ Regression: checklist↔sequence toggle works; university selector works; "Any university" shows the plain "Transfers to N schools"; no console errors.

## Scope / next
This is the plain-spoken core of Phase A (items A2 + A3 of the UX prompt). Still to do in Phase A: the **goal-first entry point** and making the planner **prominently discoverable** (A1) — deferred to keep this PR focused and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)