### PR TITLE
feat(planner): surface the planner — Phase A discoverability (A1)

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -13,6 +13,8 @@ import CollegeScorecardSection from "./CollegeScorecardSection";
 import CollegeTermSection from "./CollegeTermSection";
 import CollegeContext from "@/components/CollegeContext";
 import TopProgramsSection from "./TopProgramsSection";
+import { loadCollegePrograms } from "@/lib/programs/requirements";
+import { countRealCourses, PLAN_MIN_COURSES } from "@/lib/programs/plan-shared";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { getPrerenderStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
@@ -131,6 +133,13 @@ export default async function CollegeDetailPage(props: PageProps) {
     : (termsWithData[termsWithData.length - 1] ?? preferredTerm);
 
   const collegeSlug = institution.college_slug;
+
+  // How many of this college's programs have enough real courses to render a
+  // transfer plan? Gates the "Plan a degree" call-to-action so it never points
+  // at a programs page with no actual plans.
+  const plannableCount = (await loadCollegePrograms(state, collegeSlug)).filter(
+    (p) => countRealCourses(p) >= PLAN_MIN_COURSES,
+  ).length;
 
   // Build per-term maps for the client wrapper. Only the terms that actually
   // have data are shipped.
@@ -343,6 +352,28 @@ export default async function CollegeDetailPage(props: PageProps) {
           </div>
         </div>
       </section>
+
+      {/* Plan-a-degree call-to-action — the planner's main entry point from a
+          college page. Gated so it only shows when real plans exist. */}
+      {plannableCount > 0 && (
+        <Link
+          href={`/${state}/college/${id}/programs`}
+          className="group mt-6 flex items-center justify-between gap-4 rounded-xl border border-teal-200 dark:border-teal-900 bg-teal-50 dark:bg-teal-950/40 px-5 py-4 transition hover:bg-teal-100 dark:hover:bg-teal-900/40"
+        >
+          <div>
+            <p className="text-sm font-semibold text-teal-800 dark:text-teal-300">
+              Plan a degree at {institution.name}
+            </p>
+            <p className="mt-0.5 text-sm text-gray-600 dark:text-slate-300">
+              Pick a program and see every course it needs — which ones transfer
+              to the school you want, and what&rsquo;s open to register for now.
+            </p>
+          </div>
+          <span className="shrink-0 text-teal-700 dark:text-teal-300 group-hover:translate-x-0.5 transition-transform">
+            &rarr;
+          </span>
+        </Link>
+      )}
 
       {/* At-a-glance — data-grounded editorial context paragraphs. Renders
           nothing when fewer than 2 sentences qualify (sparse-data colleges),

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -23,6 +23,7 @@ import {
   PROGRAMS,
 } from "@/lib/programs";
 import { loadProgramAcrossColleges, checkCourseAvailability } from "@/lib/programs/requirements";
+import { countRealCourses, programSlug, PLAN_MIN_COURSES } from "@/lib/programs/plan-shared";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import SectionHeading from "@/components/SectionHeading";
 import Breadcrumbs from "@/components/Breadcrumbs";
@@ -134,6 +135,18 @@ export default async function ProgramPage(props: PageProps) {
     for (const [slug, av] of results) {
       availabilityByCollege[slug] = av;
     }
+  }
+
+  // Map each college (by institution id) to the slug of its best plannable
+  // program for this category, so the table can link straight to a real plan.
+  // Prefer a transfer-oriented degree (AS/AA/AAS) over a certificate.
+  const planSlugByCollegeId = new Map<string, string>();
+  for (const { college, programs } of requirementEntries) {
+    const plannable = programs.filter((p) => countRealCourses(p) >= PLAN_MIN_COURSES);
+    if (plannable.length === 0) continue;
+    const best =
+      plannable.find((p) => ["AS", "AA", "AAS"].includes(p.credential)) ?? plannable[0];
+    planSlugByCollegeId.set(college.id, programSlug(best));
   }
 
   const url = siteUrl();
@@ -363,9 +376,15 @@ export default async function ProgramPage(props: PageProps) {
         )}
 
         <section className="mb-10">
-          <SectionHeading id="colleges" className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+          <SectionHeading id="colleges" className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-1">
             Colleges offering {program.name}
           </SectionHeading>
+          {planSlugByCollegeId.size > 0 && (
+            <p className="mb-4 text-sm text-gray-600 dark:text-slate-400">
+              Pick a college to see its full plan — every required course, which
+              ones transfer to the school you want, and what&rsquo;s open now.
+            </p>
+          )}
           <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
             <table className="w-full text-left text-sm">
               <thead className="bg-gray-50 dark:bg-slate-800 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
@@ -411,6 +430,16 @@ export default async function ProgramPage(props: PageProps) {
                         >
                           {c.collegeName}
                         </Link>
+                        {planSlugByCollegeId.has(c.collegeId) && (
+                          <div className="mt-0.5">
+                            <Link
+                              href={`/${state}/college/${c.collegeId}/program/${planSlugByCollegeId.get(c.collegeId)}`}
+                              className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:text-teal-600 dark:hover:text-teal-400 hover:underline"
+                            >
+                              See the full plan &rarr;
+                            </Link>
+                          </div>
+                        )}
                       </td>
                       <td className="px-4 py-2.5 text-right text-gray-900 dark:text-slate-100">
                         {c.sectionCount}


### PR DESCRIPTION
## What changes for someone using the site

The Degree-Path Planner was the most useful thing on the site and the hardest to find — reachable only via a small link buried on a college's programs page. This adds two clear ways in:

1. **On a college page** — a prominent **"Plan a degree at {college}"** card right after the hero. One tap takes a student to that college's programs, where each one links to its full plan. It only appears when the college actually has plannable programs, so it never leads to a dead end.

2. **On a program hub** (e.g. `/ga/program/nursing`) — the "Colleges offering Nursing" table becomes a **guided picker**: each college now has a **"See the full plan →"** link straight to *that college's* nursing plan, under a one-line "Pick a college to see its full plan" prompt. So a student who starts from an interest ("nursing") lands on a real plan in two clicks.

## What changes technically

Two files, wiring + copy only — no change to the planner itself.
- **College page:** loads the college's programs once, counts those with ≥5 real courses (`countRealCourses`), and renders the CTA only when that's > 0.
- **Program hub:** from `loadProgramAcrossColleges`, builds a `collegeId → planSlug` map (picking the best plannable program per college, preferring AS/AA/AAS over a certificate via `programSlug`), and renders a per-row plan link.

## Test plan
- ✅ `tsc` clean · `eslint` clean · `next build` **`✓ Compiled successfully`**.
- ✅ **College CTA** confirmed in server-rendered HTML (present; gated correctly — `plannableCount = 149` for the GA test college).
- ⚠️ **Hub picker** could not be screenshotted locally: its table is driven by `loadProgramData`, which needs Supabase and renders empty in this sandbox. Verified instead by (a) direct logic probe — 19 GA colleges resolve to plannable plan slugs; (b) **join-key check at the source** — `data.colleges[].collegeId` and the picker's map key are both `institution.id`, so the lookup matches in prod where the table populates; (c) link targets are the existing, already-working plan pages. The preview browser was also unstable this session (desynced renders), so visual verification leaned on SSR output + logic checks.

## Scope / next
Completes the **discoverability** half of Phase A (A1). Noted along the way: the **homepage** "What you can do" cards are Search / Transfer / Schedule — **no planner** — a natural next entry point. The full free-text "goal router" remains a separate, larger piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)